### PR TITLE
Add proto3 to solidity link in third_party.md

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -89,6 +89,7 @@ These are projects we know about implementing Protocol Buffers for other program
 * Scala: http://code.google.com/p/protobuf-scala
 * Scala: https://github.com/SandroGrzicic/ScalaBuff
 * Scala: https://scalapb.github.io
+* Solidity: https://github.com/celer-network/pb3-gen-sol
 * Swift: https://github.com/alexeyxo/protobuf-swift
 * Swift: https://github.com/apple/swift-protobuf/
 * Vala: https://launchpad.net/protobuf-vala


### PR DESCRIPTION
pb3-gen-sol is a proto3 to solidity library generator that supports proto3 native types and uses field option for solidity native types. Both the message and generated code are more efficient than other solutions. It also includes a library to decode protobuf wireformat.