### PR TITLE
Add Bazel config for zlib support

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -16,6 +16,19 @@ config_setting(
 )
 
 ################################################################################
+# ZLIB configuration
+################################################################################
+
+config_setting(
+    name = "zlib",
+    values = {"define": "protobuf_zlib=true"},
+)
+
+ZLIB_COPTS = ["-DHAVE_ZLIB"]
+
+ZLIB_DEPS = ["//external:zlib"]
+
+################################################################################
 # Protobuf Runtime Library
 ################################################################################
 
@@ -50,6 +63,9 @@ COPTS = select({
         "-Wno-writable-strings",
         "-Wno-write-strings",
     ],
+}) + select({
+    ":zlib": ZLIB_COPTS,
+    "//conditions:default": [],
 })
 
 load(":compiler_config_setting.bzl", "create_compiler_config_setting")
@@ -117,6 +133,11 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+PROTOBUF_DEPS = select({
+    ":zlib": ZLIB_DEPS,
+    "//conditions:default": [],
+})
+
 cc_library(
     name = "protobuf",
     srcs = [
@@ -182,7 +203,7 @@ cc_library(
     includes = ["src/"],
     linkopts = LINK_OPTS,
     visibility = ["//visibility:public"],
-    deps = [":protobuf_lite"],
+    deps = [":protobuf_lite"] + PROTOBUF_DEPS,
 )
 
 # This provides just the header files for use in projects that need to build
@@ -590,7 +611,7 @@ cc_test(
         ":protobuf",
         ":protoc_lib",
         "//external:gtest_main",
-    ],
+    ] + PROTOBUF_DEPS,
 )
 
 ################################################################################

--- a/BUILD
+++ b/BUILD
@@ -24,8 +24,6 @@ config_setting(
     values = {"define": "protobuf_zlib=true"},
 )
 
-ZLIB_COPTS = ["-DHAVE_ZLIB"]
-
 ZLIB_DEPS = ["//external:zlib"]
 
 ################################################################################
@@ -55,6 +53,7 @@ COPTS = select({
     ":msvc" : MSVC_COPTS,
     "//conditions:default": [
         "-DHAVE_PTHREAD",
+        "-DHAVE_ZLIB",
         "-Wall",
         "-Woverloaded-virtual",
         "-Wno-sign-compare",
@@ -63,9 +62,6 @@ COPTS = select({
         "-Wno-writable-strings",
         "-Wno-write-strings",
     ],
-}) + select({
-    ":zlib": ZLIB_COPTS,
-    "//conditions:default": [],
 })
 
 load(":compiler_config_setting.bzl", "create_compiler_config_setting")
@@ -134,8 +130,8 @@ cc_library(
 )
 
 PROTOBUF_DEPS = select({
-    ":zlib": ZLIB_DEPS,
-    "//conditions:default": [],
+    ":msvc": [],
+    "//conditions:default": ZLIB_DEPS,
 })
 
 cc_library(

--- a/BUILD
+++ b/BUILD
@@ -19,11 +19,6 @@ config_setting(
 # ZLIB configuration
 ################################################################################
 
-config_setting(
-    name = "zlib",
-    values = {"define": "protobuf_zlib=true"},
-)
-
 ZLIB_DEPS = ["//external:zlib"]
 
 ################################################################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,11 @@
 workspace(name = "com_google_protobuf")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 new_local_repository(
     name = "submodule_gmock",
+    build_file = "@//:third_party/googletest/BUILD.bazel",
     path = "third_party/googletest",
-    build_file = "@//:third_party/googletest/BUILD.bazel"
 )
 
 http_archive(
@@ -19,6 +20,14 @@ http_archive(
     sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
     strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
     urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+)
+
+http_archive(
+    name = "net_zlib",
+    build_file = "//:third_party/zlib.BUILD",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
 )
 
 bind(
@@ -59,4 +68,9 @@ maven_jar(
 bind(
     name = "gson",
     actual = "@gson_maven//jar",
+)
+
+bind(
+    name = "zlib",
+    actual = "@net_zlib//:zlib",
 )

--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -1,0 +1,60 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # BSD/MIT-like license (for zlib)
+
+_ZLIB_HEADERS = [
+    "crc32.h",
+    "deflate.h",
+    "gzguts.h",
+    "inffast.h",
+    "inffixed.h",
+    "inflate.h",
+    "inftrees.h",
+    "trees.h",
+    "zconf.h",
+    "zlib.h",
+    "zutil.h",
+]
+
+_ZLIB_PREFIXED_HEADERS = ["zlib/include/" + hdr for hdr in _ZLIB_HEADERS]
+
+# In order to limit the damage from the `includes` propagation
+# via `:zlib`, copy the public headers to a subdirectory and
+# expose those.
+genrule(
+    name = "copy_public_headers",
+    srcs = _ZLIB_HEADERS,
+    outs = _ZLIB_PREFIXED_HEADERS,
+    cmd = "cp $(SRCS) $(@D)/zlib/include/",
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "zlib",
+    srcs = [
+        "adler32.c",
+        "compress.c",
+        "crc32.c",
+        "deflate.c",
+        "gzclose.c",
+        "gzlib.c",
+        "gzread.c",
+        "gzwrite.c",
+        "infback.c",
+        "inffast.c",
+        "inflate.c",
+        "inftrees.c",
+        "trees.c",
+        "uncompr.c",
+        "zutil.c",
+        # Include the un-prefixed headers in srcs to work
+        # around the fact that zlib isn't consistent in its
+        # choice of <> or "" delimiter when including itself.
+    ] + _ZLIB_HEADERS,
+    hdrs = _ZLIB_PREFIXED_HEADERS,
+    copts = [
+        "-Wno-unused-variable",
+        "-Wno-implicit-function-declaration",
+    ],
+    includes = ["zlib/include/"],
+)


### PR DESCRIPTION
Allow downstream Bazel clients to build protobuf library with zlib support.