### PR TITLE
Mostly fix Sun Studio configuration using SunCC compiler (GH #5141)

### DIFF
--- a/m4/acx_check_suncc.m4
+++ b/m4/acx_check_suncc.m4
@@ -26,7 +26,7 @@ AC_DEFUN([ACX_CHECK_SUNCC],[
   AS_IF([test "$SUNCC" = "yes" -a "x${ac_cv_env_CXXFLAGS_set}" = "x"],[
     dnl Sun Studio has a crashing bug with -xO4 in some cases. Keep this
     dnl at -xO3 until a proper test to detect those crashes can be done.
-    CXXFLAGS="-g0 -xO3 -xlibmil -xdepend -xbuiltin -mt -compat=5 -library=stlport4 -library=Crun -template=no%extdef ${CXXFLAGS}"
+    CXXFLAGS="-g0 -xO3 -xlibmil -xdepend -xbuiltin -mt -template=no%extdef ${CXXFLAGS}"
   ])
 
   case $host_os in
@@ -67,4 +67,7 @@ AC_DEFUN([ACX_CHECK_SUNCC],[
     ;;
   esac
 
+  AS_IF([test "$target_cpu" = "sparc" -a "x$SUNCC" = "xyes" ],[
+    CXXFLAGS="-xregs=no%appl ${CXXFLAGS}"
+  ])
 ])

--- a/src/google/protobuf/stubs/common.cc
+++ b/src/google/protobuf/stubs/common.cc
@@ -354,7 +354,8 @@ struct ShutdownData {
 };
 
 static void RunZeroArgFunc(const void* arg) {
-  reinterpret_cast<void (*)()>(const_cast<void*>(arg))();
+  void (*func)() = reinterpret_cast<void (*)()>(const_cast<void*>(arg));
+  func();
 }
 
 void OnShutdown(void (*func)()) {


### PR DESCRIPTION
Sun Studio 12.4 is required because it provides the first C++11 compiler from Sun. However, SunCC in 12.4 fails to configure because it is so buggy. The SunCC compiler in Sun Studio 12.5 crashes on the m4 macro test test_type_deduction (line 257). The m4 test can probably be reworked so Sun Studio 12.5 is supported.

The Sun Studio 12.6 compiler finishes configuring. At the moment it looks like Sun Studio 12.6 is the only one supported.