### PR TITLE
#3965 well known rich comparisons

### DIFF
--- a/python/google/protobuf/internal/well_known_types.py
+++ b/python/google/protobuf/internal/well_known_types.py
@@ -254,6 +254,31 @@ class Timestamp(object):
     self.seconds = calendar.timegm(dt.utctimetuple())
     self.nanos = dt.microsecond * _NANOS_PER_MICROSECOND
 
+  def _comparable_vector(self, obj):
+    # not dealing with datetime as didn't want to cause any surprises with 2/3
+    # differences. see https://github.com/protocolbuffers/protobuf/pull/5168
+    return (obj.seconds, obj.nanos)
+
+  # Make sure to normalize timestamps before using the following comparisons.
+  # Comparing non-normalized timestamps is not specified and may give unexpected results.
+  def __eq__(self, other):
+    return self._comparable_vector(self) == self._comparable_vector(other)
+
+  def __ne__(self, other):
+    return self._comparable_vector(self) != self._comparable_vector(other)
+
+  def __lt__(self, other):
+    return self._comparable_vector(self) < self._comparable_vector(other)
+
+  def __le__(self, other):
+    return self._comparable_vector(self) <= self._comparable_vector(other)
+
+  def __gt__(self, other):
+    return self._comparable_vector(self) > self._comparable_vector(other)
+
+  def __ge__(self, other):
+    return self._comparable_vector(self) >= self._comparable_vector(other)
+
 
 class Duration(object):
   """Class for Duration message type."""
@@ -383,6 +408,30 @@ class Duration(object):
       nanos -= _NANOS_PER_SECOND
     self.seconds = seconds
     self.nanos = nanos
+
+  def _comparable_vector(self, obj):
+    # comarison with timedelta not possible with python2 - see https://github.com/protocolbuffers/protobuf/pull/5168
+    return (obj.seconds, obj.nanos)
+
+  # Make sure to normalize timestamps before using the following comparisons.
+  # Comparing non-normalized timestamps is not specified and may give unexpected results.
+  def __eq__(self, other):
+    return self._comparable_vector(self) == self._comparable_vector(other)
+
+  def __ne__(self, other):
+    return self._comparable_vector(self) != self._comparable_vector(other)
+
+  def __lt__(self, other):
+    return self._comparable_vector(self) < self._comparable_vector(other)
+
+  def __le__(self, other):
+    return self._comparable_vector(self) <= self._comparable_vector(other)
+
+  def __gt__(self, other):
+    return self._comparable_vector(self) > self._comparable_vector(other)
+
+  def __ge__(self, other):
+    return self._comparable_vector(self) >= self._comparable_vector(other)
 
 
 def _CheckDurationValid(seconds, nanos):

--- a/python/google/protobuf/internal/well_known_types_test.py
+++ b/python/google/protobuf/internal/well_known_types_test.py
@@ -34,6 +34,7 @@
 
 __author__ = 'jieluo@google.com (Jie Luo)'
 
+import copy
 import datetime
 
 try:
@@ -60,6 +61,28 @@ from google.protobuf.internal import test_util
 from google.protobuf.internal import well_known_types
 from google.protobuf import descriptor
 from google.protobuf import text_format
+
+
+def total_ordering_test(self, lesser, greater):
+    self.assertTrue(lesser == copy.deepcopy(lesser))
+    self.assertTrue(not lesser == greater)
+
+    self.assertTrue(lesser != greater)
+    self.assertTrue(not lesser != lesser)
+
+    self.assertTrue(greater > lesser)
+    self.assertTrue(not lesser > lesser)
+
+    self.assertTrue(greater >= lesser)
+    self.assertTrue(lesser >= lesser)
+    self.assertTrue(not lesser >= greater)
+
+    self.assertTrue(lesser < greater)
+    self.assertTrue(not greater < lesser)
+
+    self.assertTrue(lesser <= greater)
+    self.assertTrue(lesser <= lesser)
+    self.assertTrue(not greater <= lesser)
 
 
 class TimeUtilTestBase(unittest.TestCase):
@@ -386,6 +409,24 @@ class TimeUtilTest(TimeUtilTestBase):
         ValueError,
         r'Duration is not valid\: Sign mismatch.',
         message.ToJsonString)
+
+  def testTimestampOrdering(self):
+    a, b = timestamp_pb2.Timestamp(), timestamp_pb2.Timestamp()
+    # normalized comparisons
+    a.seconds, a.nanos, b.seconds, b.nanos = 0, 1, 1, 0
+    total_ordering_test(self, a, b)
+    # non-normalised is not equal to normalised
+    a.seconds, a.nanos, b.seconds, b.nanos = 1, 0, 0, 1000000001
+    self.assertNotEqual(a, b)
+
+  def testDurationOrdering(self):
+    a, b = duration_pb2.Duration(), duration_pb2.Duration()
+    # normalized comparisons
+    a.seconds, a.nanos, b.seconds, b.nanos = 0, 1, 1, 0
+    total_ordering_test(self, a, b)
+    # non-normalised is not equal to normalised`
+    a.seconds, a.nanos, b.seconds, b.nanos = 1, 0, 0, 1000000001
+    self.assertNotEqual(a, b)
 
 
 class FieldMaskTest(unittest.TestCase):


### PR DESCRIPTION
For #3965
- [x] add comparisons to Timestamp
  - [x] Timestamp
  - [x] ~~datetime~~ requires `timetuple` attribute for python2. Didn't add to avoid surprises
  - [x] test
- [x] add comparisons to Duration
  - [x] Duration
  - [x] ~~timedelta~~ not doable in python2 (without a big mess?)
  - [x] test
- [x] ~~add comparisons to FieldMask~~ moved to a separate [branch](https://github.com/Code0x58/protobuf/tree/fieldmask-total-ordering)