### PR TITLE
Use ::_close rather than ::close in Win32 stubs.

### DIFF
--- a/src/google/protobuf/stubs/io_win32.cc
+++ b/src/google/protobuf/stubs/io_win32.cc
@@ -334,7 +334,7 @@ FILE* fopen(const char* path, const char* mode) {
 #endif
 }
 
-int close(int fd) { return ::close(fd); }
+int close(int fd) { return ::_close(fd); }
 
 int dup(int fd) { return ::_dup(fd); }
 


### PR DESCRIPTION
The former is the proper converse of _open, which is used in
::google::protobuf::internal::win32::open. This resolves issue #5209.