### PR TITLE
Expand hdrs and add textual_hdrs to :protobuf_objc target.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -199,9 +199,10 @@ cc_library(
 
 objc_library(
     name = "protobuf_objc",
-    hdrs = ["objectivec/GPBProtocolBuffers.h"],
+    hdrs = glob(["objectivec/**/*.h"]),
     includes = ["objectivec"],
     non_arc_srcs = ["objectivec/GPBProtocolBuffers.m"],
+    textual_hdrs = glob(["objectivec/**/*.m"]),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
A Bazel project wishing to depend on this target, for, say, linking in the objc
runtime with protoc-generated objc files needs to have the hdrs/textual_hdrs
fully defined to avoid import/link errors.