### PR TITLE
Clean up unnecessary compile warning with GCC

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -54,7 +54,6 @@ COPTS = select({
         "-Wno-sign-compare",
         "-Wno-unused-function",
         # Prevents ISO C++ const string assignment warnings for pyext sources.
-        "-Wno-writable-strings",
         "-Wno-write-strings",
     ],
 })


### PR DESCRIPTION
The -Wno-writable-strings warning flag is Clang-specific. GCC's
equivalent is -Wno-write-strings, which Clang also supports as a
synonym. So, -Wno-write strings is more compatible and there is no need
to specify both.

https://clang.llvm.org/docs/DiagnosticsReference.html#wwrite-strings
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

Compiled with both GCC 8.2 and Clang trunk.