### PR TITLE
Add check for sched_yield in librt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,6 +139,9 @@ AM_CONDITIONAL([USE_EXTERNAL_PROTOC], [test "$with_protoc" != "no"])
 ACX_PTHREAD
 AC_CXX_STL_HASH
 
+# Need to link against rt on Solaris
+AC_SEARCH_LIBS([sched_yield], [rt], [], [AC_MSG_FAILURE([sched_yield was not found on your system])])
+
 # HACK:  Make gtest's configure script pick up our copy of CFLAGS and CXXFLAGS,
 #   since the flags added by ACX_CHECK_SUNCC must be used when compiling gtest
 #   too.


### PR DESCRIPTION
In Solaris, sched_yield lives in librt, rather than libc. This patch adds a
check which will link in librt if necessary.
