### PR TITLE
fix(php): fix php `serializeToJsonString` empty ListValue.

### DIFF
--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -1389,9 +1389,12 @@ class Message
             }
             $fields = $this->desc->getField();
             $first = true;
+            $empty = true;
             foreach ($fields as $field) {
-                if ($this->existField($field) ||
-                    GPBUtil::hasJsonValue($this)) {
+                if ($this->existField($field) || GPBUtil::hasJsonValue($this)) {
+                    if ($empty) {
+                        $empty = false;
+                    }
                     if ($first) {
                         $first = false;
                     } else {
@@ -1401,6 +1404,9 @@ class Message
                         return false;
                     }
                 }
+            }
+            if (get_class($this) === ListValue::class && $empty) {
+                $output->writeRaw("[]", 2);
             }
             if (!GPBUtil::hasSpecialJsonMapping($this)) {
                 $output->writeRaw("}", 1);
@@ -1858,6 +1864,9 @@ class Message
                 if ($field_size != 0) {
                   $count++;
                 }
+            }
+            if (get_class($this) === ListValue::class && $count === 0) {
+                $size += 2;
             }
             // size for comma
             $size += $count > 0 ? ($count - 1) : 0;


### PR DESCRIPTION
PHP function `serializeToJsonString` when have an empty ListValue, it return an invalid json, just like this

# bug
```
{
    "name": "jack",
    "friends":,  // here should have an empty `[]`
    "age": 22
}
```

# after fix
```
{
    "name": "jack",
    "friends": [],
    "age": 22
}
```