### PR TITLE
Link to libatomic when necessary (eg. on armv6l)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,6 +165,22 @@ AS_IF([test "$with_zlib" != no], [
 ])
 AM_CONDITIONAL([HAVE_ZLIB], [test $HAVE_ZLIB = 1])
 
+dnl On some platforms, std::atomic needs a helper library
+AC_MSG_CHECKING(whether -latomic is needed)
+AC_LINK_IFELSE([AC_LANG_SOURCE([[
+  #include <atomic>
+  #include <cstdint>
+  std::atomic<std::int64_t> v;
+  int main() {
+    return v;
+  }
+]])], STD_ATOMIC_NEED_LIBATOMIC=no, STD_ATOMIC_NEED_LIBATOMIC=yes)
+AC_MSG_RESULT($STD_ATOMIC_NEED_LIBATOMIC)
+if test "x$STD_ATOMIC_NEED_LIBATOMIC" = xyes; then
+  LIBATOMIC_LIBS="-latomic"
+fi
+AC_SUBST([LIBATOMIC_LIBS])
+
 AS_IF([test "$with_protoc" != "no"], [
   PROTOC=$with_protoc
   AS_IF([test "$with_protoc" = "yes"], [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -166,7 +166,7 @@ nobase_include_HEADERS =                                         \
 
 lib_LTLIBRARIES = libprotobuf-lite.la libprotobuf.la libprotoc.la
 
-libprotobuf_lite_la_LIBADD = $(PTHREAD_LIBS)
+libprotobuf_lite_la_LIBADD = $(PTHREAD_LIBS) $(LIBATOMIC_LIBS)
 libprotobuf_lite_la_LDFLAGS = -version-info 17:0:0 -export-dynamic -no-undefined
 if HAVE_LD_VERSION_SCRIPT
 libprotobuf_lite_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libprotobuf-lite.map
@@ -212,7 +212,7 @@ libprotobuf_lite_la_SOURCES =                                  \
   google/protobuf/io/zero_copy_stream.cc                       \
   google/protobuf/io/zero_copy_stream_impl_lite.cc
 
-libprotobuf_la_LIBADD = $(PTHREAD_LIBS)
+libprotobuf_la_LIBADD = $(PTHREAD_LIBS) $(LIBATOMIC_LIBS)
 libprotobuf_la_LDFLAGS = -version-info 17:0:0 -export-dynamic -no-undefined
 if HAVE_LD_VERSION_SCRIPT
 libprotobuf_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libprotobuf.map

--- a/tests.sh
+++ b/tests.sh
@@ -16,8 +16,8 @@ internal_build_cpp() {
   git submodule update --init --recursive
 
   ./autogen.sh
-  ./configure CXXFLAGS="-fPIC"  # -fPIC is needed for python cpp test.
-                                # See python/setup.py for more details
+  ./configure CXXFLAGS="-fPIC -std=c++11"  # -fPIC is needed for python cpp test.
+                                           # See python/setup.py for more details
   make -j4
 }
 


### PR DESCRIPTION
This PR fixes #5219. It implements detection of whether `std::atomic` can be used without linking to `libatomic` and adds `libatomic` to the linker arguments if this fails.

It is likely mostly harmless to always link to `libatomic` (at least with gcc and clang), but this solution was chosen because many other projects have similar logic in their build systems. It is only implemented for the autotools based build, not bazel or cmake, but this was deemed adequate in #5219. I assume the bazel build has the same issue, but I have not tested it.

I tested this on Linux on x86_64, armv6l and armv7l, but I am not very familiar with autotools so this may need to be cleaned up/tweaked.