### PR TITLE
Add ContainsPythonKeyword check for message names

### DIFF
--- a/src/google/protobuf/compiler/python/python_generator.cc
+++ b/src/google/protobuf/compiler/python/python_generator.cc
@@ -834,12 +834,14 @@ void Generator::PrintMessages() const {
 void Generator::PrintMessage(const Descriptor& message_descriptor,
                              const string& prefix,
                              std::vector<string>* to_register) const {
-  string qualified_name(prefix + message_descriptor.name());
+  string message_name = message_descriptor.name();
+  string safe_message_name = ContainsPythonKeyword(message_name) ? message_name + "_" : message_name;
+  string qualified_name(prefix + safe_message_name);
   to_register->push_back(qualified_name);
   printer_->Print(
       "$name$ = _reflection.GeneratedProtocolMessageType('$name$', "
       "(_message.Message,), dict(\n",
-      "name", message_descriptor.name());
+      "name", safe_message_name);
   printer_->Indent();
 
   PrintNestedMessages(message_descriptor, qualified_name + ".", to_register);


### PR DESCRIPTION
### In a nutshell
Make the generated python work even when message names are python keyworks

### Context
- This PR complets #5281 
- This PR helps fixing #4833
----

### Example of the issue

Source with python-reserved keyword "None" used as message name...
```proto
syntax = "proto3";
message None {
    string name = 1;
}
```

...compiles into invalid python:
```python
# ...
None = _reflection.GeneratedProtocolMessageType('None', (_message.Message,), dict(
  DESCRIPTOR = _NONE,
  __module__ = 'test_pb2'
  # @@protoc_insertion_point(class_scope:None)
  ))
_sym_db.RegisterMessage(None)
```

```bash
  File "test_pb2.py", line 61
    None = _reflection.GeneratedProtocolMessageType('None', (_message.Message,), dict(
SyntaxError: cannot assign to None
```

### Proposal: Escape message name that are Python keywords

Like in #5281 this PR proposes change the generator so it appends underscore _ character to reserved Python keywords as stated in [PEP8](https://www.python.org/dev/peps/pep-0008/)
> If a function argument's name clashes with a reserved keyword, it is generally better to append a single trailing underscore rather than use an abbreviation or spelling corruption. Thus class_ is better than clss. (Perhaps better is to avoid such clashes by using a synonym.)

### Result
Diff of the generated files for the above example

```bash
--- test_pb2.py.before
+++ test_pb2.py.after
@@ -58,12 +59,12 @@ _NONE = _descriptor.Descriptor(
 DESCRIPTOR.message_types_by_name['None'] = _NONE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)

-None = _reflection.GeneratedProtocolMessageType('None', (_message.Message,), dict(
+None_ = _reflection.GeneratedProtocolMessageType('None_', (_message.Message,), dict(
   DESCRIPTOR = _NONE,
   __module__ = 'test_pb2'
   # @@protoc_insertion_point(class_scope:None)
   ))
-_sym_db.RegisterMessage(None)
+_sym_db.RegisterMessage(None_)


 # @@protoc_insertion_point(module_scope)
```

