### PR TITLE
Fix Bazel issues on javalite branch (#5490)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 new_git_repository(
     name = "googletest",
     build_file = "gmock.BUILD",
@@ -5,11 +7,11 @@ new_git_repository(
     tag = "release-1.8.0",
 )
 
-new_http_archive(
+http_archive(
     name = "six_archive",
-    build_file = "six.BUILD",
+    build_file = "@//:six.BUILD",
     sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
-    url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55",
+    urls = ["https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55"],
 )
 
 bind(

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -263,8 +263,8 @@ def internal_gen_well_known_protos_java(srcs):
   Args:
     srcs: the well known protos
   """
-  root = Label("%s//protobuf_java" % (REPOSITORY_NAME)).workspace_root
-  pkg = PACKAGE_NAME + "/" if PACKAGE_NAME else ""
+  root = Label("%s//protobuf_java" % (native.repository_name())).workspace_root
+  pkg = native.package_name() + "/" if native.package_name() else ""
   if root == "":
     include = " -I%ssrc " % pkg
   else:


### PR DESCRIPTION
This pull request cherry-picks a Bazel fix to the javalite branch and also removes the use of the
deprecated new_http_archive() rule. This fixes #5490 and should allow the javalite branch to build
with Bazel 0.21.