### PR TITLE
ParseFromString returns bytes parsed

### DIFF
--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -139,9 +139,10 @@ class MessageTest(BaseTestCase):
   def testGoldenPackedMessage(self, message_module):
     golden_data = test_util.GoldenFileData('golden_packed_fields_message')
     golden_message = message_module.TestPackedTypes()
-    golden_message.ParseFromString(golden_data)
+    parsed_bytes = golden_message.ParseFromString(golden_data)
     all_set = message_module.TestPackedTypes()
     test_util.SetAllPackedFields(all_set)
+    self.assertEqual(parsed_bytes, len(golden_data))
     self.assertEqual(all_set, golden_message)
     self.assertEqual(golden_data, all_set.SerializeToString())
     golden_copy = copy.deepcopy(golden_message)

--- a/python/google/protobuf/message.py
+++ b/python/google/protobuf/message.py
@@ -182,7 +182,7 @@ class Message(object):
     do not return the value that MergeFromString returns.
     """
     self.Clear()
-    self.MergeFromString(serialized)
+    return self.MergeFromString(serialized)
 
   def SerializeToString(self, **kwargs):
     """Serializes the protocol message to a binary string.

--- a/python/google/protobuf/message.py
+++ b/python/google/protobuf/message.py
@@ -178,8 +178,7 @@ class Message(object):
   def ParseFromString(self, serialized):
     """Parse serialized protocol buffer data into this message.
 
-    Like MergeFromString(), except we clear the object first and
-    do not return the value that MergeFromString returns.
+    Like MergeFromString(), except we clear the object first.
     """
     self.Clear()
     return self.MergeFromString(serialized)


### PR DESCRIPTION
ParseFromString is documented as returning the number of bytes parsed,
and the C++ implementation does this, so the Python implementation
should too.

See #5165.