### PR TITLE
Add wire_format_lite_inl.h include to implicit_weak_message.cc

### DIFF
--- a/src/google/protobuf/implicit_weak_message.cc
+++ b/src/google/protobuf/implicit_weak_message.cc
@@ -33,6 +33,7 @@
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <google/protobuf/stubs/once.h>
 #include <google/protobuf/wire_format_lite.h>
+#include <google/protobuf/wire_format_lite_inl.h>
 
 #include <google/protobuf/port_def.inc>
 #if GOOGLE_PROTOBUF_ENABLE_EXPERIMENTAL_PARSER


### PR DESCRIPTION
This unbreaks the Windows shared-library build of Chrome when using
Clang versions based on r344987 or later, see https://crbug.com/901776

implicit_weak_message.cc is part of protobuf_lite.dll, and it includes
wire_format_lite.h, which includes the dllexport inline function
WireFormatLite::WriteGroupToArray which will therefore be emitted.

WriteGroupToArray in turn calls the inline function
InternalWriteGroupToArray, however that definition is provided in the
_inl file. To make sure the definition is available, the _inl file must
be included.

Before Clang r344987 the build worked anyway due to luck, because
InternalWriteGroupToArray was emitted into other object files (e.g. in
wire_format_lite.obj). After that Clang revision, those definitions
started getting inlined, and so are longer available and cause a link
failure for the reference from implicit_weak_message.obj.