### PR TITLE
 Add __version__

### DIFF
--- a/python/google/protobuf/__init__.py
+++ b/python/google/protobuf/__init__.py
@@ -32,4 +32,4 @@
 #
 # Copyright 2007 Google Inc. All Rights Reserved.
 
-__version__ = '2.6.1'
+__version__ = '3.0.0-pre'


### PR DESCRIPTION
Added __version__ attr to package so that scripts that check local
packages to see if newer versions are available can work.

Almost all Python packages have a version attr, and the vast majority of
them name it "__version__"
