### PR TITLE
Some changes to the ObjC code generator to support importing into Google.

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_enum.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_enum.h
@@ -35,14 +35,9 @@
 #include <set>
 #include <vector>
 #include <google/protobuf/descriptor.h>
+#include <google/protobuf/io/printer.h>
 
 namespace google {
-namespace protobuf {
-namespace io {
-class Printer;  // printer.h
-}
-}
-
 namespace protobuf {
 namespace compiler {
 namespace objectivec {
@@ -51,6 +46,9 @@ class EnumGenerator {
  public:
   explicit EnumGenerator(const EnumDescriptor* descriptor);
   ~EnumGenerator();
+
+  EnumGenerator(const EnumGenerator&) = delete;
+  EnumGenerator& operator=(const EnumGenerator&) = delete;
 
   void GenerateHeader(io::Printer* printer);
   void GenerateSource(io::Printer* printer);
@@ -62,12 +60,11 @@ class EnumGenerator {
   std::vector<const EnumValueDescriptor*> base_values_;
   std::vector<const EnumValueDescriptor*> all_values_;
   const string name_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(EnumGenerator);
 };
 
 }  // namespace objectivec
 }  // namespace compiler
 }  // namespace protobuf
 }  // namespace google
+
 #endif  // GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_ENUM_H__

--- a/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc
@@ -32,11 +32,9 @@
 #include <string>
 
 #include <google/protobuf/compiler/objectivec/objectivec_enum_field.h>
-#include <google/protobuf/stubs/common.h>
 #include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/wire_format.h>
-#include <google/protobuf/stubs/strutil.h>
 
 namespace google {
 namespace protobuf {

--- a/src/google/protobuf/compiler/objectivec/objectivec_enum_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_enum_field.h
@@ -44,6 +44,9 @@ class EnumFieldGenerator : public SingleFieldGenerator {
   friend FieldGenerator* FieldGenerator::Make(const FieldDescriptor* field,
                                               const Options& options);
 
+  EnumFieldGenerator(const EnumFieldGenerator&) = delete;
+  EnumFieldGenerator& operator=(const EnumFieldGenerator&) = delete;
+
  public:
   virtual void GenerateCFunctionDeclarations(io::Printer* printer) const;
   virtual void GenerateCFunctionImplementations(io::Printer* printer) const;
@@ -52,9 +55,6 @@ class EnumFieldGenerator : public SingleFieldGenerator {
  protected:
   EnumFieldGenerator(const FieldDescriptor* descriptor, const Options& options);
   virtual ~EnumFieldGenerator();
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(EnumFieldGenerator);
 };
 
 class RepeatedEnumFieldGenerator : public RepeatedFieldGenerator {
@@ -68,9 +68,6 @@ class RepeatedEnumFieldGenerator : public RepeatedFieldGenerator {
   RepeatedEnumFieldGenerator(const FieldDescriptor* descriptor,
                              const Options& options);
   virtual ~RepeatedEnumFieldGenerator();
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(RepeatedEnumFieldGenerator);
 };
 
 }  // namespace objectivec

--- a/src/google/protobuf/compiler/objectivec/objectivec_extension.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_extension.h
@@ -31,16 +31,10 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_EXTENSION_H__
 #define GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_EXTENSION_H__
 
-#include <google/protobuf/stubs/common.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/io/printer.h>
 
 namespace google {
-namespace protobuf {
-class FieldDescriptor;  // descriptor.h
-namespace io {
-class Printer;  // printer.h
-}
-}
-
 namespace protobuf {
 namespace compiler {
 namespace objectivec {
@@ -51,6 +45,9 @@ class ExtensionGenerator {
                      const FieldDescriptor* descriptor);
   ~ExtensionGenerator();
 
+  ExtensionGenerator(const ExtensionGenerator&) = delete;
+  ExtensionGenerator& operator=(const ExtensionGenerator&) = delete;
+
   void GenerateMembersHeader(io::Printer* printer);
   void GenerateStaticVariablesInitialization(io::Printer* printer);
   void GenerateRegistrationSource(io::Printer* printer);
@@ -59,11 +56,11 @@ class ExtensionGenerator {
   string method_name_;
   string root_class_and_method_name_;
   const FieldDescriptor* descriptor_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ExtensionGenerator);
 };
+
 }  // namespace objectivec
 }  // namespace compiler
 }  // namespace protobuf
 }  // namespace google
+
 #endif  // GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_MESSAGE_H__

--- a/src/google/protobuf/compiler/objectivec/objectivec_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_field.cc
@@ -38,7 +38,6 @@
 #include <google/protobuf/compiler/objectivec/objectivec_primitive_field.h>
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/wire_format.h>
-#include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/strutil.h>
 
 namespace google {

--- a/src/google/protobuf/compiler/objectivec/objectivec_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_field.h
@@ -34,16 +34,11 @@
 #include <map>
 #include <string>
 #include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
-#include <google/protobuf/stubs/common.h>
 #include <google/protobuf/descriptor.h>
+#include <google/protobuf/io/printer.h>
 
 namespace google {
 namespace protobuf {
-
-namespace io {
-class Printer;  // printer.h
-}  // namespace io
-
 namespace compiler {
 namespace objectivec {
 
@@ -53,6 +48,9 @@ class FieldGenerator {
                               const Options& options);
 
   virtual ~FieldGenerator();
+
+  FieldGenerator(const FieldGenerator&) = delete;
+  FieldGenerator& operator=(const FieldGenerator&) = delete;
 
   // Exposed for subclasses to fill in.
   virtual void GenerateFieldStorageDeclaration(io::Printer* printer) const = 0;
@@ -101,14 +99,14 @@ class FieldGenerator {
 
   const FieldDescriptor* descriptor_;
   std::map<string, string> variables_;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(FieldGenerator);
 };
 
 class SingleFieldGenerator : public FieldGenerator {
  public:
   virtual ~SingleFieldGenerator();
+
+  SingleFieldGenerator(const SingleFieldGenerator&) = delete;
+  SingleFieldGenerator& operator=(const SingleFieldGenerator&) = delete;
 
   virtual void GenerateFieldStorageDeclaration(io::Printer* printer) const;
   virtual void GeneratePropertyDeclaration(io::Printer* printer) const;
@@ -121,9 +119,6 @@ class SingleFieldGenerator : public FieldGenerator {
   SingleFieldGenerator(const FieldDescriptor* descriptor,
                        const Options& options);
   virtual bool WantsHasProperty(void) const;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(SingleFieldGenerator);
 };
 
 // Subclass with common support for when the field ends up as an ObjC Object.
@@ -131,20 +126,23 @@ class ObjCObjFieldGenerator : public SingleFieldGenerator {
  public:
   virtual ~ObjCObjFieldGenerator();
 
+  ObjCObjFieldGenerator(const ObjCObjFieldGenerator&) = delete;
+  ObjCObjFieldGenerator& operator=(const ObjCObjFieldGenerator&) = delete;
+
   virtual void GenerateFieldStorageDeclaration(io::Printer* printer) const;
   virtual void GeneratePropertyDeclaration(io::Printer* printer) const;
 
  protected:
   ObjCObjFieldGenerator(const FieldDescriptor* descriptor,
                         const Options& options);
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ObjCObjFieldGenerator);
 };
 
 class RepeatedFieldGenerator : public ObjCObjFieldGenerator {
  public:
   virtual ~RepeatedFieldGenerator();
+
+  RepeatedFieldGenerator(const RepeatedFieldGenerator&) = delete;
+  RepeatedFieldGenerator& operator=(const RepeatedFieldGenerator&) = delete;
 
   virtual void GenerateFieldStorageDeclaration(io::Printer* printer) const;
   virtual void GeneratePropertyDeclaration(io::Printer* printer) const;
@@ -158,9 +156,6 @@ class RepeatedFieldGenerator : public ObjCObjFieldGenerator {
                          const Options& options);
   virtual void FinishInitialization(void);
   virtual bool WantsHasProperty(void) const;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(RepeatedFieldGenerator);
 };
 
 // Convenience class which constructs FieldGenerators for a Descriptor.
@@ -168,6 +163,9 @@ class FieldGeneratorMap {
  public:
   FieldGeneratorMap(const Descriptor* descriptor, const Options& options);
   ~FieldGeneratorMap();
+
+  FieldGeneratorMap(const FieldGeneratorMap&) = delete;
+  FieldGeneratorMap& operator=(const FieldGeneratorMap&) = delete;
 
   const FieldGenerator& get(const FieldDescriptor* field) const;
   const FieldGenerator& get_extension(int index) const;
@@ -184,11 +182,11 @@ class FieldGeneratorMap {
   const Descriptor* descriptor_;
   std::vector<std::unique_ptr<FieldGenerator>> field_generators_;
   std::vector<std::unique_ptr<FieldGenerator>> extension_generators_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(FieldGeneratorMap);
 };
+
 }  // namespace objectivec
 }  // namespace compiler
 }  // namespace protobuf
 }  // namespace google
+
 #endif  // GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_FIELD_H__

--- a/src/google/protobuf/compiler/objectivec/objectivec_file.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.h
@@ -35,16 +35,10 @@
 #include <set>
 #include <vector>
 #include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
-#include <google/protobuf/stubs/common.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/io/printer.h>
 
 namespace google {
-namespace protobuf {
-class FileDescriptor;  // descriptor.h
-namespace io {
-class Printer;  // printer.h
-}
-}
-
 namespace protobuf {
 namespace compiler {
 namespace objectivec {
@@ -57,6 +51,9 @@ class FileGenerator {
  public:
   FileGenerator(const FileDescriptor* file, const Options& options);
   ~FileGenerator();
+
+  FileGenerator(const FileGenerator&) = delete;
+  FileGenerator& operator=(const FileGenerator&) = delete;
 
   void GenerateSource(io::Printer* printer);
   void GenerateHeader(io::Printer* printer);
@@ -76,8 +73,6 @@ class FileGenerator {
 
   void PrintFileRuntimePreamble(
       io::Printer* printer, const std::set<string>& headers_to_import) const;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(FileGenerator);
 };
 
 }  // namespace objectivec

--- a/src/google/protobuf/compiler/objectivec/objectivec_generator.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_generator.h
@@ -35,6 +35,7 @@
 
 #include <string>
 #include <google/protobuf/compiler/code_generator.h>
+#include <google/protobuf/descriptor.h>
 
 #include <google/protobuf/port_def.inc>
 
@@ -52,6 +53,9 @@ class PROTOC_EXPORT ObjectiveCGenerator : public CodeGenerator {
   ObjectiveCGenerator();
   ~ObjectiveCGenerator();
 
+  ObjectiveCGenerator(const ObjectiveCGenerator&) = delete;
+  ObjectiveCGenerator& operator=(const ObjectiveCGenerator&) = delete;
+
   // implements CodeGenerator ----------------------------------------
   bool HasGenerateAll() const;
   bool Generate(const FileDescriptor* file,
@@ -62,9 +66,6 @@ class PROTOC_EXPORT ObjectiveCGenerator : public CodeGenerator {
                    const string& parameter,
                    GeneratorContext* context,
                    string* error) const;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ObjectiveCGenerator);
 };
 
 }  // namespace objectivec

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -41,14 +41,12 @@
 #include <unordered_set>
 #include <vector>
 
-#include <google/protobuf/stubs/hash.h>
 #include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
 #include <google/protobuf/compiler/objectivec/objectivec_nsobject_methods.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
-#include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/io_win32.h>
 #include <google/protobuf/stubs/strutil.h>
 

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
@@ -230,6 +230,9 @@ class PROTOC_EXPORT TextFormatDecodeData {
   TextFormatDecodeData();
   ~TextFormatDecodeData();
 
+  TextFormatDecodeData(const TextFormatDecodeData&) = delete;
+  TextFormatDecodeData& operator=(const TextFormatDecodeData&) = delete;
+
   void AddString(int32 key, const string& input_for_decode,
                  const string& desired_output);
   size_t num_entries() const { return entries_.size(); }
@@ -239,8 +242,6 @@ class PROTOC_EXPORT TextFormatDecodeData {
                                     const string& desired_output);
 
  private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(TextFormatDecodeData);
-
   typedef std::pair<int32, string> DataEntry;
   std::vector<DataEntry> entries_;
 };

--- a/src/google/protobuf/compiler/objectivec/objectivec_map_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_map_field.cc
@@ -32,11 +32,8 @@
 #include <string>
 
 #include <google/protobuf/compiler/objectivec/objectivec_map_field.h>
-#include <google/protobuf/stubs/common.h>
 #include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
 #include <google/protobuf/io/printer.h>
-#include <google/protobuf/stubs/strutil.h>
-#include <google/protobuf/stubs/substitute.h>
 
 namespace google {
 namespace protobuf {

--- a/src/google/protobuf/compiler/objectivec/objectivec_map_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_map_field.h
@@ -47,6 +47,9 @@ class MapFieldGenerator : public RepeatedFieldGenerator {
  public:
   virtual void FinishInitialization(void);
 
+  MapFieldGenerator(const MapFieldGenerator&) = delete;
+  MapFieldGenerator& operator=(const MapFieldGenerator&) = delete;
+
  protected:
   MapFieldGenerator(const FieldDescriptor* descriptor, const Options& options);
   virtual ~MapFieldGenerator();
@@ -55,8 +58,6 @@ class MapFieldGenerator : public RepeatedFieldGenerator {
 
  private:
   std::unique_ptr<FieldGenerator> value_field_generator_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(MapFieldGenerator);
 };
 
 }  // namespace objectivec

--- a/src/google/protobuf/compiler/objectivec/objectivec_message.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message.cc
@@ -32,7 +32,6 @@
 #include <iostream>
 #include <sstream>
 
-#include <google/protobuf/stubs/hash.h>
 #include <google/protobuf/compiler/objectivec/objectivec_message.h>
 #include <google/protobuf/compiler/objectivec/objectivec_enum.h>
 #include <google/protobuf/compiler/objectivec/objectivec_extension.h>

--- a/src/google/protobuf/compiler/objectivec/objectivec_message.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message.h
@@ -37,15 +37,11 @@
 #include <google/protobuf/compiler/objectivec/objectivec_field.h>
 #include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
 #include <google/protobuf/compiler/objectivec/objectivec_oneof.h>
-#include <google/protobuf/stubs/common.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/io/printer.h>
 
 namespace google {
 namespace protobuf {
-
-namespace io {
-class Printer;  // printer.h
-}  // namespace io
-
 namespace compiler {
 namespace objectivec {
 
@@ -58,6 +54,9 @@ class MessageGenerator {
                    const Descriptor* descriptor,
                    const Options& options);
   ~MessageGenerator();
+
+  MessageGenerator(const MessageGenerator&) = delete;
+  MessageGenerator& operator=(const MessageGenerator&) = delete;
 
   void GenerateStaticVariablesInitialization(io::Printer* printer);
   void GenerateEnumHeader(io::Printer* printer);
@@ -90,11 +89,11 @@ class MessageGenerator {
   std::vector<EnumGenerator*> enum_generators_;
   std::vector<MessageGenerator*> nested_message_generators_;
   std::vector<OneofGenerator*> oneof_generators_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(MessageGenerator);
 };
+
 }  // namespace objectivec
 }  // namespace compiler
 }  // namespace protobuf
 }  // namespace google
+
 #endif  // GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_MESSAGE_H__

--- a/src/google/protobuf/compiler/objectivec/objectivec_message_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message_field.cc
@@ -35,7 +35,6 @@
 #include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/wire_format.h>
-#include <google/protobuf/stubs/strutil.h>
 
 namespace google {
 namespace protobuf {

--- a/src/google/protobuf/compiler/objectivec/objectivec_message_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message_field.h
@@ -47,14 +47,15 @@ class MessageFieldGenerator : public ObjCObjFieldGenerator {
  protected:
   MessageFieldGenerator(const FieldDescriptor* descriptor,
                         const Options& options);
+
+  MessageFieldGenerator(const MessageFieldGenerator&) = delete;
+  MessageFieldGenerator& operator=(const MessageFieldGenerator&) = delete;
+
   virtual ~MessageFieldGenerator();
   virtual bool WantsHasProperty(void) const;
 
  public:
   virtual void DetermineForwardDeclarations(std::set<string>* fwd_decls) const;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(MessageFieldGenerator);
 };
 
 class RepeatedMessageFieldGenerator : public RepeatedFieldGenerator {
@@ -66,11 +67,11 @@ class RepeatedMessageFieldGenerator : public RepeatedFieldGenerator {
                                 const Options& options);
   virtual ~RepeatedMessageFieldGenerator();
 
+  RepeatedMessageFieldGenerator(const RepeatedMessageFieldGenerator&) = delete;
+  RepeatedMessageFieldGenerator operator=(const RepeatedMessageFieldGenerator&) = delete;
+
  public:
   virtual void DetermineForwardDeclarations(std::set<string>* fwd_decls) const;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(RepeatedMessageFieldGenerator);
 };
 
 }  // namespace objectivec

--- a/src/google/protobuf/compiler/objectivec/objectivec_oneof.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_oneof.h
@@ -35,14 +35,9 @@
 #include <set>
 #include <vector>
 #include <google/protobuf/descriptor.h>
+#include <google/protobuf/io/printer.h>
 
 namespace google {
-namespace protobuf {
-namespace io {
-class Printer;  // printer.h
-}
-}
-
 namespace protobuf {
 namespace compiler {
 namespace objectivec {
@@ -51,6 +46,9 @@ class OneofGenerator {
  public:
   explicit OneofGenerator(const OneofDescriptor* descriptor);
   ~OneofGenerator();
+
+  OneofGenerator(const OneofGenerator&) = delete;
+  OneofGenerator& operator=(const OneofGenerator&) = delete;
 
   void SetOneofIndexBase(int index_base);
 
@@ -68,12 +66,11 @@ class OneofGenerator {
  private:
   const OneofDescriptor* descriptor_;
   std::map<string, string> variables_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(OneofGenerator);
 };
 
 }  // namespace objectivec
 }  // namespace compiler
 }  // namespace protobuf
 }  // namespace google
+
 #endif  // GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_ONEOF_H__

--- a/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc
@@ -31,14 +31,12 @@
 #include <map>
 #include <string>
 
-#include <google/protobuf/compiler/objectivec/objectivec_primitive_field.h>
-#include <google/protobuf/stubs/common.h>
 #include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
+#include <google/protobuf/compiler/objectivec/objectivec_primitive_field.h>
 #include <google/protobuf/io/printer.h>
+#include <google/protobuf/stubs/strutil.h>
 #include <google/protobuf/wire_format.h>
 #include <google/protobuf/wire_format_lite_inl.h>
-#include <google/protobuf/stubs/strutil.h>
-#include <google/protobuf/stubs/substitute.h>
 
 namespace google {
 namespace protobuf {

--- a/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.h
@@ -49,13 +49,13 @@ class PrimitiveFieldGenerator : public SingleFieldGenerator {
                           const Options& options);
   virtual ~PrimitiveFieldGenerator();
 
+  PrimitiveFieldGenerator(const PrimitiveFieldGenerator&) = delete;
+  PrimitiveFieldGenerator& operator=(const PrimitiveFieldGenerator&) = delete;
+
   virtual void GenerateFieldStorageDeclaration(io::Printer* printer) const;
 
   virtual int ExtraRuntimeHasBitsNeeded(void) const;
   virtual void SetExtraRuntimeHasBitsBase(int index_base);
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(PrimitiveFieldGenerator);
 };
 
 class PrimitiveObjFieldGenerator : public ObjCObjFieldGenerator {
@@ -67,8 +67,9 @@ class PrimitiveObjFieldGenerator : public ObjCObjFieldGenerator {
                              const Options& options);
   virtual ~PrimitiveObjFieldGenerator();
 
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(PrimitiveObjFieldGenerator);
+  PrimitiveObjFieldGenerator(const PrimitiveObjFieldGenerator&) = delete;
+  PrimitiveObjFieldGenerator& operator=(const PrimitiveObjFieldGenerator&) =
+      delete;
 };
 
 class RepeatedPrimitiveFieldGenerator : public RepeatedFieldGenerator {
@@ -80,8 +81,10 @@ class RepeatedPrimitiveFieldGenerator : public RepeatedFieldGenerator {
                                   const Options& options);
   virtual ~RepeatedPrimitiveFieldGenerator();
 
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(RepeatedPrimitiveFieldGenerator);
+  RepeatedPrimitiveFieldGenerator(const RepeatedPrimitiveFieldGenerator&) =
+      delete;
+  RepeatedPrimitiveFieldGenerator& operator=(
+      const RepeatedPrimitiveFieldGenerator&) = delete;
 };
 
 }  // namespace objectivec


### PR DESCRIPTION
- removed use of GOOGLE_DISALLOW_EVIL_CONSTRUCTORS
  in favor of deleting them C++11 style.
- removed forward declarations of protobuf core types.
- ensured that namespaces "google" and "protobuf" are
  always opened/closed together.