### PR TITLE
Remove unused f expression from jscode gen.

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -2264,7 +2264,7 @@ void Generator::GenerateClassToObject(const GeneratorOptions& options,
       " * @suppress {unusedLocalVariables} f is only used for nested messages\n"
       " */\n"
       "$classname$.toObject = function(includeInstance, msg) {\n"
-      "  var f, obj = {",
+      "  var obj = {",
       "classname", GetMessagePath(options, desc));
 
   bool first = true;


### PR DESCRIPTION
Varadic assignment in javascript where the right hand expression is an
object yields a single set assignment with the right most lefthand variable,
while leaving the other left side expressions undefined.

For example:
var a,b = {}

will only initialize a to undefined. But will set b to the {} value.

--

For this code since f is never used, it is a safe operation to remove
it.