### PR TITLE
Remove unused types

### DIFF
--- a/src/google/protobuf/extension_set.cc
+++ b/src/google/protobuf/extension_set.cc
@@ -280,7 +280,7 @@ void ExtensionSet::ClearExtension(int number) {
 
 namespace {
 
-enum Cardinality {
+enum {
   REPEATED,
   OPTIONAL
 };

--- a/src/google/protobuf/stubs/common.cc
+++ b/src/google/protobuf/stubs/common.cc
@@ -342,7 +342,6 @@ uint32 ghtonl(uint32 x) {
 
 namespace internal {
 
-typedef void OnShutdownFunc();
 struct ShutdownData {
   ~ShutdownData() {
     std::reverse(functions.begin(), functions.end());


### PR DESCRIPTION
They're not doing anything, so might as well get rid of them.

I was running a static analysis tool over protobuf, looking for things to fix in local changes, and noticed these.