### PR TITLE
Use user-supplied descriptor pools in FileDescriptor

### DIFF
--- a/python/google/protobuf/descriptor.py
+++ b/python/google/protobuf/descriptor.py
@@ -906,7 +906,7 @@ class FileDescriptor(DescriptorBase):
     self.dependencies = (dependencies or [])
     self.public_dependencies = (public_dependencies or [])
 
-    if self.serialized_pb is not None:
+    if self.serialized_pb is not None and api_implementation.Type() == 'cpp':
       self.pool.AddSerializedFile(self.serialized_pb)
 
   def CopyToProto(self, proto):


### PR DESCRIPTION
FileDescriptor's **new** accepted a pool argument but did not
honor it. When using the C++ backend implementation, this causes
problems for those who need hot-reloading of Protobuf definitions.

This issue is addressed by honoring the pool argument if it is
supplied.
