### PR TITLE
Update LICENSE to list files that aren't copyrighted by Google Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,14 @@
-Copyright 2008, Google Inc.
-All rights reserved.
+This license applies to all parts of Protocol Buffers except the following:
+
+  - Atomicops support for generic gcc, located in
+    src/google/protobuf/stubs/atomicops_internals_generic_gcc.h.
+    This file is copyrighted by Red Hat Inc.
+
+  - Atomicops support for AIX/POWER, located in
+    src/google/protobuf/stubs/atomicops_internals_aix.h.
+    This file is copyrighted by Bloomberg Finance LP.
+
+Copyright 2014, Google Inc.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
This is following what V8 does:
https://code.google.com/p/v8/source/browse/trunk/LICENSE
