### PR TITLE
Allow internalAddGeneratedFile to depend on new nested message name

### DIFF
--- a/php/ext/google/protobuf/encode_decode.c
+++ b/php/ext/google/protobuf/encode_decode.c
@@ -36,22 +36,14 @@
 
 /* stringsink *****************************************************************/
 
-typedef struct {
-  upb_byteshandler handler;
-  upb_bytessink sink;
-  char *ptr;
-  size_t len, size;
-} stringsink;
-
-
 static void *stringsink_start(void *_sink, const void *hd, size_t size_hint) {
   stringsink *sink = _sink;
   sink->len = 0;
   return sink;
 }
 
-static size_t stringsink_string(void *_sink, const void *hd, const char *ptr,
-                                size_t len, const upb_bufhandle *handle) {
+size_t stringsink_string(void *_sink, const void *hd, const char *ptr,
+                         size_t len, const upb_bufhandle *handle) {
   stringsink *sink = _sink;
   size_t new_size = sink->size;
 

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -591,7 +591,8 @@ static void init_file_any(TSRMLS_D) {
   char* binary;
   int binary_len;
   hex_to_binary(generated_file, &binary, &binary_len);
-  internal_add_generated_file(binary, binary_len, generated_pool TSRMLS_CC);
+  internal_add_generated_file(binary, binary_len,
+                              generated_pool, true TSRMLS_CC);
   FREE(binary);
   is_inited_file_any = true;
 }
@@ -631,7 +632,8 @@ static void init_file_api(TSRMLS_D) {
   char* binary;
   int binary_len;
   hex_to_binary(generated_file, &binary, &binary_len);
-  internal_add_generated_file(binary, binary_len, generated_pool TSRMLS_CC);
+  internal_add_generated_file(binary, binary_len,
+                              generated_pool, true TSRMLS_CC);
   FREE(binary);
   is_inited_file_api = true;
 }
@@ -651,7 +653,8 @@ static void init_file_duration(TSRMLS_D) {
   char* binary;
   int binary_len;
   hex_to_binary(generated_file, &binary, &binary_len);
-  internal_add_generated_file(binary, binary_len, generated_pool TSRMLS_CC);
+  internal_add_generated_file(binary, binary_len,
+                              generated_pool, true TSRMLS_CC);
   FREE(binary);
   is_inited_file_duration = true;
 }
@@ -671,7 +674,8 @@ static void init_file_field_mask(TSRMLS_D) {
   char* binary;
   int binary_len;
   hex_to_binary(generated_file, &binary, &binary_len);
-  internal_add_generated_file(binary, binary_len, generated_pool TSRMLS_CC);
+  internal_add_generated_file(binary, binary_len,
+                              generated_pool, true TSRMLS_CC);
   FREE(binary);
   is_inited_file_field_mask = true;
 }
@@ -690,7 +694,8 @@ static void init_file_empty(TSRMLS_D) {
   char* binary;
   int binary_len;
   hex_to_binary(generated_file, &binary, &binary_len);
-  internal_add_generated_file(binary, binary_len, generated_pool TSRMLS_CC);
+  internal_add_generated_file(binary, binary_len,
+                              generated_pool, true TSRMLS_CC);
   FREE(binary);
   is_inited_file_empty = true;
 }
@@ -711,7 +716,8 @@ static void init_file_source_context(TSRMLS_D) {
   char* binary;
   int binary_len;
   hex_to_binary(generated_file, &binary, &binary_len);
-  internal_add_generated_file(binary, binary_len, generated_pool TSRMLS_CC);
+  internal_add_generated_file(binary, binary_len,
+                              generated_pool, true TSRMLS_CC);
   FREE(binary);
   is_inited_file_source_context = true;
 }
@@ -745,7 +751,8 @@ static void init_file_struct(TSRMLS_D) {
   char* binary;
   int binary_len;
   hex_to_binary(generated_file, &binary, &binary_len);
-  internal_add_generated_file(binary, binary_len, generated_pool TSRMLS_CC);
+  internal_add_generated_file(binary, binary_len,
+                              generated_pool, true TSRMLS_CC);
   FREE(binary);
   is_inited_file_struct = true;
 }
@@ -765,7 +772,8 @@ static void init_file_timestamp(TSRMLS_D) {
   char* binary;
   int binary_len;
   hex_to_binary(generated_file, &binary, &binary_len);
-  internal_add_generated_file(binary, binary_len, generated_pool TSRMLS_CC);
+  internal_add_generated_file(binary, binary_len,
+                              generated_pool, true TSRMLS_CC);
   FREE(binary);
   is_inited_file_timestamp = true;
 }
@@ -833,7 +841,8 @@ static void init_file_type(TSRMLS_D) {
   char* binary;
   int binary_len;
   hex_to_binary(generated_file, &binary, &binary_len);
-  internal_add_generated_file(binary, binary_len, generated_pool TSRMLS_CC);
+  internal_add_generated_file(binary, binary_len,
+                              generated_pool, true TSRMLS_CC);
   FREE(binary);
   is_inited_file_type = true;
 }
@@ -860,7 +869,8 @@ static void init_file_wrappers(TSRMLS_D) {
   char* binary;
   int binary_len;
   hex_to_binary(generated_file, &binary, &binary_len);
-  internal_add_generated_file(binary, binary_len, generated_pool TSRMLS_CC);
+  internal_add_generated_file(binary, binary_len,
+                              generated_pool, true TSRMLS_CC);
   FREE(binary);
   is_inited_file_wrappers = true;
 }

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -770,7 +770,8 @@ PHP_METHOD(InternalDescriptorPool, getGeneratedPool);
 PHP_METHOD(InternalDescriptorPool, internalAddGeneratedFile);
 
 void internal_add_generated_file(const char* data, PHP_PROTO_SIZE data_len,
-                                 InternalDescriptorPool* pool TSRMLS_DC);
+                                 InternalDescriptorPool* pool,
+                                 bool use_nested_submsg TSRMLS_DC);
 void init_generated_pool_once(TSRMLS_D);
 
 // wrapper of generated pool
@@ -1452,6 +1453,18 @@ upb_fieldtype_t to_fieldtype(upb_descriptortype_t type);
 const zend_class_entry* field_type_class(
     const upb_fielddef* field PHP_PROTO_TSRMLS_DC);
 void stringsink_uninit_opaque(void *sink);
+
+typedef struct {
+  upb_byteshandler handler;
+  upb_bytessink sink;
+  char *ptr;
+  size_t len, size;
+} stringsink;
+
+void stringsink_init(stringsink *sink);
+void stringsink_uninit(stringsink *sink);
+size_t stringsink_string(void *_sink, const void *hd, const char *ptr,
+                         size_t len, const upb_bufhandle *handle);
 
 // -----------------------------------------------------------------------------
 // Utilities.

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -1010,7 +1010,7 @@ void GenerateAddFileToPool(const FileDescriptor* file, bool is_descriptor,
 
     Outdent(printer);
     printer->Print(
-        "));\n\n");
+        "), true);\n\n");
   }
   printer->Print(
       "static::$is_initialized = true;\n");


### PR DESCRIPTION
Previously, internalAddGeneratedFile has to depend on old non-nested name for sub-messages.
This creates a hard dependency on old generated code for compatibility usage.
If user's code has custome error handler, the deprecation warning in the old generated code
will also be thrown (even though users haven't explicitly depended on the old message name).

To fix this problem, this change added an additional flag in the generated code to tell run
time that it's safe to use new message name. In this way, internalAddGeneratedFile can safely
depend on new name and don't trigger unnecessary deprecation warning.

After this change is released, users need to use the new protoc to re-generate code.