### PR TITLE
[objc] Provide more details/context in deprecation messages ⚠️

### DIFF
--- a/objectivec/GPBBootstrap.h
+++ b/objectivec/GPBBootstrap.h
@@ -92,10 +92,21 @@
 #endif
 
 /**
- * Attribute used for Objective-C proto interface deprecations.
+ * Attribute used for Objective-C proto interface deprecations without messages.
  **/
 #ifndef GPB_DEPRECATED
 #define GPB_DEPRECATED __attribute__((deprecated))
+#endif
+
+/**
+ * Attribute used for Objective-C proto interface deprecations with messages.
+ **/
+#ifndef GPB_DEPRECATED_MSG
+#if __has_extension(attribute_deprecated_with_message)
+#define GPB_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#else
+#define GPB_DEPRECATED_MSG(msg) __attribute__((deprecated))
+#endif
 #endif
 
 // If property name starts with init we need to annotate it to get past ARC.

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
@@ -163,11 +163,22 @@ string GetOptionalDeprecatedAttribute(
   // The file is only passed when checking Messages & Enums, so those types
   // get tagged. At the moment, it doesn't seem to make sense to tag every
   // field or enum value with when the file is deprecated.
+  bool isFileLevelDeprecation = false;
   if (!isDeprecated && file) {
-    isDeprecated = file->options().deprecated();
+    isFileLevelDeprecation = file->options().deprecated();
+    isDeprecated = isFileLevelDeprecation;
   }
   if (isDeprecated) {
-    string result = "GPB_DEPRECATED";
+    string message;
+    const FileDescriptor* sourceFile = descriptor->file();
+    if (isFileLevelDeprecation) {
+      message = sourceFile->name() + " is deprecated.";
+    } else {
+      message = descriptor->full_name() + " is deprecated (see " +
+                sourceFile->name() + ").";
+    }
+
+    string result = string("GPB_DEPRECATED_MSG(\"") + message + "\")";
     if (preSpace) {
       result.insert(0, " ");
     }


### PR DESCRIPTION
For deprecated fields, Include the full name of the deprecated field and the file containing the deprecated field in deprecation messages. For deprecated files, include the deprecated file in deprecation message. This additional context will help provide more details/context to help developers seek recommended alternatives to deprecated fields.