### PR TITLE
Cherry-picked Bazel fix from PR #5085

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -39,10 +39,9 @@ COPTS = select({
     ],
 })
 
-config_setting(
-    name = "msvc",
-    values = { "compiler": "msvc-cl" },
-)
+load(":compiler_config_setting.bzl", "create_compiler_config_setting")
+
+create_compiler_config_setting(name = "msvc", value = "msvc-cl")
 
 config_setting(
     name = "android",

--- a/compiler_config_setting.bzl
+++ b/compiler_config_setting.bzl
@@ -1,0 +1,21 @@
+"""Creates config_setting that allows selecting based on 'compiler' value."""
+
+def create_compiler_config_setting(name, value):
+    # The "do_not_use_tools_cpp_compiler_present" attribute exists to
+    # distinguish between older versions of Bazel that do not support
+    # "@bazel_tools//tools/cpp:compiler" flag_value, and newer ones that do.
+    # In the future, the only way to select on the compiler will be through
+    # flag_values{"@bazel_tools//tools/cpp:compiler"} and the else branch can
+    # be removed.
+    if hasattr(cc_common, "do_not_use_tools_cpp_compiler_present"):
+        native.config_setting(
+            name = name,
+            flag_values = {
+                "@bazel_tools//tools/cpp:compiler": value,
+            },
+        )
+    else:
+        native.config_setting(
+            name = name,
+            values = {"compiler": value},
+        )


### PR DESCRIPTION
Bazel 0.20 requires these fixes, so let's cherry-pick them to the 3.6.x branch and tag a 3.6.1.1 release.
This should unblock the Bazel release.