### PR TITLE
Don't rely on non-standard 'INT32_MAX' / 'INT32_MIN'.

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_enum.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_enum.cc
@@ -106,8 +106,8 @@ void EnumGenerator::GenerateDefinition(io::Printer* printer) {
     // INT32_MIN and INT32_MAX
     if (descriptor_->value_count() > 0) printer->Print(",\n");
     printer->Print(vars,
-        "$classname$_$prefix$INT_MIN_SENTINEL_DO_NOT_USE_ = PROTOBUF_ENUM_MIN,\n"
-        "$classname$_$prefix$INT_MAX_SENTINEL_DO_NOT_USE_ = PROTOBUF_ENUM_MAX");
+        "$classname$_$prefix$INT_MIN_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32min,\n"
+        "$classname$_$prefix$INT_MAX_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32max");
   }
 
   printer->Outdent();

--- a/src/google/protobuf/compiler/cpp/cpp_file.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_file.cc
@@ -105,12 +105,6 @@ void FileGenerator::GenerateHeader(io::Printer* printer) {
     "#define PROTOBUF_$filename_identifier$__INCLUDED\n"
     "\n"
     "#include <string>\n"
-    "#ifndef PROTOBUF_ENUM_MIN\n"
-    "#define PROTOBUF_ENUM_MIN		(int32_t)0x80000000\n"
-    "#endif\n"
-    "#ifndef PROTOBUF_ENUM_MAX\n"
-    "#define PROTOBUF_ENUM_MAX		(int32_t)0x7fffffff\n"
-    "#endif\n"
     "\n",
     "filename", file_->name(),
     "filename_identifier", filename_identifier);

--- a/src/google/protobuf/compiler/plugin.pb.h
+++ b/src/google/protobuf/compiler/plugin.pb.h
@@ -5,12 +5,6 @@
 #define PROTOBUF_google_2fprotobuf_2fcompiler_2fplugin_2eproto__INCLUDED
 
 #include <string>
-#ifndef PROTOBUF_ENUM_MIN
-#define PROTOBUF_ENUM_MIN		(int32_t)0x80000000
-#endif
-#ifndef PROTOBUF_ENUM_MAX
-#define PROTOBUF_ENUM_MAX		(int32_t)0x7fffffff
-#endif
 
 #include <google/protobuf/stubs/common.h>
 

--- a/src/google/protobuf/descriptor.pb.h
+++ b/src/google/protobuf/descriptor.pb.h
@@ -5,12 +5,6 @@
 #define PROTOBUF_google_2fprotobuf_2fdescriptor_2eproto__INCLUDED
 
 #include <string>
-#ifndef PROTOBUF_ENUM_MIN
-#define PROTOBUF_ENUM_MIN		(int32_t)0x80000000
-#endif
-#ifndef PROTOBUF_ENUM_MAX
-#define PROTOBUF_ENUM_MAX		(int32_t)0x7fffffff
-#endif
 
 #include <google/protobuf/stubs/common.h>
 


### PR DESCRIPTION
Define safe constants to use when padding enums.

Fixes #80.
