### PR TITLE
 Mark sun.misc dependency as optional

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -135,6 +135,7 @@
             <Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
             <Bundle-SymbolicName>com.google.protobuf</Bundle-SymbolicName>
             <Export-Package>com.google.protobuf;version=${project.version}</Export-Package>
+            <Import-Package>sun.misc;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
backport of #2811 to 3.6.x branch
