### PR TITLE
Add Timestamp timezone parsing error case

### DIFF
--- a/python/google/protobuf/internal/well_known_types.py
+++ b/python/google/protobuf/internal/well_known_types.py
@@ -142,7 +142,8 @@ class Timestamp(object):
       timezone_offset = value.find('+')
     if timezone_offset == -1:
       timezone_offset = value.rfind('-')
-    if timezone_offset == -1:
+    # Don't match '-' in date (YYYY-MM-DD)
+    if timezone_offset == -1 or timezone_offset < 10:
       raise ParseError(
           'Failed to parse timestamp: missing valid timezone offset.')
     time_value = value[0:timezone_offset]


### PR DESCRIPTION
Calling `Timestamp.FromJsonString()` with a string that contains no timezone will result in a Python `UnboundLocalError` exception. For example:

```python
Timestamp.FromJsonString('2018-08-21T18:56:51.707893')
```

This change causes a `ParseError` to be raised if a matched `-` comes from the initial `YYYY-MM-DD` date.
