### PR TITLE
compiler/cpp: replace NULL with nullptr

### DIFF
--- a/src/google/protobuf/any.pb.cc
+++ b/src/google/protobuf/any.pb.cc
@@ -134,13 +134,13 @@ const int Any::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Any::Any()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL), _any_metadata_(&type_url_, &value_) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr), _any_metadata_(&type_url_, &value_) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Any)
 }
 Any::Any(const Any& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _any_metadata_(&type_url_, &value_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   type_url_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -422,7 +422,7 @@ void Any::MergeFrom(const ::google::protobuf::Message& from) {
   const Any* source =
       ::google::protobuf::DynamicCastToGenerated<Any>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Any)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {

--- a/src/google/protobuf/any.pb.h
+++ b/src/google/protobuf/any.pb.h
@@ -124,7 +124,7 @@ class PROTOBUF_EXPORT Any : public ::google::protobuf::Message /* @@protoc_inser
   // implements Message ----------------------------------------------
 
   inline Any* New() const final {
-    return CreateMaybeMessage<Any>(NULL);
+    return CreateMaybeMessage<Any>(nullptr);
   }
 
   Any* New(::google::protobuf::Arena* arena) const final {
@@ -158,10 +158,10 @@ class PROTOBUF_EXPORT Any : public ::google::protobuf::Message /* @@protoc_inser
   void InternalSwap(Any* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
+    return nullptr;
   }
   inline void* MaybeArenaPtr() const {
-    return NULL;
+    return nullptr;
   }
   public:
 
@@ -243,7 +243,7 @@ inline void Any::set_type_url(::std::string&& value) {
 }
 #endif
 inline void Any::set_type_url(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   type_url_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.Any.type_url)
@@ -265,7 +265,7 @@ inline ::std::string* Any::release_type_url() {
   return type_url_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Any::set_allocated_type_url(::std::string* type_url) {
-  if (type_url != NULL) {
+  if (type_url != nullptr) {
     
   } else {
     
@@ -296,7 +296,7 @@ inline void Any::set_value(::std::string&& value) {
 }
 #endif
 inline void Any::set_value(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   value_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.Any.value)
@@ -318,7 +318,7 @@ inline ::std::string* Any::release_value() {
   return value_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Any::set_allocated_value(::std::string* value) {
-  if (value != NULL) {
+  if (value != nullptr) {
     
   } else {
     

--- a/src/google/protobuf/api.pb.cc
+++ b/src/google/protobuf/api.pb.cc
@@ -204,10 +204,10 @@ void Api::clear_options() {
   options_.Clear();
 }
 void Api::clear_source_context() {
-  if (GetArenaNoVirtual() == NULL && source_context_ != NULL) {
+  if (GetArenaNoVirtual() == nullptr && source_context_ != nullptr) {
     delete source_context_;
   }
-  source_context_ = NULL;
+  source_context_ = nullptr;
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int Api::kNameFieldNumber;
@@ -220,13 +220,13 @@ const int Api::kSyntaxFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Api::Api()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Api)
 }
 Api::Api(const Api& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       methods_(from.methods_),
       options_(from.options_),
       mixins_(from.mixins_) {
@@ -242,7 +242,7 @@ Api::Api(const Api& from)
   if (from.has_source_context()) {
     source_context_ = new ::google::protobuf::SourceContext(*from.source_context_);
   } else {
-    source_context_ = NULL;
+    source_context_ = nullptr;
   }
   syntax_ = from.syntax_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Api)
@@ -289,10 +289,10 @@ void Api::Clear() {
   mixins_.Clear();
   name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   version_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (GetArenaNoVirtual() == NULL && source_context_ != NULL) {
+  if (GetArenaNoVirtual() == nullptr && source_context_ != nullptr) {
     delete source_context_;
   }
-  source_context_ = NULL;
+  source_context_ = nullptr;
   syntax_ = 0;
   _internal_metadata_.Clear();
 }
@@ -800,7 +800,7 @@ void Api::MergeFrom(const ::google::protobuf::Message& from) {
   const Api* source =
       ::google::protobuf::DynamicCastToGenerated<Api>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Api)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -899,13 +899,13 @@ const int Method::kSyntaxFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Method::Method()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Method)
 }
 Method::Method(const Method& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       options_(from.options_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -1454,7 +1454,7 @@ void Method::MergeFrom(const ::google::protobuf::Message& from) {
   const Method* source =
       ::google::protobuf::DynamicCastToGenerated<Method>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Method)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1551,13 +1551,13 @@ const int Mixin::kRootFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Mixin::Mixin()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Mixin)
 }
 Mixin::Mixin(const Mixin& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (from.name().size() > 0) {
@@ -1851,7 +1851,7 @@ void Mixin::MergeFrom(const ::google::protobuf::Message& from) {
   const Mixin* source =
       ::google::protobuf::DynamicCastToGenerated<Mixin>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Mixin)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {

--- a/src/google/protobuf/api.pb.h
+++ b/src/google/protobuf/api.pb.h
@@ -118,7 +118,7 @@ class PROTOBUF_EXPORT Api : public ::google::protobuf::Message /* @@protoc_inser
   // implements Message ----------------------------------------------
 
   inline Api* New() const final {
-    return CreateMaybeMessage<Api>(NULL);
+    return CreateMaybeMessage<Api>(nullptr);
   }
 
   Api* New(::google::protobuf::Arena* arena) const final {
@@ -152,10 +152,10 @@ class PROTOBUF_EXPORT Api : public ::google::protobuf::Message /* @@protoc_inser
   void InternalSwap(Api* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
+    return nullptr;
   }
   inline void* MaybeArenaPtr() const {
-    return NULL;
+    return nullptr;
   }
   public:
 
@@ -308,7 +308,7 @@ class PROTOBUF_EXPORT Method : public ::google::protobuf::Message /* @@protoc_in
   // implements Message ----------------------------------------------
 
   inline Method* New() const final {
-    return CreateMaybeMessage<Method>(NULL);
+    return CreateMaybeMessage<Method>(nullptr);
   }
 
   Method* New(::google::protobuf::Arena* arena) const final {
@@ -342,10 +342,10 @@ class PROTOBUF_EXPORT Method : public ::google::protobuf::Message /* @@protoc_in
   void InternalSwap(Method* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
+    return nullptr;
   }
   inline void* MaybeArenaPtr() const {
-    return NULL;
+    return nullptr;
   }
   public:
 
@@ -491,7 +491,7 @@ class PROTOBUF_EXPORT Mixin : public ::google::protobuf::Message /* @@protoc_ins
   // implements Message ----------------------------------------------
 
   inline Mixin* New() const final {
-    return CreateMaybeMessage<Mixin>(NULL);
+    return CreateMaybeMessage<Mixin>(nullptr);
   }
 
   Mixin* New(::google::protobuf::Arena* arena) const final {
@@ -525,10 +525,10 @@ class PROTOBUF_EXPORT Mixin : public ::google::protobuf::Message /* @@protoc_ins
   void InternalSwap(Mixin* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
+    return nullptr;
   }
   inline void* MaybeArenaPtr() const {
-    return NULL;
+    return nullptr;
   }
   public:
 
@@ -609,7 +609,7 @@ inline void Api::set_name(::std::string&& value) {
 }
 #endif
 inline void Api::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.Api.name)
@@ -631,7 +631,7 @@ inline ::std::string* Api::release_name() {
   return name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Api::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     
   } else {
     
@@ -719,7 +719,7 @@ inline void Api::set_version(::std::string&& value) {
 }
 #endif
 inline void Api::set_version(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   version_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.Api.version)
@@ -741,7 +741,7 @@ inline ::std::string* Api::release_version() {
   return version_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Api::set_allocated_version(::std::string* version) {
-  if (version != NULL) {
+  if (version != nullptr) {
     
   } else {
     
@@ -752,24 +752,24 @@ inline void Api::set_allocated_version(::std::string* version) {
 
 // .google.protobuf.SourceContext source_context = 5;
 inline bool Api::has_source_context() const {
-  return this != internal_default_instance() && source_context_ != NULL;
+  return this != internal_default_instance() && source_context_ != nullptr;
 }
 inline const ::google::protobuf::SourceContext& Api::source_context() const {
   const ::google::protobuf::SourceContext* p = source_context_;
   // @@protoc_insertion_point(field_get:google.protobuf.Api.source_context)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::SourceContext*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::SourceContext*>(
       &::google::protobuf::_SourceContext_default_instance_);
 }
 inline ::google::protobuf::SourceContext* Api::release_source_context() {
   // @@protoc_insertion_point(field_release:google.protobuf.Api.source_context)
   
   ::google::protobuf::SourceContext* temp = source_context_;
-  source_context_ = NULL;
+  source_context_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::SourceContext* Api::mutable_source_context() {
   
-  if (source_context_ == NULL) {
+  if (source_context_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::SourceContext>(GetArenaNoVirtual());
     source_context_ = p;
   }
@@ -778,11 +778,11 @@ inline ::google::protobuf::SourceContext* Api::mutable_source_context() {
 }
 inline void Api::set_allocated_source_context(::google::protobuf::SourceContext* source_context) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete reinterpret_cast< ::google::protobuf::MessageLite*>(source_context_);
   }
   if (source_context) {
-    ::google::protobuf::Arena* submessage_arena = NULL;
+    ::google::protobuf::Arena* submessage_arena = nullptr;
     if (message_arena != submessage_arena) {
       source_context = ::google::protobuf::internal::GetOwnedMessage(
           message_arena, source_context, submessage_arena);
@@ -865,7 +865,7 @@ inline void Method::set_name(::std::string&& value) {
 }
 #endif
 inline void Method::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.Method.name)
@@ -887,7 +887,7 @@ inline ::std::string* Method::release_name() {
   return name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Method::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     
   } else {
     
@@ -918,7 +918,7 @@ inline void Method::set_request_type_url(::std::string&& value) {
 }
 #endif
 inline void Method::set_request_type_url(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   request_type_url_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.Method.request_type_url)
@@ -940,7 +940,7 @@ inline ::std::string* Method::release_request_type_url() {
   return request_type_url_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Method::set_allocated_request_type_url(::std::string* request_type_url) {
-  if (request_type_url != NULL) {
+  if (request_type_url != nullptr) {
     
   } else {
     
@@ -985,7 +985,7 @@ inline void Method::set_response_type_url(::std::string&& value) {
 }
 #endif
 inline void Method::set_response_type_url(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   response_type_url_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.Method.response_type_url)
@@ -1007,7 +1007,7 @@ inline ::std::string* Method::release_response_type_url() {
   return response_type_url_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Method::set_allocated_response_type_url(::std::string* response_type_url) {
-  if (response_type_url != NULL) {
+  if (response_type_url != nullptr) {
     
   } else {
     
@@ -1097,7 +1097,7 @@ inline void Mixin::set_name(::std::string&& value) {
 }
 #endif
 inline void Mixin::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.Mixin.name)
@@ -1119,7 +1119,7 @@ inline ::std::string* Mixin::release_name() {
   return name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Mixin::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     
   } else {
     
@@ -1150,7 +1150,7 @@ inline void Mixin::set_root(::std::string&& value) {
 }
 #endif
 inline void Mixin::set_root(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   root_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.Mixin.root)
@@ -1172,7 +1172,7 @@ inline ::std::string* Mixin::release_root() {
   return root_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Mixin::set_allocated_root(::std::string* root) {
-  if (root != NULL) {
+  if (root != nullptr) {
     
   } else {
     

--- a/src/google/protobuf/compiler/cpp/cpp_enum_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_enum_field.cc
@@ -365,8 +365,8 @@ void RepeatedEnumFieldGenerator::GenerateMergeFromCodedStreamWithPacking(
           "WireFormatLite::ReadPackedEnumPreserveUnknowns(\n"
           "       input,\n"
           "       $number$,\n"
-          "       NULL,\n"
-          "       NULL,\n"
+          "       nullptr,\n"
+          "       nullptr,\n"
           "       this->mutable_$name$())));\n");
     } else if (UseUnknownFieldSet(descriptor_->file(), options_)) {
       format(

--- a/src/google/protobuf/compiler/cpp/cpp_file.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_file.cc
@@ -782,10 +782,10 @@ void FileGenerator::GenerateReflectionInitializationCode(io::Printer* printer) {
         // MSVC doesn't like empty arrays, so we add a dummy.
         "const $uint32$ $tablename$::offsets[1] = {};\n"
         "static constexpr ::$proto_ns$::internal::MigrationSchema* schemas = "
-        "NULL;"
+        "nullptr;"
         "\n"
         "static constexpr ::$proto_ns$::Message* const* "
-        "file_default_instances = NULL;\n"
+        "file_default_instances = nullptr;\n"
         "\n");
   }
 
@@ -1019,7 +1019,7 @@ void FileGenerator::GenerateTables(io::Printer* printer) {
     }
 
     if (message_generators_.empty()) {
-      format("{ NULL, NULL, 0, -1, -1, false },\n");
+      format("{ nullptr, nullptr, 0, -1, -1, false },\n");
     }
 
     format.Outdent();

--- a/src/google/protobuf/compiler/cpp/cpp_map_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_map_field.cc
@@ -274,7 +274,7 @@ static void GenerateSerializationLoop(const Formatter& format,
   // If entry is allocated by arena, its desctructor should be avoided.
   if (supports_arenas) {
     format(
-        "if (entry->GetArena() != NULL) {\n"
+        "if (entry->GetArena() != nullptr) {\n"
         "  entry.release();\n"
         "}\n");
   }
@@ -395,7 +395,7 @@ GenerateByteSize(io::Printer* printer) const {
   // If entry is allocated by arena, its desctructor should be avoided.
   if (SupportsArenas(descriptor_)) {
     format(
-        "    if (entry.get() != NULL && entry->GetArena() != NULL) {\n"
+        "    if (entry.get() != nullptr && entry->GetArena() != nullptr) {\n"
         "      entry.release();\n"
         "    }\n");
   }
@@ -409,7 +409,7 @@ GenerateByteSize(io::Printer* printer) const {
   // If entry is allocated by arena, its desctructor should be avoided.
   if (SupportsArenas(descriptor_)) {
     format(
-        "  if (entry.get() != NULL && entry->GetArena() != NULL) {\n"
+        "  if (entry.get() != nullptr && entry->GetArena() != nullptr) {\n"
         "    entry.release();\n"
         "  }\n");
   }

--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -800,7 +800,7 @@ void MessageGenerator::GenerateSingularFieldHasBits(
       } else {
         format(
             "inline bool $classname$::has_$name$() const {\n"
-            "  return this != internal_default_instance() && $name$_ != NULL;\n"
+            "  return this != internal_default_instance() && $name$_ != nullptr;\n"
             "}\n");
       }
     }
@@ -1116,7 +1116,7 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
       "// implements Message ----------------------------------------------\n"
       "\n"
       "inline $classname$* New() const$ new_final$ {\n"
-      "  return CreateMaybeMessage<$classname$>(NULL);\n"
+      "  return CreateMaybeMessage<$classname$>(nullptr);\n"
       "}\n"
       "\n"
       "$classname$* New(::$proto_ns$::Arena* arena) const$ new_final$ {\n"
@@ -1226,10 +1226,10 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
     format(
         "private:\n"
         "inline ::$proto_ns$::Arena* GetArenaNoVirtual() const {\n"
-        "  return NULL;\n"
+        "  return nullptr;\n"
         "}\n"
         "inline void* MaybeArenaPtr() const {\n"
-        "  return NULL;\n"
+        "  return nullptr;\n"
         "}\n");
   }
 
@@ -1490,7 +1490,7 @@ bool MessageGenerator::GenerateParseTable(io::Printer* printer, size_t offset,
   Formatter format(printer, variables_);
 
   if (!table_driven_) {
-    format("{ NULL, NULL, 0, -1, -1, -1, -1, NULL, false },\n");
+    format("{ nullptr, nullptr, 0, -1, -1, -1, -1, nullptr, false },\n");
     return false;
   }
 
@@ -1628,7 +1628,7 @@ int MessageGenerator::GenerateFieldMetadata(io::Printer* printer) {
       vars["hasbit"] = SimpleItoa(i);
       vars["type"] =
           SimpleItoa(CalcFieldNum(generator, field, options_));
-      vars["ptr"] = "NULL";
+      vars["ptr"] = "nullptr";
       if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
         GOOGLE_CHECK(!IsMapEntryMessage(field->message_type()));
         if (!IsProto1(field->message_type()->file(), options_)) {
@@ -1654,7 +1654,7 @@ int MessageGenerator::GenerateFieldMetadata(io::Printer* printer) {
     return 2;
   }
   format(
-      "{PROTOBUF_FIELD_OFFSET($classtype$, _cached_size_), 0, 0, 0, NULL},\n");
+      "{PROTOBUF_FIELD_OFFSET($classtype$, _cached_size_), 0, 0, 0, nullptr},\n");
   std::vector<const Descriptor::ExtensionRange*> sorted_extensions;
   for (int i = 0; i < descriptor_->extension_range_count(); ++i) {
     sorted_extensions.push_back(descriptor_->extension_range(i));
@@ -1690,7 +1690,7 @@ int MessageGenerator::GenerateFieldMetadata(io::Printer* printer) {
       classfieldname = field->containing_oneof()->name();
     }
     format.Set("field_name", classfieldname);
-    string ptr = "NULL";
+    string ptr = "nullptr";
     if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
       if (IsMapEntryMessage(field->message_type())) {
         format(
@@ -1819,7 +1819,7 @@ void MessageGenerator::GenerateDefaultInstanceInitializer(
         format(
             "$package_ns$::$name$_ = reinterpret_cast<const "
             "::$proto_ns$::Message*>(&$1$);\n"
-            "if ($package_ns$::$name$_ == NULL) {\n"
+            "if ($package_ns$::$name$_ == nullptr) {\n"
             "  $package_ns$::$name$_ = "
             "::$proto_ns$::Empty::internal_default_instance();\n"
             "}\n",
@@ -2364,7 +2364,7 @@ void MessageGenerator::GenerateSharedDestructorCode(io::Printer* printer) {
   format("void $classname$::SharedDtor() {\n");
   format.Indent();
   if (SupportsArenas(descriptor_)) {
-    format("$DCHK$(GetArenaNoVirtual() == NULL);\n");
+    format("$DCHK$(GetArenaNoVirtual() == nullptr);\n");
   }
   // Write the destructors for each field except oneof members.
   // optimized_order_ does not contain oneof fields.
@@ -2440,7 +2440,7 @@ void MessageGenerator::GenerateArenaDestructorCode(io::Printer* printer) {
     format(
         "inline void $classname$::RegisterArenaDtor(::$proto_ns$::Arena* "
         "arena) {\n"
-        "  if (arena != NULL) {\n"
+        "  if (arena != nullptr) {\n"
         "    arena->OwnCustomDestructor(this, &$classname$::ArenaDtor);\n"
         "  }\n"
         "}\n");
@@ -2555,7 +2555,7 @@ void MessageGenerator::GenerateStructors(io::Printer* printer) {
     initializer_with_arena += ", _weak_field_map_(arena)";
   }
 
-  string initializer_null = superclass + "(), _internal_metadata_(NULL)";
+  string initializer_null = superclass + "(), _internal_metadata_(nullptr)";
   if (IsAnyMessage(descriptor_, options_)) {
     initializer_null += ", _any_metadata_(&type_url_, &value_)";
   }
@@ -2600,7 +2600,7 @@ void MessageGenerator::GenerateStructors(io::Printer* printer) {
     format.Indent();
     format.Indent();
     format.Indent();
-    format(",\n_internal_metadata_(NULL)");
+    format(",\n_internal_metadata_(nullptr)");
 
     if (HasFieldPresence(descriptor_->file())) {
       if (!IsProto2MessageSet(descriptor_, options_)) {
@@ -3001,7 +3001,7 @@ void MessageGenerator::GenerateSwap(io::Printer* printer) {
         "    temp->MergeFrom(*other);\n"
         "    other->CopyFrom(*this);\n"
         "    InternalSwap(temp);\n"
-        "    if (GetArenaNoVirtual() == NULL) {\n"
+        "    if (GetArenaNoVirtual() == nullptr) {\n"
         "      delete temp;\n"
         "    }\n"
         "  }\n"
@@ -3084,7 +3084,7 @@ void MessageGenerator::GenerateMergeFrom(io::Printer* printer) {
         "const $classname$* source =\n"
         "    ::$proto_ns$::DynamicCastToGenerated<$classname$>(\n"
         "        &from);\n"
-        "if (source == NULL) {\n"
+        "if (source == nullptr) {\n"
         "// @@protoc_insertion_point(generalized_merge_from_cast_fail:"
         "$full_name$)\n"
         "  ::$proto_ns$::internal::ReflectionOps::Merge(from, this);\n"

--- a/src/google/protobuf/compiler/cpp/cpp_message_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message_field.cc
@@ -149,7 +149,7 @@ void MessageFieldGenerator::GenerateNonInlineAccessorDefinitions(
         "    $type$* $name$) {\n"
         // If we're not on an arena, free whatever we were holding before.
         // (If we are on arena, we can just forget the earlier pointer.)
-        "  if (GetArenaNoVirtual() == NULL) {\n"
+        "  if (GetArenaNoVirtual() == nullptr) {\n"
         "    delete $name$_;\n"
         "  }\n"
         "  $name$_ = $name$;\n"
@@ -171,7 +171,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
       "inline const $type$& $classname$::$name$() const {\n"
       "  const $type$* p = $casted_member$;\n"
       "  // @@protoc_insertion_point(field_get:$full_name$)\n"
-      "  return p != NULL ? *p : *reinterpret_cast<const $type$*>(\n"
+      "  return p != nullptr ? *p : *reinterpret_cast<const $type$*>(\n"
       "      &$type_default_instance$);\n"
       "}\n");
 
@@ -183,12 +183,12 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
       "  $type$* temp = $casted_member$;\n");
   if (SupportsArenas(descriptor_)) {
     format(
-        "  if (GetArenaNoVirtual() != NULL) {\n"
+        "  if (GetArenaNoVirtual() != nullptr) {\n"
         "    temp = ::$proto_ns$::internal::DuplicateIfNonNull(temp);\n"
         "  }\n");
   }
   format(
-      "  $name$_ = NULL;\n"
+      "  $name$_ = nullptr;\n"
       "  return temp;\n"
       "}\n");
 
@@ -200,7 +200,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
         "$type_reference_function$"
         "  $clear_hasbit$\n"
         "  $type$* temp = $casted_member$;\n"
-        "  $name$_ = NULL;\n"
+        "  $name$_ = nullptr;\n"
         "  return temp;\n"
         "}\n");
   }
@@ -208,7 +208,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
   format(
       "inline $type$* $classname$::mutable_$name$() {\n"
       "  $set_hasbit$\n"
-      "  if ($name$_ == NULL) {\n"
+      "  if ($name$_ == nullptr) {\n"
       "    auto* p = CreateMaybeMessage<$type$>(GetArenaNoVirtual());\n");
   if (implicit_weak_field_) {
     format("    $name$_ = reinterpret_cast<::$proto_ns$::MessageLite*>(p);\n");
@@ -226,7 +226,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
   format(
       "inline void $classname$::set_allocated_$name$($type$* $name$) {\n"
       "  ::$proto_ns$::Arena* message_arena = GetArenaNoVirtual();\n");
-  format("  if (message_arena == NULL) {\n");
+  format("  if (message_arena == nullptr) {\n");
   if (IsCrossFileMessage(descriptor_)) {
     format(
         "    delete reinterpret_cast< ::$proto_ns$::MessageLite*>($name$_);\n");
@@ -245,7 +245,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
         "      "
         "reinterpret_cast<::$proto_ns$::MessageLite*>($name$)->GetArena();\n");
   } else if (!SupportsArenas(descriptor_->message_type())) {
-    format("    ::$proto_ns$::Arena* submessage_arena = NULL;\n");
+    format("    ::$proto_ns$::Arena* submessage_arena = nullptr;\n");
   } else {
     format(
         "    ::$proto_ns$::Arena* submessage_arena =\n"
@@ -297,9 +297,9 @@ GenerateInternalAccessorDefinitions(io::Printer* printer) const {
     format(
         "const ::$proto_ns$::MessageLite& $classname$::HasBitSetters::$name$(\n"
         "    const $classname$* msg) {\n"
-        "  if (msg->$name$_ != NULL) {\n"
+        "  if (msg->$name$_ != nullptr) {\n"
         "    return *msg->$name$_;\n"
-        "  } else if (&$type_default_instance$ != NULL) {\n"
+        "  } else if (&$type_default_instance$ != nullptr) {\n"
         "    return *reinterpret_cast<const ::$proto_ns$::MessageLite*>(\n"
         "        &$type_default_instance$);\n"
         "  } else {\n"
@@ -315,8 +315,8 @@ GenerateInternalAccessorDefinitions(io::Printer* printer) const {
         format("  msg->$set_hasbit$\n");
       }
       format(
-          "  if (msg->$name$_ == NULL) {\n"
-          "    if (&$type_default_instance$ == NULL) {\n"
+          "  if (msg->$name$_ == nullptr) {\n"
+          "    if (&$type_default_instance$ == nullptr) {\n"
           "      msg->$name$_ = ::$proto_ns$::Arena::CreateMessage<\n"
           "          ::$proto_ns$::internal::ImplicitWeakMessage>(\n"
           "              msg->GetArenaNoVirtual());\n"
@@ -337,8 +337,8 @@ GenerateInternalAccessorDefinitions(io::Printer* printer) const {
         format("  msg->$set_hasbit$\n");
       }
       format(
-          "  if (msg->$name$_ == NULL) {\n"
-          "    if (&$type_default_instance$ == NULL) {\n"
+          "  if (msg->$name$_ == nullptr) {\n"
+          "    if (&$type_default_instance$ == nullptr) {\n"
           "      msg->$name$_ = "
           "new ::$proto_ns$::internal::ImplicitWeakMessage;\n"
           "    } else {\n"
@@ -369,12 +369,12 @@ GenerateClearingCode(io::Printer* printer) const {
     // If we don't have has-bits, message presence is indicated only by ptr !=
     // NULL. Thus on clear, we need to delete the object.
     format(
-        "if (GetArenaNoVirtual() == NULL && $name$_ != NULL) {\n"
+        "if (GetArenaNoVirtual() == nullptr && $name$_ != nullptr) {\n"
         "  delete $name$_;\n"
         "}\n"
-        "$name$_ = NULL;\n");
+        "$name$_ = nullptr;\n");
   } else {
-    format("if ($name$_ != NULL) $name$_->Clear();\n");
+    format("if ($name$_ != nullptr) $name$_->Clear();\n");
   }
 }
 
@@ -385,13 +385,13 @@ GenerateMessageClearingCode(io::Printer* printer) const {
     // If we don't have has-bits, message presence is indicated only by ptr !=
     // NULL. Thus on clear, we need to delete the object.
     format(
-        "if (GetArenaNoVirtual() == NULL && $name$_ != NULL) {\n"
+        "if (GetArenaNoVirtual() == nullptr && $name$_ != nullptr) {\n"
         "  delete $name$_;\n"
         "}\n"
-        "$name$_ = NULL;\n");
+        "$name$_ = nullptr;\n");
   } else {
     format(
-        "$DCHK$($name$_ != NULL);\n"
+        "$DCHK$($name$_ != nullptr);\n"
         "$name$_->Clear();\n");
   }
 }
@@ -431,7 +431,7 @@ GenerateDestructorCode(io::Printer* printer) const {
 void MessageFieldGenerator::
 GenerateConstructorCode(io::Printer* printer) const {
   Formatter format(printer, variables_);
-  format("$name$_ = NULL;\n");
+  format("$name$_ = nullptr;\n");
 }
 
 void MessageFieldGenerator::
@@ -441,7 +441,7 @@ GenerateCopyConstructorCode(io::Printer* printer) const {
       "if (from.has_$name$()) {\n"
       "  $name$_ = new $type$(*from.$name$_);\n"
       "} else {\n"
-      "  $name$_ = NULL;\n"
+      "  $name$_ = nullptr;\n"
       "}\n");
 }
 
@@ -517,7 +517,7 @@ void MessageOneofFieldGenerator::GenerateNonInlineAccessorDefinitions(
         "      "
         "reinterpret_cast<::$proto_ns$::MessageLite*>($name$)->GetArena();\n");
   } else if (!SupportsArenas(descriptor_->message_type())) {
-    format("    ::$proto_ns$::Arena* submessage_arena = NULL;\n");
+    format("    ::$proto_ns$::Arena* submessage_arena = nullptr;\n");
   } else {
     format(
         "    ::$proto_ns$::Arena* submessage_arena =\n"
@@ -546,15 +546,15 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
       "      $type$* temp = $field_member$;\n");
   if (SupportsArenas(descriptor_)) {
     format(
-        "    if (GetArenaNoVirtual() != NULL) {\n"
+        "    if (GetArenaNoVirtual() != nullptr) {\n"
         "      temp = ::$proto_ns$::internal::DuplicateIfNonNull(temp);\n"
         "    }\n");
   }
   format(
-      "    $field_member$ = NULL;\n"
+      "    $field_member$ = nullptr;\n"
       "    return temp;\n"
       "  } else {\n"
-      "    return NULL;\n"
+      "    return nullptr;\n"
       "  }\n"
       "}\n");
 
@@ -574,10 +574,10 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
         "  if (has_$name$()) {\n"
         "    clear_has_$oneof_name$();\n"
         "    $type$* temp = $field_member$;\n"
-        "    $field_member$ = NULL;\n"
+        "    $field_member$ = nullptr;\n"
         "    return temp;\n"
         "  } else {\n"
-        "    return NULL;\n"
+        "    return nullptr;\n"
         "  }\n"
         "}\n"
         "inline void $classname$::unsafe_arena_set_allocated_$name$"
@@ -613,7 +613,7 @@ GenerateClearingCode(io::Printer* printer) const {
   Formatter format(printer, variables_);
   if (SupportsArenas(descriptor_)) {
     format(
-        "if (GetArenaNoVirtual() == NULL) {\n"
+        "if (GetArenaNoVirtual() == nullptr) {\n"
         "  delete $field_member$;\n"
         "}\n");
   } else {

--- a/src/google/protobuf/compiler/cpp/cpp_string_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_string_field.cc
@@ -63,7 +63,7 @@ void SetStringVariables(const FieldDescriptor* descriptor,
                 "::" + default_variable_string + ".get()";
   (*variables)["pointer_type"] =
       descriptor->type() == FieldDescriptor::TYPE_BYTES ? "void" : "char";
-  (*variables)["null_check"] = (*variables)["DCHK"] + "(value != NULL);\n";
+  (*variables)["null_check"] = (*variables)["DCHK"] + "(value != nullptr);\n";
   // NOTE: Escaped here to unblock proto1->proto2 migration.
   // TODO(liujisi): Extend this to apply for other conflicting methods.
   (*variables)["release_name"] =
@@ -293,7 +293,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
     if (HasFieldPresence(descriptor_->file())) {
       format(
           "  if (!has_$name$()) {\n"
-          "    return NULL;\n"
+          "    return nullptr;\n"
           "  }\n"
           "  $clear_hasbit$\n"
           "  return $name$_.ReleaseNonDefault("
@@ -308,7 +308,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
     format(
         "}\n"
         "inline void $classname$::set_allocated_$name$($string$* $name$) {\n"
-        "  if ($name$ != NULL) {\n"
+        "  if ($name$ != nullptr) {\n"
         "    $set_hasbit$\n"
         "  } else {\n"
         "    $clear_hasbit$\n"
@@ -322,15 +322,15 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
           "inline $string$* $classname$::unsafe_arena_release_$name$() {\n"
           "  // "
           "@@protoc_insertion_point(field_unsafe_arena_release:$full_name$)\n"
-          "  $DCHK$(GetArenaNoVirtual() != NULL);\n"
+          "  $DCHK$(GetArenaNoVirtual() != nullptr);\n"
           "  $clear_hasbit$\n"
           "  return $name$_.UnsafeArenaRelease($default_variable$,\n"
           "      GetArenaNoVirtual());\n"
           "}\n"
           "inline void $classname$::unsafe_arena_set_allocated_$name$(\n"
           "    $string$* $name$) {\n"
-          "  $DCHK$(GetArenaNoVirtual() != NULL);\n"
-          "  if ($name$ != NULL) {\n"
+          "  $DCHK$(GetArenaNoVirtual() != nullptr);\n"
+          "  if ($name$ != nullptr) {\n"
           "    $set_hasbit$\n"
           "  } else {\n"
           "    $clear_hasbit$\n"
@@ -403,7 +403,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
     if (HasFieldPresence(descriptor_->file())) {
       format(
           "  if (!has_$name$()) {\n"
-          "    return NULL;\n"
+          "    return nullptr;\n"
           "  }\n"
           "  $clear_hasbit$\n"
           "  return $name$_.ReleaseNonDefaultNoArena($default_variable$);\n");
@@ -416,7 +416,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
     format(
         "}\n"
         "inline void $classname$::set_allocated_$name$($string$* $name$) {\n"
-        "  if ($name$ != NULL) {\n"
+        "  if ($name$ != nullptr) {\n"
         "    $set_hasbit$\n"
         "  } else {\n"
         "    $clear_hasbit$\n"
@@ -631,7 +631,7 @@ GenerateMergeFromCodedStream(io::Printer* printer) const {
     // destructor necessary) or a materialized ::std::string (and is on the Arena's
     // destructor list).  No call to ArenaStringPtr::Destroy is needed.
     format(
-        "if (arena != NULL) {\n"
+        "if (arena != nullptr) {\n"
         "  ::$proto_ns$::internal::TaggedPtr<$string$> str =\n"
         "    ::$proto_ns$::internal::ReadArenaString(input, arena);\n"
         "  DO_(!str.IsNull());\n"
@@ -819,14 +819,14 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
         "    return $field_member$.Release($default_variable$,\n"
         "        GetArenaNoVirtual());\n"
         "  } else {\n"
-        "    return NULL;\n"
+        "    return nullptr;\n"
         "  }\n"
         "}\n"
         "inline void $classname$::set_allocated_$name$($string$* $name$) {\n"
         "  if (has_$oneof_name$()) {\n"
         "    clear_$oneof_name$();\n"
         "  }\n"
-        "  if ($name$ != NULL) {\n"
+        "  if ($name$ != nullptr) {\n"
         "    set_has_$name$();\n"
         "    $field_member$.UnsafeSetDefault($name$);\n"
         "  }\n"
@@ -837,18 +837,18 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
           "inline $string$* $classname$::unsafe_arena_release_$name$() {\n"
           "  // "
           "@@protoc_insertion_point(field_unsafe_arena_release:$full_name$)\n"
-          "  $DCHK$(GetArenaNoVirtual() != NULL);\n"
+          "  $DCHK$(GetArenaNoVirtual() != nullptr);\n"
           "  if (has_$name$()) {\n"
           "    clear_has_$oneof_name$();\n"
           "    return $field_member$.UnsafeArenaRelease(\n"
           "        $default_variable$, GetArenaNoVirtual());\n"
           "  } else {\n"
-          "    return NULL;\n"
+          "    return nullptr;\n"
           "  }\n"
           "}\n"
           "inline void $classname$::unsafe_arena_set_allocated_$name$("
           "$string$* $name$) {\n"
-          "  $DCHK$(GetArenaNoVirtual() != NULL);\n"
+          "  $DCHK$(GetArenaNoVirtual() != nullptr);\n"
           "  if (!has_$name$()) {\n"
           "    $field_member$.UnsafeSetDefault($default_variable$);\n"
           "  }\n"
@@ -957,14 +957,14 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
         "    clear_has_$oneof_name$();\n"
         "    return $field_member$.ReleaseNoArena($default_variable$);\n"
         "  } else {\n"
-        "    return NULL;\n"
+        "    return nullptr;\n"
         "  }\n"
         "}\n"
         "inline void $classname$::set_allocated_$name$($string$* $name$) {\n"
         "  if (has_$oneof_name$()) {\n"
         "    clear_$oneof_name$();\n"
         "  }\n"
-        "  if ($name$ != NULL) {\n"
+        "  if ($name$ != nullptr) {\n"
         "    set_has_$name$();\n"
         "    $field_member$.UnsafeSetDefault($name$);\n"
         "  }\n"
@@ -1021,7 +1021,7 @@ GenerateMergeFromCodedStream(io::Printer* printer) const {
     // destructor necessary) or a materialized ::std::string (and is on the Arena's
     // destructor list).  No call to ArenaStringPtr::Destroy is needed.
     format(
-        "if (arena != NULL) {\n"
+        "if (arena != nullptr) {\n"
         "  clear_$oneof_name$();\n"
         "  if (!has_$name$()) {\n"
         "    $field_member$.UnsafeSetDefault($default_variable$);\n"

--- a/src/google/protobuf/compiler/plugin.pb.cc
+++ b/src/google/protobuf/compiler/plugin.pb.cc
@@ -245,13 +245,13 @@ const int Version::kSuffixFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Version::Version()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.compiler.Version)
 }
 Version::Version(const Version& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   suffix_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -617,7 +617,7 @@ void Version::MergeFrom(const ::google::protobuf::Message& from) {
   const Version* source =
       ::google::protobuf::DynamicCastToGenerated<Version>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.compiler.Version)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -723,13 +723,13 @@ const int CodeGeneratorRequest::kCompilerVersionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 CodeGeneratorRequest::CodeGeneratorRequest()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.compiler.CodeGeneratorRequest)
 }
 CodeGeneratorRequest::CodeGeneratorRequest(const CodeGeneratorRequest& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       file_to_generate_(from.file_to_generate_),
       proto_file_(from.proto_file_) {
@@ -741,7 +741,7 @@ CodeGeneratorRequest::CodeGeneratorRequest(const CodeGeneratorRequest& from)
   if (from.has_compiler_version()) {
     compiler_version_ = new ::google::protobuf::compiler::Version(*from.compiler_version_);
   } else {
-    compiler_version_ = NULL;
+    compiler_version_ = nullptr;
   }
   // @@protoc_insertion_point(copy_constructor:google.protobuf.compiler.CodeGeneratorRequest)
 }
@@ -750,7 +750,7 @@ void CodeGeneratorRequest::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
       &scc_info_CodeGeneratorRequest_google_2fprotobuf_2fcompiler_2fplugin_2eproto.base);
   parameter_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  compiler_version_ = NULL;
+  compiler_version_ = nullptr;
 }
 
 CodeGeneratorRequest::~CodeGeneratorRequest() {
@@ -786,7 +786,7 @@ void CodeGeneratorRequest::Clear() {
       parameter_.ClearNonDefaultToEmptyNoArena();
     }
     if (cached_has_bits & 0x00000002u) {
-      GOOGLE_DCHECK(compiler_version_ != NULL);
+      GOOGLE_DCHECK(compiler_version_ != nullptr);
       compiler_version_->Clear();
     }
   }
@@ -1150,7 +1150,7 @@ void CodeGeneratorRequest::MergeFrom(const ::google::protobuf::Message& from) {
   const CodeGeneratorRequest* source =
       ::google::protobuf::DynamicCastToGenerated<CodeGeneratorRequest>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.compiler.CodeGeneratorRequest)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1244,13 +1244,13 @@ const int CodeGeneratorResponse_File::kContentFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 CodeGeneratorResponse_File::CodeGeneratorResponse_File()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.compiler.CodeGeneratorResponse.File)
 }
 CodeGeneratorResponse_File::CodeGeneratorResponse_File(const CodeGeneratorResponse_File& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -1629,7 +1629,7 @@ void CodeGeneratorResponse_File::MergeFrom(const ::google::protobuf::Message& fr
   const CodeGeneratorResponse_File* source =
       ::google::protobuf::DynamicCastToGenerated<CodeGeneratorResponse_File>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.compiler.CodeGeneratorResponse.File)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1719,13 +1719,13 @@ const int CodeGeneratorResponse::kFileFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 CodeGeneratorResponse::CodeGeneratorResponse()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.compiler.CodeGeneratorResponse)
 }
 CodeGeneratorResponse::CodeGeneratorResponse(const CodeGeneratorResponse& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       file_(from.file_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -2017,7 +2017,7 @@ void CodeGeneratorResponse::MergeFrom(const ::google::protobuf::Message& from) {
   const CodeGeneratorResponse* source =
       ::google::protobuf::DynamicCastToGenerated<CodeGeneratorResponse>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.compiler.CodeGeneratorResponse)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {

--- a/src/google/protobuf/compiler/plugin.pb.h
+++ b/src/google/protobuf/compiler/plugin.pb.h
@@ -137,7 +137,7 @@ class PROTOC_EXPORT Version : public ::google::protobuf::Message /* @@protoc_ins
   // implements Message ----------------------------------------------
 
   inline Version* New() const final {
-    return CreateMaybeMessage<Version>(NULL);
+    return CreateMaybeMessage<Version>(nullptr);
   }
 
   Version* New(::google::protobuf::Arena* arena) const final {
@@ -171,10 +171,10 @@ class PROTOC_EXPORT Version : public ::google::protobuf::Message /* @@protoc_ins
   void InternalSwap(Version* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
+    return nullptr;
   }
   inline void* MaybeArenaPtr() const {
-    return NULL;
+    return nullptr;
   }
   public:
 
@@ -289,7 +289,7 @@ class PROTOC_EXPORT CodeGeneratorRequest : public ::google::protobuf::Message /*
   // implements Message ----------------------------------------------
 
   inline CodeGeneratorRequest* New() const final {
-    return CreateMaybeMessage<CodeGeneratorRequest>(NULL);
+    return CreateMaybeMessage<CodeGeneratorRequest>(nullptr);
   }
 
   CodeGeneratorRequest* New(::google::protobuf::Arena* arena) const final {
@@ -323,10 +323,10 @@ class PROTOC_EXPORT CodeGeneratorRequest : public ::google::protobuf::Message /*
   void InternalSwap(CodeGeneratorRequest* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
+    return nullptr;
   }
   inline void* MaybeArenaPtr() const {
-    return NULL;
+    return nullptr;
   }
   public:
 
@@ -463,7 +463,7 @@ class PROTOC_EXPORT CodeGeneratorResponse_File : public ::google::protobuf::Mess
   // implements Message ----------------------------------------------
 
   inline CodeGeneratorResponse_File* New() const final {
-    return CreateMaybeMessage<CodeGeneratorResponse_File>(NULL);
+    return CreateMaybeMessage<CodeGeneratorResponse_File>(nullptr);
   }
 
   CodeGeneratorResponse_File* New(::google::protobuf::Arena* arena) const final {
@@ -497,10 +497,10 @@ class PROTOC_EXPORT CodeGeneratorResponse_File : public ::google::protobuf::Mess
   void InternalSwap(CodeGeneratorResponse_File* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
+    return nullptr;
   }
   inline void* MaybeArenaPtr() const {
-    return NULL;
+    return nullptr;
   }
   public:
 
@@ -623,7 +623,7 @@ class PROTOC_EXPORT CodeGeneratorResponse : public ::google::protobuf::Message /
   // implements Message ----------------------------------------------
 
   inline CodeGeneratorResponse* New() const final {
-    return CreateMaybeMessage<CodeGeneratorResponse>(NULL);
+    return CreateMaybeMessage<CodeGeneratorResponse>(nullptr);
   }
 
   CodeGeneratorResponse* New(::google::protobuf::Arena* arena) const final {
@@ -657,10 +657,10 @@ class PROTOC_EXPORT CodeGeneratorResponse : public ::google::protobuf::Message /
   void InternalSwap(CodeGeneratorResponse* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
+    return nullptr;
   }
   inline void* MaybeArenaPtr() const {
-    return NULL;
+    return nullptr;
   }
   public:
 
@@ -801,7 +801,7 @@ inline void Version::set_suffix(::std::string&& value) {
 }
 #endif
 inline void Version::set_suffix(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   suffix_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.compiler.Version.suffix)
@@ -820,13 +820,13 @@ inline ::std::string* Version::mutable_suffix() {
 inline ::std::string* Version::release_suffix() {
   // @@protoc_insertion_point(field_release:google.protobuf.compiler.Version.suffix)
   if (!has_suffix()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return suffix_.ReleaseNonDefaultNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void Version::set_allocated_suffix(::std::string* suffix) {
-  if (suffix != NULL) {
+  if (suffix != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -865,7 +865,7 @@ inline void CodeGeneratorRequest::set_file_to_generate(int index, ::std::string&
 }
 #endif
 inline void CodeGeneratorRequest::set_file_to_generate(int index, const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   file_to_generate_.Mutable(index)->assign(value);
   // @@protoc_insertion_point(field_set_char:google.protobuf.compiler.CodeGeneratorRequest.file_to_generate)
 }
@@ -889,7 +889,7 @@ inline void CodeGeneratorRequest::add_file_to_generate(::std::string&& value) {
 }
 #endif
 inline void CodeGeneratorRequest::add_file_to_generate(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   file_to_generate_.Add()->assign(value);
   // @@protoc_insertion_point(field_add_char:google.protobuf.compiler.CodeGeneratorRequest.file_to_generate)
 }
@@ -934,7 +934,7 @@ inline void CodeGeneratorRequest::set_parameter(::std::string&& value) {
 }
 #endif
 inline void CodeGeneratorRequest::set_parameter(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   parameter_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.compiler.CodeGeneratorRequest.parameter)
@@ -953,13 +953,13 @@ inline ::std::string* CodeGeneratorRequest::mutable_parameter() {
 inline ::std::string* CodeGeneratorRequest::release_parameter() {
   // @@protoc_insertion_point(field_release:google.protobuf.compiler.CodeGeneratorRequest.parameter)
   if (!has_parameter()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return parameter_.ReleaseNonDefaultNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void CodeGeneratorRequest::set_allocated_parameter(::std::string* parameter) {
-  if (parameter != NULL) {
+  if (parameter != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -1000,25 +1000,25 @@ inline bool CodeGeneratorRequest::has_compiler_version() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
 inline void CodeGeneratorRequest::clear_compiler_version() {
-  if (compiler_version_ != NULL) compiler_version_->Clear();
+  if (compiler_version_ != nullptr) compiler_version_->Clear();
   _has_bits_[0] &= ~0x00000002u;
 }
 inline const ::google::protobuf::compiler::Version& CodeGeneratorRequest::compiler_version() const {
   const ::google::protobuf::compiler::Version* p = compiler_version_;
   // @@protoc_insertion_point(field_get:google.protobuf.compiler.CodeGeneratorRequest.compiler_version)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::compiler::Version*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::compiler::Version*>(
       &::google::protobuf::compiler::_Version_default_instance_);
 }
 inline ::google::protobuf::compiler::Version* CodeGeneratorRequest::release_compiler_version() {
   // @@protoc_insertion_point(field_release:google.protobuf.compiler.CodeGeneratorRequest.compiler_version)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::compiler::Version* temp = compiler_version_;
-  compiler_version_ = NULL;
+  compiler_version_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::compiler::Version* CodeGeneratorRequest::mutable_compiler_version() {
   _has_bits_[0] |= 0x00000002u;
-  if (compiler_version_ == NULL) {
+  if (compiler_version_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::compiler::Version>(GetArenaNoVirtual());
     compiler_version_ = p;
   }
@@ -1027,11 +1027,11 @@ inline ::google::protobuf::compiler::Version* CodeGeneratorRequest::mutable_comp
 }
 inline void CodeGeneratorRequest::set_allocated_compiler_version(::google::protobuf::compiler::Version* compiler_version) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete compiler_version_;
   }
   if (compiler_version) {
-    ::google::protobuf::Arena* submessage_arena = NULL;
+    ::google::protobuf::Arena* submessage_arena = nullptr;
     if (message_arena != submessage_arena) {
       compiler_version = ::google::protobuf::internal::GetOwnedMessage(
           message_arena, compiler_version, submessage_arena);
@@ -1074,7 +1074,7 @@ inline void CodeGeneratorResponse_File::set_name(::std::string&& value) {
 }
 #endif
 inline void CodeGeneratorResponse_File::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.compiler.CodeGeneratorResponse.File.name)
@@ -1093,13 +1093,13 @@ inline ::std::string* CodeGeneratorResponse_File::mutable_name() {
 inline ::std::string* CodeGeneratorResponse_File::release_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.compiler.CodeGeneratorResponse.File.name)
   if (!has_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return name_.ReleaseNonDefaultNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void CodeGeneratorResponse_File::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -1134,7 +1134,7 @@ inline void CodeGeneratorResponse_File::set_insertion_point(::std::string&& valu
 }
 #endif
 inline void CodeGeneratorResponse_File::set_insertion_point(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000002u;
   insertion_point_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.compiler.CodeGeneratorResponse.File.insertion_point)
@@ -1153,13 +1153,13 @@ inline ::std::string* CodeGeneratorResponse_File::mutable_insertion_point() {
 inline ::std::string* CodeGeneratorResponse_File::release_insertion_point() {
   // @@protoc_insertion_point(field_release:google.protobuf.compiler.CodeGeneratorResponse.File.insertion_point)
   if (!has_insertion_point()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000002u;
   return insertion_point_.ReleaseNonDefaultNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void CodeGeneratorResponse_File::set_allocated_insertion_point(::std::string* insertion_point) {
-  if (insertion_point != NULL) {
+  if (insertion_point != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -1194,7 +1194,7 @@ inline void CodeGeneratorResponse_File::set_content(::std::string&& value) {
 }
 #endif
 inline void CodeGeneratorResponse_File::set_content(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000004u;
   content_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.compiler.CodeGeneratorResponse.File.content)
@@ -1213,13 +1213,13 @@ inline ::std::string* CodeGeneratorResponse_File::mutable_content() {
 inline ::std::string* CodeGeneratorResponse_File::release_content() {
   // @@protoc_insertion_point(field_release:google.protobuf.compiler.CodeGeneratorResponse.File.content)
   if (!has_content()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000004u;
   return content_.ReleaseNonDefaultNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void CodeGeneratorResponse_File::set_allocated_content(::std::string* content) {
-  if (content != NULL) {
+  if (content != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -1258,7 +1258,7 @@ inline void CodeGeneratorResponse::set_error(::std::string&& value) {
 }
 #endif
 inline void CodeGeneratorResponse::set_error(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   error_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.compiler.CodeGeneratorResponse.error)
@@ -1277,13 +1277,13 @@ inline ::std::string* CodeGeneratorResponse::mutable_error() {
 inline ::std::string* CodeGeneratorResponse::release_error() {
   // @@protoc_insertion_point(field_release:google.protobuf.compiler.CodeGeneratorResponse.error)
   if (!has_error()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return error_.ReleaseNonDefaultNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void CodeGeneratorResponse::set_allocated_error(::std::string* error) {
-  if (error != NULL) {
+  if (error != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;

--- a/src/google/protobuf/descriptor.pb.cc
+++ b/src/google/protobuf/descriptor.pb.cc
@@ -1403,7 +1403,7 @@ const int FileDescriptorSet::kFileFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 FileDescriptorSet::FileDescriptorSet()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.FileDescriptorSet)
 }
@@ -1417,7 +1417,7 @@ FileDescriptorSet::FileDescriptorSet(::google::protobuf::Arena* arena)
 }
 FileDescriptorSet::FileDescriptorSet(const FileDescriptorSet& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       file_(from.file_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -1435,7 +1435,7 @@ FileDescriptorSet::~FileDescriptorSet() {
 }
 
 void FileDescriptorSet::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void FileDescriptorSet::ArenaDtor(void* object) {
@@ -1641,7 +1641,7 @@ void FileDescriptorSet::MergeFrom(const ::google::protobuf::Message& from) {
   const FileDescriptorSet* source =
       ::google::protobuf::DynamicCastToGenerated<FileDescriptorSet>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.FileDescriptorSet)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1688,7 +1688,7 @@ void FileDescriptorSet::Swap(FileDescriptorSet* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -1750,7 +1750,7 @@ FileDescriptorProto::HasBitSetters::source_code_info(const FileDescriptorProto* 
 }
 void FileDescriptorProto::unsafe_arena_set_allocated_options(
     ::google::protobuf::FileOptions* options) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete options_;
   }
   options_ = options;
@@ -1763,7 +1763,7 @@ void FileDescriptorProto::unsafe_arena_set_allocated_options(
 }
 void FileDescriptorProto::unsafe_arena_set_allocated_source_code_info(
     ::google::protobuf::SourceCodeInfo* source_code_info) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete source_code_info_;
   }
   source_code_info_ = source_code_info;
@@ -1790,7 +1790,7 @@ const int FileDescriptorProto::kSyntaxFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 FileDescriptorProto::FileDescriptorProto()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.FileDescriptorProto)
 }
@@ -1810,7 +1810,7 @@ FileDescriptorProto::FileDescriptorProto(::google::protobuf::Arena* arena)
 }
 FileDescriptorProto::FileDescriptorProto(const FileDescriptorProto& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       dependency_(from.dependency_),
       message_type_(from.message_type_),
@@ -1838,12 +1838,12 @@ FileDescriptorProto::FileDescriptorProto(const FileDescriptorProto& from)
   if (from.has_options()) {
     options_ = new ::google::protobuf::FileOptions(*from.options_);
   } else {
-    options_ = NULL;
+    options_ = nullptr;
   }
   if (from.has_source_code_info()) {
     source_code_info_ = new ::google::protobuf::SourceCodeInfo(*from.source_code_info_);
   } else {
-    source_code_info_ = NULL;
+    source_code_info_ = nullptr;
   }
   // @@protoc_insertion_point(copy_constructor:google.protobuf.FileDescriptorProto)
 }
@@ -1865,7 +1865,7 @@ FileDescriptorProto::~FileDescriptorProto() {
 }
 
 void FileDescriptorProto::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   package_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   syntax_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -1913,11 +1913,11 @@ void FileDescriptorProto::Clear() {
       syntax_.ClearNonDefaultToEmpty();
     }
     if (cached_has_bits & 0x00000008u) {
-      GOOGLE_DCHECK(options_ != NULL);
+      GOOGLE_DCHECK(options_ != nullptr);
       options_->Clear();
     }
     if (cached_has_bits & 0x00000010u) {
-      GOOGLE_DCHECK(source_code_info_ != NULL);
+      GOOGLE_DCHECK(source_code_info_ != nullptr);
       source_code_info_->Clear();
     }
   }
@@ -2738,7 +2738,7 @@ void FileDescriptorProto::MergeFrom(const ::google::protobuf::Message& from) {
   const FileDescriptorProto* source =
       ::google::protobuf::DynamicCastToGenerated<FileDescriptorProto>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.FileDescriptorProto)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -2815,7 +2815,7 @@ void FileDescriptorProto::Swap(FileDescriptorProto* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -2878,7 +2878,7 @@ DescriptorProto_ExtensionRange::HasBitSetters::options(const DescriptorProto_Ext
 }
 void DescriptorProto_ExtensionRange::unsafe_arena_set_allocated_options(
     ::google::protobuf::ExtensionRangeOptions* options) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete options_;
   }
   options_ = options;
@@ -2896,7 +2896,7 @@ const int DescriptorProto_ExtensionRange::kOptionsFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 DescriptorProto_ExtensionRange::DescriptorProto_ExtensionRange()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.DescriptorProto.ExtensionRange)
 }
@@ -2909,13 +2909,13 @@ DescriptorProto_ExtensionRange::DescriptorProto_ExtensionRange(::google::protobu
 }
 DescriptorProto_ExtensionRange::DescriptorProto_ExtensionRange(const DescriptorProto_ExtensionRange& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   if (from.has_options()) {
     options_ = new ::google::protobuf::ExtensionRangeOptions(*from.options_);
   } else {
-    options_ = NULL;
+    options_ = nullptr;
   }
   ::memcpy(&start_, &from.start_,
     static_cast<size_t>(reinterpret_cast<char*>(&end_) -
@@ -2937,7 +2937,7 @@ DescriptorProto_ExtensionRange::~DescriptorProto_ExtensionRange() {
 }
 
 void DescriptorProto_ExtensionRange::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   if (this != internal_default_instance()) delete options_;
 }
 
@@ -2964,7 +2964,7 @@ void DescriptorProto_ExtensionRange::Clear() {
 
   cached_has_bits = _has_bits_[0];
   if (cached_has_bits & 0x00000001u) {
-    GOOGLE_DCHECK(options_ != NULL);
+    GOOGLE_DCHECK(options_ != nullptr);
     options_->Clear();
   }
   if (cached_has_bits & 0x00000006u) {
@@ -3227,7 +3227,7 @@ void DescriptorProto_ExtensionRange::MergeFrom(const ::google::protobuf::Message
   const DescriptorProto_ExtensionRange* source =
       ::google::protobuf::DynamicCastToGenerated<DescriptorProto_ExtensionRange>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.DescriptorProto.ExtensionRange)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -3288,7 +3288,7 @@ void DescriptorProto_ExtensionRange::Swap(DescriptorProto_ExtensionRange* other)
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -3333,7 +3333,7 @@ const int DescriptorProto_ReservedRange::kEndFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 DescriptorProto_ReservedRange::DescriptorProto_ReservedRange()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.DescriptorProto.ReservedRange)
 }
@@ -3346,7 +3346,7 @@ DescriptorProto_ReservedRange::DescriptorProto_ReservedRange(::google::protobuf:
 }
 DescriptorProto_ReservedRange::DescriptorProto_ReservedRange(const DescriptorProto_ReservedRange& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::memcpy(&start_, &from.start_,
@@ -3367,7 +3367,7 @@ DescriptorProto_ReservedRange::~DescriptorProto_ReservedRange() {
 }
 
 void DescriptorProto_ReservedRange::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void DescriptorProto_ReservedRange::ArenaDtor(void* object) {
@@ -3606,7 +3606,7 @@ void DescriptorProto_ReservedRange::MergeFrom(const ::google::protobuf::Message&
   const DescriptorProto_ReservedRange* source =
       ::google::protobuf::DynamicCastToGenerated<DescriptorProto_ReservedRange>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.DescriptorProto.ReservedRange)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -3661,7 +3661,7 @@ void DescriptorProto_ReservedRange::Swap(DescriptorProto_ReservedRange* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -3708,7 +3708,7 @@ DescriptorProto::HasBitSetters::options(const DescriptorProto* msg) {
 }
 void DescriptorProto::unsafe_arena_set_allocated_options(
     ::google::protobuf::MessageOptions* options) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete options_;
   }
   options_ = options;
@@ -3733,7 +3733,7 @@ const int DescriptorProto::kReservedNameFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 DescriptorProto::DescriptorProto()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.DescriptorProto)
 }
@@ -3754,7 +3754,7 @@ DescriptorProto::DescriptorProto(::google::protobuf::Arena* arena)
 }
 DescriptorProto::DescriptorProto(const DescriptorProto& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       field_(from.field_),
       nested_type_(from.nested_type_),
@@ -3773,7 +3773,7 @@ DescriptorProto::DescriptorProto(const DescriptorProto& from)
   if (from.has_options()) {
     options_ = new ::google::protobuf::MessageOptions(*from.options_);
   } else {
-    options_ = NULL;
+    options_ = nullptr;
   }
   // @@protoc_insertion_point(copy_constructor:google.protobuf.DescriptorProto)
 }
@@ -3782,7 +3782,7 @@ void DescriptorProto::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
       &scc_info_DescriptorProto_google_2fprotobuf_2fdescriptor_2eproto.base);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  options_ = NULL;
+  options_ = nullptr;
 }
 
 DescriptorProto::~DescriptorProto() {
@@ -3791,7 +3791,7 @@ DescriptorProto::~DescriptorProto() {
 }
 
 void DescriptorProto::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != internal_default_instance()) delete options_;
 }
@@ -3831,7 +3831,7 @@ void DescriptorProto::Clear() {
       name_.ClearNonDefaultToEmpty();
     }
     if (cached_has_bits & 0x00000002u) {
-      GOOGLE_DCHECK(options_ != NULL);
+      GOOGLE_DCHECK(options_ != nullptr);
       options_->Clear();
     }
   }
@@ -4537,7 +4537,7 @@ void DescriptorProto::MergeFrom(const ::google::protobuf::Message& from) {
   const DescriptorProto* source =
       ::google::protobuf::DynamicCastToGenerated<DescriptorProto>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.DescriptorProto)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -4608,7 +4608,7 @@ void DescriptorProto::Swap(DescriptorProto* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -4654,7 +4654,7 @@ const int ExtensionRangeOptions::kUninterpretedOptionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ExtensionRangeOptions::ExtensionRangeOptions()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.ExtensionRangeOptions)
 }
@@ -4669,7 +4669,7 @@ ExtensionRangeOptions::ExtensionRangeOptions(::google::protobuf::Arena* arena)
 }
 ExtensionRangeOptions::ExtensionRangeOptions(const ExtensionRangeOptions& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       uninterpreted_option_(from.uninterpreted_option_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -4688,7 +4688,7 @@ ExtensionRangeOptions::~ExtensionRangeOptions() {
 }
 
 void ExtensionRangeOptions::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void ExtensionRangeOptions::ArenaDtor(void* object) {
@@ -4918,7 +4918,7 @@ void ExtensionRangeOptions::MergeFrom(const ::google::protobuf::Message& from) {
   const ExtensionRangeOptions* source =
       ::google::protobuf::DynamicCastToGenerated<ExtensionRangeOptions>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.ExtensionRangeOptions)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -4970,7 +4970,7 @@ void ExtensionRangeOptions::Swap(ExtensionRangeOptions* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -5041,7 +5041,7 @@ FieldDescriptorProto::HasBitSetters::options(const FieldDescriptorProto* msg) {
 }
 void FieldDescriptorProto::unsafe_arena_set_allocated_options(
     ::google::protobuf::FieldOptions* options) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete options_;
   }
   options_ = options;
@@ -5066,7 +5066,7 @@ const int FieldDescriptorProto::kOptionsFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 FieldDescriptorProto::FieldDescriptorProto()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.FieldDescriptorProto)
 }
@@ -5079,7 +5079,7 @@ FieldDescriptorProto::FieldDescriptorProto(::google::protobuf::Arena* arena)
 }
 FieldDescriptorProto::FieldDescriptorProto(const FieldDescriptorProto& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -5110,7 +5110,7 @@ FieldDescriptorProto::FieldDescriptorProto(const FieldDescriptorProto& from)
   if (from.has_options()) {
     options_ = new ::google::protobuf::FieldOptions(*from.options_);
   } else {
-    options_ = NULL;
+    options_ = nullptr;
   }
   ::memcpy(&number_, &from.number_,
     static_cast<size_t>(reinterpret_cast<char*>(&type_) -
@@ -5139,7 +5139,7 @@ FieldDescriptorProto::~FieldDescriptorProto() {
 }
 
 void FieldDescriptorProto::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   extendee_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   type_name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -5187,7 +5187,7 @@ void FieldDescriptorProto::Clear() {
       json_name_.ClearNonDefaultToEmpty();
     }
     if (cached_has_bits & 0x00000020u) {
-      GOOGLE_DCHECK(options_ != NULL);
+      GOOGLE_DCHECK(options_ != nullptr);
       options_->Clear();
     }
   }
@@ -5869,7 +5869,7 @@ void FieldDescriptorProto::MergeFrom(const ::google::protobuf::Message& from) {
   const FieldDescriptorProto* source =
       ::google::protobuf::DynamicCastToGenerated<FieldDescriptorProto>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.FieldDescriptorProto)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -5954,7 +5954,7 @@ void FieldDescriptorProto::Swap(FieldDescriptorProto* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -6014,7 +6014,7 @@ OneofDescriptorProto::HasBitSetters::options(const OneofDescriptorProto* msg) {
 }
 void OneofDescriptorProto::unsafe_arena_set_allocated_options(
     ::google::protobuf::OneofOptions* options) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete options_;
   }
   options_ = options;
@@ -6031,7 +6031,7 @@ const int OneofDescriptorProto::kOptionsFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 OneofDescriptorProto::OneofDescriptorProto()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.OneofDescriptorProto)
 }
@@ -6044,7 +6044,7 @@ OneofDescriptorProto::OneofDescriptorProto(::google::protobuf::Arena* arena)
 }
 OneofDescriptorProto::OneofDescriptorProto(const OneofDescriptorProto& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -6055,7 +6055,7 @@ OneofDescriptorProto::OneofDescriptorProto(const OneofDescriptorProto& from)
   if (from.has_options()) {
     options_ = new ::google::protobuf::OneofOptions(*from.options_);
   } else {
-    options_ = NULL;
+    options_ = nullptr;
   }
   // @@protoc_insertion_point(copy_constructor:google.protobuf.OneofDescriptorProto)
 }
@@ -6064,7 +6064,7 @@ void OneofDescriptorProto::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
       &scc_info_OneofDescriptorProto_google_2fprotobuf_2fdescriptor_2eproto.base);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  options_ = NULL;
+  options_ = nullptr;
 }
 
 OneofDescriptorProto::~OneofDescriptorProto() {
@@ -6073,7 +6073,7 @@ OneofDescriptorProto::~OneofDescriptorProto() {
 }
 
 void OneofDescriptorProto::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != internal_default_instance()) delete options_;
 }
@@ -6105,7 +6105,7 @@ void OneofDescriptorProto::Clear() {
       name_.ClearNonDefaultToEmpty();
     }
     if (cached_has_bits & 0x00000002u) {
-      GOOGLE_DCHECK(options_ != NULL);
+      GOOGLE_DCHECK(options_ != nullptr);
       options_->Clear();
     }
   }
@@ -6346,7 +6346,7 @@ void OneofDescriptorProto::MergeFrom(const ::google::protobuf::Message& from) {
   const OneofDescriptorProto* source =
       ::google::protobuf::DynamicCastToGenerated<OneofDescriptorProto>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.OneofDescriptorProto)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -6403,7 +6403,7 @@ void OneofDescriptorProto::Swap(OneofDescriptorProto* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -6448,7 +6448,7 @@ const int EnumDescriptorProto_EnumReservedRange::kEndFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 EnumDescriptorProto_EnumReservedRange::EnumDescriptorProto_EnumReservedRange()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.EnumDescriptorProto.EnumReservedRange)
 }
@@ -6461,7 +6461,7 @@ EnumDescriptorProto_EnumReservedRange::EnumDescriptorProto_EnumReservedRange(::g
 }
 EnumDescriptorProto_EnumReservedRange::EnumDescriptorProto_EnumReservedRange(const EnumDescriptorProto_EnumReservedRange& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::memcpy(&start_, &from.start_,
@@ -6482,7 +6482,7 @@ EnumDescriptorProto_EnumReservedRange::~EnumDescriptorProto_EnumReservedRange() 
 }
 
 void EnumDescriptorProto_EnumReservedRange::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void EnumDescriptorProto_EnumReservedRange::ArenaDtor(void* object) {
@@ -6721,7 +6721,7 @@ void EnumDescriptorProto_EnumReservedRange::MergeFrom(const ::google::protobuf::
   const EnumDescriptorProto_EnumReservedRange* source =
       ::google::protobuf::DynamicCastToGenerated<EnumDescriptorProto_EnumReservedRange>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.EnumDescriptorProto.EnumReservedRange)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -6776,7 +6776,7 @@ void EnumDescriptorProto_EnumReservedRange::Swap(EnumDescriptorProto_EnumReserve
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -6823,7 +6823,7 @@ EnumDescriptorProto::HasBitSetters::options(const EnumDescriptorProto* msg) {
 }
 void EnumDescriptorProto::unsafe_arena_set_allocated_options(
     ::google::protobuf::EnumOptions* options) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete options_;
   }
   options_ = options;
@@ -6843,7 +6843,7 @@ const int EnumDescriptorProto::kReservedNameFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 EnumDescriptorProto::EnumDescriptorProto()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.EnumDescriptorProto)
 }
@@ -6859,7 +6859,7 @@ EnumDescriptorProto::EnumDescriptorProto(::google::protobuf::Arena* arena)
 }
 EnumDescriptorProto::EnumDescriptorProto(const EnumDescriptorProto& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       value_(from.value_),
       reserved_range_(from.reserved_range_),
@@ -6873,7 +6873,7 @@ EnumDescriptorProto::EnumDescriptorProto(const EnumDescriptorProto& from)
   if (from.has_options()) {
     options_ = new ::google::protobuf::EnumOptions(*from.options_);
   } else {
-    options_ = NULL;
+    options_ = nullptr;
   }
   // @@protoc_insertion_point(copy_constructor:google.protobuf.EnumDescriptorProto)
 }
@@ -6882,7 +6882,7 @@ void EnumDescriptorProto::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
       &scc_info_EnumDescriptorProto_google_2fprotobuf_2fdescriptor_2eproto.base);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  options_ = NULL;
+  options_ = nullptr;
 }
 
 EnumDescriptorProto::~EnumDescriptorProto() {
@@ -6891,7 +6891,7 @@ EnumDescriptorProto::~EnumDescriptorProto() {
 }
 
 void EnumDescriptorProto::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != internal_default_instance()) delete options_;
 }
@@ -6926,7 +6926,7 @@ void EnumDescriptorProto::Clear() {
       name_.ClearNonDefaultToEmpty();
     }
     if (cached_has_bits & 0x00000002u) {
-      GOOGLE_DCHECK(options_ != NULL);
+      GOOGLE_DCHECK(options_ != nullptr);
       options_->Clear();
     }
   }
@@ -7347,7 +7347,7 @@ void EnumDescriptorProto::MergeFrom(const ::google::protobuf::Message& from) {
   const EnumDescriptorProto* source =
       ::google::protobuf::DynamicCastToGenerated<EnumDescriptorProto>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.EnumDescriptorProto)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -7408,7 +7408,7 @@ void EnumDescriptorProto::Swap(EnumDescriptorProto* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -7462,7 +7462,7 @@ EnumValueDescriptorProto::HasBitSetters::options(const EnumValueDescriptorProto*
 }
 void EnumValueDescriptorProto::unsafe_arena_set_allocated_options(
     ::google::protobuf::EnumValueOptions* options) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete options_;
   }
   options_ = options;
@@ -7480,7 +7480,7 @@ const int EnumValueDescriptorProto::kOptionsFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 EnumValueDescriptorProto::EnumValueDescriptorProto()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.EnumValueDescriptorProto)
 }
@@ -7493,7 +7493,7 @@ EnumValueDescriptorProto::EnumValueDescriptorProto(::google::protobuf::Arena* ar
 }
 EnumValueDescriptorProto::EnumValueDescriptorProto(const EnumValueDescriptorProto& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -7504,7 +7504,7 @@ EnumValueDescriptorProto::EnumValueDescriptorProto(const EnumValueDescriptorProt
   if (from.has_options()) {
     options_ = new ::google::protobuf::EnumValueOptions(*from.options_);
   } else {
-    options_ = NULL;
+    options_ = nullptr;
   }
   number_ = from.number_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.EnumValueDescriptorProto)
@@ -7525,7 +7525,7 @@ EnumValueDescriptorProto::~EnumValueDescriptorProto() {
 }
 
 void EnumValueDescriptorProto::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != internal_default_instance()) delete options_;
 }
@@ -7557,7 +7557,7 @@ void EnumValueDescriptorProto::Clear() {
       name_.ClearNonDefaultToEmpty();
     }
     if (cached_has_bits & 0x00000002u) {
-      GOOGLE_DCHECK(options_ != NULL);
+      GOOGLE_DCHECK(options_ != nullptr);
       options_->Clear();
     }
   }
@@ -7839,7 +7839,7 @@ void EnumValueDescriptorProto::MergeFrom(const ::google::protobuf::Message& from
   const EnumValueDescriptorProto* source =
       ::google::protobuf::DynamicCastToGenerated<EnumValueDescriptorProto>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.EnumValueDescriptorProto)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -7900,7 +7900,7 @@ void EnumValueDescriptorProto::Swap(EnumValueDescriptorProto* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -7949,7 +7949,7 @@ ServiceDescriptorProto::HasBitSetters::options(const ServiceDescriptorProto* msg
 }
 void ServiceDescriptorProto::unsafe_arena_set_allocated_options(
     ::google::protobuf::ServiceOptions* options) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete options_;
   }
   options_ = options;
@@ -7967,7 +7967,7 @@ const int ServiceDescriptorProto::kOptionsFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ServiceDescriptorProto::ServiceDescriptorProto()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.ServiceDescriptorProto)
 }
@@ -7981,7 +7981,7 @@ ServiceDescriptorProto::ServiceDescriptorProto(::google::protobuf::Arena* arena)
 }
 ServiceDescriptorProto::ServiceDescriptorProto(const ServiceDescriptorProto& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       method_(from.method_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -7993,7 +7993,7 @@ ServiceDescriptorProto::ServiceDescriptorProto(const ServiceDescriptorProto& fro
   if (from.has_options()) {
     options_ = new ::google::protobuf::ServiceOptions(*from.options_);
   } else {
-    options_ = NULL;
+    options_ = nullptr;
   }
   // @@protoc_insertion_point(copy_constructor:google.protobuf.ServiceDescriptorProto)
 }
@@ -8002,7 +8002,7 @@ void ServiceDescriptorProto::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
       &scc_info_ServiceDescriptorProto_google_2fprotobuf_2fdescriptor_2eproto.base);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  options_ = NULL;
+  options_ = nullptr;
 }
 
 ServiceDescriptorProto::~ServiceDescriptorProto() {
@@ -8011,7 +8011,7 @@ ServiceDescriptorProto::~ServiceDescriptorProto() {
 }
 
 void ServiceDescriptorProto::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != internal_default_instance()) delete options_;
 }
@@ -8044,7 +8044,7 @@ void ServiceDescriptorProto::Clear() {
       name_.ClearNonDefaultToEmpty();
     }
     if (cached_has_bits & 0x00000002u) {
-      GOOGLE_DCHECK(options_ != NULL);
+      GOOGLE_DCHECK(options_ != nullptr);
       options_->Clear();
     }
   }
@@ -8342,7 +8342,7 @@ void ServiceDescriptorProto::MergeFrom(const ::google::protobuf::Message& from) 
   const ServiceDescriptorProto* source =
       ::google::protobuf::DynamicCastToGenerated<ServiceDescriptorProto>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.ServiceDescriptorProto)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -8401,7 +8401,7 @@ void ServiceDescriptorProto::Swap(ServiceDescriptorProto* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -8462,7 +8462,7 @@ MethodDescriptorProto::HasBitSetters::options(const MethodDescriptorProto* msg) 
 }
 void MethodDescriptorProto::unsafe_arena_set_allocated_options(
     ::google::protobuf::MethodOptions* options) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete options_;
   }
   options_ = options;
@@ -8483,7 +8483,7 @@ const int MethodDescriptorProto::kServerStreamingFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 MethodDescriptorProto::MethodDescriptorProto()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.MethodDescriptorProto)
 }
@@ -8496,7 +8496,7 @@ MethodDescriptorProto::MethodDescriptorProto(::google::protobuf::Arena* arena)
 }
 MethodDescriptorProto::MethodDescriptorProto(const MethodDescriptorProto& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -8517,7 +8517,7 @@ MethodDescriptorProto::MethodDescriptorProto(const MethodDescriptorProto& from)
   if (from.has_options()) {
     options_ = new ::google::protobuf::MethodOptions(*from.options_);
   } else {
-    options_ = NULL;
+    options_ = nullptr;
   }
   ::memcpy(&client_streaming_, &from.client_streaming_,
     static_cast<size_t>(reinterpret_cast<char*>(&server_streaming_) -
@@ -8542,7 +8542,7 @@ MethodDescriptorProto::~MethodDescriptorProto() {
 }
 
 void MethodDescriptorProto::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   input_type_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   output_type_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -8582,7 +8582,7 @@ void MethodDescriptorProto::Clear() {
       output_type_.ClearNonDefaultToEmpty();
     }
     if (cached_has_bits & 0x00000008u) {
-      GOOGLE_DCHECK(options_ != NULL);
+      GOOGLE_DCHECK(options_ != nullptr);
       options_->Clear();
     }
   }
@@ -9026,7 +9026,7 @@ void MethodDescriptorProto::MergeFrom(const ::google::protobuf::Message& from) {
   const MethodDescriptorProto* source =
       ::google::protobuf::DynamicCastToGenerated<MethodDescriptorProto>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.MethodDescriptorProto)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -9096,7 +9096,7 @@ void MethodDescriptorProto::Swap(MethodDescriptorProto* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -9220,7 +9220,7 @@ const int FileOptions::kUninterpretedOptionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 FileOptions::FileOptions()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.FileOptions)
 }
@@ -9235,7 +9235,7 @@ FileOptions::FileOptions(::google::protobuf::Arena* arena)
 }
 FileOptions::FileOptions(const FileOptions& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       uninterpreted_option_(from.uninterpreted_option_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -9321,7 +9321,7 @@ FileOptions::~FileOptions() {
 }
 
 void FileOptions::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   java_package_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   java_outer_classname_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   go_package_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -10629,7 +10629,7 @@ void FileOptions::MergeFrom(const ::google::protobuf::Message& from) {
   const FileOptions* source =
       ::google::protobuf::DynamicCastToGenerated<FileOptions>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.FileOptions)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -10750,7 +10750,7 @@ void FileOptions::Swap(FileOptions* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -10833,7 +10833,7 @@ const int MessageOptions::kUninterpretedOptionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 MessageOptions::MessageOptions()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.MessageOptions)
 }
@@ -10848,7 +10848,7 @@ MessageOptions::MessageOptions(::google::protobuf::Arena* arena)
 }
 MessageOptions::MessageOptions(const MessageOptions& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       uninterpreted_option_(from.uninterpreted_option_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -10873,7 +10873,7 @@ MessageOptions::~MessageOptions() {
 }
 
 void MessageOptions::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void MessageOptions::ArenaDtor(void* object) {
@@ -11263,7 +11263,7 @@ void MessageOptions::MergeFrom(const ::google::protobuf::Message& from) {
   const MessageOptions* source =
       ::google::protobuf::DynamicCastToGenerated<MessageOptions>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.MessageOptions)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -11331,7 +11331,7 @@ void MessageOptions::Swap(MessageOptions* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -11396,7 +11396,7 @@ const int FieldOptions::kUninterpretedOptionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 FieldOptions::FieldOptions()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.FieldOptions)
 }
@@ -11411,7 +11411,7 @@ FieldOptions::FieldOptions(::google::protobuf::Arena* arena)
 }
 FieldOptions::FieldOptions(const FieldOptions& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       uninterpreted_option_(from.uninterpreted_option_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -11436,7 +11436,7 @@ FieldOptions::~FieldOptions() {
 }
 
 void FieldOptions::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void FieldOptions::ArenaDtor(void* object) {
@@ -11931,7 +11931,7 @@ void FieldOptions::MergeFrom(const ::google::protobuf::Message& from) {
   const FieldOptions* source =
       ::google::protobuf::DynamicCastToGenerated<FieldOptions>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.FieldOptions)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -12005,7 +12005,7 @@ void FieldOptions::Swap(FieldOptions* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -12048,7 +12048,7 @@ const int OneofOptions::kUninterpretedOptionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 OneofOptions::OneofOptions()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.OneofOptions)
 }
@@ -12063,7 +12063,7 @@ OneofOptions::OneofOptions(::google::protobuf::Arena* arena)
 }
 OneofOptions::OneofOptions(const OneofOptions& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       uninterpreted_option_(from.uninterpreted_option_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -12082,7 +12082,7 @@ OneofOptions::~OneofOptions() {
 }
 
 void OneofOptions::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void OneofOptions::ArenaDtor(void* object) {
@@ -12312,7 +12312,7 @@ void OneofOptions::MergeFrom(const ::google::protobuf::Message& from) {
   const OneofOptions* source =
       ::google::protobuf::DynamicCastToGenerated<OneofOptions>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.OneofOptions)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -12364,7 +12364,7 @@ void OneofOptions::Swap(OneofOptions* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -12409,7 +12409,7 @@ const int EnumOptions::kUninterpretedOptionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 EnumOptions::EnumOptions()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.EnumOptions)
 }
@@ -12424,7 +12424,7 @@ EnumOptions::EnumOptions(::google::protobuf::Arena* arena)
 }
 EnumOptions::EnumOptions(const EnumOptions& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       uninterpreted_option_(from.uninterpreted_option_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -12449,7 +12449,7 @@ EnumOptions::~EnumOptions() {
 }
 
 void EnumOptions::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void EnumOptions::ArenaDtor(void* object) {
@@ -12763,7 +12763,7 @@ void EnumOptions::MergeFrom(const ::google::protobuf::Message& from) {
   const EnumOptions* source =
       ::google::protobuf::DynamicCastToGenerated<EnumOptions>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.EnumOptions)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -12825,7 +12825,7 @@ void EnumOptions::Swap(EnumOptions* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -12868,7 +12868,7 @@ const int EnumValueOptions::kUninterpretedOptionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 EnumValueOptions::EnumValueOptions()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.EnumValueOptions)
 }
@@ -12883,7 +12883,7 @@ EnumValueOptions::EnumValueOptions(::google::protobuf::Arena* arena)
 }
 EnumValueOptions::EnumValueOptions(const EnumValueOptions& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       uninterpreted_option_(from.uninterpreted_option_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -12904,7 +12904,7 @@ EnumValueOptions::~EnumValueOptions() {
 }
 
 void EnumValueOptions::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void EnumValueOptions::ArenaDtor(void* object) {
@@ -13176,7 +13176,7 @@ void EnumValueOptions::MergeFrom(const ::google::protobuf::Message& from) {
   const EnumValueOptions* source =
       ::google::protobuf::DynamicCastToGenerated<EnumValueOptions>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.EnumValueOptions)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -13231,7 +13231,7 @@ void EnumValueOptions::Swap(EnumValueOptions* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -13273,7 +13273,7 @@ const int ServiceOptions::kUninterpretedOptionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ServiceOptions::ServiceOptions()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.ServiceOptions)
 }
@@ -13288,7 +13288,7 @@ ServiceOptions::ServiceOptions(::google::protobuf::Arena* arena)
 }
 ServiceOptions::ServiceOptions(const ServiceOptions& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       uninterpreted_option_(from.uninterpreted_option_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -13309,7 +13309,7 @@ ServiceOptions::~ServiceOptions() {
 }
 
 void ServiceOptions::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void ServiceOptions::ArenaDtor(void* object) {
@@ -13581,7 +13581,7 @@ void ServiceOptions::MergeFrom(const ::google::protobuf::Message& from) {
   const ServiceOptions* source =
       ::google::protobuf::DynamicCastToGenerated<ServiceOptions>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.ServiceOptions)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -13636,7 +13636,7 @@ void ServiceOptions::Swap(ServiceOptions* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -13682,7 +13682,7 @@ const int MethodOptions::kUninterpretedOptionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 MethodOptions::MethodOptions()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.MethodOptions)
 }
@@ -13697,7 +13697,7 @@ MethodOptions::MethodOptions(::google::protobuf::Arena* arena)
 }
 MethodOptions::MethodOptions(const MethodOptions& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       uninterpreted_option_(from.uninterpreted_option_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -13722,7 +13722,7 @@ MethodOptions::~MethodOptions() {
 }
 
 void MethodOptions::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void MethodOptions::ArenaDtor(void* object) {
@@ -14052,7 +14052,7 @@ void MethodOptions::MergeFrom(const ::google::protobuf::Message& from) {
   const MethodOptions* source =
       ::google::protobuf::DynamicCastToGenerated<MethodOptions>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.MethodOptions)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -14114,7 +14114,7 @@ void MethodOptions::Swap(MethodOptions* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -14160,7 +14160,7 @@ const int UninterpretedOption_NamePart::kIsExtensionFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 UninterpretedOption_NamePart::UninterpretedOption_NamePart()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.UninterpretedOption.NamePart)
 }
@@ -14173,7 +14173,7 @@ UninterpretedOption_NamePart::UninterpretedOption_NamePart(::google::protobuf::A
 }
 UninterpretedOption_NamePart::UninterpretedOption_NamePart(const UninterpretedOption_NamePart& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_part_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -14198,7 +14198,7 @@ UninterpretedOption_NamePart::~UninterpretedOption_NamePart() {
 }
 
 void UninterpretedOption_NamePart::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_part_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
@@ -14472,7 +14472,7 @@ void UninterpretedOption_NamePart::MergeFrom(const ::google::protobuf::Message& 
   const UninterpretedOption_NamePart* source =
       ::google::protobuf::DynamicCastToGenerated<UninterpretedOption_NamePart>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.UninterpretedOption.NamePart)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -14528,7 +14528,7 @@ void UninterpretedOption_NamePart::Swap(UninterpretedOption_NamePart* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -14590,7 +14590,7 @@ const int UninterpretedOption::kAggregateValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 UninterpretedOption::UninterpretedOption()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.UninterpretedOption)
 }
@@ -14604,7 +14604,7 @@ UninterpretedOption::UninterpretedOption(::google::protobuf::Arena* arena)
 }
 UninterpretedOption::UninterpretedOption(const UninterpretedOption& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       name_(from.name_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -14646,7 +14646,7 @@ UninterpretedOption::~UninterpretedOption() {
 }
 
 void UninterpretedOption::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   identifier_value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   string_value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   aggregate_value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -15167,7 +15167,7 @@ void UninterpretedOption::MergeFrom(const ::google::protobuf::Message& from) {
   const UninterpretedOption* source =
       ::google::protobuf::DynamicCastToGenerated<UninterpretedOption>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.UninterpretedOption)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -15236,7 +15236,7 @@ void UninterpretedOption::Swap(UninterpretedOption* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -15291,7 +15291,7 @@ const int SourceCodeInfo_Location::kLeadingDetachedCommentsFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 SourceCodeInfo_Location::SourceCodeInfo_Location()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.SourceCodeInfo.Location)
 }
@@ -15307,7 +15307,7 @@ SourceCodeInfo_Location::SourceCodeInfo_Location(::google::protobuf::Arena* aren
 }
 SourceCodeInfo_Location::SourceCodeInfo_Location(const SourceCodeInfo_Location& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       path_(from.path_),
       span_(from.span_),
@@ -15339,7 +15339,7 @@ SourceCodeInfo_Location::~SourceCodeInfo_Location() {
 }
 
 void SourceCodeInfo_Location::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   leading_comments_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   trailing_comments_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
@@ -15852,7 +15852,7 @@ void SourceCodeInfo_Location::MergeFrom(const ::google::protobuf::Message& from)
   const SourceCodeInfo_Location* source =
       ::google::protobuf::DynamicCastToGenerated<SourceCodeInfo_Location>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.SourceCodeInfo.Location)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -15909,7 +15909,7 @@ void SourceCodeInfo_Location::Swap(SourceCodeInfo_Location* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -15951,7 +15951,7 @@ const int SourceCodeInfo::kLocationFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 SourceCodeInfo::SourceCodeInfo()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.SourceCodeInfo)
 }
@@ -15965,7 +15965,7 @@ SourceCodeInfo::SourceCodeInfo(::google::protobuf::Arena* arena)
 }
 SourceCodeInfo::SourceCodeInfo(const SourceCodeInfo& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       location_(from.location_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -15983,7 +15983,7 @@ SourceCodeInfo::~SourceCodeInfo() {
 }
 
 void SourceCodeInfo::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void SourceCodeInfo::ArenaDtor(void* object) {
@@ -16189,7 +16189,7 @@ void SourceCodeInfo::MergeFrom(const ::google::protobuf::Message& from) {
   const SourceCodeInfo* source =
       ::google::protobuf::DynamicCastToGenerated<SourceCodeInfo>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.SourceCodeInfo)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -16235,7 +16235,7 @@ void SourceCodeInfo::Swap(SourceCodeInfo* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -16283,7 +16283,7 @@ const int GeneratedCodeInfo_Annotation::kEndFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 GeneratedCodeInfo_Annotation::GeneratedCodeInfo_Annotation()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.GeneratedCodeInfo.Annotation)
 }
@@ -16297,7 +16297,7 @@ GeneratedCodeInfo_Annotation::GeneratedCodeInfo_Annotation(::google::protobuf::A
 }
 GeneratedCodeInfo_Annotation::GeneratedCodeInfo_Annotation(const GeneratedCodeInfo_Annotation& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       path_(from.path_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -16327,7 +16327,7 @@ GeneratedCodeInfo_Annotation::~GeneratedCodeInfo_Annotation() {
 }
 
 void GeneratedCodeInfo_Annotation::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   source_file_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
@@ -16711,7 +16711,7 @@ void GeneratedCodeInfo_Annotation::MergeFrom(const ::google::protobuf::Message& 
   const GeneratedCodeInfo_Annotation* source =
       ::google::protobuf::DynamicCastToGenerated<GeneratedCodeInfo_Annotation>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.GeneratedCodeInfo.Annotation)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -16770,7 +16770,7 @@ void GeneratedCodeInfo_Annotation::Swap(GeneratedCodeInfo_Annotation* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -16810,7 +16810,7 @@ const int GeneratedCodeInfo::kAnnotationFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 GeneratedCodeInfo::GeneratedCodeInfo()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.GeneratedCodeInfo)
 }
@@ -16824,7 +16824,7 @@ GeneratedCodeInfo::GeneratedCodeInfo(::google::protobuf::Arena* arena)
 }
 GeneratedCodeInfo::GeneratedCodeInfo(const GeneratedCodeInfo& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       _has_bits_(from._has_bits_),
       annotation_(from.annotation_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -16842,7 +16842,7 @@ GeneratedCodeInfo::~GeneratedCodeInfo() {
 }
 
 void GeneratedCodeInfo::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void GeneratedCodeInfo::ArenaDtor(void* object) {
@@ -17048,7 +17048,7 @@ void GeneratedCodeInfo::MergeFrom(const ::google::protobuf::Message& from) {
   const GeneratedCodeInfo* source =
       ::google::protobuf::DynamicCastToGenerated<GeneratedCodeInfo>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.GeneratedCodeInfo)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -17094,7 +17094,7 @@ void GeneratedCodeInfo::Swap(GeneratedCodeInfo* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }

--- a/src/google/protobuf/descriptor.pb.h
+++ b/src/google/protobuf/descriptor.pb.h
@@ -362,7 +362,7 @@ class PROTOBUF_EXPORT FileDescriptorSet : public ::google::protobuf::Message /* 
   // implements Message ----------------------------------------------
 
   inline FileDescriptorSet* New() const final {
-    return CreateMaybeMessage<FileDescriptorSet>(NULL);
+    return CreateMaybeMessage<FileDescriptorSet>(nullptr);
   }
 
   FileDescriptorSet* New(::google::protobuf::Arena* arena) const final {
@@ -502,7 +502,7 @@ class PROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Message /
   // implements Message ----------------------------------------------
 
   inline FileDescriptorProto* New() const final {
-    return CreateMaybeMessage<FileDescriptorProto>(NULL);
+    return CreateMaybeMessage<FileDescriptorProto>(nullptr);
   }
 
   FileDescriptorProto* New(::google::protobuf::Arena* arena) const final {
@@ -831,7 +831,7 @@ class PROTOBUF_EXPORT DescriptorProto_ExtensionRange : public ::google::protobuf
   // implements Message ----------------------------------------------
 
   inline DescriptorProto_ExtensionRange* New() const final {
-    return CreateMaybeMessage<DescriptorProto_ExtensionRange>(NULL);
+    return CreateMaybeMessage<DescriptorProto_ExtensionRange>(nullptr);
   }
 
   DescriptorProto_ExtensionRange* New(::google::protobuf::Arena* arena) const final {
@@ -987,7 +987,7 @@ class PROTOBUF_EXPORT DescriptorProto_ReservedRange : public ::google::protobuf:
   // implements Message ----------------------------------------------
 
   inline DescriptorProto_ReservedRange* New() const final {
-    return CreateMaybeMessage<DescriptorProto_ReservedRange>(NULL);
+    return CreateMaybeMessage<DescriptorProto_ReservedRange>(nullptr);
   }
 
   DescriptorProto_ReservedRange* New(::google::protobuf::Arena* arena) const final {
@@ -1130,7 +1130,7 @@ class PROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /* @@
   // implements Message ----------------------------------------------
 
   inline DescriptorProto* New() const final {
-    return CreateMaybeMessage<DescriptorProto>(NULL);
+    return CreateMaybeMessage<DescriptorProto>(nullptr);
   }
 
   DescriptorProto* New(::google::protobuf::Arena* arena) const final {
@@ -1412,7 +1412,7 @@ class PROTOBUF_EXPORT ExtensionRangeOptions : public ::google::protobuf::Message
   // implements Message ----------------------------------------------
 
   inline ExtensionRangeOptions* New() const final {
-    return CreateMaybeMessage<ExtensionRangeOptions>(NULL);
+    return CreateMaybeMessage<ExtensionRangeOptions>(nullptr);
   }
 
   ExtensionRangeOptions* New(::google::protobuf::Arena* arena) const final {
@@ -1555,7 +1555,7 @@ class PROTOBUF_EXPORT FieldDescriptorProto : public ::google::protobuf::Message 
   // implements Message ----------------------------------------------
 
   inline FieldDescriptorProto* New() const final {
-    return CreateMaybeMessage<FieldDescriptorProto>(NULL);
+    return CreateMaybeMessage<FieldDescriptorProto>(nullptr);
   }
 
   FieldDescriptorProto* New(::google::protobuf::Arena* arena) const final {
@@ -1938,7 +1938,7 @@ class PROTOBUF_EXPORT OneofDescriptorProto : public ::google::protobuf::Message 
   // implements Message ----------------------------------------------
 
   inline OneofDescriptorProto* New() const final {
-    return CreateMaybeMessage<OneofDescriptorProto>(NULL);
+    return CreateMaybeMessage<OneofDescriptorProto>(nullptr);
   }
 
   OneofDescriptorProto* New(::google::protobuf::Arena* arena) const final {
@@ -2103,7 +2103,7 @@ class PROTOBUF_EXPORT EnumDescriptorProto_EnumReservedRange : public ::google::p
   // implements Message ----------------------------------------------
 
   inline EnumDescriptorProto_EnumReservedRange* New() const final {
-    return CreateMaybeMessage<EnumDescriptorProto_EnumReservedRange>(NULL);
+    return CreateMaybeMessage<EnumDescriptorProto_EnumReservedRange>(nullptr);
   }
 
   EnumDescriptorProto_EnumReservedRange* New(::google::protobuf::Arena* arena) const final {
@@ -2246,7 +2246,7 @@ class PROTOBUF_EXPORT EnumDescriptorProto : public ::google::protobuf::Message /
   // implements Message ----------------------------------------------
 
   inline EnumDescriptorProto* New() const final {
-    return CreateMaybeMessage<EnumDescriptorProto>(NULL);
+    return CreateMaybeMessage<EnumDescriptorProto>(nullptr);
   }
 
   EnumDescriptorProto* New(::google::protobuf::Arena* arena) const final {
@@ -2462,7 +2462,7 @@ class PROTOBUF_EXPORT EnumValueDescriptorProto : public ::google::protobuf::Mess
   // implements Message ----------------------------------------------
 
   inline EnumValueDescriptorProto* New() const final {
-    return CreateMaybeMessage<EnumValueDescriptorProto>(NULL);
+    return CreateMaybeMessage<EnumValueDescriptorProto>(nullptr);
   }
 
   EnumValueDescriptorProto* New(::google::protobuf::Arena* arena) const final {
@@ -2635,7 +2635,7 @@ class PROTOBUF_EXPORT ServiceDescriptorProto : public ::google::protobuf::Messag
   // implements Message ----------------------------------------------
 
   inline ServiceDescriptorProto* New() const final {
-    return CreateMaybeMessage<ServiceDescriptorProto>(NULL);
+    return CreateMaybeMessage<ServiceDescriptorProto>(nullptr);
   }
 
   ServiceDescriptorProto* New(::google::protobuf::Arena* arena) const final {
@@ -2813,7 +2813,7 @@ class PROTOBUF_EXPORT MethodDescriptorProto : public ::google::protobuf::Message
   // implements Message ----------------------------------------------
 
   inline MethodDescriptorProto* New() const final {
-    return CreateMaybeMessage<MethodDescriptorProto>(NULL);
+    return CreateMaybeMessage<MethodDescriptorProto>(nullptr);
   }
 
   MethodDescriptorProto* New(::google::protobuf::Arena* arena) const final {
@@ -3044,7 +3044,7 @@ class PROTOBUF_EXPORT FileOptions : public ::google::protobuf::Message /* @@prot
   // implements Message ----------------------------------------------
 
   inline FileOptions* New() const final {
-    return CreateMaybeMessage<FileOptions>(NULL);
+    return CreateMaybeMessage<FileOptions>(nullptr);
   }
 
   FileOptions* New(::google::protobuf::Arena* arena) const final {
@@ -3545,7 +3545,7 @@ class PROTOBUF_EXPORT MessageOptions : public ::google::protobuf::Message /* @@p
   // implements Message ----------------------------------------------
 
   inline MessageOptions* New() const final {
-    return CreateMaybeMessage<MessageOptions>(NULL);
+    return CreateMaybeMessage<MessageOptions>(nullptr);
   }
 
   MessageOptions* New(::google::protobuf::Arena* arena) const final {
@@ -3720,7 +3720,7 @@ class PROTOBUF_EXPORT FieldOptions : public ::google::protobuf::Message /* @@pro
   // implements Message ----------------------------------------------
 
   inline FieldOptions* New() const final {
-    return CreateMaybeMessage<FieldOptions>(NULL);
+    return CreateMaybeMessage<FieldOptions>(nullptr);
   }
 
   FieldOptions* New(::google::protobuf::Arena* arena) const final {
@@ -3967,7 +3967,7 @@ class PROTOBUF_EXPORT OneofOptions : public ::google::protobuf::Message /* @@pro
   // implements Message ----------------------------------------------
 
   inline OneofOptions* New() const final {
-    return CreateMaybeMessage<OneofOptions>(NULL);
+    return CreateMaybeMessage<OneofOptions>(nullptr);
   }
 
   OneofOptions* New(::google::protobuf::Arena* arena) const final {
@@ -4110,7 +4110,7 @@ class PROTOBUF_EXPORT EnumOptions : public ::google::protobuf::Message /* @@prot
   // implements Message ----------------------------------------------
 
   inline EnumOptions* New() const final {
-    return CreateMaybeMessage<EnumOptions>(NULL);
+    return CreateMaybeMessage<EnumOptions>(nullptr);
   }
 
   EnumOptions* New(::google::protobuf::Arena* arena) const final {
@@ -4269,7 +4269,7 @@ class PROTOBUF_EXPORT EnumValueOptions : public ::google::protobuf::Message /* @
   // implements Message ----------------------------------------------
 
   inline EnumValueOptions* New() const final {
-    return CreateMaybeMessage<EnumValueOptions>(NULL);
+    return CreateMaybeMessage<EnumValueOptions>(nullptr);
   }
 
   EnumValueOptions* New(::google::protobuf::Arena* arena) const final {
@@ -4420,7 +4420,7 @@ class PROTOBUF_EXPORT ServiceOptions : public ::google::protobuf::Message /* @@p
   // implements Message ----------------------------------------------
 
   inline ServiceOptions* New() const final {
-    return CreateMaybeMessage<ServiceOptions>(NULL);
+    return CreateMaybeMessage<ServiceOptions>(nullptr);
   }
 
   ServiceOptions* New(::google::protobuf::Arena* arena) const final {
@@ -4571,7 +4571,7 @@ class PROTOBUF_EXPORT MethodOptions : public ::google::protobuf::Message /* @@pr
   // implements Message ----------------------------------------------
 
   inline MethodOptions* New() const final {
-    return CreateMaybeMessage<MethodOptions>(NULL);
+    return CreateMaybeMessage<MethodOptions>(nullptr);
   }
 
   MethodOptions* New(::google::protobuf::Arena* arena) const final {
@@ -4758,7 +4758,7 @@ class PROTOBUF_EXPORT UninterpretedOption_NamePart : public ::google::protobuf::
   // implements Message ----------------------------------------------
 
   inline UninterpretedOption_NamePart* New() const final {
-    return CreateMaybeMessage<UninterpretedOption_NamePart>(NULL);
+    return CreateMaybeMessage<UninterpretedOption_NamePart>(nullptr);
   }
 
   UninterpretedOption_NamePart* New(::google::protobuf::Arena* arena) const final {
@@ -4921,7 +4921,7 @@ class PROTOBUF_EXPORT UninterpretedOption : public ::google::protobuf::Message /
   // implements Message ----------------------------------------------
 
   inline UninterpretedOption* New() const final {
-    return CreateMaybeMessage<UninterpretedOption>(NULL);
+    return CreateMaybeMessage<UninterpretedOption>(nullptr);
   }
 
   UninterpretedOption* New(::google::protobuf::Arena* arena) const final {
@@ -5162,7 +5162,7 @@ class PROTOBUF_EXPORT SourceCodeInfo_Location : public ::google::protobuf::Messa
   // implements Message ----------------------------------------------
 
   inline SourceCodeInfo_Location* New() const final {
-    return CreateMaybeMessage<SourceCodeInfo_Location>(NULL);
+    return CreateMaybeMessage<SourceCodeInfo_Location>(nullptr);
   }
 
   SourceCodeInfo_Location* New(::google::protobuf::Arena* arena) const final {
@@ -5390,7 +5390,7 @@ class PROTOBUF_EXPORT SourceCodeInfo : public ::google::protobuf::Message /* @@p
   // implements Message ----------------------------------------------
 
   inline SourceCodeInfo* New() const final {
-    return CreateMaybeMessage<SourceCodeInfo>(NULL);
+    return CreateMaybeMessage<SourceCodeInfo>(nullptr);
   }
 
   SourceCodeInfo* New(::google::protobuf::Arena* arena) const final {
@@ -5532,7 +5532,7 @@ class PROTOBUF_EXPORT GeneratedCodeInfo_Annotation : public ::google::protobuf::
   // implements Message ----------------------------------------------
 
   inline GeneratedCodeInfo_Annotation* New() const final {
-    return CreateMaybeMessage<GeneratedCodeInfo_Annotation>(NULL);
+    return CreateMaybeMessage<GeneratedCodeInfo_Annotation>(nullptr);
   }
 
   GeneratedCodeInfo_Annotation* New(::google::protobuf::Arena* arena) const final {
@@ -5714,7 +5714,7 @@ class PROTOBUF_EXPORT GeneratedCodeInfo : public ::google::protobuf::Message /* 
   // implements Message ----------------------------------------------
 
   inline GeneratedCodeInfo* New() const final {
-    return CreateMaybeMessage<GeneratedCodeInfo>(NULL);
+    return CreateMaybeMessage<GeneratedCodeInfo>(nullptr);
   }
 
   GeneratedCodeInfo* New(::google::protobuf::Arena* arena) const final {
@@ -5864,7 +5864,7 @@ inline void FileDescriptorProto::set_name(::std::string&& value) {
 }
 #endif
 inline void FileDescriptorProto::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -5885,13 +5885,13 @@ inline ::std::string* FileDescriptorProto::mutable_name() {
 inline ::std::string* FileDescriptorProto::release_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileDescriptorProto.name)
   if (!has_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return name_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileDescriptorProto::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -5902,15 +5902,15 @@ inline void FileDescriptorProto::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* FileDescriptorProto::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileDescriptorProto.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileDescriptorProto::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -5946,7 +5946,7 @@ inline void FileDescriptorProto::set_package(::std::string&& value) {
 }
 #endif
 inline void FileDescriptorProto::set_package(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000002u;
   package_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -5967,13 +5967,13 @@ inline ::std::string* FileDescriptorProto::mutable_package() {
 inline ::std::string* FileDescriptorProto::release_package() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileDescriptorProto.package)
   if (!has_package()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000002u;
   return package_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileDescriptorProto::set_allocated_package(::std::string* package) {
-  if (package != NULL) {
+  if (package != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -5984,15 +5984,15 @@ inline void FileDescriptorProto::set_allocated_package(::std::string* package) {
 }
 inline ::std::string* FileDescriptorProto::unsafe_arena_release_package() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileDescriptorProto.package)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000002u;
   return package_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileDescriptorProto::unsafe_arena_set_allocated_package(
     ::std::string* package) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (package != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (package != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -6028,7 +6028,7 @@ inline void FileDescriptorProto::set_dependency(int index, ::std::string&& value
 }
 #endif
 inline void FileDescriptorProto::set_dependency(int index, const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   dependency_.Mutable(index)->assign(value);
   // @@protoc_insertion_point(field_set_char:google.protobuf.FileDescriptorProto.dependency)
 }
@@ -6052,7 +6052,7 @@ inline void FileDescriptorProto::add_dependency(::std::string&& value) {
 }
 #endif
 inline void FileDescriptorProto::add_dependency(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   dependency_.Add()->assign(value);
   // @@protoc_insertion_point(field_add_char:google.protobuf.FileDescriptorProto.dependency)
 }
@@ -6256,35 +6256,35 @@ inline bool FileDescriptorProto::has_options() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void FileDescriptorProto::clear_options() {
-  if (options_ != NULL) options_->Clear();
+  if (options_ != nullptr) options_->Clear();
   _has_bits_[0] &= ~0x00000008u;
 }
 inline const ::google::protobuf::FileOptions& FileDescriptorProto::options() const {
   const ::google::protobuf::FileOptions* p = options_;
   // @@protoc_insertion_point(field_get:google.protobuf.FileDescriptorProto.options)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::FileOptions*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::FileOptions*>(
       &::google::protobuf::_FileOptions_default_instance_);
 }
 inline ::google::protobuf::FileOptions* FileDescriptorProto::release_options() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileDescriptorProto.options)
   _has_bits_[0] &= ~0x00000008u;
   ::google::protobuf::FileOptions* temp = options_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::FileOptions* FileDescriptorProto::unsafe_arena_release_options() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileDescriptorProto.options)
   _has_bits_[0] &= ~0x00000008u;
   ::google::protobuf::FileOptions* temp = options_;
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::FileOptions* FileDescriptorProto::mutable_options() {
   _has_bits_[0] |= 0x00000008u;
-  if (options_ == NULL) {
+  if (options_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::FileOptions>(GetArenaNoVirtual());
     options_ = p;
   }
@@ -6293,7 +6293,7 @@ inline ::google::protobuf::FileOptions* FileDescriptorProto::mutable_options() {
 }
 inline void FileDescriptorProto::set_allocated_options(::google::protobuf::FileOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete options_;
   }
   if (options) {
@@ -6316,35 +6316,35 @@ inline bool FileDescriptorProto::has_source_code_info() const {
   return (_has_bits_[0] & 0x00000010u) != 0;
 }
 inline void FileDescriptorProto::clear_source_code_info() {
-  if (source_code_info_ != NULL) source_code_info_->Clear();
+  if (source_code_info_ != nullptr) source_code_info_->Clear();
   _has_bits_[0] &= ~0x00000010u;
 }
 inline const ::google::protobuf::SourceCodeInfo& FileDescriptorProto::source_code_info() const {
   const ::google::protobuf::SourceCodeInfo* p = source_code_info_;
   // @@protoc_insertion_point(field_get:google.protobuf.FileDescriptorProto.source_code_info)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::SourceCodeInfo*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::SourceCodeInfo*>(
       &::google::protobuf::_SourceCodeInfo_default_instance_);
 }
 inline ::google::protobuf::SourceCodeInfo* FileDescriptorProto::release_source_code_info() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileDescriptorProto.source_code_info)
   _has_bits_[0] &= ~0x00000010u;
   ::google::protobuf::SourceCodeInfo* temp = source_code_info_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  source_code_info_ = NULL;
+  source_code_info_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::SourceCodeInfo* FileDescriptorProto::unsafe_arena_release_source_code_info() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileDescriptorProto.source_code_info)
   _has_bits_[0] &= ~0x00000010u;
   ::google::protobuf::SourceCodeInfo* temp = source_code_info_;
-  source_code_info_ = NULL;
+  source_code_info_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::SourceCodeInfo* FileDescriptorProto::mutable_source_code_info() {
   _has_bits_[0] |= 0x00000010u;
-  if (source_code_info_ == NULL) {
+  if (source_code_info_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::SourceCodeInfo>(GetArenaNoVirtual());
     source_code_info_ = p;
   }
@@ -6353,7 +6353,7 @@ inline ::google::protobuf::SourceCodeInfo* FileDescriptorProto::mutable_source_c
 }
 inline void FileDescriptorProto::set_allocated_source_code_info(::google::protobuf::SourceCodeInfo* source_code_info) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete source_code_info_;
   }
   if (source_code_info) {
@@ -6397,7 +6397,7 @@ inline void FileDescriptorProto::set_syntax(::std::string&& value) {
 }
 #endif
 inline void FileDescriptorProto::set_syntax(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000004u;
   syntax_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -6418,13 +6418,13 @@ inline ::std::string* FileDescriptorProto::mutable_syntax() {
 inline ::std::string* FileDescriptorProto::release_syntax() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileDescriptorProto.syntax)
   if (!has_syntax()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000004u;
   return syntax_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileDescriptorProto::set_allocated_syntax(::std::string* syntax) {
-  if (syntax != NULL) {
+  if (syntax != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -6435,15 +6435,15 @@ inline void FileDescriptorProto::set_allocated_syntax(::std::string* syntax) {
 }
 inline ::std::string* FileDescriptorProto::unsafe_arena_release_syntax() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileDescriptorProto.syntax)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000004u;
   return syntax_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileDescriptorProto::unsafe_arena_set_allocated_syntax(
     ::std::string* syntax) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (syntax != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (syntax != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -6498,35 +6498,35 @@ inline bool DescriptorProto_ExtensionRange::has_options() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
 inline void DescriptorProto_ExtensionRange::clear_options() {
-  if (options_ != NULL) options_->Clear();
+  if (options_ != nullptr) options_->Clear();
   _has_bits_[0] &= ~0x00000001u;
 }
 inline const ::google::protobuf::ExtensionRangeOptions& DescriptorProto_ExtensionRange::options() const {
   const ::google::protobuf::ExtensionRangeOptions* p = options_;
   // @@protoc_insertion_point(field_get:google.protobuf.DescriptorProto.ExtensionRange.options)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::ExtensionRangeOptions*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::ExtensionRangeOptions*>(
       &::google::protobuf::_ExtensionRangeOptions_default_instance_);
 }
 inline ::google::protobuf::ExtensionRangeOptions* DescriptorProto_ExtensionRange::release_options() {
   // @@protoc_insertion_point(field_release:google.protobuf.DescriptorProto.ExtensionRange.options)
   _has_bits_[0] &= ~0x00000001u;
   ::google::protobuf::ExtensionRangeOptions* temp = options_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::ExtensionRangeOptions* DescriptorProto_ExtensionRange::unsafe_arena_release_options() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.DescriptorProto.ExtensionRange.options)
   _has_bits_[0] &= ~0x00000001u;
   ::google::protobuf::ExtensionRangeOptions* temp = options_;
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::ExtensionRangeOptions* DescriptorProto_ExtensionRange::mutable_options() {
   _has_bits_[0] |= 0x00000001u;
-  if (options_ == NULL) {
+  if (options_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::ExtensionRangeOptions>(GetArenaNoVirtual());
     options_ = p;
   }
@@ -6535,7 +6535,7 @@ inline ::google::protobuf::ExtensionRangeOptions* DescriptorProto_ExtensionRange
 }
 inline void DescriptorProto_ExtensionRange::set_allocated_options(::google::protobuf::ExtensionRangeOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete options_;
   }
   if (options) {
@@ -6623,7 +6623,7 @@ inline void DescriptorProto::set_name(::std::string&& value) {
 }
 #endif
 inline void DescriptorProto::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -6644,13 +6644,13 @@ inline ::std::string* DescriptorProto::mutable_name() {
 inline ::std::string* DescriptorProto::release_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.DescriptorProto.name)
   if (!has_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return name_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void DescriptorProto::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -6661,15 +6661,15 @@ inline void DescriptorProto::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* DescriptorProto::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.DescriptorProto.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void DescriptorProto::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -6864,35 +6864,35 @@ inline bool DescriptorProto::has_options() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
 inline void DescriptorProto::clear_options() {
-  if (options_ != NULL) options_->Clear();
+  if (options_ != nullptr) options_->Clear();
   _has_bits_[0] &= ~0x00000002u;
 }
 inline const ::google::protobuf::MessageOptions& DescriptorProto::options() const {
   const ::google::protobuf::MessageOptions* p = options_;
   // @@protoc_insertion_point(field_get:google.protobuf.DescriptorProto.options)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::MessageOptions*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::MessageOptions*>(
       &::google::protobuf::_MessageOptions_default_instance_);
 }
 inline ::google::protobuf::MessageOptions* DescriptorProto::release_options() {
   // @@protoc_insertion_point(field_release:google.protobuf.DescriptorProto.options)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::MessageOptions* temp = options_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::MessageOptions* DescriptorProto::unsafe_arena_release_options() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.DescriptorProto.options)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::MessageOptions* temp = options_;
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::MessageOptions* DescriptorProto::mutable_options() {
   _has_bits_[0] |= 0x00000002u;
-  if (options_ == NULL) {
+  if (options_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::MessageOptions>(GetArenaNoVirtual());
     options_ = p;
   }
@@ -6901,7 +6901,7 @@ inline ::google::protobuf::MessageOptions* DescriptorProto::mutable_options() {
 }
 inline void DescriptorProto::set_allocated_options(::google::protobuf::MessageOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete options_;
   }
   if (options) {
@@ -6975,7 +6975,7 @@ inline void DescriptorProto::set_reserved_name(int index, ::std::string&& value)
 }
 #endif
 inline void DescriptorProto::set_reserved_name(int index, const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   reserved_name_.Mutable(index)->assign(value);
   // @@protoc_insertion_point(field_set_char:google.protobuf.DescriptorProto.reserved_name)
 }
@@ -6999,7 +6999,7 @@ inline void DescriptorProto::add_reserved_name(::std::string&& value) {
 }
 #endif
 inline void DescriptorProto::add_reserved_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   reserved_name_.Add()->assign(value);
   // @@protoc_insertion_point(field_add_char:google.protobuf.DescriptorProto.reserved_name)
 }
@@ -7082,7 +7082,7 @@ inline void FieldDescriptorProto::set_name(::std::string&& value) {
 }
 #endif
 inline void FieldDescriptorProto::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -7103,13 +7103,13 @@ inline ::std::string* FieldDescriptorProto::mutable_name() {
 inline ::std::string* FieldDescriptorProto::release_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.FieldDescriptorProto.name)
   if (!has_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return name_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FieldDescriptorProto::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -7120,15 +7120,15 @@ inline void FieldDescriptorProto::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* FieldDescriptorProto::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FieldDescriptorProto.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FieldDescriptorProto::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -7220,7 +7220,7 @@ inline void FieldDescriptorProto::set_type_name(::std::string&& value) {
 }
 #endif
 inline void FieldDescriptorProto::set_type_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000004u;
   type_name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -7241,13 +7241,13 @@ inline ::std::string* FieldDescriptorProto::mutable_type_name() {
 inline ::std::string* FieldDescriptorProto::release_type_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.FieldDescriptorProto.type_name)
   if (!has_type_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000004u;
   return type_name_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FieldDescriptorProto::set_allocated_type_name(::std::string* type_name) {
-  if (type_name != NULL) {
+  if (type_name != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -7258,15 +7258,15 @@ inline void FieldDescriptorProto::set_allocated_type_name(::std::string* type_na
 }
 inline ::std::string* FieldDescriptorProto::unsafe_arena_release_type_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FieldDescriptorProto.type_name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000004u;
   return type_name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FieldDescriptorProto::unsafe_arena_set_allocated_type_name(
     ::std::string* type_name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (type_name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (type_name != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -7302,7 +7302,7 @@ inline void FieldDescriptorProto::set_extendee(::std::string&& value) {
 }
 #endif
 inline void FieldDescriptorProto::set_extendee(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000002u;
   extendee_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -7323,13 +7323,13 @@ inline ::std::string* FieldDescriptorProto::mutable_extendee() {
 inline ::std::string* FieldDescriptorProto::release_extendee() {
   // @@protoc_insertion_point(field_release:google.protobuf.FieldDescriptorProto.extendee)
   if (!has_extendee()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000002u;
   return extendee_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FieldDescriptorProto::set_allocated_extendee(::std::string* extendee) {
-  if (extendee != NULL) {
+  if (extendee != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -7340,15 +7340,15 @@ inline void FieldDescriptorProto::set_allocated_extendee(::std::string* extendee
 }
 inline ::std::string* FieldDescriptorProto::unsafe_arena_release_extendee() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FieldDescriptorProto.extendee)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000002u;
   return extendee_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FieldDescriptorProto::unsafe_arena_set_allocated_extendee(
     ::std::string* extendee) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (extendee != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (extendee != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -7384,7 +7384,7 @@ inline void FieldDescriptorProto::set_default_value(::std::string&& value) {
 }
 #endif
 inline void FieldDescriptorProto::set_default_value(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000008u;
   default_value_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -7405,13 +7405,13 @@ inline ::std::string* FieldDescriptorProto::mutable_default_value() {
 inline ::std::string* FieldDescriptorProto::release_default_value() {
   // @@protoc_insertion_point(field_release:google.protobuf.FieldDescriptorProto.default_value)
   if (!has_default_value()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000008u;
   return default_value_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FieldDescriptorProto::set_allocated_default_value(::std::string* default_value) {
-  if (default_value != NULL) {
+  if (default_value != nullptr) {
     _has_bits_[0] |= 0x00000008u;
   } else {
     _has_bits_[0] &= ~0x00000008u;
@@ -7422,15 +7422,15 @@ inline void FieldDescriptorProto::set_allocated_default_value(::std::string* def
 }
 inline ::std::string* FieldDescriptorProto::unsafe_arena_release_default_value() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FieldDescriptorProto.default_value)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000008u;
   return default_value_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FieldDescriptorProto::unsafe_arena_set_allocated_default_value(
     ::std::string* default_value) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (default_value != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (default_value != nullptr) {
     _has_bits_[0] |= 0x00000008u;
   } else {
     _has_bits_[0] &= ~0x00000008u;
@@ -7484,7 +7484,7 @@ inline void FieldDescriptorProto::set_json_name(::std::string&& value) {
 }
 #endif
 inline void FieldDescriptorProto::set_json_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000010u;
   json_name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -7505,13 +7505,13 @@ inline ::std::string* FieldDescriptorProto::mutable_json_name() {
 inline ::std::string* FieldDescriptorProto::release_json_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.FieldDescriptorProto.json_name)
   if (!has_json_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000010u;
   return json_name_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FieldDescriptorProto::set_allocated_json_name(::std::string* json_name) {
-  if (json_name != NULL) {
+  if (json_name != nullptr) {
     _has_bits_[0] |= 0x00000010u;
   } else {
     _has_bits_[0] &= ~0x00000010u;
@@ -7522,15 +7522,15 @@ inline void FieldDescriptorProto::set_allocated_json_name(::std::string* json_na
 }
 inline ::std::string* FieldDescriptorProto::unsafe_arena_release_json_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FieldDescriptorProto.json_name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000010u;
   return json_name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FieldDescriptorProto::unsafe_arena_set_allocated_json_name(
     ::std::string* json_name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (json_name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (json_name != nullptr) {
     _has_bits_[0] |= 0x00000010u;
   } else {
     _has_bits_[0] &= ~0x00000010u;
@@ -7545,35 +7545,35 @@ inline bool FieldDescriptorProto::has_options() const {
   return (_has_bits_[0] & 0x00000020u) != 0;
 }
 inline void FieldDescriptorProto::clear_options() {
-  if (options_ != NULL) options_->Clear();
+  if (options_ != nullptr) options_->Clear();
   _has_bits_[0] &= ~0x00000020u;
 }
 inline const ::google::protobuf::FieldOptions& FieldDescriptorProto::options() const {
   const ::google::protobuf::FieldOptions* p = options_;
   // @@protoc_insertion_point(field_get:google.protobuf.FieldDescriptorProto.options)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::FieldOptions*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::FieldOptions*>(
       &::google::protobuf::_FieldOptions_default_instance_);
 }
 inline ::google::protobuf::FieldOptions* FieldDescriptorProto::release_options() {
   // @@protoc_insertion_point(field_release:google.protobuf.FieldDescriptorProto.options)
   _has_bits_[0] &= ~0x00000020u;
   ::google::protobuf::FieldOptions* temp = options_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::FieldOptions* FieldDescriptorProto::unsafe_arena_release_options() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FieldDescriptorProto.options)
   _has_bits_[0] &= ~0x00000020u;
   ::google::protobuf::FieldOptions* temp = options_;
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::FieldOptions* FieldDescriptorProto::mutable_options() {
   _has_bits_[0] |= 0x00000020u;
-  if (options_ == NULL) {
+  if (options_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::FieldOptions>(GetArenaNoVirtual());
     options_ = p;
   }
@@ -7582,7 +7582,7 @@ inline ::google::protobuf::FieldOptions* FieldDescriptorProto::mutable_options()
 }
 inline void FieldDescriptorProto::set_allocated_options(::google::protobuf::FieldOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete options_;
   }
   if (options) {
@@ -7630,7 +7630,7 @@ inline void OneofDescriptorProto::set_name(::std::string&& value) {
 }
 #endif
 inline void OneofDescriptorProto::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -7651,13 +7651,13 @@ inline ::std::string* OneofDescriptorProto::mutable_name() {
 inline ::std::string* OneofDescriptorProto::release_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.OneofDescriptorProto.name)
   if (!has_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return name_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void OneofDescriptorProto::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -7668,15 +7668,15 @@ inline void OneofDescriptorProto::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* OneofDescriptorProto::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.OneofDescriptorProto.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void OneofDescriptorProto::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -7691,35 +7691,35 @@ inline bool OneofDescriptorProto::has_options() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
 inline void OneofDescriptorProto::clear_options() {
-  if (options_ != NULL) options_->Clear();
+  if (options_ != nullptr) options_->Clear();
   _has_bits_[0] &= ~0x00000002u;
 }
 inline const ::google::protobuf::OneofOptions& OneofDescriptorProto::options() const {
   const ::google::protobuf::OneofOptions* p = options_;
   // @@protoc_insertion_point(field_get:google.protobuf.OneofDescriptorProto.options)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::OneofOptions*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::OneofOptions*>(
       &::google::protobuf::_OneofOptions_default_instance_);
 }
 inline ::google::protobuf::OneofOptions* OneofDescriptorProto::release_options() {
   // @@protoc_insertion_point(field_release:google.protobuf.OneofDescriptorProto.options)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::OneofOptions* temp = options_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::OneofOptions* OneofDescriptorProto::unsafe_arena_release_options() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.OneofDescriptorProto.options)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::OneofOptions* temp = options_;
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::OneofOptions* OneofDescriptorProto::mutable_options() {
   _has_bits_[0] |= 0x00000002u;
-  if (options_ == NULL) {
+  if (options_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::OneofOptions>(GetArenaNoVirtual());
     options_ = p;
   }
@@ -7728,7 +7728,7 @@ inline ::google::protobuf::OneofOptions* OneofDescriptorProto::mutable_options()
 }
 inline void OneofDescriptorProto::set_allocated_options(::google::protobuf::OneofOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete options_;
   }
   if (options) {
@@ -7816,7 +7816,7 @@ inline void EnumDescriptorProto::set_name(::std::string&& value) {
 }
 #endif
 inline void EnumDescriptorProto::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -7837,13 +7837,13 @@ inline ::std::string* EnumDescriptorProto::mutable_name() {
 inline ::std::string* EnumDescriptorProto::release_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.EnumDescriptorProto.name)
   if (!has_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return name_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void EnumDescriptorProto::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -7854,15 +7854,15 @@ inline void EnumDescriptorProto::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* EnumDescriptorProto::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.EnumDescriptorProto.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void EnumDescriptorProto::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -7907,35 +7907,35 @@ inline bool EnumDescriptorProto::has_options() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
 inline void EnumDescriptorProto::clear_options() {
-  if (options_ != NULL) options_->Clear();
+  if (options_ != nullptr) options_->Clear();
   _has_bits_[0] &= ~0x00000002u;
 }
 inline const ::google::protobuf::EnumOptions& EnumDescriptorProto::options() const {
   const ::google::protobuf::EnumOptions* p = options_;
   // @@protoc_insertion_point(field_get:google.protobuf.EnumDescriptorProto.options)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::EnumOptions*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::EnumOptions*>(
       &::google::protobuf::_EnumOptions_default_instance_);
 }
 inline ::google::protobuf::EnumOptions* EnumDescriptorProto::release_options() {
   // @@protoc_insertion_point(field_release:google.protobuf.EnumDescriptorProto.options)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::EnumOptions* temp = options_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::EnumOptions* EnumDescriptorProto::unsafe_arena_release_options() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.EnumDescriptorProto.options)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::EnumOptions* temp = options_;
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::EnumOptions* EnumDescriptorProto::mutable_options() {
   _has_bits_[0] |= 0x00000002u;
-  if (options_ == NULL) {
+  if (options_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::EnumOptions>(GetArenaNoVirtual());
     options_ = p;
   }
@@ -7944,7 +7944,7 @@ inline ::google::protobuf::EnumOptions* EnumDescriptorProto::mutable_options() {
 }
 inline void EnumDescriptorProto::set_allocated_options(::google::protobuf::EnumOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete options_;
   }
   if (options) {
@@ -8018,7 +8018,7 @@ inline void EnumDescriptorProto::set_reserved_name(int index, ::std::string&& va
 }
 #endif
 inline void EnumDescriptorProto::set_reserved_name(int index, const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   reserved_name_.Mutable(index)->assign(value);
   // @@protoc_insertion_point(field_set_char:google.protobuf.EnumDescriptorProto.reserved_name)
 }
@@ -8042,7 +8042,7 @@ inline void EnumDescriptorProto::add_reserved_name(::std::string&& value) {
 }
 #endif
 inline void EnumDescriptorProto::add_reserved_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   reserved_name_.Add()->assign(value);
   // @@protoc_insertion_point(field_add_char:google.protobuf.EnumDescriptorProto.reserved_name)
 }
@@ -8091,7 +8091,7 @@ inline void EnumValueDescriptorProto::set_name(::std::string&& value) {
 }
 #endif
 inline void EnumValueDescriptorProto::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -8112,13 +8112,13 @@ inline ::std::string* EnumValueDescriptorProto::mutable_name() {
 inline ::std::string* EnumValueDescriptorProto::release_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.EnumValueDescriptorProto.name)
   if (!has_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return name_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void EnumValueDescriptorProto::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -8129,15 +8129,15 @@ inline void EnumValueDescriptorProto::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* EnumValueDescriptorProto::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.EnumValueDescriptorProto.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void EnumValueDescriptorProto::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -8170,35 +8170,35 @@ inline bool EnumValueDescriptorProto::has_options() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
 inline void EnumValueDescriptorProto::clear_options() {
-  if (options_ != NULL) options_->Clear();
+  if (options_ != nullptr) options_->Clear();
   _has_bits_[0] &= ~0x00000002u;
 }
 inline const ::google::protobuf::EnumValueOptions& EnumValueDescriptorProto::options() const {
   const ::google::protobuf::EnumValueOptions* p = options_;
   // @@protoc_insertion_point(field_get:google.protobuf.EnumValueDescriptorProto.options)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::EnumValueOptions*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::EnumValueOptions*>(
       &::google::protobuf::_EnumValueOptions_default_instance_);
 }
 inline ::google::protobuf::EnumValueOptions* EnumValueDescriptorProto::release_options() {
   // @@protoc_insertion_point(field_release:google.protobuf.EnumValueDescriptorProto.options)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::EnumValueOptions* temp = options_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::EnumValueOptions* EnumValueDescriptorProto::unsafe_arena_release_options() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.EnumValueDescriptorProto.options)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::EnumValueOptions* temp = options_;
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::EnumValueOptions* EnumValueDescriptorProto::mutable_options() {
   _has_bits_[0] |= 0x00000002u;
-  if (options_ == NULL) {
+  if (options_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::EnumValueOptions>(GetArenaNoVirtual());
     options_ = p;
   }
@@ -8207,7 +8207,7 @@ inline ::google::protobuf::EnumValueOptions* EnumValueDescriptorProto::mutable_o
 }
 inline void EnumValueDescriptorProto::set_allocated_options(::google::protobuf::EnumValueOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete options_;
   }
   if (options) {
@@ -8255,7 +8255,7 @@ inline void ServiceDescriptorProto::set_name(::std::string&& value) {
 }
 #endif
 inline void ServiceDescriptorProto::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -8276,13 +8276,13 @@ inline ::std::string* ServiceDescriptorProto::mutable_name() {
 inline ::std::string* ServiceDescriptorProto::release_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.ServiceDescriptorProto.name)
   if (!has_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return name_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void ServiceDescriptorProto::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -8293,15 +8293,15 @@ inline void ServiceDescriptorProto::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* ServiceDescriptorProto::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.ServiceDescriptorProto.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void ServiceDescriptorProto::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -8346,35 +8346,35 @@ inline bool ServiceDescriptorProto::has_options() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
 inline void ServiceDescriptorProto::clear_options() {
-  if (options_ != NULL) options_->Clear();
+  if (options_ != nullptr) options_->Clear();
   _has_bits_[0] &= ~0x00000002u;
 }
 inline const ::google::protobuf::ServiceOptions& ServiceDescriptorProto::options() const {
   const ::google::protobuf::ServiceOptions* p = options_;
   // @@protoc_insertion_point(field_get:google.protobuf.ServiceDescriptorProto.options)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::ServiceOptions*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::ServiceOptions*>(
       &::google::protobuf::_ServiceOptions_default_instance_);
 }
 inline ::google::protobuf::ServiceOptions* ServiceDescriptorProto::release_options() {
   // @@protoc_insertion_point(field_release:google.protobuf.ServiceDescriptorProto.options)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::ServiceOptions* temp = options_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::ServiceOptions* ServiceDescriptorProto::unsafe_arena_release_options() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.ServiceDescriptorProto.options)
   _has_bits_[0] &= ~0x00000002u;
   ::google::protobuf::ServiceOptions* temp = options_;
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::ServiceOptions* ServiceDescriptorProto::mutable_options() {
   _has_bits_[0] |= 0x00000002u;
-  if (options_ == NULL) {
+  if (options_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::ServiceOptions>(GetArenaNoVirtual());
     options_ = p;
   }
@@ -8383,7 +8383,7 @@ inline ::google::protobuf::ServiceOptions* ServiceDescriptorProto::mutable_optio
 }
 inline void ServiceDescriptorProto::set_allocated_options(::google::protobuf::ServiceOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete options_;
   }
   if (options) {
@@ -8431,7 +8431,7 @@ inline void MethodDescriptorProto::set_name(::std::string&& value) {
 }
 #endif
 inline void MethodDescriptorProto::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -8452,13 +8452,13 @@ inline ::std::string* MethodDescriptorProto::mutable_name() {
 inline ::std::string* MethodDescriptorProto::release_name() {
   // @@protoc_insertion_point(field_release:google.protobuf.MethodDescriptorProto.name)
   if (!has_name()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return name_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void MethodDescriptorProto::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -8469,15 +8469,15 @@ inline void MethodDescriptorProto::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* MethodDescriptorProto::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.MethodDescriptorProto.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void MethodDescriptorProto::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -8513,7 +8513,7 @@ inline void MethodDescriptorProto::set_input_type(::std::string&& value) {
 }
 #endif
 inline void MethodDescriptorProto::set_input_type(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000002u;
   input_type_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -8534,13 +8534,13 @@ inline ::std::string* MethodDescriptorProto::mutable_input_type() {
 inline ::std::string* MethodDescriptorProto::release_input_type() {
   // @@protoc_insertion_point(field_release:google.protobuf.MethodDescriptorProto.input_type)
   if (!has_input_type()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000002u;
   return input_type_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void MethodDescriptorProto::set_allocated_input_type(::std::string* input_type) {
-  if (input_type != NULL) {
+  if (input_type != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -8551,15 +8551,15 @@ inline void MethodDescriptorProto::set_allocated_input_type(::std::string* input
 }
 inline ::std::string* MethodDescriptorProto::unsafe_arena_release_input_type() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.MethodDescriptorProto.input_type)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000002u;
   return input_type_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void MethodDescriptorProto::unsafe_arena_set_allocated_input_type(
     ::std::string* input_type) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (input_type != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (input_type != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -8595,7 +8595,7 @@ inline void MethodDescriptorProto::set_output_type(::std::string&& value) {
 }
 #endif
 inline void MethodDescriptorProto::set_output_type(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000004u;
   output_type_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -8616,13 +8616,13 @@ inline ::std::string* MethodDescriptorProto::mutable_output_type() {
 inline ::std::string* MethodDescriptorProto::release_output_type() {
   // @@protoc_insertion_point(field_release:google.protobuf.MethodDescriptorProto.output_type)
   if (!has_output_type()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000004u;
   return output_type_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void MethodDescriptorProto::set_allocated_output_type(::std::string* output_type) {
-  if (output_type != NULL) {
+  if (output_type != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -8633,15 +8633,15 @@ inline void MethodDescriptorProto::set_allocated_output_type(::std::string* outp
 }
 inline ::std::string* MethodDescriptorProto::unsafe_arena_release_output_type() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.MethodDescriptorProto.output_type)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000004u;
   return output_type_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void MethodDescriptorProto::unsafe_arena_set_allocated_output_type(
     ::std::string* output_type) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (output_type != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (output_type != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -8656,35 +8656,35 @@ inline bool MethodDescriptorProto::has_options() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void MethodDescriptorProto::clear_options() {
-  if (options_ != NULL) options_->Clear();
+  if (options_ != nullptr) options_->Clear();
   _has_bits_[0] &= ~0x00000008u;
 }
 inline const ::google::protobuf::MethodOptions& MethodDescriptorProto::options() const {
   const ::google::protobuf::MethodOptions* p = options_;
   // @@protoc_insertion_point(field_get:google.protobuf.MethodDescriptorProto.options)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::MethodOptions*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::MethodOptions*>(
       &::google::protobuf::_MethodOptions_default_instance_);
 }
 inline ::google::protobuf::MethodOptions* MethodDescriptorProto::release_options() {
   // @@protoc_insertion_point(field_release:google.protobuf.MethodDescriptorProto.options)
   _has_bits_[0] &= ~0x00000008u;
   ::google::protobuf::MethodOptions* temp = options_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::MethodOptions* MethodDescriptorProto::unsafe_arena_release_options() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.MethodDescriptorProto.options)
   _has_bits_[0] &= ~0x00000008u;
   ::google::protobuf::MethodOptions* temp = options_;
-  options_ = NULL;
+  options_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::MethodOptions* MethodDescriptorProto::mutable_options() {
   _has_bits_[0] |= 0x00000008u;
-  if (options_ == NULL) {
+  if (options_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::MethodOptions>(GetArenaNoVirtual());
     options_ = p;
   }
@@ -8693,7 +8693,7 @@ inline ::google::protobuf::MethodOptions* MethodDescriptorProto::mutable_options
 }
 inline void MethodDescriptorProto::set_allocated_options(::google::protobuf::MethodOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete options_;
   }
   if (options) {
@@ -8777,7 +8777,7 @@ inline void FileOptions::set_java_package(::std::string&& value) {
 }
 #endif
 inline void FileOptions::set_java_package(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   java_package_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -8798,13 +8798,13 @@ inline ::std::string* FileOptions::mutable_java_package() {
 inline ::std::string* FileOptions::release_java_package() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileOptions.java_package)
   if (!has_java_package()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return java_package_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileOptions::set_allocated_java_package(::std::string* java_package) {
-  if (java_package != NULL) {
+  if (java_package != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -8815,15 +8815,15 @@ inline void FileOptions::set_allocated_java_package(::std::string* java_package)
 }
 inline ::std::string* FileOptions::unsafe_arena_release_java_package() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileOptions.java_package)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return java_package_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileOptions::unsafe_arena_set_allocated_java_package(
     ::std::string* java_package) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (java_package != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (java_package != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -8859,7 +8859,7 @@ inline void FileOptions::set_java_outer_classname(::std::string&& value) {
 }
 #endif
 inline void FileOptions::set_java_outer_classname(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000002u;
   java_outer_classname_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -8880,13 +8880,13 @@ inline ::std::string* FileOptions::mutable_java_outer_classname() {
 inline ::std::string* FileOptions::release_java_outer_classname() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileOptions.java_outer_classname)
   if (!has_java_outer_classname()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000002u;
   return java_outer_classname_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileOptions::set_allocated_java_outer_classname(::std::string* java_outer_classname) {
-  if (java_outer_classname != NULL) {
+  if (java_outer_classname != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -8897,15 +8897,15 @@ inline void FileOptions::set_allocated_java_outer_classname(::std::string* java_
 }
 inline ::std::string* FileOptions::unsafe_arena_release_java_outer_classname() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileOptions.java_outer_classname)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000002u;
   return java_outer_classname_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileOptions::unsafe_arena_set_allocated_java_outer_classname(
     ::std::string* java_outer_classname) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (java_outer_classname != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (java_outer_classname != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -9014,7 +9014,7 @@ inline void FileOptions::set_go_package(::std::string&& value) {
 }
 #endif
 inline void FileOptions::set_go_package(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000004u;
   go_package_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -9035,13 +9035,13 @@ inline ::std::string* FileOptions::mutable_go_package() {
 inline ::std::string* FileOptions::release_go_package() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileOptions.go_package)
   if (!has_go_package()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000004u;
   return go_package_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileOptions::set_allocated_go_package(::std::string* go_package) {
-  if (go_package != NULL) {
+  if (go_package != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -9052,15 +9052,15 @@ inline void FileOptions::set_allocated_go_package(::std::string* go_package) {
 }
 inline ::std::string* FileOptions::unsafe_arena_release_go_package() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileOptions.go_package)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000004u;
   return go_package_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileOptions::unsafe_arena_set_allocated_go_package(
     ::std::string* go_package) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (go_package != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (go_package != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -9204,7 +9204,7 @@ inline void FileOptions::set_objc_class_prefix(::std::string&& value) {
 }
 #endif
 inline void FileOptions::set_objc_class_prefix(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000008u;
   objc_class_prefix_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -9225,13 +9225,13 @@ inline ::std::string* FileOptions::mutable_objc_class_prefix() {
 inline ::std::string* FileOptions::release_objc_class_prefix() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileOptions.objc_class_prefix)
   if (!has_objc_class_prefix()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000008u;
   return objc_class_prefix_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileOptions::set_allocated_objc_class_prefix(::std::string* objc_class_prefix) {
-  if (objc_class_prefix != NULL) {
+  if (objc_class_prefix != nullptr) {
     _has_bits_[0] |= 0x00000008u;
   } else {
     _has_bits_[0] &= ~0x00000008u;
@@ -9242,15 +9242,15 @@ inline void FileOptions::set_allocated_objc_class_prefix(::std::string* objc_cla
 }
 inline ::std::string* FileOptions::unsafe_arena_release_objc_class_prefix() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileOptions.objc_class_prefix)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000008u;
   return objc_class_prefix_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileOptions::unsafe_arena_set_allocated_objc_class_prefix(
     ::std::string* objc_class_prefix) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (objc_class_prefix != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (objc_class_prefix != nullptr) {
     _has_bits_[0] |= 0x00000008u;
   } else {
     _has_bits_[0] &= ~0x00000008u;
@@ -9286,7 +9286,7 @@ inline void FileOptions::set_csharp_namespace(::std::string&& value) {
 }
 #endif
 inline void FileOptions::set_csharp_namespace(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000010u;
   csharp_namespace_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -9307,13 +9307,13 @@ inline ::std::string* FileOptions::mutable_csharp_namespace() {
 inline ::std::string* FileOptions::release_csharp_namespace() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileOptions.csharp_namespace)
   if (!has_csharp_namespace()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000010u;
   return csharp_namespace_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileOptions::set_allocated_csharp_namespace(::std::string* csharp_namespace) {
-  if (csharp_namespace != NULL) {
+  if (csharp_namespace != nullptr) {
     _has_bits_[0] |= 0x00000010u;
   } else {
     _has_bits_[0] &= ~0x00000010u;
@@ -9324,15 +9324,15 @@ inline void FileOptions::set_allocated_csharp_namespace(::std::string* csharp_na
 }
 inline ::std::string* FileOptions::unsafe_arena_release_csharp_namespace() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileOptions.csharp_namespace)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000010u;
   return csharp_namespace_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileOptions::unsafe_arena_set_allocated_csharp_namespace(
     ::std::string* csharp_namespace) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (csharp_namespace != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (csharp_namespace != nullptr) {
     _has_bits_[0] |= 0x00000010u;
   } else {
     _has_bits_[0] &= ~0x00000010u;
@@ -9368,7 +9368,7 @@ inline void FileOptions::set_swift_prefix(::std::string&& value) {
 }
 #endif
 inline void FileOptions::set_swift_prefix(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000020u;
   swift_prefix_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -9389,13 +9389,13 @@ inline ::std::string* FileOptions::mutable_swift_prefix() {
 inline ::std::string* FileOptions::release_swift_prefix() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileOptions.swift_prefix)
   if (!has_swift_prefix()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000020u;
   return swift_prefix_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileOptions::set_allocated_swift_prefix(::std::string* swift_prefix) {
-  if (swift_prefix != NULL) {
+  if (swift_prefix != nullptr) {
     _has_bits_[0] |= 0x00000020u;
   } else {
     _has_bits_[0] &= ~0x00000020u;
@@ -9406,15 +9406,15 @@ inline void FileOptions::set_allocated_swift_prefix(::std::string* swift_prefix)
 }
 inline ::std::string* FileOptions::unsafe_arena_release_swift_prefix() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileOptions.swift_prefix)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000020u;
   return swift_prefix_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileOptions::unsafe_arena_set_allocated_swift_prefix(
     ::std::string* swift_prefix) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (swift_prefix != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (swift_prefix != nullptr) {
     _has_bits_[0] |= 0x00000020u;
   } else {
     _has_bits_[0] &= ~0x00000020u;
@@ -9450,7 +9450,7 @@ inline void FileOptions::set_php_class_prefix(::std::string&& value) {
 }
 #endif
 inline void FileOptions::set_php_class_prefix(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000040u;
   php_class_prefix_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -9471,13 +9471,13 @@ inline ::std::string* FileOptions::mutable_php_class_prefix() {
 inline ::std::string* FileOptions::release_php_class_prefix() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileOptions.php_class_prefix)
   if (!has_php_class_prefix()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000040u;
   return php_class_prefix_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileOptions::set_allocated_php_class_prefix(::std::string* php_class_prefix) {
-  if (php_class_prefix != NULL) {
+  if (php_class_prefix != nullptr) {
     _has_bits_[0] |= 0x00000040u;
   } else {
     _has_bits_[0] &= ~0x00000040u;
@@ -9488,15 +9488,15 @@ inline void FileOptions::set_allocated_php_class_prefix(::std::string* php_class
 }
 inline ::std::string* FileOptions::unsafe_arena_release_php_class_prefix() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileOptions.php_class_prefix)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000040u;
   return php_class_prefix_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileOptions::unsafe_arena_set_allocated_php_class_prefix(
     ::std::string* php_class_prefix) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (php_class_prefix != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (php_class_prefix != nullptr) {
     _has_bits_[0] |= 0x00000040u;
   } else {
     _has_bits_[0] &= ~0x00000040u;
@@ -9532,7 +9532,7 @@ inline void FileOptions::set_php_namespace(::std::string&& value) {
 }
 #endif
 inline void FileOptions::set_php_namespace(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000080u;
   php_namespace_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -9553,13 +9553,13 @@ inline ::std::string* FileOptions::mutable_php_namespace() {
 inline ::std::string* FileOptions::release_php_namespace() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileOptions.php_namespace)
   if (!has_php_namespace()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000080u;
   return php_namespace_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileOptions::set_allocated_php_namespace(::std::string* php_namespace) {
-  if (php_namespace != NULL) {
+  if (php_namespace != nullptr) {
     _has_bits_[0] |= 0x00000080u;
   } else {
     _has_bits_[0] &= ~0x00000080u;
@@ -9570,15 +9570,15 @@ inline void FileOptions::set_allocated_php_namespace(::std::string* php_namespac
 }
 inline ::std::string* FileOptions::unsafe_arena_release_php_namespace() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileOptions.php_namespace)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000080u;
   return php_namespace_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileOptions::unsafe_arena_set_allocated_php_namespace(
     ::std::string* php_namespace) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (php_namespace != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (php_namespace != nullptr) {
     _has_bits_[0] |= 0x00000080u;
   } else {
     _has_bits_[0] &= ~0x00000080u;
@@ -9614,7 +9614,7 @@ inline void FileOptions::set_php_metadata_namespace(::std::string&& value) {
 }
 #endif
 inline void FileOptions::set_php_metadata_namespace(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000100u;
   php_metadata_namespace_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -9635,13 +9635,13 @@ inline ::std::string* FileOptions::mutable_php_metadata_namespace() {
 inline ::std::string* FileOptions::release_php_metadata_namespace() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileOptions.php_metadata_namespace)
   if (!has_php_metadata_namespace()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000100u;
   return php_metadata_namespace_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileOptions::set_allocated_php_metadata_namespace(::std::string* php_metadata_namespace) {
-  if (php_metadata_namespace != NULL) {
+  if (php_metadata_namespace != nullptr) {
     _has_bits_[0] |= 0x00000100u;
   } else {
     _has_bits_[0] &= ~0x00000100u;
@@ -9652,15 +9652,15 @@ inline void FileOptions::set_allocated_php_metadata_namespace(::std::string* php
 }
 inline ::std::string* FileOptions::unsafe_arena_release_php_metadata_namespace() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileOptions.php_metadata_namespace)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000100u;
   return php_metadata_namespace_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileOptions::unsafe_arena_set_allocated_php_metadata_namespace(
     ::std::string* php_metadata_namespace) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (php_metadata_namespace != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (php_metadata_namespace != nullptr) {
     _has_bits_[0] |= 0x00000100u;
   } else {
     _has_bits_[0] &= ~0x00000100u;
@@ -9696,7 +9696,7 @@ inline void FileOptions::set_ruby_package(::std::string&& value) {
 }
 #endif
 inline void FileOptions::set_ruby_package(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000200u;
   ruby_package_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -9717,13 +9717,13 @@ inline ::std::string* FileOptions::mutable_ruby_package() {
 inline ::std::string* FileOptions::release_ruby_package() {
   // @@protoc_insertion_point(field_release:google.protobuf.FileOptions.ruby_package)
   if (!has_ruby_package()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000200u;
   return ruby_package_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void FileOptions::set_allocated_ruby_package(::std::string* ruby_package) {
-  if (ruby_package != NULL) {
+  if (ruby_package != nullptr) {
     _has_bits_[0] |= 0x00000200u;
   } else {
     _has_bits_[0] &= ~0x00000200u;
@@ -9734,15 +9734,15 @@ inline void FileOptions::set_allocated_ruby_package(::std::string* ruby_package)
 }
 inline ::std::string* FileOptions::unsafe_arena_release_ruby_package() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.FileOptions.ruby_package)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000200u;
   return ruby_package_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void FileOptions::unsafe_arena_set_allocated_ruby_package(
     ::std::string* ruby_package) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (ruby_package != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (ruby_package != nullptr) {
     _has_bits_[0] |= 0x00000200u;
   } else {
     _has_bits_[0] &= ~0x00000200u;
@@ -10341,7 +10341,7 @@ inline void UninterpretedOption_NamePart::set_name_part(::std::string&& value) {
 }
 #endif
 inline void UninterpretedOption_NamePart::set_name_part(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   name_part_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -10362,13 +10362,13 @@ inline ::std::string* UninterpretedOption_NamePart::mutable_name_part() {
 inline ::std::string* UninterpretedOption_NamePart::release_name_part() {
   // @@protoc_insertion_point(field_release:google.protobuf.UninterpretedOption.NamePart.name_part)
   if (!has_name_part()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return name_part_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void UninterpretedOption_NamePart::set_allocated_name_part(::std::string* name_part) {
-  if (name_part != NULL) {
+  if (name_part != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -10379,15 +10379,15 @@ inline void UninterpretedOption_NamePart::set_allocated_name_part(::std::string*
 }
 inline ::std::string* UninterpretedOption_NamePart::unsafe_arena_release_name_part() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.UninterpretedOption.NamePart.name_part)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return name_part_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void UninterpretedOption_NamePart::unsafe_arena_set_allocated_name_part(
     ::std::string* name_part) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name_part != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name_part != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -10475,7 +10475,7 @@ inline void UninterpretedOption::set_identifier_value(::std::string&& value) {
 }
 #endif
 inline void UninterpretedOption::set_identifier_value(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   identifier_value_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -10496,13 +10496,13 @@ inline ::std::string* UninterpretedOption::mutable_identifier_value() {
 inline ::std::string* UninterpretedOption::release_identifier_value() {
   // @@protoc_insertion_point(field_release:google.protobuf.UninterpretedOption.identifier_value)
   if (!has_identifier_value()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return identifier_value_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void UninterpretedOption::set_allocated_identifier_value(::std::string* identifier_value) {
-  if (identifier_value != NULL) {
+  if (identifier_value != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -10513,15 +10513,15 @@ inline void UninterpretedOption::set_allocated_identifier_value(::std::string* i
 }
 inline ::std::string* UninterpretedOption::unsafe_arena_release_identifier_value() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.UninterpretedOption.identifier_value)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return identifier_value_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void UninterpretedOption::unsafe_arena_set_allocated_identifier_value(
     ::std::string* identifier_value) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (identifier_value != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (identifier_value != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -10611,7 +10611,7 @@ inline void UninterpretedOption::set_string_value(::std::string&& value) {
 }
 #endif
 inline void UninterpretedOption::set_string_value(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000002u;
   string_value_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -10632,13 +10632,13 @@ inline ::std::string* UninterpretedOption::mutable_string_value() {
 inline ::std::string* UninterpretedOption::release_string_value() {
   // @@protoc_insertion_point(field_release:google.protobuf.UninterpretedOption.string_value)
   if (!has_string_value()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000002u;
   return string_value_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void UninterpretedOption::set_allocated_string_value(::std::string* string_value) {
-  if (string_value != NULL) {
+  if (string_value != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -10649,15 +10649,15 @@ inline void UninterpretedOption::set_allocated_string_value(::std::string* strin
 }
 inline ::std::string* UninterpretedOption::unsafe_arena_release_string_value() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.UninterpretedOption.string_value)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000002u;
   return string_value_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void UninterpretedOption::unsafe_arena_set_allocated_string_value(
     ::std::string* string_value) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (string_value != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (string_value != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -10693,7 +10693,7 @@ inline void UninterpretedOption::set_aggregate_value(::std::string&& value) {
 }
 #endif
 inline void UninterpretedOption::set_aggregate_value(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000004u;
   aggregate_value_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -10714,13 +10714,13 @@ inline ::std::string* UninterpretedOption::mutable_aggregate_value() {
 inline ::std::string* UninterpretedOption::release_aggregate_value() {
   // @@protoc_insertion_point(field_release:google.protobuf.UninterpretedOption.aggregate_value)
   if (!has_aggregate_value()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000004u;
   return aggregate_value_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void UninterpretedOption::set_allocated_aggregate_value(::std::string* aggregate_value) {
-  if (aggregate_value != NULL) {
+  if (aggregate_value != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -10731,15 +10731,15 @@ inline void UninterpretedOption::set_allocated_aggregate_value(::std::string* ag
 }
 inline ::std::string* UninterpretedOption::unsafe_arena_release_aggregate_value() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.UninterpretedOption.aggregate_value)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000004u;
   return aggregate_value_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void UninterpretedOption::unsafe_arena_set_allocated_aggregate_value(
     ::std::string* aggregate_value) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (aggregate_value != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (aggregate_value != nullptr) {
     _has_bits_[0] |= 0x00000004u;
   } else {
     _has_bits_[0] &= ~0x00000004u;
@@ -10839,7 +10839,7 @@ inline void SourceCodeInfo_Location::set_leading_comments(::std::string&& value)
 }
 #endif
 inline void SourceCodeInfo_Location::set_leading_comments(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   leading_comments_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -10860,13 +10860,13 @@ inline ::std::string* SourceCodeInfo_Location::mutable_leading_comments() {
 inline ::std::string* SourceCodeInfo_Location::release_leading_comments() {
   // @@protoc_insertion_point(field_release:google.protobuf.SourceCodeInfo.Location.leading_comments)
   if (!has_leading_comments()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return leading_comments_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void SourceCodeInfo_Location::set_allocated_leading_comments(::std::string* leading_comments) {
-  if (leading_comments != NULL) {
+  if (leading_comments != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -10877,15 +10877,15 @@ inline void SourceCodeInfo_Location::set_allocated_leading_comments(::std::strin
 }
 inline ::std::string* SourceCodeInfo_Location::unsafe_arena_release_leading_comments() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.SourceCodeInfo.Location.leading_comments)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return leading_comments_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void SourceCodeInfo_Location::unsafe_arena_set_allocated_leading_comments(
     ::std::string* leading_comments) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (leading_comments != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (leading_comments != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -10921,7 +10921,7 @@ inline void SourceCodeInfo_Location::set_trailing_comments(::std::string&& value
 }
 #endif
 inline void SourceCodeInfo_Location::set_trailing_comments(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000002u;
   trailing_comments_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -10942,13 +10942,13 @@ inline ::std::string* SourceCodeInfo_Location::mutable_trailing_comments() {
 inline ::std::string* SourceCodeInfo_Location::release_trailing_comments() {
   // @@protoc_insertion_point(field_release:google.protobuf.SourceCodeInfo.Location.trailing_comments)
   if (!has_trailing_comments()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000002u;
   return trailing_comments_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void SourceCodeInfo_Location::set_allocated_trailing_comments(::std::string* trailing_comments) {
-  if (trailing_comments != NULL) {
+  if (trailing_comments != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -10959,15 +10959,15 @@ inline void SourceCodeInfo_Location::set_allocated_trailing_comments(::std::stri
 }
 inline ::std::string* SourceCodeInfo_Location::unsafe_arena_release_trailing_comments() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.SourceCodeInfo.Location.trailing_comments)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000002u;
   return trailing_comments_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void SourceCodeInfo_Location::unsafe_arena_set_allocated_trailing_comments(
     ::std::string* trailing_comments) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (trailing_comments != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (trailing_comments != nullptr) {
     _has_bits_[0] |= 0x00000002u;
   } else {
     _has_bits_[0] &= ~0x00000002u;
@@ -11003,7 +11003,7 @@ inline void SourceCodeInfo_Location::set_leading_detached_comments(int index, ::
 }
 #endif
 inline void SourceCodeInfo_Location::set_leading_detached_comments(int index, const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   leading_detached_comments_.Mutable(index)->assign(value);
   // @@protoc_insertion_point(field_set_char:google.protobuf.SourceCodeInfo.Location.leading_detached_comments)
 }
@@ -11027,7 +11027,7 @@ inline void SourceCodeInfo_Location::add_leading_detached_comments(::std::string
 }
 #endif
 inline void SourceCodeInfo_Location::add_leading_detached_comments(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   leading_detached_comments_.Add()->assign(value);
   // @@protoc_insertion_point(field_add_char:google.protobuf.SourceCodeInfo.Location.leading_detached_comments)
 }
@@ -11140,7 +11140,7 @@ inline void GeneratedCodeInfo_Annotation::set_source_file(::std::string&& value)
 }
 #endif
 inline void GeneratedCodeInfo_Annotation::set_source_file(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   _has_bits_[0] |= 0x00000001u;
   source_file_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -11161,13 +11161,13 @@ inline ::std::string* GeneratedCodeInfo_Annotation::mutable_source_file() {
 inline ::std::string* GeneratedCodeInfo_Annotation::release_source_file() {
   // @@protoc_insertion_point(field_release:google.protobuf.GeneratedCodeInfo.Annotation.source_file)
   if (!has_source_file()) {
-    return NULL;
+    return nullptr;
   }
   _has_bits_[0] &= ~0x00000001u;
   return source_file_.ReleaseNonDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void GeneratedCodeInfo_Annotation::set_allocated_source_file(::std::string* source_file) {
-  if (source_file != NULL) {
+  if (source_file != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;
@@ -11178,15 +11178,15 @@ inline void GeneratedCodeInfo_Annotation::set_allocated_source_file(::std::strin
 }
 inline ::std::string* GeneratedCodeInfo_Annotation::unsafe_arena_release_source_file() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.GeneratedCodeInfo.Annotation.source_file)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   _has_bits_[0] &= ~0x00000001u;
   return source_file_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void GeneratedCodeInfo_Annotation::unsafe_arena_set_allocated_source_file(
     ::std::string* source_file) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (source_file != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (source_file != nullptr) {
     _has_bits_[0] |= 0x00000001u;
   } else {
     _has_bits_[0] &= ~0x00000001u;

--- a/src/google/protobuf/duration.pb.cc
+++ b/src/google/protobuf/duration.pb.cc
@@ -109,7 +109,7 @@ const int Duration::kNanosFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Duration::Duration()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Duration)
 }
@@ -122,7 +122,7 @@ Duration::Duration(::google::protobuf::Arena* arena)
 }
 Duration::Duration(const Duration& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::memcpy(&seconds_, &from.seconds_,
     static_cast<size_t>(reinterpret_cast<char*>(&nanos_) -
@@ -142,7 +142,7 @@ Duration::~Duration() {
 }
 
 void Duration::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void Duration::ArenaDtor(void* object) {
@@ -372,7 +372,7 @@ void Duration::MergeFrom(const ::google::protobuf::Message& from) {
   const Duration* source =
       ::google::protobuf::DynamicCastToGenerated<Duration>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Duration)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -423,7 +423,7 @@ void Duration::Swap(Duration* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }

--- a/src/google/protobuf/duration.pb.h
+++ b/src/google/protobuf/duration.pb.h
@@ -115,7 +115,7 @@ class PROTOBUF_EXPORT Duration : public ::google::protobuf::Message /* @@protoc_
   // implements Message ----------------------------------------------
 
   inline Duration* New() const final {
-    return CreateMaybeMessage<Duration>(NULL);
+    return CreateMaybeMessage<Duration>(nullptr);
   }
 
   Duration* New(::google::protobuf::Arena* arena) const final {

--- a/src/google/protobuf/empty.pb.cc
+++ b/src/google/protobuf/empty.pb.cc
@@ -104,7 +104,7 @@ class Empty::HasBitSetters {
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Empty::Empty()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Empty)
 }
@@ -117,7 +117,7 @@ Empty::Empty(::google::protobuf::Arena* arena)
 }
 Empty::Empty(const Empty& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Empty)
 }
@@ -131,7 +131,7 @@ Empty::~Empty() {
 }
 
 void Empty::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void Empty::ArenaDtor(void* object) {
@@ -273,7 +273,7 @@ void Empty::MergeFrom(const ::google::protobuf::Message& from) {
   const Empty* source =
       ::google::protobuf::DynamicCastToGenerated<Empty>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Empty)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -318,7 +318,7 @@ void Empty::Swap(Empty* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }

--- a/src/google/protobuf/empty.pb.h
+++ b/src/google/protobuf/empty.pb.h
@@ -115,7 +115,7 @@ class PROTOBUF_EXPORT Empty : public ::google::protobuf::Message /* @@protoc_ins
   // implements Message ----------------------------------------------
 
   inline Empty* New() const final {
-    return CreateMaybeMessage<Empty>(NULL);
+    return CreateMaybeMessage<Empty>(nullptr);
   }
 
   Empty* New(::google::protobuf::Arena* arena) const final {

--- a/src/google/protobuf/field_mask.pb.cc
+++ b/src/google/protobuf/field_mask.pb.cc
@@ -107,7 +107,7 @@ const int FieldMask::kPathsFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 FieldMask::FieldMask()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.FieldMask)
 }
@@ -121,7 +121,7 @@ FieldMask::FieldMask(::google::protobuf::Arena* arena)
 }
 FieldMask::FieldMask(const FieldMask& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       paths_(from.paths_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   // @@protoc_insertion_point(copy_constructor:google.protobuf.FieldMask)
@@ -138,7 +138,7 @@ FieldMask::~FieldMask() {
 }
 
 void FieldMask::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void FieldMask::ArenaDtor(void* object) {
@@ -352,7 +352,7 @@ void FieldMask::MergeFrom(const ::google::protobuf::Message& from) {
   const FieldMask* source =
       ::google::protobuf::DynamicCastToGenerated<FieldMask>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.FieldMask)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -398,7 +398,7 @@ void FieldMask::Swap(FieldMask* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }

--- a/src/google/protobuf/field_mask.pb.h
+++ b/src/google/protobuf/field_mask.pb.h
@@ -115,7 +115,7 @@ class PROTOBUF_EXPORT FieldMask : public ::google::protobuf::Message /* @@protoc
   // implements Message ----------------------------------------------
 
   inline FieldMask* New() const final {
-    return CreateMaybeMessage<FieldMask>(NULL);
+    return CreateMaybeMessage<FieldMask>(nullptr);
   }
 
   FieldMask* New(::google::protobuf::Arena* arena) const final {
@@ -238,7 +238,7 @@ inline void FieldMask::set_paths(int index, ::std::string&& value) {
 }
 #endif
 inline void FieldMask::set_paths(int index, const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   paths_.Mutable(index)->assign(value);
   // @@protoc_insertion_point(field_set_char:google.protobuf.FieldMask.paths)
 }
@@ -262,7 +262,7 @@ inline void FieldMask::add_paths(::std::string&& value) {
 }
 #endif
 inline void FieldMask::add_paths(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   paths_.Add()->assign(value);
   // @@protoc_insertion_point(field_add_char:google.protobuf.FieldMask.paths)
 }

--- a/src/google/protobuf/source_context.pb.cc
+++ b/src/google/protobuf/source_context.pb.cc
@@ -108,13 +108,13 @@ const int SourceContext::kFileNameFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 SourceContext::SourceContext()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.SourceContext)
 }
 SourceContext::SourceContext(const SourceContext& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   file_name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (from.file_name().size() > 0) {
@@ -339,7 +339,7 @@ void SourceContext::MergeFrom(const ::google::protobuf::Message& from) {
   const SourceContext* source =
       ::google::protobuf::DynamicCastToGenerated<SourceContext>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.SourceContext)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {

--- a/src/google/protobuf/source_context.pb.h
+++ b/src/google/protobuf/source_context.pb.h
@@ -108,7 +108,7 @@ class PROTOBUF_EXPORT SourceContext : public ::google::protobuf::Message /* @@pr
   // implements Message ----------------------------------------------
 
   inline SourceContext* New() const final {
-    return CreateMaybeMessage<SourceContext>(NULL);
+    return CreateMaybeMessage<SourceContext>(nullptr);
   }
 
   SourceContext* New(::google::protobuf::Arena* arena) const final {
@@ -142,10 +142,10 @@ class PROTOBUF_EXPORT SourceContext : public ::google::protobuf::Message /* @@pr
   void InternalSwap(SourceContext* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
+    return nullptr;
   }
   inline void* MaybeArenaPtr() const {
-    return NULL;
+    return nullptr;
   }
   public:
 
@@ -211,7 +211,7 @@ inline void SourceContext::set_file_name(::std::string&& value) {
 }
 #endif
 inline void SourceContext::set_file_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   file_name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
   // @@protoc_insertion_point(field_set_char:google.protobuf.SourceContext.file_name)
@@ -233,7 +233,7 @@ inline ::std::string* SourceContext::release_file_name() {
   return file_name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 inline void SourceContext::set_allocated_file_name(::std::string* file_name) {
-  if (file_name != NULL) {
+  if (file_name != nullptr) {
     
   } else {
     

--- a/src/google/protobuf/struct.pb.cc
+++ b/src/google/protobuf/struct.pb.cc
@@ -237,7 +237,7 @@ const int Struct::kFieldsFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Struct::Struct()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Struct)
 }
@@ -251,7 +251,7 @@ Struct::Struct(::google::protobuf::Arena* arena)
 }
 Struct::Struct(const Struct& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   fields_.MergeFrom(from.fields_);
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Struct)
@@ -268,7 +268,7 @@ Struct::~Struct() {
 }
 
 void Struct::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void Struct::ArenaDtor(void* object) {
@@ -442,7 +442,7 @@ void Struct::SerializeWithCachedSizes(
       for (size_type i = 0; i < n; i++) {
         entry.reset(fields_.NewEntryWrapper(items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
         ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(1, *entry, output);
-        if (entry->GetArena() != NULL) {
+        if (entry->GetArena() != nullptr) {
           entry.release();
         }
         Utf8Check::Check(&(*items[static_cast<ptrdiff_t>(i)]));
@@ -454,7 +454,7 @@ void Struct::SerializeWithCachedSizes(
           it != this->fields().end(); ++it) {
         entry.reset(fields_.NewEntryWrapper(it->first, it->second));
         ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(1, *entry, output);
-        if (entry->GetArena() != NULL) {
+        if (entry->GetArena() != nullptr) {
           entry.release();
         }
         Utf8Check::Check(&(*it));
@@ -507,7 +507,7 @@ void Struct::SerializeWithCachedSizes(
       for (size_type i = 0; i < n; i++) {
         entry.reset(fields_.NewEntryWrapper(items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
         target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessageNoVirtualToArray(1, *entry, deterministic, target);
-        if (entry->GetArena() != NULL) {
+        if (entry->GetArena() != nullptr) {
           entry.release();
         }
         Utf8Check::Check(&(*items[static_cast<ptrdiff_t>(i)]));
@@ -519,7 +519,7 @@ void Struct::SerializeWithCachedSizes(
           it != this->fields().end(); ++it) {
         entry.reset(fields_.NewEntryWrapper(it->first, it->second));
         target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessageNoVirtualToArray(1, *entry, deterministic, target);
-        if (entry->GetArena() != NULL) {
+        if (entry->GetArena() != nullptr) {
           entry.release();
         }
         Utf8Check::Check(&(*it));
@@ -556,14 +556,14 @@ size_t Struct::ByteSizeLong() const {
     for (::google::protobuf::Map< ::std::string, ::google::protobuf::Value >::const_iterator
         it = this->fields().begin();
         it != this->fields().end(); ++it) {
-      if (entry.get() != NULL && entry->GetArena() != NULL) {
+      if (entry.get() != nullptr && entry->GetArena() != nullptr) {
         entry.release();
       }
       entry.reset(fields_.NewEntryWrapper(it->first, it->second));
       total_size += ::google::protobuf::internal::WireFormatLite::
           MessageSizeNoVirtual(*entry);
     }
-    if (entry.get() != NULL && entry->GetArena() != NULL) {
+    if (entry.get() != nullptr && entry->GetArena() != nullptr) {
       entry.release();
     }
   }
@@ -579,7 +579,7 @@ void Struct::MergeFrom(const ::google::protobuf::Message& from) {
   const Struct* source =
       ::google::protobuf::DynamicCastToGenerated<Struct>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Struct)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -625,7 +625,7 @@ void Struct::Swap(Struct* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -714,7 +714,7 @@ const int Value::kListValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Value::Value()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Value)
 }
@@ -727,7 +727,7 @@ Value::Value(::google::protobuf::Arena* arena)
 }
 Value::Value(const Value& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   clear_has_kind();
   switch (from.kind_case()) {
@@ -774,7 +774,7 @@ Value::~Value() {
 }
 
 void Value::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   if (has_kind()) {
     clear_kind();
   }
@@ -816,13 +816,13 @@ void Value::clear_kind() {
       break;
     }
     case kStructValue: {
-      if (GetArenaNoVirtual() == NULL) {
+      if (GetArenaNoVirtual() == nullptr) {
         delete kind_.struct_value_;
       }
       break;
     }
     case kListValue: {
-      if (GetArenaNoVirtual() == NULL) {
+      if (GetArenaNoVirtual() == nullptr) {
         delete kind_.list_value_;
       }
       break;
@@ -1243,7 +1243,7 @@ void Value::MergeFrom(const ::google::protobuf::Message& from) {
   const Value* source =
       ::google::protobuf::DynamicCastToGenerated<Value>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Value)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1317,7 +1317,7 @@ void Value::Swap(Value* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -1353,7 +1353,7 @@ const int ListValue::kValuesFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ListValue::ListValue()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.ListValue)
 }
@@ -1367,7 +1367,7 @@ ListValue::ListValue(::google::protobuf::Arena* arena)
 }
 ListValue::ListValue(const ListValue& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       values_(from.values_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   // @@protoc_insertion_point(copy_constructor:google.protobuf.ListValue)
@@ -1384,7 +1384,7 @@ ListValue::~ListValue() {
 }
 
 void ListValue::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void ListValue::ArenaDtor(void* object) {
@@ -1589,7 +1589,7 @@ void ListValue::MergeFrom(const ::google::protobuf::Message& from) {
   const ListValue* source =
       ::google::protobuf::DynamicCastToGenerated<ListValue>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.ListValue)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1635,7 +1635,7 @@ void ListValue::Swap(ListValue* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }

--- a/src/google/protobuf/struct.pb.h
+++ b/src/google/protobuf/struct.pb.h
@@ -175,7 +175,7 @@ class PROTOBUF_EXPORT Struct : public ::google::protobuf::Message /* @@protoc_in
   // implements Message ----------------------------------------------
 
   inline Struct* New() const final {
-    return CreateMaybeMessage<Struct>(NULL);
+    return CreateMaybeMessage<Struct>(nullptr);
   }
 
   Struct* New(::google::protobuf::Arena* arena) const final {
@@ -320,7 +320,7 @@ class PROTOBUF_EXPORT Value : public ::google::protobuf::Message /* @@protoc_ins
   // implements Message ----------------------------------------------
 
   inline Value* New() const final {
-    return CreateMaybeMessage<Value>(NULL);
+    return CreateMaybeMessage<Value>(nullptr);
   }
 
   Value* New(::google::protobuf::Arena* arena) const final {
@@ -538,7 +538,7 @@ class PROTOBUF_EXPORT ListValue : public ::google::protobuf::Message /* @@protoc
   // implements Message ----------------------------------------------
 
   inline ListValue* New() const final {
-    return CreateMaybeMessage<ListValue>(NULL);
+    return CreateMaybeMessage<ListValue>(nullptr);
   }
 
   ListValue* New(::google::protobuf::Arena* arena) const final {
@@ -752,7 +752,7 @@ inline void Value::set_string_value(::std::string&& value) {
 }
 #endif
 inline void Value::set_string_value(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   if (!has_string_value()) {
     clear_kind();
     set_has_string_value();
@@ -792,14 +792,14 @@ inline ::std::string* Value::release_string_value() {
     return kind_.string_value_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
         GetArenaNoVirtual());
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 inline void Value::set_allocated_string_value(::std::string* string_value) {
   if (has_kind()) {
     clear_kind();
   }
-  if (string_value != NULL) {
+  if (string_value != nullptr) {
     set_has_string_value();
     kind_.string_value_.UnsafeSetDefault(string_value);
   }
@@ -807,17 +807,17 @@ inline void Value::set_allocated_string_value(::std::string* string_value) {
 }
 inline ::std::string* Value::unsafe_arena_release_string_value() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Value.string_value)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   if (has_string_value()) {
     clear_has_kind();
     return kind_.string_value_.UnsafeArenaRelease(
         &::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 inline void Value::unsafe_arena_set_allocated_string_value(::std::string* string_value) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   if (!has_string_value()) {
     kind_.string_value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   }
@@ -867,7 +867,7 @@ inline void Value::set_has_struct_value() {
 }
 inline void Value::clear_struct_value() {
   if (has_struct_value()) {
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete kind_.struct_value_;
     }
     clear_has_kind();
@@ -878,13 +878,13 @@ inline ::google::protobuf::Struct* Value::release_struct_value() {
   if (has_struct_value()) {
     clear_has_kind();
       ::google::protobuf::Struct* temp = kind_.struct_value_;
-    if (GetArenaNoVirtual() != NULL) {
+    if (GetArenaNoVirtual() != nullptr) {
       temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
     }
-    kind_.struct_value_ = NULL;
+    kind_.struct_value_ = nullptr;
     return temp;
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 inline const ::google::protobuf::Struct& Value::struct_value() const {
@@ -898,10 +898,10 @@ inline ::google::protobuf::Struct* Value::unsafe_arena_release_struct_value() {
   if (has_struct_value()) {
     clear_has_kind();
     ::google::protobuf::Struct* temp = kind_.struct_value_;
-    kind_.struct_value_ = NULL;
+    kind_.struct_value_ = nullptr;
     return temp;
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 inline void Value::unsafe_arena_set_allocated_struct_value(::google::protobuf::Struct* struct_value) {
@@ -932,7 +932,7 @@ inline void Value::set_has_list_value() {
 }
 inline void Value::clear_list_value() {
   if (has_list_value()) {
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete kind_.list_value_;
     }
     clear_has_kind();
@@ -943,13 +943,13 @@ inline ::google::protobuf::ListValue* Value::release_list_value() {
   if (has_list_value()) {
     clear_has_kind();
       ::google::protobuf::ListValue* temp = kind_.list_value_;
-    if (GetArenaNoVirtual() != NULL) {
+    if (GetArenaNoVirtual() != nullptr) {
       temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
     }
-    kind_.list_value_ = NULL;
+    kind_.list_value_ = nullptr;
     return temp;
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 inline const ::google::protobuf::ListValue& Value::list_value() const {
@@ -963,10 +963,10 @@ inline ::google::protobuf::ListValue* Value::unsafe_arena_release_list_value() {
   if (has_list_value()) {
     clear_has_kind();
     ::google::protobuf::ListValue* temp = kind_.list_value_;
-    kind_.list_value_ = NULL;
+    kind_.list_value_ = nullptr;
     return temp;
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 inline void Value::unsafe_arena_set_allocated_list_value(::google::protobuf::ListValue* list_value) {

--- a/src/google/protobuf/timestamp.pb.cc
+++ b/src/google/protobuf/timestamp.pb.cc
@@ -109,7 +109,7 @@ const int Timestamp::kNanosFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Timestamp::Timestamp()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Timestamp)
 }
@@ -122,7 +122,7 @@ Timestamp::Timestamp(::google::protobuf::Arena* arena)
 }
 Timestamp::Timestamp(const Timestamp& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::memcpy(&seconds_, &from.seconds_,
     static_cast<size_t>(reinterpret_cast<char*>(&nanos_) -
@@ -142,7 +142,7 @@ Timestamp::~Timestamp() {
 }
 
 void Timestamp::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void Timestamp::ArenaDtor(void* object) {
@@ -372,7 +372,7 @@ void Timestamp::MergeFrom(const ::google::protobuf::Message& from) {
   const Timestamp* source =
       ::google::protobuf::DynamicCastToGenerated<Timestamp>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Timestamp)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -423,7 +423,7 @@ void Timestamp::Swap(Timestamp* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }

--- a/src/google/protobuf/timestamp.pb.h
+++ b/src/google/protobuf/timestamp.pb.h
@@ -115,7 +115,7 @@ class PROTOBUF_EXPORT Timestamp : public ::google::protobuf::Message /* @@protoc
   // implements Message ----------------------------------------------
 
   inline Timestamp* New() const final {
-    return CreateMaybeMessage<Timestamp>(NULL);
+    return CreateMaybeMessage<Timestamp>(nullptr);
   }
 
   Timestamp* New(::google::protobuf::Arena* arena) const final {

--- a/src/google/protobuf/type.pb.cc
+++ b/src/google/protobuf/type.pb.cc
@@ -384,7 +384,7 @@ Type::HasBitSetters::source_context(const Type* msg) {
 }
 void Type::unsafe_arena_set_allocated_source_context(
     ::google::protobuf::SourceContext* source_context) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete source_context_;
   }
   source_context_ = source_context;
@@ -396,10 +396,10 @@ void Type::unsafe_arena_set_allocated_source_context(
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.Type.source_context)
 }
 void Type::clear_source_context() {
-  if (GetArenaNoVirtual() == NULL && source_context_ != NULL) {
+  if (GetArenaNoVirtual() == nullptr && source_context_ != nullptr) {
     delete source_context_;
   }
-  source_context_ = NULL;
+  source_context_ = nullptr;
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int Type::kNameFieldNumber;
@@ -411,7 +411,7 @@ const int Type::kSyntaxFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Type::Type()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Type)
 }
@@ -427,7 +427,7 @@ Type::Type(::google::protobuf::Arena* arena)
 }
 Type::Type(const Type& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       fields_(from.fields_),
       oneofs_(from.oneofs_),
       options_(from.options_) {
@@ -440,7 +440,7 @@ Type::Type(const Type& from)
   if (from.has_source_context()) {
     source_context_ = new ::google::protobuf::SourceContext(*from.source_context_);
   } else {
-    source_context_ = NULL;
+    source_context_ = nullptr;
   }
   syntax_ = from.syntax_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Type)
@@ -461,7 +461,7 @@ Type::~Type() {
 }
 
 void Type::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != internal_default_instance()) delete source_context_;
 }
@@ -491,10 +491,10 @@ void Type::Clear() {
   oneofs_.Clear();
   options_.Clear();
   name_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
-  if (GetArenaNoVirtual() == NULL && source_context_ != NULL) {
+  if (GetArenaNoVirtual() == nullptr && source_context_ != nullptr) {
     delete source_context_;
   }
-  source_context_ = NULL;
+  source_context_ = nullptr;
   syntax_ = 0;
   _internal_metadata_.Clear();
 }
@@ -949,7 +949,7 @@ void Type::MergeFrom(const ::google::protobuf::Message& from) {
   const Type* source =
       ::google::protobuf::DynamicCastToGenerated<Type>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Type)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1006,7 +1006,7 @@ void Type::Swap(Type* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -1056,7 +1056,7 @@ const int Field::kDefaultValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Field::Field()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Field)
 }
@@ -1070,7 +1070,7 @@ Field::Field(::google::protobuf::Arena* arena)
 }
 Field::Field(const Field& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       options_(from.options_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -1117,7 +1117,7 @@ Field::~Field() {
 }
 
 void Field::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   type_url_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   json_name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -1783,7 +1783,7 @@ void Field::MergeFrom(const ::google::protobuf::Message& from) {
   const Field* source =
       ::google::protobuf::DynamicCastToGenerated<Field>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Field)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1856,7 +1856,7 @@ void Field::Swap(Field* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -1908,7 +1908,7 @@ Enum::HasBitSetters::source_context(const Enum* msg) {
 }
 void Enum::unsafe_arena_set_allocated_source_context(
     ::google::protobuf::SourceContext* source_context) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete source_context_;
   }
   source_context_ = source_context;
@@ -1920,10 +1920,10 @@ void Enum::unsafe_arena_set_allocated_source_context(
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.Enum.source_context)
 }
 void Enum::clear_source_context() {
-  if (GetArenaNoVirtual() == NULL && source_context_ != NULL) {
+  if (GetArenaNoVirtual() == nullptr && source_context_ != nullptr) {
     delete source_context_;
   }
-  source_context_ = NULL;
+  source_context_ = nullptr;
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int Enum::kNameFieldNumber;
@@ -1934,7 +1934,7 @@ const int Enum::kSyntaxFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Enum::Enum()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Enum)
 }
@@ -1949,7 +1949,7 @@ Enum::Enum(::google::protobuf::Arena* arena)
 }
 Enum::Enum(const Enum& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       enumvalue_(from.enumvalue_),
       options_(from.options_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -1961,7 +1961,7 @@ Enum::Enum(const Enum& from)
   if (from.has_source_context()) {
     source_context_ = new ::google::protobuf::SourceContext(*from.source_context_);
   } else {
-    source_context_ = NULL;
+    source_context_ = nullptr;
   }
   syntax_ = from.syntax_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Enum)
@@ -1982,7 +1982,7 @@ Enum::~Enum() {
 }
 
 void Enum::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != internal_default_instance()) delete source_context_;
 }
@@ -2011,10 +2011,10 @@ void Enum::Clear() {
   enumvalue_.Clear();
   options_.Clear();
   name_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
-  if (GetArenaNoVirtual() == NULL && source_context_ != NULL) {
+  if (GetArenaNoVirtual() == nullptr && source_context_ != nullptr) {
     delete source_context_;
   }
-  source_context_ = NULL;
+  source_context_ = nullptr;
   syntax_ = 0;
   _internal_metadata_.Clear();
 }
@@ -2403,7 +2403,7 @@ void Enum::MergeFrom(const ::google::protobuf::Message& from) {
   const Enum* source =
       ::google::protobuf::DynamicCastToGenerated<Enum>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Enum)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -2459,7 +2459,7 @@ void Enum::Swap(Enum* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -2501,7 +2501,7 @@ const int EnumValue::kOptionsFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 EnumValue::EnumValue()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.EnumValue)
 }
@@ -2515,7 +2515,7 @@ EnumValue::EnumValue(::google::protobuf::Arena* arena)
 }
 EnumValue::EnumValue(const EnumValue& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL),
+      _internal_metadata_(nullptr),
       options_(from.options_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
@@ -2540,7 +2540,7 @@ EnumValue::~EnumValue() {
 }
 
 void EnumValue::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
@@ -2850,7 +2850,7 @@ void EnumValue::MergeFrom(const ::google::protobuf::Message& from) {
   const EnumValue* source =
       ::google::protobuf::DynamicCastToGenerated<EnumValue>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.EnumValue)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -2902,7 +2902,7 @@ void EnumValue::Swap(EnumValue* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -2944,7 +2944,7 @@ Option::HasBitSetters::value(const Option* msg) {
 }
 void Option::unsafe_arena_set_allocated_value(
     ::google::protobuf::Any* value) {
-  if (GetArenaNoVirtual() == NULL) {
+  if (GetArenaNoVirtual() == nullptr) {
     delete value_;
   }
   value_ = value;
@@ -2956,10 +2956,10 @@ void Option::unsafe_arena_set_allocated_value(
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.Option.value)
 }
 void Option::clear_value() {
-  if (GetArenaNoVirtual() == NULL && value_ != NULL) {
+  if (GetArenaNoVirtual() == nullptr && value_ != nullptr) {
     delete value_;
   }
-  value_ = NULL;
+  value_ = nullptr;
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int Option::kNameFieldNumber;
@@ -2967,7 +2967,7 @@ const int Option::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Option::Option()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Option)
 }
@@ -2980,7 +2980,7 @@ Option::Option(::google::protobuf::Arena* arena)
 }
 Option::Option(const Option& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (from.name().size() > 0) {
@@ -2990,7 +2990,7 @@ Option::Option(const Option& from)
   if (from.has_value()) {
     value_ = new ::google::protobuf::Any(*from.value_);
   } else {
-    value_ = NULL;
+    value_ = nullptr;
   }
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Option)
 }
@@ -2999,7 +2999,7 @@ void Option::SharedCtor() {
   ::google::protobuf::internal::InitSCC(
       &scc_info_Option_google_2fprotobuf_2ftype_2eproto.base);
   name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  value_ = NULL;
+  value_ = nullptr;
 }
 
 Option::~Option() {
@@ -3008,7 +3008,7 @@ Option::~Option() {
 }
 
 void Option::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != internal_default_instance()) delete value_;
 }
@@ -3035,10 +3035,10 @@ void Option::Clear() {
   (void) cached_has_bits;
 
   name_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
-  if (GetArenaNoVirtual() == NULL && value_ != NULL) {
+  if (GetArenaNoVirtual() == nullptr && value_ != nullptr) {
     delete value_;
   }
-  value_ = NULL;
+  value_ = nullptr;
   _internal_metadata_.Clear();
 }
 
@@ -3270,7 +3270,7 @@ void Option::MergeFrom(const ::google::protobuf::Message& from) {
   const Option* source =
       ::google::protobuf::DynamicCastToGenerated<Option>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Option)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -3321,7 +3321,7 @@ void Option::Swap(Option* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }

--- a/src/google/protobuf/type.pb.h
+++ b/src/google/protobuf/type.pb.h
@@ -216,7 +216,7 @@ class PROTOBUF_EXPORT Type : public ::google::protobuf::Message /* @@protoc_inse
   // implements Message ----------------------------------------------
 
   inline Type* New() const final {
-    return CreateMaybeMessage<Type>(NULL);
+    return CreateMaybeMessage<Type>(nullptr);
   }
 
   Type* New(::google::protobuf::Arena* arena) const final {
@@ -428,7 +428,7 @@ class PROTOBUF_EXPORT Field : public ::google::protobuf::Message /* @@protoc_ins
   // implements Message ----------------------------------------------
 
   inline Field* New() const final {
-    return CreateMaybeMessage<Field>(NULL);
+    return CreateMaybeMessage<Field>(nullptr);
   }
 
   Field* New(::google::protobuf::Arena* arena) const final {
@@ -781,7 +781,7 @@ class PROTOBUF_EXPORT Enum : public ::google::protobuf::Message /* @@protoc_inse
   // implements Message ----------------------------------------------
 
   inline Enum* New() const final {
-    return CreateMaybeMessage<Enum>(NULL);
+    return CreateMaybeMessage<Enum>(nullptr);
   }
 
   Enum* New(::google::protobuf::Arena* arena) const final {
@@ -970,7 +970,7 @@ class PROTOBUF_EXPORT EnumValue : public ::google::protobuf::Message /* @@protoc
   // implements Message ----------------------------------------------
 
   inline EnumValue* New() const final {
-    return CreateMaybeMessage<EnumValue>(NULL);
+    return CreateMaybeMessage<EnumValue>(nullptr);
   }
 
   EnumValue* New(::google::protobuf::Arena* arena) const final {
@@ -1133,7 +1133,7 @@ class PROTOBUF_EXPORT Option : public ::google::protobuf::Message /* @@protoc_in
   // implements Message ----------------------------------------------
 
   inline Option* New() const final {
-    return CreateMaybeMessage<Option>(NULL);
+    return CreateMaybeMessage<Option>(nullptr);
   }
 
   Option* New(::google::protobuf::Arena* arena) const final {
@@ -1266,7 +1266,7 @@ inline void Type::set_name(::std::string&& value) {
 }
 #endif
 inline void Type::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -1290,7 +1290,7 @@ inline ::std::string* Type::release_name() {
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void Type::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     
   } else {
     
@@ -1301,15 +1301,15 @@ inline void Type::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* Type::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Type.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void Type::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     
   } else {
     
@@ -1375,7 +1375,7 @@ inline void Type::set_oneofs(int index, ::std::string&& value) {
 }
 #endif
 inline void Type::set_oneofs(int index, const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   oneofs_.Mutable(index)->assign(value);
   // @@protoc_insertion_point(field_set_char:google.protobuf.Type.oneofs)
 }
@@ -1399,7 +1399,7 @@ inline void Type::add_oneofs(::std::string&& value) {
 }
 #endif
 inline void Type::add_oneofs(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   oneofs_.Add()->assign(value);
   // @@protoc_insertion_point(field_add_char:google.protobuf.Type.oneofs)
 }
@@ -1450,34 +1450,34 @@ Type::options() const {
 
 // .google.protobuf.SourceContext source_context = 5;
 inline bool Type::has_source_context() const {
-  return this != internal_default_instance() && source_context_ != NULL;
+  return this != internal_default_instance() && source_context_ != nullptr;
 }
 inline const ::google::protobuf::SourceContext& Type::source_context() const {
   const ::google::protobuf::SourceContext* p = source_context_;
   // @@protoc_insertion_point(field_get:google.protobuf.Type.source_context)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::SourceContext*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::SourceContext*>(
       &::google::protobuf::_SourceContext_default_instance_);
 }
 inline ::google::protobuf::SourceContext* Type::release_source_context() {
   // @@protoc_insertion_point(field_release:google.protobuf.Type.source_context)
   
   ::google::protobuf::SourceContext* temp = source_context_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  source_context_ = NULL;
+  source_context_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::SourceContext* Type::unsafe_arena_release_source_context() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Type.source_context)
   
   ::google::protobuf::SourceContext* temp = source_context_;
-  source_context_ = NULL;
+  source_context_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::SourceContext* Type::mutable_source_context() {
   
-  if (source_context_ == NULL) {
+  if (source_context_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::SourceContext>(GetArenaNoVirtual());
     source_context_ = p;
   }
@@ -1486,11 +1486,11 @@ inline ::google::protobuf::SourceContext* Type::mutable_source_context() {
 }
 inline void Type::set_allocated_source_context(::google::protobuf::SourceContext* source_context) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete reinterpret_cast< ::google::protobuf::MessageLite*>(source_context_);
   }
   if (source_context) {
-    ::google::protobuf::Arena* submessage_arena = NULL;
+    ::google::protobuf::Arena* submessage_arena = nullptr;
     if (message_arena != submessage_arena) {
       source_context = ::google::protobuf::internal::GetOwnedMessage(
           message_arena, source_context, submessage_arena);
@@ -1585,7 +1585,7 @@ inline void Field::set_name(::std::string&& value) {
 }
 #endif
 inline void Field::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -1609,7 +1609,7 @@ inline ::std::string* Field::release_name() {
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void Field::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     
   } else {
     
@@ -1620,15 +1620,15 @@ inline void Field::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* Field::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Field.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void Field::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     
   } else {
     
@@ -1660,7 +1660,7 @@ inline void Field::set_type_url(::std::string&& value) {
 }
 #endif
 inline void Field::set_type_url(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   type_url_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -1684,7 +1684,7 @@ inline ::std::string* Field::release_type_url() {
   return type_url_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void Field::set_allocated_type_url(::std::string* type_url) {
-  if (type_url != NULL) {
+  if (type_url != nullptr) {
     
   } else {
     
@@ -1695,15 +1695,15 @@ inline void Field::set_allocated_type_url(::std::string* type_url) {
 }
 inline ::std::string* Field::unsafe_arena_release_type_url() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Field.type_url)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   
   return type_url_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void Field::unsafe_arena_set_allocated_type_url(
     ::std::string* type_url) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (type_url != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (type_url != nullptr) {
     
   } else {
     
@@ -1793,7 +1793,7 @@ inline void Field::set_json_name(::std::string&& value) {
 }
 #endif
 inline void Field::set_json_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   json_name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -1817,7 +1817,7 @@ inline ::std::string* Field::release_json_name() {
   return json_name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void Field::set_allocated_json_name(::std::string* json_name) {
-  if (json_name != NULL) {
+  if (json_name != nullptr) {
     
   } else {
     
@@ -1828,15 +1828,15 @@ inline void Field::set_allocated_json_name(::std::string* json_name) {
 }
 inline ::std::string* Field::unsafe_arena_release_json_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Field.json_name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   
   return json_name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void Field::unsafe_arena_set_allocated_json_name(
     ::std::string* json_name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (json_name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (json_name != nullptr) {
     
   } else {
     
@@ -1868,7 +1868,7 @@ inline void Field::set_default_value(::std::string&& value) {
 }
 #endif
 inline void Field::set_default_value(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   default_value_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -1892,7 +1892,7 @@ inline ::std::string* Field::release_default_value() {
   return default_value_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void Field::set_allocated_default_value(::std::string* default_value) {
-  if (default_value != NULL) {
+  if (default_value != nullptr) {
     
   } else {
     
@@ -1903,15 +1903,15 @@ inline void Field::set_allocated_default_value(::std::string* default_value) {
 }
 inline ::std::string* Field::unsafe_arena_release_default_value() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Field.default_value)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   
   return default_value_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void Field::unsafe_arena_set_allocated_default_value(
     ::std::string* default_value) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (default_value != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (default_value != nullptr) {
     
   } else {
     
@@ -1947,7 +1947,7 @@ inline void Enum::set_name(::std::string&& value) {
 }
 #endif
 inline void Enum::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -1971,7 +1971,7 @@ inline ::std::string* Enum::release_name() {
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void Enum::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     
   } else {
     
@@ -1982,15 +1982,15 @@ inline void Enum::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* Enum::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Enum.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void Enum::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     
   } else {
     
@@ -2062,34 +2062,34 @@ Enum::options() const {
 
 // .google.protobuf.SourceContext source_context = 4;
 inline bool Enum::has_source_context() const {
-  return this != internal_default_instance() && source_context_ != NULL;
+  return this != internal_default_instance() && source_context_ != nullptr;
 }
 inline const ::google::protobuf::SourceContext& Enum::source_context() const {
   const ::google::protobuf::SourceContext* p = source_context_;
   // @@protoc_insertion_point(field_get:google.protobuf.Enum.source_context)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::SourceContext*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::SourceContext*>(
       &::google::protobuf::_SourceContext_default_instance_);
 }
 inline ::google::protobuf::SourceContext* Enum::release_source_context() {
   // @@protoc_insertion_point(field_release:google.protobuf.Enum.source_context)
   
   ::google::protobuf::SourceContext* temp = source_context_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  source_context_ = NULL;
+  source_context_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::SourceContext* Enum::unsafe_arena_release_source_context() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Enum.source_context)
   
   ::google::protobuf::SourceContext* temp = source_context_;
-  source_context_ = NULL;
+  source_context_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::SourceContext* Enum::mutable_source_context() {
   
-  if (source_context_ == NULL) {
+  if (source_context_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::SourceContext>(GetArenaNoVirtual());
     source_context_ = p;
   }
@@ -2098,11 +2098,11 @@ inline ::google::protobuf::SourceContext* Enum::mutable_source_context() {
 }
 inline void Enum::set_allocated_source_context(::google::protobuf::SourceContext* source_context) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete reinterpret_cast< ::google::protobuf::MessageLite*>(source_context_);
   }
   if (source_context) {
-    ::google::protobuf::Arena* submessage_arena = NULL;
+    ::google::protobuf::Arena* submessage_arena = nullptr;
     if (message_arena != submessage_arena) {
       source_context = ::google::protobuf::internal::GetOwnedMessage(
           message_arena, source_context, submessage_arena);
@@ -2155,7 +2155,7 @@ inline void EnumValue::set_name(::std::string&& value) {
 }
 #endif
 inline void EnumValue::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -2179,7 +2179,7 @@ inline ::std::string* EnumValue::release_name() {
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void EnumValue::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     
   } else {
     
@@ -2190,15 +2190,15 @@ inline void EnumValue::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* EnumValue::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.EnumValue.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void EnumValue::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     
   } else {
     
@@ -2278,7 +2278,7 @@ inline void Option::set_name(::std::string&& value) {
 }
 #endif
 inline void Option::set_name(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -2302,7 +2302,7 @@ inline ::std::string* Option::release_name() {
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void Option::set_allocated_name(::std::string* name) {
-  if (name != NULL) {
+  if (name != nullptr) {
     
   } else {
     
@@ -2313,15 +2313,15 @@ inline void Option::set_allocated_name(::std::string* name) {
 }
 inline ::std::string* Option::unsafe_arena_release_name() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Option.name)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void Option::unsafe_arena_set_allocated_name(
     ::std::string* name) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (name != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (name != nullptr) {
     
   } else {
     
@@ -2333,34 +2333,34 @@ inline void Option::unsafe_arena_set_allocated_name(
 
 // .google.protobuf.Any value = 2;
 inline bool Option::has_value() const {
-  return this != internal_default_instance() && value_ != NULL;
+  return this != internal_default_instance() && value_ != nullptr;
 }
 inline const ::google::protobuf::Any& Option::value() const {
   const ::google::protobuf::Any* p = value_;
   // @@protoc_insertion_point(field_get:google.protobuf.Option.value)
-  return p != NULL ? *p : *reinterpret_cast<const ::google::protobuf::Any*>(
+  return p != nullptr ? *p : *reinterpret_cast<const ::google::protobuf::Any*>(
       &::google::protobuf::_Any_default_instance_);
 }
 inline ::google::protobuf::Any* Option::release_value() {
   // @@protoc_insertion_point(field_release:google.protobuf.Option.value)
   
   ::google::protobuf::Any* temp = value_;
-  if (GetArenaNoVirtual() != NULL) {
+  if (GetArenaNoVirtual() != nullptr) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
   }
-  value_ = NULL;
+  value_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::Any* Option::unsafe_arena_release_value() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.Option.value)
   
   ::google::protobuf::Any* temp = value_;
-  value_ = NULL;
+  value_ = nullptr;
   return temp;
 }
 inline ::google::protobuf::Any* Option::mutable_value() {
   
-  if (value_ == NULL) {
+  if (value_ == nullptr) {
     auto* p = CreateMaybeMessage<::google::protobuf::Any>(GetArenaNoVirtual());
     value_ = p;
   }
@@ -2369,11 +2369,11 @@ inline ::google::protobuf::Any* Option::mutable_value() {
 }
 inline void Option::set_allocated_value(::google::protobuf::Any* value) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
-  if (message_arena == NULL) {
+  if (message_arena == nullptr) {
     delete reinterpret_cast< ::google::protobuf::MessageLite*>(value_);
   }
   if (value) {
-    ::google::protobuf::Arena* submessage_arena = NULL;
+    ::google::protobuf::Arena* submessage_arena = nullptr;
     if (message_arena != submessage_arena) {
       value = ::google::protobuf::internal::GetOwnedMessage(
           message_arena, value, submessage_arena);

--- a/src/google/protobuf/wrappers.pb.cc
+++ b/src/google/protobuf/wrappers.pb.cc
@@ -329,7 +329,7 @@ const int DoubleValue::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 DoubleValue::DoubleValue()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.DoubleValue)
 }
@@ -342,7 +342,7 @@ DoubleValue::DoubleValue(::google::protobuf::Arena* arena)
 }
 DoubleValue::DoubleValue(const DoubleValue& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   value_ = from.value_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.DoubleValue)
@@ -358,7 +358,7 @@ DoubleValue::~DoubleValue() {
 }
 
 void DoubleValue::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void DoubleValue::ArenaDtor(void* object) {
@@ -543,7 +543,7 @@ void DoubleValue::MergeFrom(const ::google::protobuf::Message& from) {
   const DoubleValue* source =
       ::google::protobuf::DynamicCastToGenerated<DoubleValue>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.DoubleValue)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -591,7 +591,7 @@ void DoubleValue::Swap(DoubleValue* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -626,7 +626,7 @@ const int FloatValue::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 FloatValue::FloatValue()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.FloatValue)
 }
@@ -639,7 +639,7 @@ FloatValue::FloatValue(::google::protobuf::Arena* arena)
 }
 FloatValue::FloatValue(const FloatValue& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   value_ = from.value_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.FloatValue)
@@ -655,7 +655,7 @@ FloatValue::~FloatValue() {
 }
 
 void FloatValue::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void FloatValue::ArenaDtor(void* object) {
@@ -840,7 +840,7 @@ void FloatValue::MergeFrom(const ::google::protobuf::Message& from) {
   const FloatValue* source =
       ::google::protobuf::DynamicCastToGenerated<FloatValue>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.FloatValue)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -888,7 +888,7 @@ void FloatValue::Swap(FloatValue* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -923,7 +923,7 @@ const int Int64Value::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Int64Value::Int64Value()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Int64Value)
 }
@@ -936,7 +936,7 @@ Int64Value::Int64Value(::google::protobuf::Arena* arena)
 }
 Int64Value::Int64Value(const Int64Value& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   value_ = from.value_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Int64Value)
@@ -952,7 +952,7 @@ Int64Value::~Int64Value() {
 }
 
 void Int64Value::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void Int64Value::ArenaDtor(void* object) {
@@ -1140,7 +1140,7 @@ void Int64Value::MergeFrom(const ::google::protobuf::Message& from) {
   const Int64Value* source =
       ::google::protobuf::DynamicCastToGenerated<Int64Value>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Int64Value)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1188,7 +1188,7 @@ void Int64Value::Swap(Int64Value* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -1223,7 +1223,7 @@ const int UInt64Value::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 UInt64Value::UInt64Value()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.UInt64Value)
 }
@@ -1236,7 +1236,7 @@ UInt64Value::UInt64Value(::google::protobuf::Arena* arena)
 }
 UInt64Value::UInt64Value(const UInt64Value& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   value_ = from.value_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.UInt64Value)
@@ -1252,7 +1252,7 @@ UInt64Value::~UInt64Value() {
 }
 
 void UInt64Value::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void UInt64Value::ArenaDtor(void* object) {
@@ -1440,7 +1440,7 @@ void UInt64Value::MergeFrom(const ::google::protobuf::Message& from) {
   const UInt64Value* source =
       ::google::protobuf::DynamicCastToGenerated<UInt64Value>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.UInt64Value)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1488,7 +1488,7 @@ void UInt64Value::Swap(UInt64Value* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -1523,7 +1523,7 @@ const int Int32Value::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Int32Value::Int32Value()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.Int32Value)
 }
@@ -1536,7 +1536,7 @@ Int32Value::Int32Value(::google::protobuf::Arena* arena)
 }
 Int32Value::Int32Value(const Int32Value& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   value_ = from.value_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.Int32Value)
@@ -1552,7 +1552,7 @@ Int32Value::~Int32Value() {
 }
 
 void Int32Value::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void Int32Value::ArenaDtor(void* object) {
@@ -1740,7 +1740,7 @@ void Int32Value::MergeFrom(const ::google::protobuf::Message& from) {
   const Int32Value* source =
       ::google::protobuf::DynamicCastToGenerated<Int32Value>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.Int32Value)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -1788,7 +1788,7 @@ void Int32Value::Swap(Int32Value* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -1823,7 +1823,7 @@ const int UInt32Value::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 UInt32Value::UInt32Value()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.UInt32Value)
 }
@@ -1836,7 +1836,7 @@ UInt32Value::UInt32Value(::google::protobuf::Arena* arena)
 }
 UInt32Value::UInt32Value(const UInt32Value& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   value_ = from.value_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.UInt32Value)
@@ -1852,7 +1852,7 @@ UInt32Value::~UInt32Value() {
 }
 
 void UInt32Value::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void UInt32Value::ArenaDtor(void* object) {
@@ -2040,7 +2040,7 @@ void UInt32Value::MergeFrom(const ::google::protobuf::Message& from) {
   const UInt32Value* source =
       ::google::protobuf::DynamicCastToGenerated<UInt32Value>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.UInt32Value)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -2088,7 +2088,7 @@ void UInt32Value::Swap(UInt32Value* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -2123,7 +2123,7 @@ const int BoolValue::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 BoolValue::BoolValue()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.BoolValue)
 }
@@ -2136,7 +2136,7 @@ BoolValue::BoolValue(::google::protobuf::Arena* arena)
 }
 BoolValue::BoolValue(const BoolValue& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   value_ = from.value_;
   // @@protoc_insertion_point(copy_constructor:google.protobuf.BoolValue)
@@ -2152,7 +2152,7 @@ BoolValue::~BoolValue() {
 }
 
 void BoolValue::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
 }
 
 void BoolValue::ArenaDtor(void* object) {
@@ -2338,7 +2338,7 @@ void BoolValue::MergeFrom(const ::google::protobuf::Message& from) {
   const BoolValue* source =
       ::google::protobuf::DynamicCastToGenerated<BoolValue>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.BoolValue)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -2386,7 +2386,7 @@ void BoolValue::Swap(BoolValue* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -2421,7 +2421,7 @@ const int StringValue::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 StringValue::StringValue()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.StringValue)
 }
@@ -2434,7 +2434,7 @@ StringValue::StringValue(::google::protobuf::Arena* arena)
 }
 StringValue::StringValue(const StringValue& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (from.value().size() > 0) {
@@ -2456,7 +2456,7 @@ StringValue::~StringValue() {
 }
 
 void StringValue::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
@@ -2667,7 +2667,7 @@ void StringValue::MergeFrom(const ::google::protobuf::Message& from) {
   const StringValue* source =
       ::google::protobuf::DynamicCastToGenerated<StringValue>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.StringValue)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -2715,7 +2715,7 @@ void StringValue::Swap(StringValue* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }
@@ -2751,7 +2751,7 @@ const int BytesValue::kValueFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 BytesValue::BytesValue()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  : ::google::protobuf::Message(), _internal_metadata_(nullptr) {
   SharedCtor();
   // @@protoc_insertion_point(constructor:google.protobuf.BytesValue)
 }
@@ -2764,7 +2764,7 @@ BytesValue::BytesValue(::google::protobuf::Arena* arena)
 }
 BytesValue::BytesValue(const BytesValue& from)
   : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
+      _internal_metadata_(nullptr) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   value_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (from.value().size() > 0) {
@@ -2786,7 +2786,7 @@ BytesValue::~BytesValue() {
 }
 
 void BytesValue::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == nullptr);
   value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
@@ -2984,7 +2984,7 @@ void BytesValue::MergeFrom(const ::google::protobuf::Message& from) {
   const BytesValue* source =
       ::google::protobuf::DynamicCastToGenerated<BytesValue>(
           &from);
-  if (source == NULL) {
+  if (source == nullptr) {
   // @@protoc_insertion_point(generalized_merge_from_cast_fail:google.protobuf.BytesValue)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
@@ -3032,7 +3032,7 @@ void BytesValue::Swap(BytesValue* other) {
     temp->MergeFrom(*other);
     other->CopyFrom(*this);
     InternalSwap(temp);
-    if (GetArenaNoVirtual() == NULL) {
+    if (GetArenaNoVirtual() == nullptr) {
       delete temp;
     }
   }

--- a/src/google/protobuf/wrappers.pb.h
+++ b/src/google/protobuf/wrappers.pb.h
@@ -147,7 +147,7 @@ class PROTOBUF_EXPORT DoubleValue : public ::google::protobuf::Message /* @@prot
   // implements Message ----------------------------------------------
 
   inline DoubleValue* New() const final {
-    return CreateMaybeMessage<DoubleValue>(NULL);
+    return CreateMaybeMessage<DoubleValue>(nullptr);
   }
 
   DoubleValue* New(::google::protobuf::Arena* arena) const final {
@@ -273,7 +273,7 @@ class PROTOBUF_EXPORT FloatValue : public ::google::protobuf::Message /* @@proto
   // implements Message ----------------------------------------------
 
   inline FloatValue* New() const final {
-    return CreateMaybeMessage<FloatValue>(NULL);
+    return CreateMaybeMessage<FloatValue>(nullptr);
   }
 
   FloatValue* New(::google::protobuf::Arena* arena) const final {
@@ -399,7 +399,7 @@ class PROTOBUF_EXPORT Int64Value : public ::google::protobuf::Message /* @@proto
   // implements Message ----------------------------------------------
 
   inline Int64Value* New() const final {
-    return CreateMaybeMessage<Int64Value>(NULL);
+    return CreateMaybeMessage<Int64Value>(nullptr);
   }
 
   Int64Value* New(::google::protobuf::Arena* arena) const final {
@@ -525,7 +525,7 @@ class PROTOBUF_EXPORT UInt64Value : public ::google::protobuf::Message /* @@prot
   // implements Message ----------------------------------------------
 
   inline UInt64Value* New() const final {
-    return CreateMaybeMessage<UInt64Value>(NULL);
+    return CreateMaybeMessage<UInt64Value>(nullptr);
   }
 
   UInt64Value* New(::google::protobuf::Arena* arena) const final {
@@ -651,7 +651,7 @@ class PROTOBUF_EXPORT Int32Value : public ::google::protobuf::Message /* @@proto
   // implements Message ----------------------------------------------
 
   inline Int32Value* New() const final {
-    return CreateMaybeMessage<Int32Value>(NULL);
+    return CreateMaybeMessage<Int32Value>(nullptr);
   }
 
   Int32Value* New(::google::protobuf::Arena* arena) const final {
@@ -777,7 +777,7 @@ class PROTOBUF_EXPORT UInt32Value : public ::google::protobuf::Message /* @@prot
   // implements Message ----------------------------------------------
 
   inline UInt32Value* New() const final {
-    return CreateMaybeMessage<UInt32Value>(NULL);
+    return CreateMaybeMessage<UInt32Value>(nullptr);
   }
 
   UInt32Value* New(::google::protobuf::Arena* arena) const final {
@@ -903,7 +903,7 @@ class PROTOBUF_EXPORT BoolValue : public ::google::protobuf::Message /* @@protoc
   // implements Message ----------------------------------------------
 
   inline BoolValue* New() const final {
-    return CreateMaybeMessage<BoolValue>(NULL);
+    return CreateMaybeMessage<BoolValue>(nullptr);
   }
 
   BoolValue* New(::google::protobuf::Arena* arena) const final {
@@ -1029,7 +1029,7 @@ class PROTOBUF_EXPORT StringValue : public ::google::protobuf::Message /* @@prot
   // implements Message ----------------------------------------------
 
   inline StringValue* New() const final {
-    return CreateMaybeMessage<StringValue>(NULL);
+    return CreateMaybeMessage<StringValue>(nullptr);
   }
 
   StringValue* New(::google::protobuf::Arena* arena) const final {
@@ -1172,7 +1172,7 @@ class PROTOBUF_EXPORT BytesValue : public ::google::protobuf::Message /* @@proto
   // implements Message ----------------------------------------------
 
   inline BytesValue* New() const final {
-    return CreateMaybeMessage<BytesValue>(NULL);
+    return CreateMaybeMessage<BytesValue>(nullptr);
   }
 
   BytesValue* New(::google::protobuf::Arena* arena) const final {
@@ -1418,7 +1418,7 @@ inline void StringValue::set_value(::std::string&& value) {
 }
 #endif
 inline void StringValue::set_value(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   value_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -1442,7 +1442,7 @@ inline ::std::string* StringValue::release_value() {
   return value_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void StringValue::set_allocated_value(::std::string* value) {
-  if (value != NULL) {
+  if (value != nullptr) {
     
   } else {
     
@@ -1453,15 +1453,15 @@ inline void StringValue::set_allocated_value(::std::string* value) {
 }
 inline ::std::string* StringValue::unsafe_arena_release_value() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.StringValue.value)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   
   return value_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void StringValue::unsafe_arena_set_allocated_value(
     ::std::string* value) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (value != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (value != nullptr) {
     
   } else {
     
@@ -1497,7 +1497,7 @@ inline void BytesValue::set_value(::std::string&& value) {
 }
 #endif
 inline void BytesValue::set_value(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
+  GOOGLE_DCHECK(value != nullptr);
   
   value_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
@@ -1521,7 +1521,7 @@ inline ::std::string* BytesValue::release_value() {
   return value_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline void BytesValue::set_allocated_value(::std::string* value) {
-  if (value != NULL) {
+  if (value != nullptr) {
     
   } else {
     
@@ -1532,15 +1532,15 @@ inline void BytesValue::set_allocated_value(::std::string* value) {
 }
 inline ::std::string* BytesValue::unsafe_arena_release_value() {
   // @@protoc_insertion_point(field_unsafe_arena_release:google.protobuf.BytesValue.value)
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
   
   return value_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
 }
 inline void BytesValue::unsafe_arena_set_allocated_value(
     ::std::string* value) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
-  if (value != NULL) {
+  GOOGLE_DCHECK(GetArenaNoVirtual() != nullptr);
+  if (value != nullptr) {
     
   } else {
     


### PR DESCRIPTION
This avoids compiler errors/warnings if zero-as-null-pointer-constant is considered an error or warning.

Not sure this is something you want as is. May be an option would be to pass a flag to `protoc` to specify if you want code for c++11 or older, for example?