### PR TITLE
[protobuf/objc] Introduce a protobuf-specific deprecation annotation ⚠️

### DIFF
--- a/objectivec/GPBBootstrap.h
+++ b/objectivec/GPBBootstrap.h
@@ -91,6 +91,13 @@
 #endif
 #endif
 
+/**
+ * Attribute used for Objective-C proto interface deprecations.
+ **/
+#ifndef GPB_DEPRECATED
+#define GPB_DEPRECATED __attribute__((deprecated))
+#endif
+
 // If property name starts with init we need to annotate it to get past ARC.
 // http://stackoverflow.com/questions/18723226/how-do-i-annotate-an-objective-c-property-with-an-objc-method-family/18723227#18723227
 //

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
@@ -167,7 +167,7 @@ string GetOptionalDeprecatedAttribute(
     isDeprecated = file->options().deprecated();
   }
   if (isDeprecated) {
-    string result = "DEPRECATED_ATTRIBUTE";
+    string result = "GPB_DEPRECATED";
     if (preSpace) {
       result.insert(0, " ");
     }


### PR DESCRIPTION
Instead of using DEPRECATED_ATTRIBUTE from AvailabilityMacros.h, we should introduce a Google-specific Objective-C protobuf deprecation annotation. This helps address IWYU issues with using DEPRECATED_ATTRIBUTE and also enables allows clients to redefine the macro to treat protobuf warnings differently than other types of warnings (e.g., treating protobuf deprecation warnings as errors or ignoring them).