### PR TITLE
DynamicMessage.newBuilder support set initialCapacity.

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/DynamicMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/DynamicMessage.java
@@ -141,6 +141,11 @@ public final class DynamicMessage extends AbstractMessage {
     return new Builder(type);
   }
 
+  /** Construct a {@link Message.Builder} for the given type. */
+  public static Builder newBuilder(Descriptor type, int initialCapacity) {
+    return new Builder(type, initialCapacity);
+  }
+
   /**
    * Construct a {@link Message.Builder} for a message of the same type as {@code prototype}, and
    * initialize it with {@code prototype}'s contents.
@@ -326,6 +331,18 @@ public final class DynamicMessage extends AbstractMessage {
     private Builder(Descriptor type) {
       this.type = type;
       this.fields = FieldSet.newFieldSet();
+      this.unknownFields = UnknownFieldSet.getDefaultInstance();
+      this.oneofCases = new FieldDescriptor[type.toProto().getOneofDeclCount()];
+      // A MapEntry has all of its fields present at all times.
+      if (type.getOptions().getMapEntry()) {
+        populateMapEntry();
+      }
+    }
+
+    /** Construct a {@code Builder} for the given type. */
+    private Builder(Descriptor type, int initialCapacity) {
+      this.type = type;
+      this.fields = FieldSet.newFieldSet(initialCapacity);
       this.unknownFields = UnknownFieldSet.getDefaultInstance();
       this.oneofCases = new FieldDescriptor[type.toProto().getOneofDeclCount()];
       // A MapEntry has all of its fields present at all times.

--- a/java/core/src/main/java/com/google/protobuf/FieldSet.java
+++ b/java/core/src/main/java/com/google/protobuf/FieldSet.java
@@ -81,6 +81,11 @@ final class FieldSet<
     this.fields = SmallSortedMap.newFieldMap(16);
   }
 
+  /** Construct a new FieldSet. */
+  private FieldSet(int initialCapacity) {
+    this.fields = SmallSortedMap.newFieldMap(initialCapacity);
+  }
+
   /** Construct an empty FieldSet. This is only used to initialize DEFAULT_INSTANCE. */
   private FieldSet(final boolean dummy) {
     this.fields = SmallSortedMap.newFieldMap(0);
@@ -90,6 +95,11 @@ final class FieldSet<
   /** Construct a new FieldSet. */
   public static <T extends FieldSet.FieldDescriptorLite<T>> FieldSet<T> newFieldSet() {
     return new FieldSet<T>();
+  }
+
+  /** Construct a new FieldSet. */
+  public static <T extends FieldSet.FieldDescriptorLite<T>> FieldSet<T> newFieldSet(int fieldsInitSize) {
+    return new FieldSet<T>(fieldsInitSize);
   }
 
   /** Get an immutable empty FieldSet. */


### PR DESCRIPTION
If the number of Fields is greater than 16, specifying initialCapacity can improve performance.