### PR TITLE
Support finding fields in UpperCamelCase when composing objects from JSON

### DIFF
--- a/src/google/protobuf/util/internal/proto_writer.cc
+++ b/src/google/protobuf/util/internal/proto_writer.cc
@@ -69,6 +69,7 @@ ProtoWriter::ProtoWriter(TypeResolver* type_resolver,
       ignore_unknown_fields_(false),
       ignore_unknown_enum_values_(false),
       use_lower_camel_for_enums_(false),
+      try_lower_camel_for_unknown_fields_(false),
       element_(nullptr),
       size_insert_(),
       output_(output),
@@ -89,6 +90,7 @@ ProtoWriter::ProtoWriter(const TypeInfo* typeinfo,
       ignore_unknown_fields_(false),
       ignore_unknown_enum_values_(false),
       use_lower_camel_for_enums_(false),
+      try_lower_camel_for_unknown_fields_(false),
       element_(nullptr),
       size_insert_(),
       output_(output),
@@ -755,6 +757,11 @@ const google::protobuf::Field* ProtoWriter::Lookup(
   }
   const google::protobuf::Field* field =
       typeinfo_->FindField(&e->type(), unnormalized_name);
+
+  if (field == nullptr && try_lower_camel_for_unknown_fields_) {
+    field = FindLowerCamelFieldInTypeOrNull(&e->type(), unnormalized_name);
+  }
+
   if (field == nullptr && !ignore_unknown_fields_) {
     InvalidName(unnormalized_name, "Cannot find field.");
   }

--- a/src/google/protobuf/util/internal/proto_writer.h
+++ b/src/google/protobuf/util/internal/proto_writer.h
@@ -154,6 +154,10 @@ class PROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
     ignore_unknown_fields_ = ignore_unknown_fields;
   }
 
+  void set_try_lower_camel_for_unknown_fields(bool try_lower_camel_for_unknown_fields) {
+    try_lower_camel_for_unknown_fields_ = try_lower_camel_for_unknown_fields;
+  }
+
   void set_ignore_unknown_enum_values(bool ignore_unknown_enum_values) {
     ignore_unknown_enum_values_ = ignore_unknown_enum_values;
   }
@@ -337,6 +341,9 @@ class PROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
   // If true, check if enum name in camel case or without underscore matches the
   // field name.
   bool use_lower_camel_for_enums_;
+
+  // If true, will try to match unknown JSON fields names with lower camel case of fields name.
+  bool try_lower_camel_for_unknown_fields_;
 
   // Variable for internal state processing:
   // element_    : the current element.

--- a/src/google/protobuf/util/internal/protostream_objectwriter.cc
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.cc
@@ -73,6 +73,7 @@ ProtoStreamObjectWriter::ProtoStreamObjectWriter(
   set_ignore_unknown_fields(options_.ignore_unknown_fields);
   set_ignore_unknown_enum_values(options_.ignore_unknown_enum_values);
   set_use_lower_camel_for_enums(options_.use_lower_camel_for_enums);
+  set_try_lower_camel_for_unknown_fields(options_.try_lower_camel_for_unknown_fields);
 }
 
 ProtoStreamObjectWriter::ProtoStreamObjectWriter(
@@ -84,7 +85,8 @@ ProtoStreamObjectWriter::ProtoStreamObjectWriter(
       current_(nullptr),
       options_(options) {
   set_ignore_unknown_fields(options_.ignore_unknown_fields);
-  set_use_lower_camel_for_enums(options.use_lower_camel_for_enums);
+  set_use_lower_camel_for_enums(options_.use_lower_camel_for_enums);
+  set_try_lower_camel_for_unknown_fields(options_.try_lower_camel_for_unknown_fields);
 }
 
 ProtoStreamObjectWriter::ProtoStreamObjectWriter(

--- a/src/google/protobuf/util/internal/protostream_objectwriter.h
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.h
@@ -104,6 +104,9 @@ class PROTOBUF_EXPORT ProtoStreamObjectWriter : public ProtoWriter {
     // the field name.
     bool use_lower_camel_for_enums;
 
+    // If true, will try to match unknown JSON fields names with lower camel case of fields name.
+    bool try_lower_camel_for_unknown_fields;
+
     // If true, skips rendering the map entry if map value is null unless the
     // value type is google.protobuf.NullType.
     bool ignore_null_value_map_entry;
@@ -113,6 +116,7 @@ class PROTOBUF_EXPORT ProtoStreamObjectWriter : public ProtoWriter {
           ignore_unknown_fields(false),
           ignore_unknown_enum_values(false),
           use_lower_camel_for_enums(false),
+          try_lower_camel_for_unknown_fields(false),
           ignore_null_value_map_entry(false) {}
 
     // Default instance of Options with all options set to defaults.

--- a/src/google/protobuf/util/internal/utility.cc
+++ b/src/google/protobuf/util/internal/utility.cc
@@ -162,6 +162,21 @@ const google::protobuf::Field* FindFieldInTypeOrNull(
   return nullptr;
 }
 
+const google::protobuf::Field* FindLowerCamelFieldInTypeOrNull(
+    const google::protobuf::Type* type, StringPiece field_name) {
+  if (type != nullptr && !field_name.empty()) {
+    string upper_camel_field_name = field_name.as_string();
+    upper_camel_field_name[0] = toupper(upper_camel_field_name[0]);
+    for (int i = 0; i < type->fields_size(); ++i) {
+      const google::protobuf::Field& field = type->fields(i);
+      if (field.json_name() == upper_camel_field_name) {
+        return &field;
+      }
+    }
+  }
+  return nullptr;
+}
+
 const google::protobuf::Field* FindJsonFieldInTypeOrNull(
     const google::protobuf::Type* type, StringPiece json_name) {
   if (type != nullptr) {

--- a/src/google/protobuf/util/internal/utility.h
+++ b/src/google/protobuf/util/internal/utility.h
@@ -131,6 +131,12 @@ const google::protobuf::Option* FindOptionOrNull(
 const google::protobuf::Field* FindFieldInTypeOrNull(
     const google::protobuf::Type* type, StringPiece field_name);
 
+
+// Finds and returns the field identified by field_name in the passed tech Type
+// object. Returns nullptr if none found.
+const google::protobuf::Field* FindLowerCamelFieldInTypeOrNull(
+    const google::protobuf::Type* type, StringPiece field_name);
+
 // Similar to FindFieldInTypeOrNull, but this looks up fields with given
 // json_name.
 const google::protobuf::Field* FindJsonFieldInTypeOrNull(

--- a/src/google/protobuf/util/json_format_proto3.proto
+++ b/src/google/protobuf/util/json_format_proto3.proto
@@ -64,6 +64,7 @@ message TestMessage {
   bytes bytes_value = 9;
   EnumType enum_value = 10;
   MessageType message_value = 11;
+  string PascalCaseNaming = 12;
 
   repeated bool repeated_bool_value = 21;
   repeated int32 repeated_int32_value = 22;

--- a/src/google/protobuf/util/json_util.cc
+++ b/src/google/protobuf/util/json_util.cc
@@ -186,6 +186,8 @@ util::Status JsonToBinaryStream(TypeResolver* resolver,
   proto_writer_options.ignore_unknown_fields = options.ignore_unknown_fields;
   proto_writer_options.ignore_unknown_enum_values =
       options.ignore_unknown_fields;
+  proto_writer_options.try_lower_camel_for_unknown_fields =
+      options.try_lower_camel_for_unknown_fields;
   converter::ProtoStreamObjectWriter proto_writer(resolver, type, &sink,
                                                   &listener,
                                                   proto_writer_options);

--- a/src/google/protobuf/util/json_util.h
+++ b/src/google/protobuf/util/json_util.h
@@ -52,7 +52,16 @@ struct JsonParseOptions {
   // Whether to ignore unknown JSON fields during parsing
   bool ignore_unknown_fields;
 
-  JsonParseOptions() : ignore_unknown_fields(false) {}
+  // If true, will try to match unknown JSON fields names with lower camel case of fields name.
+  // For example, if the proto field name is "SomeField" and json field name is "someField", it
+  // would be recognized if this flag value equals to true.
+  // If the flag value equals to false, it would be either ignored (depending on ignore_unknown_fields flag)
+  // or "can not find field" error would occur.
+  bool try_lower_camel_for_unknown_fields;
+
+  JsonParseOptions()
+    : ignore_unknown_fields(false),
+      try_lower_camel_for_unknown_fields(false) {}
 };
 
 struct JsonPrintOptions {

--- a/src/google/protobuf/util/json_util_test.cc
+++ b/src/google/protobuf/util/json_util_test.cc
@@ -118,6 +118,7 @@ TEST_F(JsonUtilTest, TestDefaultValues) {
       "\"stringValue\":\"\","
       "\"bytesValue\":\"\","
       "\"enumValue\":\"FOO\","
+      "\"PascalCaseNaming\":\"\","
       "\"repeatedBoolValue\":[],"
       "\"repeatedInt32Value\":[],"
       "\"repeatedInt64Value\":[],"
@@ -146,6 +147,7 @@ TEST_F(JsonUtilTest, TestDefaultValues) {
       "\"stringValue\":\"i am a test string value\","
       "\"bytesValue\":\"aSBhbSBhIHRlc3QgYnl0ZXMgdmFsdWU=\","
       "\"enumValue\":\"FOO\","
+      "\"PascalCaseNaming\":\"\","
       "\"repeatedBoolValue\":[],"
       "\"repeatedInt32Value\":[],"
       "\"repeatedInt64Value\":[],"
@@ -174,6 +176,7 @@ TEST_F(JsonUtilTest, TestDefaultValues) {
       "\"string_value\":\"i am a test string value\","
       "\"bytes_value\":\"aSBhbSBhIHRlc3QgYnl0ZXMgdmFsdWU=\","
       "\"enum_value\":\"FOO\","
+      "\"PascalCaseNaming\":\"\","
       "\"repeated_bool_value\":[],"
       "\"repeated_int32_value\":[],"
       "\"repeated_int64_value\":[],"
@@ -308,6 +311,15 @@ TEST_F(JsonUtilTest, TestParseIgnoreUnknownFields) {
   JsonParseOptions options;
   options.ignore_unknown_fields = true;
   EXPECT_TRUE(FromJson("{\"unknownName\":0}", &m, options));
+}
+
+TEST_F(JsonUtilTest, TestParseTryLowerCamelForUnknownFields) {
+  TestMessage m;
+  JsonParseOptions options;
+  EXPECT_FALSE(FromJson("{\"pascalCaseNaming\":\"1\"}", &m, options));
+  EXPECT_TRUE(FromJson("{\"PascalCaseNaming\":\"1\"}", &m, options));
+  options.try_lower_camel_for_unknown_fields = true;
+  EXPECT_TRUE(FromJson("{\"pascalCaseNaming\":\"1\"}", &m, options));
 }
 
 TEST_F(JsonUtilTest, TestParseErrors) {


### PR DESCRIPTION
Hello!

I have been trying to come up with an idea on how to resolve the #5414 issue. The main reason why this issue was created is because `ToJsonName` does not make the first letter lower comparing to `ToCamelCase` function which indeed makes the first letter lower.

Of course, one the solutions is just to change the documentation and change the status of this issue into "Won't Fix" :)

But I thought that it might be somehow useful to support find fields in UpperCamelCase when composing a proto object from JSON.

Since we are not allowed to break backwards compatibility and may not change the behaviour of `ToJsonName` function, I have came up with the following solution:

1. Add new option (`try_lower_camel_for_unknown_fields`) to `JsonParseOptions` which will be responsible for the needed check.
2. If the flag is set, we just need to check that the field name is UpperCamelCase of the name we are looking for (this logic is implemented in `FindLowerCamelFieldInTypeOrNull`).

Looking forward to hear your opinion! @acozzette @TeBoring @BSBandme 

Fix #5414 
