### PR TITLE
Fix descriptor validation logic for packed enum fields.

### DIFF
--- a/java/src/main/java/com/google/protobuf/Descriptors.java
+++ b/java/src/main/java/com/google/protobuf/Descriptors.java
@@ -1103,13 +1103,6 @@ public final class Descriptors {
           "Field numbers must be positive integers.");
       }
 
-      // Only repeated primitive fields may be packed.
-      if (proto.getOptions().getPacked() && !isPackable()) {
-        throw new DescriptorValidationException(this,
-          "[packed = true] can only be specified for repeated primitive " +
-          "fields.");
-      }
-
       if (isExtension) {
         if (!proto.hasExtendee()) {
           throw new DescriptorValidationException(this,
@@ -1216,6 +1209,13 @@ public final class Descriptors {
           throw new DescriptorValidationException(this,
             "Field with message or enum type missing type_name.");
         }
+      }
+
+      // Only repeated primitive fields may be packed.
+      if (proto.getOptions().getPacked() && !isPackable()) {
+        throw new DescriptorValidationException(this,
+          "[packed = true] can only be specified for repeated primitive " +
+          "fields.");
       }
 
       // We don't attempt to parse the default value until here because for

--- a/java/src/test/java/com/google/protobuf/DescriptorsTest.java
+++ b/java/src/test/java/com/google/protobuf/DescriptorsTest.java
@@ -705,4 +705,31 @@ public class DescriptorsTest extends TestCase {
     assertFalse(TestMultipleExtensionRanges.getDescriptor().isExtensionNumber(4142));
     assertTrue(TestMultipleExtensionRanges.getDescriptor().isExtensionNumber(4143));
   }
+
+  public void testPackedEnumField() throws Exception {
+    FileDescriptorProto fileDescriptorProto = FileDescriptorProto.newBuilder()
+        .setName("foo.proto")
+        .addEnumType(EnumDescriptorProto.newBuilder()
+          .setName("Enum")
+          .addValue(EnumValueDescriptorProto.newBuilder()
+            .setName("FOO")
+            .setNumber(1)
+            .build())
+          .build())
+        .addMessageType(DescriptorProto.newBuilder()
+          .setName("Message")
+          .addField(FieldDescriptorProto.newBuilder()
+            .setName("foo")
+            .setTypeName("Enum")
+            .setNumber(1)
+            .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
+            .setOptions(DescriptorProtos.FieldOptions.newBuilder()
+              .setPacked(true)
+              .build())
+            .build())
+          .build())
+        .build();
+    Descriptors.FileDescriptor.buildFrom(
+        fileDescriptorProto, new FileDescriptor[0]);
+  }
 }


### PR DESCRIPTION
Reviewers: @pherl @protobufel

Fixes #24 

The original validation code tries to access the "FieldDescriptor.type" field which for enum fields may only be available after cross-link and thus may result in a NullPointerException. This change fixes the problem by moving the validation logic to the cross-link phase.

Note that this problem only occurs for users who manually construct FileDescriptorProto. The FileDescriptorProto generated by protocol compiler already has the "type" field filled even for enum/message/group fields so it doesn't have such problems.
