### PR TITLE
Fix for construction of messages in the C++ Python implementation.

### DIFF
--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -1766,12 +1766,6 @@ class Proto3Test(BaseTestCase):
     msg.map_int32_foreign_message[19].c = 128
     self.assertEqual(msg.ByteSize(), size + 1)
 
-  def testMapFieldConstruction(self):
-    msg1 = map_unittest_pb2.TestMap()
-    msg1.map_string_foreign_message['test'].c = 42
-    msg2 = map_unittest_pb2.TestMap(map_string_foreign_message=msg1.map_string_foreign_message)
-    self.assertEqual(42, msg2.map_string_foreign_message['test'].c)
-
   def testMergeFrom(self):
     msg = map_unittest_pb2.TestMap()
     msg.map_int32_int32[12] = 34
@@ -2122,6 +2116,19 @@ class Proto3Test(BaseTestCase):
     msg = map_unittest_pb2.TestMap(
         map_int32_foreign_message={3: unittest_pb2.ForeignMessage(c=5)})
     self.assertEqual(5, msg.map_int32_foreign_message[3].c)
+
+  def testMapScalarFieldConstruction(self):
+    msg1 = map_unittest_pb2.TestMap()
+    msg1.map_int32_int32[1] = 42
+    msg2 = map_unittest_pb2.TestMap(map_int32_int32=msg1.map_int32_int32)
+    self.assertEqual(42, msg2.map_int32_int32[1])
+
+  def testMapMessageFieldConstruction(self):
+    msg1 = map_unittest_pb2.TestMap()
+    msg1.map_string_foreign_message['test'].c = 42
+    msg2 = map_unittest_pb2.TestMap(
+      map_string_foreign_message=msg1.map_string_foreign_message)
+    self.assertEqual(42, msg2.map_string_foreign_message['test'].c)
 
   def testMapValidAfterFieldCleared(self):
     # Map needs to work even if field is cleared.

--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -1766,6 +1766,12 @@ class Proto3Test(BaseTestCase):
     msg.map_int32_foreign_message[19].c = 128
     self.assertEqual(msg.ByteSize(), size + 1)
 
+  def testMapFieldConstruction(self):
+    msg1 = map_unittest_pb2.TestMap()
+    msg1.map_string_foreign_message['test'].c = 42
+    msg2 = map_unittest_pb2.TestMap(map_string_foreign_message=msg1.map_string_foreign_message)
+    self.assertEqual(42, msg2.map_string_foreign_message['test'].c)
+
   def testMergeFrom(self):
     msg = map_unittest_pb2.TestMap()
     msg.map_int32_int32[12] = 34

--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -2130,6 +2130,11 @@ class Proto3Test(BaseTestCase):
       map_string_foreign_message=msg1.map_string_foreign_message)
     self.assertEqual(42, msg2.map_string_foreign_message['test'].c)
 
+  def testMapFieldRaisesCorrectError(self):
+    # Should raise a TypeError when given a non-iterable.
+    with self.assertRaises(TypeError):
+      map_unittest_pb2.TestMap(map_string_foreign_message=1)
+
   def testMapValidAfterFieldCleared(self):
     # Map needs to work even if field is cleared.
     # For the C++ implementation this tests the correctness of

--- a/python/google/protobuf/pyext/message.cc
+++ b/python/google/protobuf/pyext/message.cc
@@ -1236,20 +1236,45 @@ int InitAttributes(CMessage* self, PyObject* args, PyObject* kwargs) {
       const FieldDescriptor* value_descriptor =
           descriptor->message_type()->FindFieldByName("value");
       if (value_descriptor->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
-        Py_ssize_t map_pos = 0;
-        PyObject* map_key;
-        PyObject* map_value;
-        while (PyDict_Next(value, &map_pos, &map_key, &map_value)) {
-          ScopedPyObjectPtr function_return;
-          function_return.reset(PyObject_GetItem(map.get(), map_key));
-          if (function_return.get() == NULL) {
+        if (PyDict_Check(value)) {
+          Py_ssize_t map_pos = 0;
+          PyObject* map_key;
+          PyObject* map_value;
+          while (PyDict_Next(value, &map_pos, &map_key, &map_value)) {
+            ScopedPyObjectPtr function_return;
+            function_return.reset(PyObject_GetItem(map.get(), map_key));
+            if (function_return.get() == NULL) {
+              return -1;
+            }
+            ScopedPyObjectPtr ok(PyObject_CallMethod(
+                function_return.get(), "MergeFrom", "O", map_value));
+            if (ok.get() == NULL) {
+              return -1;
+            }
+          }
+        } else if (PyObject_TypeCheck(value, MessageMapContainer_Type)) {
+          ScopedPyObjectPtr iter(PyObject_GetIter(value));
+          if (iter == NULL) {
+            PyErr_SetString(PyExc_TypeError, "Inexplicably non-iterable message map.");
             return -1;
           }
-          ScopedPyObjectPtr ok(PyObject_CallMethod(
-              function_return.get(), "MergeFrom", "O", map_value));
-          if (ok.get() == NULL) {
-            return -1;
+          ScopedPyObjectPtr next;
+          while ((next.reset(PyIter_Next(iter.get()))) != NULL) {
+            ScopedPyObjectPtr source_value(PyObject_GetItem(value, next.get()));
+            ScopedPyObjectPtr dest_value(PyObject_GetItem(map.get(), next.get()));
+            if (source_value.get() == NULL || dest_value.get() == NULL) {
+              return -1;
+            }
+            ScopedPyObjectPtr ok(PyObject_CallMethod(
+                dest_value.get(), "MergeFrom", "O", source_value.get()));
+            if (ok.get() == NULL) {
+              return -1;
+            }
           }
+        } else {
+          PyErr_Format(PyExc_TypeError, "Argument %s is not a dict or message map",
+                       PyString_AsString(name));
+          return -1;
         }
       } else {
         ScopedPyObjectPtr function_return;

--- a/python/google/protobuf/pyext/message.cc
+++ b/python/google/protobuf/pyext/message.cc
@@ -1252,10 +1252,10 @@ int InitAttributes(CMessage* self, PyObject* args, PyObject* kwargs) {
               return -1;
             }
           }
-        } else if (PyObject_TypeCheck(value, MessageMapContainer_Type)) {
+        } else {
           ScopedPyObjectPtr iter(PyObject_GetIter(value));
           if (iter == NULL) {
-            PyErr_SetString(PyExc_TypeError, "Inexplicably non-iterable message map.");
+            PyErr_Format(PyExc_TypeError, "Argument %s is not iterable", PyString_AsString(name));
             return -1;
           }
           ScopedPyObjectPtr next;
@@ -1271,10 +1271,6 @@ int InitAttributes(CMessage* self, PyObject* args, PyObject* kwargs) {
               return -1;
             }
           }
-        } else {
-          PyErr_Format(PyExc_TypeError, "Argument %s is not a dict or message map",
-                       PyString_AsString(name));
-          return -1;
         }
       } else {
         ScopedPyObjectPtr function_return;

--- a/python/google/protobuf/pyext/message.cc
+++ b/python/google/protobuf/pyext/message.cc
@@ -1236,40 +1236,22 @@ int InitAttributes(CMessage* self, PyObject* args, PyObject* kwargs) {
       const FieldDescriptor* value_descriptor =
           descriptor->message_type()->FindFieldByName("value");
       if (value_descriptor->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
-        if (PyDict_Check(value)) {
-          Py_ssize_t map_pos = 0;
-          PyObject* map_key;
-          PyObject* map_value;
-          while (PyDict_Next(value, &map_pos, &map_key, &map_value)) {
-            ScopedPyObjectPtr function_return;
-            function_return.reset(PyObject_GetItem(map.get(), map_key));
-            if (function_return.get() == NULL) {
-              return -1;
-            }
-            ScopedPyObjectPtr ok(PyObject_CallMethod(
-                function_return.get(), "MergeFrom", "O", map_value));
-            if (ok.get() == NULL) {
-              return -1;
-            }
-          }
-        } else {
-          ScopedPyObjectPtr iter(PyObject_GetIter(value));
-          if (iter == NULL) {
-            PyErr_Format(PyExc_TypeError, "Argument %s is not iterable", PyString_AsString(name));
+        ScopedPyObjectPtr iter(PyObject_GetIter(value));
+        if (iter == NULL) {
+          PyErr_Format(PyExc_TypeError, "Argument %s is not iterable", PyString_AsString(name));
+          return -1;
+        }
+        ScopedPyObjectPtr next;
+        while ((next.reset(PyIter_Next(iter.get()))) != NULL) {
+          ScopedPyObjectPtr source_value(PyObject_GetItem(value, next.get()));
+          ScopedPyObjectPtr dest_value(PyObject_GetItem(map.get(), next.get()));
+          if (source_value.get() == NULL || dest_value.get() == NULL) {
             return -1;
           }
-          ScopedPyObjectPtr next;
-          while ((next.reset(PyIter_Next(iter.get()))) != NULL) {
-            ScopedPyObjectPtr source_value(PyObject_GetItem(value, next.get()));
-            ScopedPyObjectPtr dest_value(PyObject_GetItem(map.get(), next.get()));
-            if (source_value.get() == NULL || dest_value.get() == NULL) {
-              return -1;
-            }
-            ScopedPyObjectPtr ok(PyObject_CallMethod(
-                dest_value.get(), "MergeFrom", "O", source_value.get()));
-            if (ok.get() == NULL) {
-              return -1;
-            }
+          ScopedPyObjectPtr ok(PyObject_CallMethod(
+              dest_value.get(), "MergeFrom", "O", source_value.get()));
+          if (ok.get() == NULL) {
+            return -1;
           }
         }
       } else {


### PR DESCRIPTION
Fixes the case where a message has a map field and the caller passes in a map container (e.g. from another message object) as a constructor argument. Currently the field is silently left empty.
