### PR TITLE
Update python version / setuptools instructions

### DIFF
--- a/python/README.txt
+++ b/python/README.txt
@@ -26,7 +26,7 @@ join the Protocol Buffers discussion list and let us know!
 Installation
 ============
 
-1) Make sure you have Python 2.4 or newer.  If in doubt, run:
+1) Make sure you have Python 2.6 or newer.  If in doubt, run:
 
      $ python -V
 
@@ -35,7 +35,7 @@ Installation
    If you would rather install it manually, you may do so by following
    the instructions on this page:
 
-     http://peak.telecommunity.com/DevCenter/EasyInstall#installation-instructions
+     https://packaging.python.org/en/latest/installing.html#setup-for-installing-packages
 
 3) Build the C++ code, or install a binary distribution of protoc.  If
    you install a binary distribution, make sure that it is the same


### PR DESCRIPTION
Reflect the change that protobuf should now only be supporting 2.6+ (I'd guess note python 3.x+ when its supported in implementation)

Refer to the Python Packaging User Guide for installing setuptools (and pip) instead of out of date telecommunity guide.
