### PR TITLE
[Python] Allow json_format.ParseDict to parse messages with extensions containing scalar types.

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -202,6 +202,17 @@ class JsonFormatTest(JsonFormatBase):
     json_format.ParseDict(message_dict, parsed_message)
     self.assertEqual(message, parsed_message)
 
+  def testExtensionToDictAndBackWithScalar(self):
+    message = unittest_pb2.TestAllExtensions()
+    ext1 = unittest_pb2.TestNestedExtension.test
+    message.Extensions[ext1] = 'data'
+    message_dict = json_format.MessageToDict(
+        message
+    )
+    parsed_message = unittest_pb2.TestAllExtensions()
+    json_format.ParseDict(message_dict, parsed_message)
+    self.assertEqual(message, parsed_message)
+
   def testJsonParseDictToAnyDoesNotAlterInput(self):
     orig_dict = {
         'int32Value': 20,

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -564,7 +564,10 @@ class _Parser(object):
           sub_message.SetInParent()
           self.ConvertMessage(value, sub_message)
         else:
-          setattr(message, field.name, _ConvertScalarFieldValue(value, field))
+          if field.is_extension:
+            message.Extensions[field] = _ConvertScalarFieldValue(value, field)
+          else:
+            setattr(message, field.name, _ConvertScalarFieldValue(value, field))
       except ParseError as e:
         if field and field.containing_oneof is None:
           raise ParseError('Failed to parse {0} field: {1}'.format(name, e))


### PR DESCRIPTION
This PR fixes an issue with `json_format.ParseDict` in Python, in which certain Protobuf definitions that contain extensions fail to be parsed. See [`protobuf-python-bug`](https://github.com/psobot/protobuf-python-bug) for a direct example of the bug outside of the `protobuf` codebase itself, but the gist of it is that any attempt to use `ParseDict` to deserialize a dict representation of a message containing a non-repeating extension field of scalar type currently fails. (I believe that's the simplest and smallest reproducible case of this bug that I could find, but my understanding of the problem could be incomplete.)