### PR TITLE
PHP string-to-int and int-to-string methods to enums

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -639,6 +639,7 @@ php_EXTRA_DIST=                                                       \
   php/src/Google/Protobuf/Internal/EnumDescriptorProto.php            \
   php/src/Google/Protobuf/Internal/EnumDescriptorProto/EnumReservedRange.php \
   php/src/Google/Protobuf/Internal/EnumOptions.php                    \
+  php/src/Google/Protobuf/Internal/EnumTrait.php                      \
   php/src/Google/Protobuf/Internal/EnumValueDescriptorProto.php       \
   php/src/Google/Protobuf/Internal/EnumValueOptions.php               \
   php/src/Google/Protobuf/Internal/ExtensionRangeOptions.php          \

--- a/php/src/Google/Protobuf/Field/Cardinality.php
+++ b/php/src/Google/Protobuf/Field/Cardinality.php
@@ -4,6 +4,8 @@
 
 namespace Google\Protobuf\Field;
 
+use Google\Protobuf\Internal\EnumTrait;
+
 /**
  * Whether a field is optional, required, or repeated.
  *
@@ -11,6 +13,8 @@ namespace Google\Protobuf\Field;
  */
 class Cardinality
 {
+    use EnumTrait;
+
     /**
      * For fields with unknown cardinality.
      *
@@ -35,6 +39,13 @@ class Cardinality
      * Generated from protobuf enum <code>CARDINALITY_REPEATED = 3;</code>
      */
     const CARDINALITY_REPEATED = 3;
+
+    private static $valueToName = [
+        self::CARDINALITY_UNKNOWN => 'CARDINALITY_UNKNOWN',
+        self::CARDINALITY_OPTIONAL => 'CARDINALclITY_OPTIONAL',
+        self::CARDINALITY_REQUIRED => 'CARDINALITY_REQUIRED',
+        self::CARDINALITY_REPEATED => 'CARDINALITY_REPEATED',
+    ];
 }
 
 // Adding a class alias for backwards compatibility with the previous class name.

--- a/php/src/Google/Protobuf/Field/Kind.php
+++ b/php/src/Google/Protobuf/Field/Kind.php
@@ -4,6 +4,8 @@
 
 namespace Google\Protobuf\Field;
 
+use Google\Protobuf\Internal\EnumTrait;
+
 /**
  * Basic field types.
  *
@@ -11,6 +13,8 @@ namespace Google\Protobuf\Field;
  */
 class Kind
 {
+    use EnumTrait;
+
     /**
      * Field type unknown.
      *
@@ -125,6 +129,28 @@ class Kind
      * Generated from protobuf enum <code>TYPE_SINT64 = 18;</code>
      */
     const TYPE_SINT64 = 18;
+
+    private static $valueToName = [
+        self::TYPE_UNKNOWN => 'TYPE_UNKNOWN',
+        self::TYPE_DOUBLE => 'TYPE_DOUBLE',
+        self::TYPE_FLOAT => 'TYPE_FLOAT',
+        self::TYPE_INT64 => 'TYPE_INT64',
+        self::TYPE_UINT64 => 'TYPE_UINT64',
+        self::TYPE_INT32 => 'TYPE_INT32',
+        self::TYPE_FIXED64 => 'TYPE_FIXED64',
+        self::TYPE_FIXED32 => 'TYPE_FIXED32',
+        self::TYPE_BOOL => 'TYPE_BOOL',
+        self::TYPE_STRING => 'TYPE_STRING',
+        self::TYPE_GROUP => 'TYPE_GROUP',
+        self::TYPE_MESSAGE => 'TYPE_MESSAGE',
+        self::TYPE_BYTES => 'TYPE_BYTES',
+        self::TYPE_UINT32 => 'TYPE_UINT32',
+        self::TYPE_ENUM => 'TYPE_ENUM',
+        self::TYPE_SFIXED32 => 'TYPE_SFIXED32',
+        self::TYPE_SFIXED64 => 'TYPE_SFIXED64',
+        self::TYPE_SINT32 => 'TYPE_SINT32',
+        self::TYPE_SINT64 => 'TYPE_SINT64',
+    ];
 }
 
 // Adding a class alias for backwards compatibility with the previous class name.

--- a/php/src/Google/Protobuf/Internal/EnumTrait.php
+++ b/php/src/Google/Protobuf/Internal/EnumTrait.php
@@ -39,11 +39,6 @@ trait EnumTrait
 {
     public static function name($value)
     {
-        if (!property_exists(__CLASS__, 'valueToName')) {
-            throw new LogicException(sprintf('Classes implementing %s must '
-                . 'define the static property $valueToName to use this '
-                . 'function', __TRAIT__));
-        }
         if (!isset(self::$valueToName[$value])) {
             throw new UnexpectedValueException(sprintf(
                 'Enum %s has no name defined for value %s', __CLASS__, $value));

--- a/php/src/Google/Protobuf/Internal/EnumTrait.php
+++ b/php/src/Google/Protobuf/Internal/EnumTrait.php
@@ -1,0 +1,63 @@
+<?php
+
+// Protocol Buffers - Google's data interchange format
+// Copyright 2018 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+namespace Google\Protobuf\Internal;
+
+use LogicException;
+use UnexpectedValueException;
+
+trait EnumTrait
+{
+    public static function name($value)
+    {
+        if (!property_exists(__CLASS__, 'valueToName')) {
+            throw new LogicException(sprintf('Classes implementing %s must '
+                . 'define the static property $valueToName to use this '
+                . 'function', __TRAIT__));
+        }
+        if (!isset(self::$valueToName[$value])) {
+            throw new UnexpectedValueException(sprintf(
+                'Enum %s has no name defined for value %s', __CLASS__, $value));
+        }
+        return self::$valueToName[$value];
+    }
+
+    public static function value($name)
+    {
+        $const = __CLASS__ . '::' . strtoupper($name);
+        if (!defined($const)) {
+            throw new UnexpectedValueException(sprintf(
+                'Enum %s has no value defined for name %s', __CLASS__, $name));
+        }
+        return constant($const);
+    }
+}

--- a/php/src/Google/Protobuf/Internal/FieldDescriptorProto/Label.php
+++ b/php/src/Google/Protobuf/Internal/FieldDescriptorProto/Label.php
@@ -4,11 +4,15 @@
 
 namespace Google\Protobuf\Internal\FieldDescriptorProto;
 
+use Google\Protobuf\Internal\EnumTrait;
+
 /**
  * Protobuf type <code>google.protobuf.FieldDescriptorProto.Label</code>
  */
 class Label
 {
+    use EnumTrait;
+
     /**
      * 0 is reserved for errors
      *
@@ -23,6 +27,12 @@ class Label
      * Generated from protobuf enum <code>LABEL_REPEATED = 3;</code>
      */
     const LABEL_REPEATED = 3;
+
+    private static $valueToName = [
+        self::LABEL_OPTIONAL => 'LABEL_OPTIONAL',
+        self::LABEL_REQUIRED => 'LABEL_REQUIRED',
+        self::LABEL_REPEATED => 'LABEL_REPEATED',
+    ];
 }
 
 // Adding a class alias for backwards compatibility with the previous class name.

--- a/php/src/Google/Protobuf/Internal/FieldDescriptorProto/Type.php
+++ b/php/src/Google/Protobuf/Internal/FieldDescriptorProto/Type.php
@@ -4,11 +4,15 @@
 
 namespace Google\Protobuf\Internal\FieldDescriptorProto;
 
+use Google\Protobuf\Internal\EnumTrait;
+
 /**
  * Protobuf type <code>google.protobuf.FieldDescriptorProto.Type</code>
  */
 class Type
 {
+    use EnumTrait;
+
     /**
      * 0 is reserved for errors.
      * Order is weird for historical reasons.
@@ -103,6 +107,27 @@ class Type
      * Generated from protobuf enum <code>TYPE_SINT64 = 18;</code>
      */
     const TYPE_SINT64 = 18;
+
+    private static $valueToName = [
+        self::TYPE_DOUBLE => 'TYPE_DOUBLE',
+        self::TYPE_FLOAT => 'TYPE_FLOAT',
+        self::TYPE_INT64 => 'TYPE_INT64',
+        self::TYPE_UINT64 => 'TYPE_UINT64',
+        self::TYPE_INT32 => 'TYPE_INT32',
+        self::TYPE_FIXED64 => 'TYPE_FIXED64',
+        self::TYPE_FIXED32 => 'TYPE_FIXED32',
+        self::TYPE_BOOL => 'TYPE_BOOL',
+        self::TYPE_STRING => 'TYPE_STRING',
+        self::TYPE_GROUP => 'TYPE_GROUP',
+        self::TYPE_MESSAGE => 'TYPE_MESSAGE',
+        self::TYPE_BYTES => 'TYPE_BYTES',
+        self::TYPE_UINT32 => 'TYPE_UINT32',
+        self::TYPE_ENUM => 'TYPE_ENUM',
+        self::TYPE_SFIXED32 => 'TYPE_SFIXED32',
+        self::TYPE_SFIXED64 => 'TYPE_SFIXED64',
+        self::TYPE_SINT32 => 'TYPE_SINT32',
+        self::TYPE_SINT64 => 'TYPE_SINT64',
+    ];
 }
 
 // Adding a class alias for backwards compatibility with the previous class name.

--- a/php/src/Google/Protobuf/Internal/FieldOptions/CType.php
+++ b/php/src/Google/Protobuf/Internal/FieldOptions/CType.php
@@ -4,11 +4,15 @@
 
 namespace Google\Protobuf\Internal\FieldOptions;
 
+use Google\Protobuf\Internal\EnumTrait;
+
 /**
  * Protobuf type <code>google.protobuf.FieldOptions.CType</code>
  */
 class CType
 {
+    use EnumTrait;
+
     /**
      * Default mode.
      *
@@ -23,6 +27,12 @@ class CType
      * Generated from protobuf enum <code>STRING_PIECE = 2;</code>
      */
     const STRING_PIECE = 2;
+
+    private static $valueToName = [
+        self::STRING => 'STRING',
+        self::CORD => 'CORD',
+        self::STRING_PIECE => 'STRING_PIECE',
+    ];
 }
 
 // Adding a class alias for backwards compatibility with the previous class name.

--- a/php/src/Google/Protobuf/Internal/FieldOptions/JSType.php
+++ b/php/src/Google/Protobuf/Internal/FieldOptions/JSType.php
@@ -4,11 +4,15 @@
 
 namespace Google\Protobuf\Internal\FieldOptions;
 
+use Google\Protobuf\Internal\EnumTrait;
+
 /**
  * Protobuf type <code>google.protobuf.FieldOptions.JSType</code>
  */
 class JSType
 {
+    use EnumTrait;
+
     /**
      * Use the default type.
      *
@@ -27,6 +31,12 @@ class JSType
      * Generated from protobuf enum <code>JS_NUMBER = 2;</code>
      */
     const JS_NUMBER = 2;
+
+    private static $valueToName = [
+        self::JS_NORMAL => 'JS_NORMAL',
+        self::JS_STRING => 'JS_STRING',
+        self::JS_NUMBER => 'JS_NUMBER',
+    ];
 }
 
 // Adding a class alias for backwards compatibility with the previous class name.

--- a/php/src/Google/Protobuf/Internal/FileOptions/OptimizeMode.php
+++ b/php/src/Google/Protobuf/Internal/FileOptions/OptimizeMode.php
@@ -4,6 +4,8 @@
 
 namespace Google\Protobuf\Internal\FileOptions;
 
+use Google\Protobuf\Internal\EnumTrait;
+
 /**
  * Generated classes can be optimized for speed or code size.
  *
@@ -11,6 +13,8 @@ namespace Google\Protobuf\Internal\FileOptions;
  */
 class OptimizeMode
 {
+    use EnumTrait;
+
     /**
      * Generate complete code for parsing, serialization,
      *
@@ -29,6 +33,12 @@ class OptimizeMode
      * Generated from protobuf enum <code>LITE_RUNTIME = 3;</code>
      */
     const LITE_RUNTIME = 3;
+
+    private static $valueToName = [
+        self::SPEED => 'SPEED',
+        self::CODE_SIZE => 'CODE_SIZE',
+        self::LITE_RUNTIME => 'LITE_RUNTIME',
+    ];
 }
 
 // Adding a class alias for backwards compatibility with the previous class name.

--- a/php/src/Google/Protobuf/Internal/MethodOptions/IdempotencyLevel.php
+++ b/php/src/Google/Protobuf/Internal/MethodOptions/IdempotencyLevel.php
@@ -4,6 +4,8 @@
 
 namespace Google\Protobuf\Internal\MethodOptions;
 
+use Google\Protobuf\Internal\EnumTrait;
+
 /**
  * Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
  * or neither? HTTP based RPC implementation may choose GET verb for safe
@@ -13,6 +15,8 @@ namespace Google\Protobuf\Internal\MethodOptions;
  */
 class IdempotencyLevel
 {
+    use EnumTrait;
+
     /**
      * Generated from protobuf enum <code>IDEMPOTENCY_UNKNOWN = 0;</code>
      */
@@ -29,6 +33,12 @@ class IdempotencyLevel
      * Generated from protobuf enum <code>IDEMPOTENT = 2;</code>
      */
     const IDEMPOTENT = 2;
+
+    private static $valueToName = [
+        self::IDEMPOTENCY_UNKNOWN => 'IDEMPOTENCY_UNKNOWN',
+        self::NO_SIDE_EFFECTS => 'NO_SIDE_EFFECTS',
+        self::IDEMPOTENT => 'IDEMPOTENT',
+    ];
 }
 
 // Adding a class alias for backwards compatibility with the previous class name.

--- a/php/src/Google/Protobuf/NullValue.php
+++ b/php/src/Google/Protobuf/NullValue.php
@@ -4,6 +4,8 @@
 
 namespace Google\Protobuf;
 
+use Google\Protobuf\Internal\EnumTrait;
+
 /**
  * `NullValue` is a singleton enumeration to represent the null value for the
  * `Value` type union.
@@ -13,11 +15,17 @@ namespace Google\Protobuf;
  */
 class NullValue
 {
+    use EnumTrait;
+
     /**
      * Null value.
      *
      * Generated from protobuf enum <code>NULL_VALUE = 0;</code>
      */
     const NULL_VALUE = 0;
+
+    private static $valueToName = [
+        self::NULL_VALUE => 'NULL_VALUE',
+    ];
 }
 

--- a/php/src/Google/Protobuf/Syntax.php
+++ b/php/src/Google/Protobuf/Syntax.php
@@ -4,6 +4,8 @@
 
 namespace Google\Protobuf;
 
+use Google\Protobuf\Internal\EnumTrait;
+
 /**
  * The syntax in which a protocol buffer element is defined.
  *
@@ -11,6 +13,8 @@ namespace Google\Protobuf;
  */
 class Syntax
 {
+    use EnumTrait;
+
     /**
      * Syntax `proto2`.
      *
@@ -23,5 +27,10 @@ class Syntax
      * Generated from protobuf enum <code>SYNTAX_PROTO3 = 1;</code>
      */
     const SYNTAX_PROTO3 = 1;
+
+    private static $valueToName = [
+        self::SYNTAX_PROTO2 => 'SYNTAX_PROTO2',
+        self::SYNTAX_PROTO3 => 'SYNTAX_PROTO3',
+    ];
 }
 

--- a/php/tests/generated_class_test.php
+++ b/php/tests/generated_class_test.php
@@ -8,6 +8,7 @@ require_once('test_util.php');
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\MapField;
 use Google\Protobuf\Internal\GPBType;
+use Google\Protobuf\Internal\EnumTrait;
 use Bar\TestLegacyMessage;
 use Bar\TestLegacyMessage_NestedEnum;
 use Bar\TestLegacyMessage_NestedMessage;
@@ -232,6 +233,28 @@ class GeneratedClassTest extends TestBase
         // Set string.
         $m->setOptionalEnum("1");
         $this->assertEquals(TestEnum::ONE, $m->getOptionalEnum());
+
+        // Test Enum methods
+        $this->assertEquals('ONE', TestEnum::name(1));
+        $this->assertEquals(1, TestEnum::value('ONE'));
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     * @expectedExceptionMessage Enum Foo\TestEnum has no name defined for value -1
+     */
+    public function testInvalidEnumValueThrowsException()
+    {
+        TestEnum::name(-1);
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     * @expectedExceptionMessage Enum Foo\TestEnum has no value defined for name DOES_NOT_EXIST
+     */
+    public function testInvalidEnumNameThrowsException()
+    {
+        TestEnum::value('DOES_NOT_EXIST');
     }
 
     public function testNestedEnum()

--- a/php/tests/php_implementation_test.php
+++ b/php/tests/php_implementation_test.php
@@ -13,6 +13,7 @@ use Google\Protobuf\Internal\GPBLabel;
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\GPBWire;
 use Google\Protobuf\Internal\CodedOutputStream;
+use Google\Protobuf\Internal\EnumTrait;
 
 class ImplementationTest extends TestBase
 {
@@ -584,4 +585,18 @@ class ImplementationTest extends TestBase
             [['map_int32_int32' => null]],
         ];
     }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage Classes implementing Google\Protobuf\Internal\EnumTrait must define the static property $valueToName to use this function
+     */
+    public function testBadEnumThrowsException()
+    {
+        BadEnum::name(1);
+    }
+}
+
+class BadEnum
+{
+    use EnumTrait;
 }

--- a/php/tests/php_implementation_test.php
+++ b/php/tests/php_implementation_test.php
@@ -585,18 +585,4 @@ class ImplementationTest extends TestBase
             [['map_int32_int32' => null]],
         ];
     }
-
-    /**
-     * @expectedException LogicException
-     * @expectedExceptionMessage Classes implementing Google\Protobuf\Internal\EnumTrait must define the static property $valueToName to use this function
-     */
-    public function testBadEnumThrowsException()
-    {
-        BadEnum::name(1);
-    }
-}
-
-class BadEnum
-{
-    use EnumTrait;
 }

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -1107,17 +1107,21 @@ void GenerateEnumFile(const FileDescriptor* file, const EnumDescriptor* en,
         "name", fullname.substr(0, lastindex));
   }
 
+  printer.Print("use Google\\Protobuf\\Internal\\EnumTrait;\n\n");
+
+  GenerateEnumDocComment(&printer, en, is_descriptor);
+
   if (lastindex != string::npos) {
     fullname = fullname.substr(lastindex + 1);
   }
-
-  GenerateEnumDocComment(&printer, en, is_descriptor);
 
   printer.Print(
       "class ^name^\n"
       "{\n",
       "name", fullname);
   Indent(&printer);
+
+  printer.Print("use EnumTrait;\n\n");
 
   for (int i = 0; i < en->value_count(); i++) {
     const EnumValueDescriptor* value = en->value(i);
@@ -1126,6 +1130,16 @@ void GenerateEnumFile(const FileDescriptor* file, const EnumDescriptor* en,
                   "name", ConstantNamePrefix(value->name()) + value->name(),
                   "number", IntToString(value->number()));
   }
+
+  printer.Print("\nprivate static $valueToName = [\n");
+  Indent(&printer);
+  for (int i = 0; i < en->value_count(); i++) {
+    const EnumValueDescriptor* value = en->value(i);
+    printer.Print("self::^name^ => '^name^',\n",
+                  "name", ConstantNamePrefix(value->name()) + value->name());
+  }
+  Outdent(&printer);
+  printer.Print("];\n");
 
   Outdent(&printer);
   printer.Print("}\n\n");


### PR DESCRIPTION
In accordance with [Python](https://developers.google.com/protocol-buffers/docs/reference/python-generated#enum), this PR adds `name` and `value` methods to PHP Protobuf Enums, so that conversion is programmatically possible between the two.

```php
$this->assertEquals('VALUE_A', SomeEnum::name(SomeEnum::VALUE_A));
$this->assertEquals(5, SomeEnum::value('VALUE_B'))
```

cc @michaelbausor @dwsupplee @tmatsuo