### PR TITLE
Add `Serializable` attribute to generated C# classes as compiler option

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_generator.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_generator.cc
@@ -81,6 +81,8 @@ bool Generator::Generate(
       cli_options.base_namespace_specified = true;
     } else if (options[i].first == "internal_access") {
       cli_options.internal_access = true;
+    } else if (options[i].first == "serializable") {
+      cli_options.serializable = true;
     } else {
       *error = "Unknown generator option: " + options[i].first;
       return false;

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -42,6 +42,7 @@
 #include <google/protobuf/wire_format.h>
 #include <google/protobuf/wire_format_lite.h>
 
+#include <google/protobuf/compiler/csharp/csharp_options.h>
 #include <google/protobuf/compiler/csharp/csharp_doc_comment.h>
 #include <google/protobuf/compiler/csharp/csharp_enum.h>
 #include <google/protobuf/compiler/csharp/csharp_field_base.h>
@@ -102,6 +103,12 @@ void MessageGenerator::AddDeprecatedFlag(io::Printer* printer) {
   }
 }
 
+void MessageGenerator::AddSerializableAttribute(io::Printer* printer) {
+  if (this->options()->serializable) {
+    printer->Print("[global::System.SerializableAttribute]\n");
+  }
+}
+
 void MessageGenerator::Generate(io::Printer* printer) {
   std::map<string, string> vars;
   vars["class_name"] = class_name();
@@ -109,6 +116,7 @@ void MessageGenerator::Generate(io::Printer* printer) {
 
   WriteMessageDocComment(printer, descriptor_);
   AddDeprecatedFlag(printer);
+  AddSerializableAttribute(printer);
 
   printer->Print(
     vars,

--- a/src/google/protobuf/compiler/csharp/csharp_message.h
+++ b/src/google/protobuf/compiler/csharp/csharp_message.h
@@ -70,6 +70,7 @@ class MessageGenerator : public SourceGeneratorBase {
   bool HasNestedGeneratedTypes();
 
   void AddDeprecatedFlag(io::Printer* printer);
+  void AddSerializableAttribute(io::Printer* printer);
   
   std::string class_name();
   std::string full_class_name();

--- a/src/google/protobuf/compiler/csharp/csharp_options.h
+++ b/src/google/protobuf/compiler/csharp/csharp_options.h
@@ -45,7 +45,8 @@ struct Options {
       file_extension(".cs"),
       base_namespace(""),
       base_namespace_specified(false),
-      internal_access(false) {
+      internal_access(false),
+      serializable(false) {
   }
   // Extension of the generated file. Defaults to ".cs"
   string file_extension;
@@ -68,6 +69,9 @@ struct Options {
   // Whether the generated classes should have accessibility level of "internal".
   // Defaults to false that generates "public" classes.
   bool internal_access;
+  // Whether the generated classes should have a global::System.Serializable attribute added
+  // Defaults to false
+  bool serializable;
 };
 
 }  // namespace csharp


### PR DESCRIPTION
Adds option "`serializable`" for C# protoc compiler that adds a `[global::System.SerializableAttribute]` above all generated classes.

Resolves #5148 