### PR TITLE
Updated Bazel workspace in examples/ to handle zlib dependency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1103,6 +1103,7 @@ EXTRA_DIST = $(@DIST_LANG@_EXTRA_DIST)   \
   examples/list_people.py                \
   examples/list_people_test.go           \
   examples/pubspec.yaml                  \
+  examples/third_party/zlib.BUILD        \
   protobuf.bzl                           \
   python/release/wheel/build_wheel_manylinux.sh  \
   python/release/wheel/Dockerfile                \

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # This com_google_protobuf repository is required for proto_library rule.
 # It provides the protocol compiler binary (i.e., protoc).
 http_archive(
@@ -37,6 +39,19 @@ http_archive(
     sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
     strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
     urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+)
+
+http_archive(
+    name = "net_zlib",
+    build_file = "//:third_party/zlib.BUILD",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+)
+
+bind(
+    name = "zlib",
+    actual = "@net_zlib//:zlib",
 )
 
 load("@bazel_skylib//lib:versions.bzl", "versions")

--- a/examples/third_party/zlib.BUILD
+++ b/examples/third_party/zlib.BUILD
@@ -1,0 +1,1 @@
+../../third_party/zlib.BUILD


### PR DESCRIPTION
To make this work, I created a symlink to the existing zlib.BUILD file.
Maybe there is a better way to do this, but this is at least a quick
workaround to fix the build.