### PR TITLE
Remove GOOGLE_PROTOBUF_ARCH_PPC

### DIFF
--- a/src/google/protobuf/stubs/platform_macros.h
+++ b/src/google/protobuf/stubs/platform_macros.h
@@ -62,9 +62,6 @@
 #endif
 #elif defined(__pnacl__)
 #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
-#elif defined(__ppc__)
-#define GOOGLE_PROTOBUF_ARCH_PPC 1
-#define GOOGLE_PROTOBUF_ARCH_32_BIT 1
 #elif defined(__GNUC__) && \
  (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4))
 // We fallback to the generic GCC >= 4.7 implementation in atomicops.h


### PR DESCRIPTION
The macro GOOGLE_PROTOBUF_ARCH_PPC is not used anywhere in the protobuf
source; there is no Power-specific atomics implementation, etc.

Funnily enough, the macro **ppc** is not actually defined on 32-bit
Power on GCC/Linux, according to the following webpage:

```
http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros#POWER
```

and verified on a 32-bit Debian sid 'powerpc' chroot:

```
(sid_powerpc-dchroot)edmonds@partch:~$ gcc -dM -E - < /dev/null | grep -c __ppc__
0
(sid_powerpc-dchroot)edmonds@partch:~$ gcc -dM -E - < /dev/null | grep -c __LP64__
0
```
