### PR TITLE
Change references to `vector` to use `std::vector`

### DIFF
--- a/src/google/protobuf/extension_set.h
+++ b/src/google/protobuf/extension_set.h
@@ -182,7 +182,7 @@ class LIBPROTOBUF_EXPORT ExtensionSet {
   // is useful to implement Reflection::ListFields().
   void AppendToList(const Descriptor* containing_type,
                     const DescriptorPool* pool,
-                    vector<const FieldDescriptor*>* output) const;
+                    std::vector<const FieldDescriptor*>* output) const;
 
   // =================================================================
   // Accessors

--- a/src/google/protobuf/unknown_field_set.h
+++ b/src/google/protobuf/unknown_field_set.h
@@ -145,7 +145,7 @@ class LIBPROTOBUF_EXPORT UnknownFieldSet {
 
   void ClearFallback();
 
-  vector<UnknownField>* fields_;
+  std::vector<UnknownField>* fields_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(UnknownFieldSet);
 };


### PR DESCRIPTION
Upstreaming patch used by Chromium in
https://codereview.chromium.org/693773003/
