### PR TITLE
Improved little endian byte order detection

### DIFF
--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -123,7 +123,8 @@
   #endif
 #else
   #include <sys/param.h>   // __BYTE_ORDER
-  #if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN && \
+  #if ((defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)) || \
+         (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN)) && \
       !defined(PROTOBUF_DISABLE_LITTLE_ENDIAN_OPT_FOR_TEST)
     #define PROTOBUF_LITTLE_ENDIAN 1
   #endif


### PR DESCRIPTION
Including <sys/param.h> on Mac/iOS doesn't define **BYTE_ORDER so
PROTOBUF_LITTLE_ENDIAN was never being defined. This commit adds a check
for the __LITTLE_ENDIAN** macro which is defined by clang and Apple gcc on
little endian architectures.
