### PR TITLE
Fix potential linking errors for MSVC

### DIFF
--- a/src/google/protobuf/type.pb.cc
+++ b/src/google/protobuf/type.pb.cc
@@ -443,6 +443,10 @@ Type::Type(const Type& from)
   syntax_ = from.syntax_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Type)
 }
+Type::Type(Type&& from) noexcept
+  : Type() {
+  *this = ::std::move(from);
+}
 
 void Type::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
@@ -1089,6 +1093,10 @@ Field::Field(const Field& from)
     static_cast<size_t>(reinterpret_cast<char*>(&packed_) -
     reinterpret_cast<char*>(&kind_)) + sizeof(packed_));
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Field)
+}
+Field::Field(Field&& from) noexcept
+  : Field() {
+  *this = ::std::move(from);
 }
 
 void Field::SharedCtor() {
@@ -1946,6 +1954,10 @@ Enum::Enum(const Enum& from)
   syntax_ = from.syntax_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Enum)
 }
+Enum::Enum(Enum&& from) noexcept
+  : Enum() {
+  *this = ::std::move(from);
+}
 
 void Enum::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
@@ -2503,6 +2515,10 @@ EnumValue::EnumValue(const EnumValue& from)
   number_ = from.number_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.EnumValue)
 }
+EnumValue::EnumValue(EnumValue&& from) noexcept
+  : EnumValue() {
+  *this = ::std::move(from);
+}
 
 void EnumValue::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
@@ -2967,6 +2983,10 @@ Option::Option(const Option& from)
     value_ = NULL;
   }
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Option)
+}
+Option::Option(Option&& from) noexcept
+  : Option() {
+  *this = ::std::move(from);
 }
 
 void Option::SharedCtor() {

--- a/src/google/protobuf/type.pb.cc
+++ b/src/google/protobuf/type.pb.cc
@@ -443,10 +443,12 @@ Type::Type(const Type& from)
   syntax_ = from.syntax_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Type)
 }
+#if LANG_CXX11
 Type::Type(Type&& from) noexcept
   : Type() {
   *this = ::std::move(from);
 }
+#endif
 
 void Type::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
@@ -1094,10 +1096,12 @@ Field::Field(const Field& from)
     reinterpret_cast<char*>(&kind_)) + sizeof(packed_));
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Field)
 }
+#if LANG_CXX11
 Field::Field(Field&& from) noexcept
   : Field() {
   *this = ::std::move(from);
 }
+#endif
 
 void Field::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
@@ -1954,10 +1958,12 @@ Enum::Enum(const Enum& from)
   syntax_ = from.syntax_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Enum)
 }
+#if LANG_CXX11
 Enum::Enum(Enum&& from) noexcept
   : Enum() {
   *this = ::std::move(from);
 }
+#endif
 
 void Enum::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
@@ -2515,10 +2521,12 @@ EnumValue::EnumValue(const EnumValue& from)
   number_ = from.number_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.EnumValue)
 }
+#if LANG_CXX11
 EnumValue::EnumValue(EnumValue&& from) noexcept
   : EnumValue() {
   *this = ::std::move(from);
 }
+#endif
 
 void EnumValue::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
@@ -2984,10 +2992,12 @@ Option::Option(const Option& from)
   }
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Option)
 }
+#if LANG_CXX11
 Option::Option(Option&& from) noexcept
   : Option() {
   *this = ::std::move(from);
 }
+#endif
 
 void Option::SharedCtor() {
   ::google::protobuf::internal::InitSCC(

--- a/src/google/protobuf/type.pb.h
+++ b/src/google/protobuf/type.pb.h
@@ -174,10 +174,7 @@ class PROTOBUF_EXPORT Type : public ::google::protobuf::Message /* @@protoc_inse
     return *this;
   }
   #if LANG_CXX11
-  Type(Type&& from) noexcept
-    : Type() {
-    *this = ::std::move(from);
-  }
+  Type(Type&& from) noexcept;
 
   inline Type& operator=(Type&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
@@ -386,10 +383,7 @@ class PROTOBUF_EXPORT Field : public ::google::protobuf::Message /* @@protoc_ins
     return *this;
   }
   #if LANG_CXX11
-  Field(Field&& from) noexcept
-    : Field() {
-    *this = ::std::move(from);
-  }
+  Field(Field&& from) noexcept;
 
   inline Field& operator=(Field&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
@@ -928,10 +922,7 @@ class PROTOBUF_EXPORT EnumValue : public ::google::protobuf::Message /* @@protoc
     return *this;
   }
   #if LANG_CXX11
-  EnumValue(EnumValue&& from) noexcept
-    : EnumValue() {
-    *this = ::std::move(from);
-  }
+  EnumValue(EnumValue&& from) noexcept;
 
   inline EnumValue& operator=(EnumValue&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
@@ -1091,10 +1082,7 @@ class PROTOBUF_EXPORT Option : public ::google::protobuf::Message /* @@protoc_in
     return *this;
   }
   #if LANG_CXX11
-  Option(Option&& from) noexcept
-    : Option() {
-    *this = ::std::move(from);
-  }
+  Option(Option&& from) noexcept;
 
   inline Option& operator=(Option&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {


### PR DESCRIPTION
When the moving semantics is used on a Type in the statically built library, the following error will be thrown: `error LNK2019: unresolved external symbol "const NAMESPACE::Type::`vftable'"`. It can be solved by moving the implementation of the moving constructor to the source file.