### PR TITLE
In debug builds output a warning about NSCoding and extensions.

### DIFF
--- a/objectivec/GPBMessage.m
+++ b/objectivec/GPBMessage.m
@@ -3249,6 +3249,15 @@ static void ResolveIvarSet(__unsafe_unretained GPBFieldDescriptor *field,
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
+#if defined(DEBUG) && DEBUG
+  if (extensionMap_.count) {
+    // Hint to go along with the docs on GPBMessage about this.
+    NSLog(@"Warning: writing out a GPBMessage (%@) via NSCoding and it"
+          @" has %ld extensions; when read back in, those fields will be"
+          @" in the unknownFields property instead.",
+          [self class], (long)extensionMap_.count);
+  }
+#endif
   NSData *data = [self data];
   if (data.length) {
     [aCoder encodeObject:data forKey:kGPBDataCoderKey];


### PR DESCRIPTION
Using NSCoding with a Message that has extensions is risky because
when reloaded, there is no way to provide a registry through the
NSCoding plumbing, so output a warnings to atleast give developers
a hint about the potential issues.