### PR TITLE
fix a compile warning

### DIFF
--- a/src/google/protobuf/generated_message_reflection.h
+++ b/src/google/protobuf/generated_message_reflection.h
@@ -368,7 +368,7 @@ class LIBPROTOBUF_EXPORT GeneratedMessageReflection : public Reflection {
 
   inline const uint32* GetHasBits(const Message& message) const;
   inline uint32* MutableHasBits(Message* message) const;
-  inline const uint32 GetOneofCase(
+  inline uint32 GetOneofCase(
       const Message& message,
       const OneofDescriptor* oneof_descriptor) const;
   inline uint32* MutableOneofCase(


### PR DESCRIPTION
This change fixes the following compiler warning:

warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
