### PR TITLE
3rd-party: include Protolock utility

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -170,3 +170,4 @@ There are miscellaneous other things you may find useful as a Protocol Buffers d
 * [Make protoc plugins in NodeJS](https://github.com/konsumer/node-protoc-plugin)
 * [ProfaneDB - A Protocol Buffers database](https://profanedb.gitlab.io)
 * [Protocol Buffer property-based testing utility and example message generator (Python / Hypothesis)](https://github.com/CurataEng/hypothesis-protobuf)
+* [Protolock - CLI utility to prevent backward-incompatible changes to .proto files](https://github.com/nilslice/protolock) 


### PR DESCRIPTION
[`protolock`](https://github.com/nilslice/protolock) is a utility to help ensure no API-breaking changes are made to a set of protocol buffer definitions. This includes all native protobuf types and services + RPCs. 

A list of all rules enforced by `protolock` include: 
```
No Using Reserved Fields
No Removing Reserved Fields
No Removing Fields Without Reserve
No Changing Field IDs
No Changing Field Types
No Changing Field Names
No Removing RPCs
No Changing RPC Signature
```

Additionally, users can define their own plugins to add custom checks. `protolock` plugins are similar in use and creation to `protoc` plugins. 

A more comprehensive presentation of the tool can be found [here](https://docs.google.com/presentation/d/1QUGZ2VqTAIR-lF-dXI7b_vUjFA3C45bXpGhPWUX7AvI/edit#slide=id.p). 