### PR TITLE
Do not add DEBUG_POSTFIX on non-Windows

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -44,7 +44,12 @@ cmake_dependent_option(protobuf_MSVC_STATIC_RUNTIME "Link static runtime librari
   "NOT protobuf_BUILD_SHARED_LIBS" OFF)
 set(protobuf_WITH_ZLIB_DEFAULT ON)
 option(protobuf_WITH_ZLIB "Build with zlib support" ${protobuf_WITH_ZLIB_DEFAULT})
-set(protobuf_DEBUG_POSTFIX "d"
+if (WIN32)
+  set(protobuf_DEBUG_POSTFIX_DEFAULT "d")
+else (WIN32)
+  SET(protobuf_DEBUG_POSTFIX_DEFAULT "")
+endif (WIN32)
+set(protobuf_DEBUG_POSTFIX ${protobuf_DEBUG_POSTFIX_DEFAULT}
   CACHE STRING "Default debug postfix")
 mark_as_advanced(protobuf_DEBUG_POSTFIX)
 # User options


### PR DESCRIPTION
My projects builds protobuf together when building itself, using CMake ExternalProject; on Windows the CMake build works very well, but on Linux the file names are a little bit surprising.  UNIX-like systems typically do not ship separately release and debug libraries.

I am aware that I can use autotools on Linux, but the CMake build integrates better, e.g. parallel builds get controlled together.