### PR TITLE
Removed configure check for sched_yield

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,15 +205,6 @@ AM_CONDITIONAL([HAVE_PTHREAD], [test "x$ax_pthread_ok" = "xyes"])
 # We still keep this for improving pbconfig.h for unsupported platforms.
 AC_CXX_STL_HASH
 
-case "$target_os" in
-  mingw* | cygwin* | win* | aix* | *android* )
-    ;;
-  *)
-    # Need to link against rt on Solaris
-    AC_SEARCH_LIBS([sched_yield], [rt], [], [AC_MSG_FAILURE([sched_yield was not found on your system])])
-    ;;
-esac
-
 # Enable ObjC support for conformance directory on OS X.
 OBJC_CONFORMANCE_TEST=0
 case "$target_os" in


### PR DESCRIPTION
In the past we used sched_yield for some initialization code, but we are
no longer using it. This change removes the configure script check for
sched_yield so that we can still build even if sched_yield does not seem
to be available. This fixes #5435.