### PR TITLE
doc: apply consistent indentation to Any examples

### DIFF
--- a/src/google/protobuf/any.proto
+++ b/src/google/protobuf/any.proto
@@ -64,7 +64,7 @@ option objc_class_prefix = "GPB";
 //       foo = any.unpack(Foo.class);
 //     }
 //
-//  Example 3: Pack and unpack a message in Python.
+// Example 3: Pack and unpack a message in Python.
 //
 //     foo = Foo(...)
 //     any = Any()
@@ -74,7 +74,7 @@ option objc_class_prefix = "GPB";
 //       any.Unpack(foo)
 //       ...
 //
-//  Example 4: Pack and unpack a message in Go
+// Example 4: Pack and unpack a message in Go
 //
 //      foo := &pb.Foo{...}
 //      any, err := ptypes.MarshalAny(foo)


### PR DESCRIPTION
The extra space causes an improper GoDoc to be generated after imported to the golang/protobuf repo at https://github.com/golang/protobuf/ due to Examples 3 and 4 having an extra leading space causing  them to appear as part of Example 2 rather than distinct snippets

https://i.imgur.com/FSwehb1.png
https://godoc.org/github.com/golang/protobuf/ptypes/any#Any