### PR TITLE
[Protoc] Show error on duplicate json names

### DIFF
--- a/python/google/protobuf/internal/descriptor_test.py
+++ b/python/google/protobuf/internal/descriptor_test.py
@@ -1037,9 +1037,9 @@ class MakeDescriptorTest(unittest.TestCase):
     descriptor_proto = descriptor_pb2.DescriptorProto()
     descriptor_proto.name = 'TestJsonName'
     names = ['field_name_x', 'fieldName', 'FieldName',
-             '_field_name', 'FIELD_NAME', 'json_name']
+             '_field_name_x', 'FIELD_NAME', 'json_name']
     json_names = ['fieldNameX', 'fieldName', 'FieldName',
-                  'FieldName', 'FIELDNAME', '@type']
+                  'FieldNameX', 'FIELDNAME', '@type']
     for index in range(len(names)):
       field = descriptor_proto.field.add()
       field.number = index + 1

--- a/python/google/protobuf/internal/descriptor_test.py
+++ b/python/google/protobuf/internal/descriptor_test.py
@@ -1022,8 +1022,8 @@ class MakeDescriptorTest(unittest.TestCase):
   def testCamelcaseName(self):
     descriptor_proto = descriptor_pb2.DescriptorProto()
     descriptor_proto.name = 'Bar'
-    names = ['foo_foo', 'FooBar', 'fooBaz', 'fooFoo', 'foobar']
-    camelcase_names = ['fooFoo', 'fooBar', 'fooBaz', 'fooFoo', 'foobar']
+    names = ['foo_foo_x', 'FooBar', 'fooBaz', 'fooFoo', 'foobar']
+    camelcase_names = ['fooFooX', 'fooBar', 'fooBaz', 'fooFoo', 'foobar']
     for index in range(len(names)):
       field = descriptor_proto.field.add()
       field.number = index + 1
@@ -1036,9 +1036,9 @@ class MakeDescriptorTest(unittest.TestCase):
   def testJsonName(self):
     descriptor_proto = descriptor_pb2.DescriptorProto()
     descriptor_proto.name = 'TestJsonName'
-    names = ['field_name', 'fieldName', 'FieldName',
+    names = ['field_name_x', 'fieldName', 'FieldName',
              '_field_name', 'FIELD_NAME', 'json_name']
-    json_names = ['fieldName', 'fieldName', 'FieldName',
+    json_names = ['fieldNameX', 'fieldName', 'FieldName',
                   'FieldName', 'FIELDNAME', '@type']
     for index in range(len(names)):
       field = descriptor_proto.field.add()

--- a/src/google/protobuf/descriptor.h
+++ b/src/google/protobuf/descriptor.h
@@ -1600,6 +1600,7 @@ class PROTOBUF_EXPORT DescriptorPool {
     enum ErrorLocation {
       NAME,              // the symbol name, or the package name for files
       NUMBER,            // field or extension range number
+      JSON_NAME,         // field json name
       TYPE,              // field type
       EXTENDEE,          // field extendee
       DEFAULT_VALUE,     // field default value


### PR DESCRIPTION
When having two fields with the same json name `protoc` did not fail with error neither showed a warning.

For example:
```proto
syntax = "proto3";
message Hi {
    int32 f1 = 1 [json_name = "fooBar"];
    int32 f2 = 2 [json_name = "fooBar"];
}
```

This MR shows warning when using `protoc` in the following format:
>> dup_json_test.proto: warning: Fields with names "Hi.f2" and "Hi.f1" have the same JSON name "fooBar". This may cause problems.

I decided to show warning instead of error in order to save backwards compatibility. It could be replaced with error later on.

cc: @xfxyjwf @acozzette @TeBoring @dsnet 


Fix #5063