### PR TITLE
Fix cmake module - quote output directory for generation

### DIFF
--- a/cmake/protobuf-module.cmake.in
+++ b/cmake/protobuf-module.cmake.in
@@ -42,8 +42,8 @@ function(PROTOBUF_GENERATE_CPP SRCS HDRS)
     add_custom_command(
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc"
              "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h"
-      COMMAND  ${Protobuf_PROTOC_EXECUTABLE}
-      ARGS --cpp_out  ${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
+      COMMAND  "${Protobuf_PROTOC_EXECUTABLE}"
+      ARGS --cpp_out  "${CMAKE_CURRENT_BINARY_DIR}" ${_protobuf_include_path} ${ABS_FIL}
       DEPENDS ${ABS_FIL} ${Protobuf_PROTOC_EXECUTABLE}
       COMMENT "Running C++ protocol buffer compiler on ${FIL}"
       VERBATIM )


### PR DESCRIPTION
Just a small fix to the CMake module, quoting the executable as well as the output directory, in case there are spaces in those paths.

Made on 3.0.x since that's what I assumed was a stable branch - not sure if the 3.1.x or 3.2.x branches I now see replace it or if all pulls should be against master, but this one is against 3.0.x since that's where I merged it personally and used it. Just a single commit so should be cherry-pickable.