### PR TITLE
Expose generic atomicops on Clang

### DIFF
--- a/src/google/protobuf/stubs/atomicops.h
+++ b/src/google/protobuf/stubs/atomicops.h
@@ -192,7 +192,8 @@ GOOGLE_PROTOBUF_ATOMICOPS_ERROR
 #include <google/protobuf/stubs/atomicops_internals_mips_gcc.h>
 #elif defined(__native_client__)
 #include <google/protobuf/stubs/atomicops_internals_pnacl.h>
-#elif (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4))
+#elif (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4)) || \
+ (defined(__clang__) && __has_extension(c_atomic))
 #include <google/protobuf/stubs/atomicops_internals_generic_gcc.h>
 #else
 GOOGLE_PROTOBUF_ATOMICOPS_ERROR

--- a/src/google/protobuf/stubs/platform_macros.h
+++ b/src/google/protobuf/stubs/platform_macros.h
@@ -63,7 +63,8 @@
 #elif defined(__pnacl__)
 #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
 #elif defined(__GNUC__) && \
- (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4))
+ ((((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4)) || \
+  (defined(__clang__) && __has_extension(c_atomic)))
 // We fallback to the generic GCC >= 4.7 implementation in atomicops.h
 # if __LP64__
 #  define GOOGLE_PROTOBUF_ARCH_64_BIT 1


### PR DESCRIPTION
The generic atomicops implementation is only exposed if GCC >= 4.7 is
available, but Clang, where the underlying __atomic built-ins are also
available, typically only claims to be GCC 4.2. This causes build
failures when compiling protobuf or the output of protoc's C++ code
generator on an architecture that needs the generic atomicops
implementation with Clang.

Clang has a "c_atomic" extension which can be tested for which almost
does what we want:

```
C11 atomic operations

Use __has_feature(c_atomic) or __has_extension(c_atomic) to
determine if support for atomic types using _Atomic is enabled.
Clang also provides a set of builtins which can be used to implement
the <stdatomic.h> operations on _Atomic types.
```

I'm not sure if this guarantees that the GNU atomic builtins (the ones
with the __atomic prefix) are also available, but in practice this
should guarantee that Clang is new enough.

With this change in place, Clang generates several diagnostics when
compiling the generic atomicops implementation. These appear to be bugs
in the generic atomicops implementation and are not Clang-specific.
