### PR TITLE
benchmark-dashboard fixing

### DIFF
--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -521,10 +521,10 @@ php-benchmark: proto3_middleman_php generate_proto3_data
 	@chmod +x php-benchmark
 
 php: php-benchmark proto3_middleman_php
-	./php-benchmark $(proto3_data)
+	./php-benchmark --behavior_prefix="php" $(proto3_data)
 
 php_c_extension:
-	cd $(top_srcdir)/php/ext/google/protobuf && ./configure CFLAGS='-O3' && make -j8
+	cd $(top_srcdir)/php/ext/google/protobuf && phpize && ./configure CFLAGS='-O3' && make -j8
 
 php-c-benchmark: proto3_middleman_php generate_proto3_data php_c_extension php_c_extension
 	mkdir -p "tmp/php/Google/Protobuf/Benchmark" && cp php/PhpBenchmark.php "tmp/php/Google/Protobuf/Benchmark" 
@@ -540,7 +540,7 @@ php-c-benchmark: proto3_middleman_php generate_proto3_data php_c_extension php_c
 	@chmod +x php-c-benchmark
 
 php_c: php-c-benchmark proto3_middleman_php
-	./php-c-benchmark $(proto3_data)
+	./php-c-benchmark --behavior_prefix="php_c" $(proto3_data)
 
 
 ############ PHP RULES END #################

--- a/benchmarks/php/PhpBenchmark.php
+++ b/benchmarks/php/PhpBenchmark.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Google\Protobuf\Benchmark;
+ini_set('memory_limit', '4096M');
 
 const NAME = "PhpBenchmark.php";
 

--- a/benchmarks/python/py_benchmark.py
+++ b/benchmarks/python/py_benchmark.py
@@ -138,7 +138,7 @@ class Benchmark:
         t = timeit.timeit(stmt="%s(%s)" % (self.test_method, test_method_args),
                           setup=self.full_setup_code(setup_method_args),
                           number=reps);
-    return self.total_bytes * 1.0 / 2 ** 20 / (1.0 * t / reps)
+    return self.total_bytes * 1.0 / 2 ** 20 / (1.0 * t / reps * self.full_iteration)  
   
 
 if __name__ == "__main__":

--- a/kokoro/linux/benchmark/build.sh
+++ b/kokoro/linux/benchmark/build.sh
@@ -2,8 +2,25 @@
 
 cd $(dirname $0)/../../..
 
-export DOCKERFILE_DIR=kokoro/linux/64-bit
-export DOCKER_RUN_SCRIPT=kokoro/linux/pull_request_in_docker.sh
-export OUTPUT_DIR=testoutput
-export TEST_SET="benchmark"
-./kokoro/linux/build_and_run_docker.sh
+# prepare php environments
+sudo apt-get update && sudo apt-get install -y --force-yes php5
+sudo ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
+mkdir php_temp
+cd php_temp
+curl -sS https://getcomposer.org/installer | php
+sudo mv composer.phar /usr/local/bin/composer
+git clone https://github.com/php/php-src
+cd php-src && git checkout PHP-7.2.13 && ./buildconf --force
+./configure \
+	--enable-bcmatch \
+	--with-gmp --with-openssl \
+	--with-zlib  \
+	--prefix=/usr/local/php-7.2 && \
+make -j8 && sudo make install && make clean
+wget -O phpunit https://phar.phpunit.de/phpunit-7.phar && \
+	chmod +x phpunit && \
+	sudo cp phpunit /usr/local/php-7.2/bin
+sudo apt-get install -y --force-yes valgrind
+cd ../..
+
+./tests.sh benchmark

--- a/tests.sh
+++ b/tests.sh
@@ -525,7 +525,7 @@ build_php_all() {
 }
 
 build_benchmark() {
-  use_php 7.1
+  use_php 7.2
   cd kokoro/linux/benchmark && ./run.sh
 }
 
@@ -562,7 +562,7 @@ Usage: $0 { cpp |
             php7.1   |
             php7.1_c |
             php_all |
-			benchmark)
+            benchmark)
 "
   exit 1
 fi


### PR DESCRIPTION
Fix python benchmark throughput; 
Change back to not using docker for benchmark;
Fix php benchmark to set memory usage limit to 4GB;