### PR TITLE
`Libs` should not include `@PTHREAD_CFLAGS@`

### DIFF
--- a/protobuf-lite.pc.in
+++ b/protobuf-lite.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: Protocol Buffers
 Description: Google's Data Interchange Format
 Version: @VERSION@
-Libs: -L${libdir} -lprotobuf-lite @PTHREAD_CFLAGS@ @PTHREAD_LIBS@
+Libs: -L${libdir} -lprotobuf-lite @PTHREAD_LIBS@
 Cflags: -I${includedir} @PTHREAD_CFLAGS@
 Conflicts: protobuf

--- a/protobuf.pc.in
+++ b/protobuf.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: Protocol Buffers
 Description: Google's Data Interchange Format
 Version: @VERSION@
-Libs: -L${libdir} -lprotobuf @PTHREAD_CFLAGS@ @PTHREAD_LIBS@
+Libs: -L${libdir} -lprotobuf @PTHREAD_LIBS@
 Libs.private: @LIBS@
 Cflags: -I${includedir} @PTHREAD_CFLAGS@ @CXXFLAGS@
 Conflicts: protobuf-lite


### PR DESCRIPTION
That should be only on the CFlags. When using the compiler
as the linker driver, one may want to also call pkg-config to get the
cflags, but when invoking the linker, there should be no compiler flags.