### PR TITLE
Import versions from @bazel_skylib//lib:versions.bzl

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -39,5 +39,5 @@ http_archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
 )
 
-load("@bazel_skylib//:lib.bzl", "versions")
+load("@bazel_skylib//lib:versions.bzl", "versions")
 versions.check(minimum_bazel_version = "0.5.4")

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -1,4 +1,4 @@
-load("@bazel_skylib//:lib.bzl", "versions")
+load("@bazel_skylib//lib:versions.bzl", "versions")
 
 def _GetPath(ctx, path):
   if ctx.label.workspace_root:


### PR DESCRIPTION
@bazel_skylib//:lib is supposedly deprecated. The 'versions' struct in lib.bzl was committed to bazel-skylib at the same time as //lib:versions.bzl, so there should be no backward incompatibility.