### PR TITLE
Various Ruby encoding changes

### DIFF
--- a/ruby/ext/google/protobuf_c/encode_decode.c
+++ b/ruby/ext/google/protobuf_c/encode_decode.c
@@ -193,8 +193,7 @@ static void* appendstr_handler(void *closure,
                                const void *hd,
                                size_t size_hint) {
   VALUE ary = (VALUE)closure;
-  VALUE str = rb_str_new2("");
-  rb_enc_associate(str, kRubyStringUtf8Encoding);
+  VALUE str = rb_utf8_str_new_cstr("");
   RepeatedField_push_native(ary, &str);
   return (void*)str;
 }
@@ -224,8 +223,7 @@ static void* str_handler(void *closure,
   MessageHeader* msg = closure;
   const field_handlerdata_t *fieldhandler = hd;
 
-  VALUE str = rb_str_new2("");
-  rb_enc_associate(str, kRubyStringUtf8Encoding);
+  VALUE str = rb_utf8_str_new_cstr("");
   DEREF(msg, fieldhandler->ofs, VALUE) = str;
   set_hasbit(closure, fieldhandler->hasbit);
   return (void*)str;
@@ -459,8 +457,7 @@ static void *oneofstr_handler(void *closure,
                               size_t size_hint) {
   MessageHeader* msg = closure;
   const oneof_handlerdata_t *oneofdata = hd;
-  VALUE str = rb_str_new2("");
-  rb_enc_associate(str, kRubyStringUtf8Encoding);
+  VALUE str = rb_utf8_str_new_cstr("");
   DEREF(msg, oneofdata->case_ofs, uint32_t) =
       oneofdata->oneof_case_num;
   DEREF(msg, oneofdata->ofs, VALUE) = str;
@@ -1354,7 +1351,7 @@ VALUE Message_encode_json(int argc, VALUE* argv, VALUE klass) {
 
     putmsg(msg_rb, desc, upb_json_printer_input(printer), 0, RTEST(emit_defaults));
 
-    ret = rb_enc_str_new(sink.ptr, sink.len, rb_utf8_encoding());
+    ret = rb_utf8_str_new(sink.ptr, sink.len);
 
     stackenv_uninit(&se);
     stringsink_uninit(&sink);

--- a/ruby/ext/google/protobuf_c/encode_decode.c
+++ b/ruby/ext/google/protobuf_c/encode_decode.c
@@ -211,7 +211,6 @@ static void* appendbytes_handler(void *closure,
                                  size_t size_hint) {
   VALUE ary = (VALUE)closure;
   VALUE str = rb_str_new2("");
-  rb_enc_associate(str, kRubyString8bitEncoding);
   RepeatedField_push_native(ary, &str);
   return (void*)str;
 }
@@ -237,7 +236,6 @@ static void* bytes_handler(void *closure,
   const field_handlerdata_t *fieldhandler = hd;
 
   VALUE str = rb_str_new2("");
-  rb_enc_associate(str, kRubyString8bitEncoding);
   DEREF(msg, fieldhandler->ofs, VALUE) = str;
   set_hasbit(closure, fieldhandler->hasbit);
   return (void*)str;
@@ -470,7 +468,6 @@ static void *oneofbytes_handler(void *closure,
   MessageHeader* msg = closure;
   const oneof_handlerdata_t *oneofdata = hd;
   VALUE str = rb_str_new2("");
-  rb_enc_associate(str, kRubyString8bitEncoding);
   DEREF(msg, oneofdata->case_ofs, uint32_t) =
       oneofdata->oneof_case_num;
   DEREF(msg, oneofdata->ofs, VALUE) = str;

--- a/ruby/ext/google/protobuf_c/extconf.rb
+++ b/ruby/ext/google/protobuf_c/extconf.rb
@@ -16,4 +16,7 @@ $objs = ["protobuf.o", "defs.o", "storage.o", "message.o",
          "repeated_field.o", "map.o", "encode_decode.o", "upb.o",
          "wrap_memcpy.o"]
 
+have_func("rb_utf8_str_new")
+have_func("rb_utf8_str_new_cstr")
+
 create_makefile("google/protobuf_c")

--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -101,11 +101,11 @@ static VALUE table_key_to_ruby(Map* self, const char* buf, size_t length) {
   switch (self->key_type) {
     case UPB_TYPE_BYTES:
     case UPB_TYPE_STRING: {
-      VALUE ret = rb_str_new(buf, length);
-      rb_enc_associate(ret,
-                       (self->key_type == UPB_TYPE_BYTES) ?
-                       kRubyString8bitEncoding : kRubyStringUtf8Encoding);
-      return ret;
+      if (self->key_type == UPB_TYPE_BYTES) {
+	  return rb_str_new(buf, length);
+      } else {
+	  return rb_utf8_str_new(buf, length);
+      }
     }
 
     case UPB_TYPE_BOOL:

--- a/ruby/ext/google/protobuf_c/protobuf.c
+++ b/ruby/ext/google/protobuf_c/protobuf.c
@@ -30,6 +30,26 @@
 
 #include "protobuf.h"
 
+#ifndef HAVE_RB_UTF8_STR_NEW_CSTR
+VALUE
+rb_utf8_str_new_cstr(const char *ptr)
+{
+    VALUE str = rb_str_new_cstr(ptr);
+    rb_enc_associate_index(str, rb_utf8_encindex());
+    return str;
+}
+#endif
+
+#ifndef HAVE_RB_UTF8_STR_NEW
+VALUE
+rb_utf8_str_new(const char *ptr, long len)
+{
+    VALUE str = str_new(rb_cString, ptr, len);
+    rb_enc_associate_index(str, rb_utf8_encindex());
+    return str;
+}
+#endif
+
 // -----------------------------------------------------------------------------
 // Global map from upb {msg,enum}defs to wrapper Descriptor/EnumDescriptor
 // instances.

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -608,4 +608,12 @@ void check_upb_status(const upb_status* status, const char* msg);
 
 extern ID descriptor_instancevar_interned;
 
+#ifndef HAVE_RB_UTF8_STR_NEW_CSTR
+VALUE rb_utf8_str_new_cstr(const char *ptr);
+#endif
+
+#ifndef HAVE_RB_UTF8_STR_NEW
+VALUE rb_utf8_str_new(const char *ptr, long len);
+#endif
+
 #endif  // __GOOGLE_PROTOBUF_RUBY_PROTOBUF_H__

--- a/ruby/ext/google/protobuf_c/storage.c
+++ b/ruby/ext/google/protobuf_c/storage.c
@@ -278,9 +278,11 @@ void native_slot_init(upb_fieldtype_t type, void* memory) {
       break;
     case UPB_TYPE_STRING:
     case UPB_TYPE_BYTES:
-      DEREF(memory, VALUE) = rb_str_new2("");
-      rb_enc_associate(DEREF(memory, VALUE), (type == UPB_TYPE_BYTES) ?
-                       kRubyString8bitEncoding : kRubyStringUtf8Encoding);
+      if (type == UPB_TYPE_BYTES) {
+	  DEREF(memory, VALUE) = rb_str_new2("");
+      } else {
+	  DEREF(memory, VALUE) = rb_utf8_str_new_cstr("");
+      }
       break;
     case UPB_TYPE_MESSAGE:
       DEREF(memory, VALUE) = Qnil;
@@ -688,10 +690,14 @@ VALUE layout_get_default(const upb_fielddef *field) {
     case UPB_TYPE_BYTES: {
       size_t size;
       const char *str = upb_fielddef_defaultstr(field, &size);
-      VALUE str_rb = rb_str_new(str, size);
+      VALUE str_rb;
 
-      rb_enc_associate(str_rb, (upb_fielddef_type(field) == UPB_TYPE_BYTES) ?
-                 kRubyString8bitEncoding : kRubyStringUtf8Encoding);
+      if (upb_fielddef_type(field) == UPB_TYPE_BYTES) {
+	  str_rb = rb_str_new(str, size);
+      } else {
+	  str_rb = rb_utf8_str_new(str, size);
+      }
+
       rb_obj_freeze(str_rb);
       return str_rb;
     }


### PR DESCRIPTION
These commits are just a little clean up around encoding handling in the Ruby extension.  Each commit has commits for why I made the change.  In some cases, we can avoid some runtime overhead, in addition to deleting some code.

I *think* we can eventually remove the `kRubyStringUtf8Encoding` encoding constants.  (It looks like `kRubyStringASCIIEncoding` isn't used at all and can be removed).

Thanks!