### PR TITLE
JsonFormat supports add customized fields

### DIFF
--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -224,23 +224,27 @@ public class JsonFormatTest extends TestCase {
   }
 
   public void testAdditionalFieldPrinter() throws Exception {
-    JsonTestProto.EmptyMessageWrapper emptyMessageWrapper = JsonTestProto.EmptyMessageWrapper
-        .newBuilder()
-        .mergeEmptyMessage(JsonTestProto.EmptyMessage.newBuilder().build())
+    TestWrappers testWrappers = TestWrappers.newBuilder()
+        .mergeBoolValue(
+            BoolValue.newBuilder().build()
+        )
+        .mergeStringValue(
+            StringValue.newBuilder().build()
+        )
         .build();
 
-    List<JsonFormat.AdditionalFieldRegistry> additionalFieldRegistries = new LinkedList<>();
+    final List<JsonFormat.AdditionalFieldRegistry> additionalFieldRegistries = new LinkedList<>();
 
     additionalFieldRegistries.add(new JsonFormat.AdditionalFieldRegistry() {
       @Override
       public List<JsonFormat.AdditionalField> add(MessageOrBuilder message) {
         List<JsonFormat.AdditionalField> additionalFields = new LinkedList<>();
-        if (message.getDescriptorForType().getFields().isEmpty()) {
-          additionalFields.add(
-              new JsonFormat.AdditionalField("__is_empty__",
-                  "true", false)
-          );
-        }
+        additionalFields.add(
+            new JsonFormat.AdditionalField(
+            "number_of_fields_set",
+            String.valueOf(message.getAllFields().size()), false)
+        );
+
         return additionalFields;
       }
     });
@@ -251,10 +255,10 @@ public class JsonFormatTest extends TestCase {
         .includeAdditionalPrinter(additionalFieldRegistries);
 
     assertEquals("{\n" +
-        "  \"empty_message\": {\n" +
-        "    \"__is_empty__\": true\n" +
-        "  }\n" +
-        "}", printer.print(emptyMessageWrapper));
+        "  \"number_of_fields_set\": 2,\n" +
+        "  \"bool_value\": false,\n" +
+        "  \"string_value\": \"\"\n" +
+        "}", printer.print(testWrappers));
   }
 
   public void testUnknownEnumValues() throws Exception {

--- a/java/util/src/test/proto/com/google/protobuf/util/json_test.proto
+++ b/java/util/src/test/proto/com/google/protobuf/util/json_test.proto
@@ -176,11 +176,3 @@ message TestRecursive {
   int32 value = 1;
   TestRecursive nested = 2;
 }
-
-message EmptyMessage {
-
-}
-
-message EmptyMessageWrapper {
-  EmptyMessage empty_message = 1;
-}

--- a/java/util/src/test/proto/com/google/protobuf/util/json_test.proto
+++ b/java/util/src/test/proto/com/google/protobuf/util/json_test.proto
@@ -176,3 +176,11 @@ message TestRecursive {
   int32 value = 1;
   TestRecursive nested = 2;
 }
+
+message EmptyMessage {
+
+}
+
+message EmptyMessageWrapper {
+  EmptyMessage empty_message = 1;
+}


### PR DESCRIPTION
Allow users to add plugin functions that evaluate the protobuf object and inject customized fields in JSON.

For example, given a protobuf IDL like:
```
message TestWrappers {
  google.protobuf.Int32Value int32_value = 1;
  google.protobuf.UInt32Value uint32_value = 2;
  google.protobuf.Int64Value int64_value = 3;
  google.protobuf.UInt64Value uint64_value = 4;
  google.protobuf.FloatValue float_value = 5;
  google.protobuf.DoubleValue double_value = 6;
  google.protobuf.BoolValue bool_value = 7;
  google.protobuf.StringValue string_value = 8;
  google.protobuf.BytesValue bytes_value = 9;
}
```

user may want to add a tag in JSON that counts the number fields set in the protobuf object:
```
{
  "number_of_fields_set": 2,
  "bool_value": false,
  "string_value": ""
}
```

The user can add a plugin function that evaluate the structure of the protobuf
object and then inject custom fields in JSON.




