### PR TITLE
Remove mention of Buffer in utils.js

### DIFF
--- a/js/binary/utils.js
+++ b/js/binary/utils.js
@@ -971,6 +971,10 @@ jspb.utils.byteSourceToUint8Array = function(data) {
     return /** @type {!Uint8Array} */(new Uint8Array(data));
   }
 
+  if (data.constructor === Buffer) {
+    return /** @type {!Uint8Array} */(new Uint8Array(data));
+  }
+
   if (data.constructor === Array) {
     data = /** @type {!Array<number>} */(data);
     return /** @type {!Uint8Array} */(new Uint8Array(data));

--- a/js/binary/utils.js
+++ b/js/binary/utils.js
@@ -971,9 +971,10 @@ jspb.utils.byteSourceToUint8Array = function(data) {
     return /** @type {!Uint8Array} */(new Uint8Array(data));
   }
 
-  if (data.constructor === Buffer) {
-    return /** @type {!Uint8Array} */(new Uint8Array(data));
-  }
+  if (typeof Buffer != 'undefined' && data.constructor === Buffer) {
+    return /** @type {!Uint8Array} */ (
+        new Uint8Array(/** @type {?} */ (data)));
+   }
 
   if (data.constructor === Array) {
     data = /** @type {!Array<number>} */(data);

--- a/js/binary/utils.js
+++ b/js/binary/utils.js
@@ -971,10 +971,6 @@ jspb.utils.byteSourceToUint8Array = function(data) {
     return /** @type {!Uint8Array} */(new Uint8Array(data));
   }
 
-  if (data.constructor === Buffer) {
-    return /** @type {!Uint8Array} */(new Uint8Array(data));
-  }
-
   if (data.constructor === Array) {
     data = /** @type {!Array<number>} */(data);
     return /** @type {!Uint8Array} */(new Uint8Array(data));


### PR DESCRIPTION
This replays this [commit](f00e06c95bc117fb2ed0ca56c96041c93039f1fe) on 3.6.x branch.
Without this commit, tests are failing on closure compiler, because Buffer class is undefined.