### PR TITLE
Fix atomicops build failure on non-Clang

### DIFF
--- a/src/google/protobuf/stubs/atomicops.h
+++ b/src/google/protobuf/stubs/atomicops.h
@@ -192,9 +192,14 @@ GOOGLE_PROTOBUF_ATOMICOPS_ERROR
 #include <google/protobuf/stubs/atomicops_internals_mips_gcc.h>
 #elif defined(__native_client__)
 #include <google/protobuf/stubs/atomicops_internals_pnacl.h>
-#elif (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4)) || \
- (defined(__clang__) && __has_extension(c_atomic))
+#elif (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4))
 #include <google/protobuf/stubs/atomicops_internals_generic_gcc.h>
+#elif defined(__clang__)
+#if __has_extension(c_atomic)
+#include <google/protobuf/stubs/atomicops_internals_generic_gcc.h>
+#else
+GOOGLE_PROTOBUF_ATOMICOPS_ERROR
+#endif
 #else
 GOOGLE_PROTOBUF_ATOMICOPS_ERROR
 #endif

--- a/src/google/protobuf/stubs/platform_macros.h
+++ b/src/google/protobuf/stubs/platform_macros.h
@@ -33,6 +33,9 @@
 
 #include <google/protobuf/stubs/common.h>
 
+#define GOOGLE_PROTOBUF_PLATFORM_ERROR \
+#error "Host platform was not detected as supported by protobuf"
+
 // Processor architecture detection.  For more info on what's defined, see:
 //   http://msdn.microsoft.com/en-us/library/b0084kay.aspx
 //   http://www.agner.org/optimize/calling_conventions.pdf
@@ -62,17 +65,22 @@
 #endif
 #elif defined(__pnacl__)
 #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
-#elif defined(__GNUC__) && \
- ((((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4)) || \
-  (defined(__clang__) && __has_extension(c_atomic)))
-// We fallback to the generic GCC >= 4.7 implementation in atomicops.h
+#elif defined(__GNUC__)
+# if (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4))
+// We fallback to the generic Clang/GCC >= 4.7 implementation in atomicops.h
+# elif defined(__clang__)
+#  if !__has_extension(c_atomic)
+GOOGLE_PROTOBUF_PLATFORM_ERROR
+#  endif
+// We fallback to the generic Clang/GCC >= 4.7 implementation in atomicops.h
+# endif
 # if __LP64__
 #  define GOOGLE_PROTOBUF_ARCH_64_BIT 1
 # else
 #  define GOOGLE_PROTOBUF_ARCH_32_BIT 1
 # endif
 #else
-#error Host architecture was not detected as supported by protobuf
+GOOGLE_PROTOBUF_PLATFORM_ERROR
 #endif
 
 #if defined(__APPLE__)


### PR DESCRIPTION
We cannot use Clang's `__has_extension` macro unless we really are compiling on Clang, which means we cannot use this expression:

```
    #if (defined(__clang__) && __has_extension(c_atomic)))
    // ...
    #endif
```

On GCC, this generates the following errors:

```
    In file included from ./google/protobuf/stubs/atomicops.h:59:0,
                     from google/protobuf/stubs/atomicops_internals_x86_gcc.cc:36:
    ./google/protobuf/stubs/platform_macros.h:67:41: error: missing binary operator before token "("
       (defined(__clang__) && __has_extension(c_atomic)))
                                             ^
    In file included from google/protobuf/stubs/atomicops_internals_x86_gcc.cc:36:0:
    ./google/protobuf/stubs/atomicops.h:196:40: error: missing binary operator before token "("
      (defined(__clang__) && __has_extension(c_atomic))
                                            ^
```

Instead, we have to protect the `__has_extension` expression by only executing it when `__clang__` is defined:

```
    #if defined(__clang__)
    # if __has_extension(c_atomic)
    // ...
    # endif
    #endif
```
