### PR TITLE
Corrected code example in coded_stream.h

### DIFF
--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -49,7 +49,7 @@
 //   // to identify the file type, then write a length-delimited string.  The
 //   // string is composed of a varint giving the length followed by the raw
 //   // bytes.
-//   int fd = open("myfile", O_WRONLY);
+//   int fd = open("myfile", O_CREAT | O_WRONLY);
 //   ZeroCopyOutputStream* raw_output = new FileOutputStream(fd);
 //   CodedOutputStream* coded_output = new CodedOutputStream(raw_output);
 //


### PR DESCRIPTION
There is an example at the top of the page which contains code that appears to show a user how to create and serialize a message to a file. However the flags to open the file lack the O_CREAT flag which allows creating the file if it doesn't exist. I was troubleshooting a situation where this snippet was used and compiled, but never created a file.
