### PR TITLE
Updating Iterators to be compatible with C++17 in MSVC

### DIFF
--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -2205,23 +2205,14 @@ namespace internal {
 // This code based on net/proto/proto-array-internal.h by Jeffrey Yasskin
 // (jyasskin@google.com).
 template<typename Element>
-class RepeatedPtrIterator
-    : public std::iterator<
-          std::random_access_iterator_tag, Element> {
+class RepeatedPtrIterator {
  public:
   typedef RepeatedPtrIterator<Element> iterator;
-  typedef std::iterator<
-          std::random_access_iterator_tag, Element> superclass;
-
-  // Shadow the value_type in std::iterator<> because const_iterator::value_type
-  // needs to be T, not const T.
-  typedef typename std::remove_const<Element>::type value_type;
-
-  // Let the compiler know that these are type names, so we don't have to
-  // write "typename" in front of them everywhere.
-  typedef typename superclass::reference reference;
-  typedef typename superclass::pointer pointer;
-  typedef typename superclass::difference_type difference_type;
+  typedef std::random_access_iterator_tag iterator_category;
+  typedef Element value_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef Element* pointer;
+  typedef Element& reference;
 
   RepeatedPtrIterator() : it_(NULL) {}
   explicit RepeatedPtrIterator(void* const* it) : it_(it) {}
@@ -2301,21 +2292,14 @@ class RepeatedPtrIterator
 // referenced by the iterator.  It should either be "void *" for a mutable
 // iterator, or "const void* const" for a constant iterator.
 template <typename Element, typename VoidPtr>
-class RepeatedPtrOverPtrsIterator
-    : public std::iterator<std::random_access_iterator_tag, Element> {
+class RepeatedPtrOverPtrsIterator {
  public:
   typedef RepeatedPtrOverPtrsIterator<Element, VoidPtr> iterator;
-  typedef std::iterator<std::random_access_iterator_tag, Element> superclass;
-
-  // Shadow the value_type in std::iterator<> because const_iterator::value_type
-  // needs to be T, not const T.
-  typedef typename std::remove_const<Element>::type value_type;
-
-  // Let the compiler know that these are type names, so we don't have to
-  // write "typename" in front of them everywhere.
-  typedef typename superclass::reference reference;
-  typedef typename superclass::pointer pointer;
-  typedef typename superclass::difference_type difference_type;
+  typedef std::random_access_iterator_tag iterator_category;
+  typedef Element value_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef Element* pointer;
+  typedef Element& reference;
 
   RepeatedPtrOverPtrsIterator() : it_(NULL) {}
   explicit RepeatedPtrOverPtrsIterator(VoidPtr* it) : it_(it) {}

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -2209,7 +2209,7 @@ class RepeatedPtrIterator {
  public:
   typedef RepeatedPtrIterator<Element> iterator;
   typedef std::random_access_iterator_tag iterator_category;
-  typedef Element value_type;
+  typedef typename std::remove_const<Element>::type value_type;
   typedef std::ptrdiff_t difference_type;
   typedef Element* pointer;
   typedef Element& reference;
@@ -2296,7 +2296,7 @@ class RepeatedPtrOverPtrsIterator {
  public:
   typedef RepeatedPtrOverPtrsIterator<Element, VoidPtr> iterator;
   typedef std::random_access_iterator_tag iterator_category;
-  typedef Element value_type;
+  typedef typename std::remove_const<Element>::type value_type;
   typedef std::ptrdiff_t difference_type;
   typedef Element* pointer;
   typedef Element& reference;


### PR DESCRIPTION
The std::iterator class is being deprecated on MSVC++,
and currently if the compilation flag /std:c++latest
is used a warning is issued in this regard if any
iterators use the class as a base class.

If an external source file being compiled includes
the repeated_field.h header, the iterator clases
RepeatedPtrIterator and RepeatedPtrOverPtrsIterator
trigger the warning.

This change solves the warning and should avoid it in
the future when the default is to deprecate the class.