### PR TITLE
Remove Debug Statement for Ruby on Windows / MinGW

### DIFF
--- a/ruby/ext/google/protobuf_c/extconf.rb
+++ b/ruby/ext/google/protobuf_c/extconf.rb
@@ -2,10 +2,7 @@
 
 require 'mkmf'
 
-unless RUBY_PLATFORM =~ /mswin|mingw/
-  $CFLAGS += " -std=c99 -O3 -DNDEBUG"
-end
-
+$CFLAGS += " -std=c99 -O3 -DNDEBUG"
 
 if RUBY_PLATFORM =~ /linux/
   # Instruct the linker to point memcpy calls at our __wrap_memcpy wrapper.


### PR DESCRIPTION
This pull request fixes #5025. It fixes the problem that the protobuf library is built under debug mode for Windows / MINGW environment.