### PR TITLE
Python/C++: Add tests to ensure that AllowOversizeProtos also handles deeper levels of recursion.

### DIFF
--- a/python/google/protobuf/internal/more_messages.proto
+++ b/python/google/protobuf/internal/more_messages.proto
@@ -358,3 +358,15 @@ message LotsNestedMessage {
   message B254 {}
   message B255 {}
 }
+
+message Tree {
+  optional Node left = 1;
+  optional Node right = 2;
+}
+
+message Node {
+  oneof Child {
+    Tree tree = 1;
+    sint64 value = 2;
+  }
+}


### PR DESCRIPTION
Add tests to ensure that AllowOversizeProtos also handles deeper levels of recursion.

EDIT: Was originally intending to try to fix a problem where `SetAllowOversizeProtos` was supposed to set the maximum Protobuf message size _and_ recursion depth arbitrarily high, but under most non-trivial circumstances the recursion depth setting didn't actually seem to be affected. This happened to be fixed as part of 3.7.0 and I erroneously thought my changes fixed the problem.

Included a test case which would have failed without the accompanying code change that intentionally creates a deeper message that the C++ parser implementation for Python would normally allow.