### PR TITLE
Comments on the next line will go to the next field.

### DIFF
--- a/conformance/conformance.proto
+++ b/conformance/conformance.proto
@@ -68,8 +68,8 @@ enum TestCategory {
   // https://developers.google.com/protocol-buffers/docs/proto3#json_options
   // for more detail.
   JSON_IGNORE_UNKNOWN_PARSING_TEST = 3;
-  JSPB_TEST = 4;  // Test jspb wire format. Google internal only.
-                  // Opensource testees just skip it.
+  // Test jspb wire format. Google internal only. Opensource testees just skip it.
+  JSPB_TEST = 4;
 }
 
 message FailureSet {
@@ -92,8 +92,8 @@ message ConformanceRequest {
   oneof payload {
     bytes protobuf_payload = 1;
     string json_payload = 2;
-    string jspb_payload = 7;  // Google internal only.
-                              // Opensource testees just skip it.
+    // Google internal only.  Opensource testees just skip it.
+    string jspb_payload = 7;
   }
 
   // Which format should the testee serialize its message to?

--- a/csharp/src/Google.Protobuf.Conformance/Conformance.cs
+++ b/csharp/src/Google.Protobuf.Conformance/Conformance.cs
@@ -86,7 +86,7 @@ namespace Conformance {
     /// </summary>
     [pbr::OriginalName("JSON_IGNORE_UNKNOWN_PARSING_TEST")] JsonIgnoreUnknownParsingTest = 3,
     /// <summary>
-    /// Test jspb wire format. Google internal only.
+    /// Test jspb wire format. Google internal only. Opensource testees just skip it.
     /// </summary>
     [pbr::OriginalName("JSPB_TEST")] JspbTest = 4,
   }
@@ -298,7 +298,7 @@ namespace Conformance {
     /// <summary>Field number for the "jspb_payload" field.</summary>
     public const int JspbPayloadFieldNumber = 7;
     /// <summary>
-    /// Google internal only.
+    /// Google internal only.  Opensource testees just skip it.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string JspbPayload {


### PR DESCRIPTION
Even though the comments were indented to appear to go with the jspb
case/field, protoc doesn't collect comments like that, so these "hanging"
comments actually "attach" to the next thing added to each.  Looking at
https://github.com/protocolbuffers/protobuf/pull/5566 you see where
the generated code picked up the comment on the wrong field.