### PR TITLE
print repeated primitives in Java TextFormat same as in c++

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/TextFormat.java
+++ b/java/core/src/main/java/com/google/protobuf/TextFormat.java
@@ -329,14 +329,7 @@ public final class TextFormat {
 
     private void printField(final FieldDescriptor field, final Object value,
         final TextGenerator generator) throws IOException {
-      if (field.isRepeated()) {
-        // Repeated field.  Print each element.
-        for (Object element : (List<?>) value) {
-          printSingleField(field, element, generator);
-        }
-      } else {
-        printSingleField(field, value, generator);
-      }
+      printSingleField(field, value, generator);
     }
 
     private void printSingleField(final FieldDescriptor field,
@@ -373,12 +366,34 @@ public final class TextFormat {
         generator.print(": ");
       }
 
-      printFieldValue(field, value, generator);
+      if (field.isRepeated()) {
+          generator.print("[");
+      }
+
+      if (field.isRepeated()) {
+          boolean first = true;
+          for (Object object : (List<?>) value) {
+              if (!first) {
+                  generator.print(", ");
+              } else {
+                  first = false;
+              }
+
+              printFieldValue(field, object, generator);
+          }
+      } else {
+          printFieldValue(field, value, generator);
+      }
 
       if (field.getJavaType() == FieldDescriptor.JavaType.MESSAGE) {
         generator.outdent();
         generator.print("}");
       }
+
+      if (field.isRepeated()) {
+        generator.print("]");
+      }
+
       generator.eol();
     }
 


### PR DESCRIPTION
Hi, 
I saw the bug #4907 and decided to fix the printer to print the values of repeated primitives to be as in c++.
I didn't touch the parser, because the parser already knows to work with this prints already.

