### PR TITLE
Revert "doc: apply consistent indentation to Any examples"

### DIFF
--- a/src/google/protobuf/any.proto
+++ b/src/google/protobuf/any.proto
@@ -64,7 +64,7 @@ option objc_class_prefix = "GPB";
 //       foo = any.unpack(Foo.class);
 //     }
 //
-// Example 3: Pack and unpack a message in Python.
+//  Example 3: Pack and unpack a message in Python.
 //
 //     foo = Foo(...)
 //     any = Any()
@@ -74,7 +74,7 @@ option objc_class_prefix = "GPB";
 //       any.Unpack(foo)
 //       ...
 //
-// Example 4: Pack and unpack a message in Go
+//  Example 4: Pack and unpack a message in Go
 //
 //      foo := &pb.Foo{...}
 //      any, err := ptypes.MarshalAny(foo)


### PR DESCRIPTION
Reverts protocolbuffers/protobuf#5597

This breaks c# bootstrap test. To fix that, run ./generate_descriptor_proto.sh