### PR TITLE
[Cherry-pick to 3.6.x] NVCC complains about static constexpr in dllexport class.

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -947,7 +947,7 @@ GenerateClassDefinition(io::Printer* printer) {
       "  return reinterpret_cast<const $classname$*>(\n"
       "             &_$classname$_default_instance_);\n"
       "}\n"
-      "static constexpr int kIndexInFileMessages =\n"
+      "static const int kIndexInFileMessages =\n"
       "  $message_index$;\n"
       "\n");
 

--- a/src/google/protobuf/extension_set.cc
+++ b/src/google/protobuf/extension_set.cc
@@ -1881,7 +1881,7 @@ void ExtensionSet::GrowCapacity(size_t minimum_new_capacity) {
 }
 
 // static
-constexpr uint16 ExtensionSet::kMaximumFlatCapacity;
+const uint16 ExtensionSet::kMaximumFlatCapacity;
 
 void ExtensionSet::Erase(int key) {
   if (GOOGLE_PREDICT_FALSE(is_large())) {

--- a/src/google/protobuf/extension_set.h
+++ b/src/google/protobuf/extension_set.h
@@ -618,7 +618,7 @@ class LIBPROTOBUF_EXPORT ExtensionSet {
   // Grows the flat_capacity_.
   // If flat_capacity_ > kMaximumFlatCapacity, converts to LargeMap.
   void GrowCapacity(size_t minimum_new_capacity);
-  static constexpr uint16 kMaximumFlatCapacity = 256;
+  static const uint16 kMaximumFlatCapacity = 256;
   bool is_large() const { return flat_capacity_ > kMaximumFlatCapacity; }
 
   // Removes a key from the ExtensionSet.


### PR DESCRIPTION
Cherry-pick #5522 back to 3.6.x branch with conflicts resolved.