### PR TITLE
Fix RepeatedField#first in Ruby gem

### DIFF
--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -79,7 +79,7 @@ module Google
 
 
       def first(n=nil)
-        n ? self[0..n] : self[0]
+        n ? self[0...n] : self[0]
       end
 
 

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -28,7 +28,10 @@ class RepeatedFieldTest < Test::Unit::TestCase
     m = TestMessage.new
     repeated_field_names(TestMessage).each do |field_name|
       assert_nil m.send(field_name).first
+      assert_equal [], m.send(field_name).first(0)
+      assert_equal [], m.send(field_name).first(1)
     end
+
     fill_test_msg(m)
     assert_equal -10, m.repeated_int32.first
     assert_equal -1_000_000, m.repeated_int64.first
@@ -41,6 +44,11 @@ class RepeatedFieldTest < Test::Unit::TestCase
     assert_equal "bar".encode!('ASCII-8BIT'), m.repeated_bytes.first
     assert_equal TestMessage2.new(:foo => 1), m.repeated_msg.first
     assert_equal :A, m.repeated_enum.first
+
+    assert_equal [], m.repeated_int32.first(0)
+    assert_equal [-10], m.repeated_int32.first(1)
+    assert_equal [-10, -11], m.repeated_int32.first(2)
+    assert_equal [-10, -11], m.repeated_int32.first(3)
   end
 
 


### PR DESCRIPTION
Given an argument, the previous implementation was off by one (`.first(2)` would return 3 elements) compared to the `Enumerable#first` method.