### PR TITLE
[C#] Make it possible to run tests under .NET 3.5

### DIFF
--- a/csharp/README.md
+++ b/csharp/README.md
@@ -71,6 +71,9 @@ target frameworks, noting that the `TargetFrameworks` element appears twice in
 the file (once in the first `PropertyGroup` element, and again in the second 
 `PropertyGroup` element, i.e., the one with the conditional).
 
+`dotnet test` is unable to run unit tests under .NET 3.5, but after building 
+Google.Protobuf.Test.csproj you can run the tests by running Google.Protobuf.Test.exe.
+
 History of C# protobufs
 =======================
 

--- a/csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
+++ b/csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
@@ -6,6 +6,14 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <IsPackable>False</IsPackable>
+    <OutputType>Exe</OutputType>
+    <!-- 
+      - Microsoft.NET.Test.Sdk checks <GenerateProgramFile> to decide whether or not to 
+      - add an entrypoint during the build. We disable the addition of an entrypoint
+      - because Google.Protobuf.Test.csproj has <OutputType> set to Exe, which already
+      - adds an entrypoint; two entrypoints would result in a build error.
+      -->
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,9 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" Condition=" '$(TargetFramework)' != 'net35' " />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnitLite" Version="3.9.0" />
   </ItemGroup>
 
   <!-- 

--- a/csharp/src/Google.Protobuf.Test/Program.cs
+++ b/csharp/src/Google.Protobuf.Test/Program.cs
@@ -1,0 +1,48 @@
+﻿#region Copyright notice and license
+// Protocol Buffers - Google's data interchange format
+// Copyright 2017 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+using NUnitLite;
+using System.Reflection;
+
+namespace Google.Protobuf.Test
+{
+    class Program
+    {
+        public static int Main(string[] args)
+        {
+#if NET35
+            return new AutoRun(typeof(Program).Assembly).Execute(args);
+#else
+                return new AutoRun(typeof(Program).GetTypeInfo().Assembly).Execute(args);
+#endif
+        }
+    }
+}


### PR DESCRIPTION
For those who want to create custom builds of Google.Protobuf.dll targeting .NET 3.5, this change makes it possible to also run the tests under 3.5.

`dotnet test` is unable to run tests under 3.5, so I've changed Google.Protobuf.Test.csproj to produce an EXE instead of a DLL. One can run the tests simply by running Google.Protobuf.Test.exe.

This is undoing some of the changes made in commit e823897005b88b03088fe17d219ffaeeabb2961d. Before that commit, Google.Protobuf.Test.csproj was producing an EXE instead of a DLL.