### PR TITLE
Build updates

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -26,6 +26,17 @@ __EOF__
   exit 1
 fi
 
+# Verify the third_party directory before we start writing to it below.
+if test ! -d third_party/googletest/googletest; then
+  cat >&2 << __EOF__
+Third party code is missing.  Please run the following command, if you have
+not yet done so:
+
+git submodule update --init --recursive
+__EOF__
+  exit 1
+fi
+
 set -ex
 
 # The absence of a m4 directory in googletest causes autoreconf to fail when

--- a/autogen.sh
+++ b/autogen.sh
@@ -26,23 +26,16 @@ __EOF__
   exit 1
 fi
 
-# Verify the third_party directory before we start writing to it below.
-if test ! -d third_party/googletest/googletest; then
-  cat >&2 << __EOF__
-Third party code is missing.  Please run the following command, if you have
-not yet done so:
-
-git submodule update --init --recursive
-__EOF__
-  exit 1
-fi
-
 set -ex
 
 # The absence of a m4 directory in googletest causes autoreconf to fail when
 # building under the CentOS docker image. It's a warning in regular build on
-# Ubuntu/gLinux as well.
-mkdir -p third_party/googletest/m4
+# Ubuntu/gLinux as well. (This is only needed if git submodules have been
+# initialized, which is typically only needed for testing; see the installation
+# instructions for details.)
+if test -d third_party/googletest; then
+  mkdir -p third_party/googletest/m4
+fi
 
 # TODO(kenton):  Remove the ",no-obsolete" part and fix the resulting warnings.
 autoreconf -f -i -Wall,no-obsolete

--- a/objectivec/README.md
+++ b/objectivec/README.md
@@ -188,4 +188,4 @@ Documentation
 The complete documentation for Protocol Buffers is available via the
 web at:
 
-    https://developers.google.com/protocol-buffers/
+https://developers.google.com/protocol-buffers/

--- a/src/README.md
+++ b/src/README.md
@@ -225,4 +225,4 @@ Usage
 The complete documentation for Protocol Buffers is available via the
 web at:
 
-    https://developers.google.com/protocol-buffers/
+https://developers.google.com/protocol-buffers/


### PR DESCRIPTION
Make language instructions' documentation links clickable. (See 86208c5.)

Add a `git submodules` check to autogen.sh. Running `./autogen.sh && ./configure && make` happens to work without initializing git submodules - but autogen.sh writes to what is supposed to be a git submodules directory, so trying to later initialize git submodules fails. Adding a check makes building a bit more reliable for people who miss this step.