### PR TITLE
There is no need to adjust UInt32 values when php supports 8 byte integers

### DIFF
--- a/php/src/Google/Protobuf/Internal/GPBUtil.php
+++ b/php/src/Google/Protobuf/Internal/GPBUtil.php
@@ -102,7 +102,6 @@ class GPBUtil
         if (is_numeric($var)) {
             if (PHP_INT_SIZE === 8) {
                 $var = intval($var);
-                $var |= ((-(($var >> 31) & 0x1)) & ~0xFFFFFFFF);
             } else {
                 if (bccomp($var, 0x7FFFFFFF) > 0) {
                     $var = bcsub($var, "4294967296");


### PR DESCRIPTION
And the conversion actually causes an exception when calling `serializeToString()`

```
Caught an error, errno: 1024, msg: Output stream doesn't have enough buffer., /var/www/vendor/google/protobuf/php/src/Google/Protobuf/Internal/OutputStream.php:92
```

Removing this line fixes the issue.