### PR TITLE
Cleanup PHP tests, add PSR-4 auto loading for tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -730,19 +730,19 @@ php_EXTRA_DIST=                                                       \
   php/src/Google/Protobuf/UInt64Value.php                             \
   php/src/Google/Protobuf/Value.php                                   \
   php/src/phpdoc.dist.xml                                             \
-  php/tests/array_test.php                                            \
   php/tests/autoload.php                                              \
   php/tests/bootstrap_phpunit.php                                     \
   php/tests/compatibility_test.sh                                     \
-  php/tests/descriptors_test.php                                      \
-  php/tests/encode_decode_test.php                                    \
+  php/tests/DescriptorsTest.php                                       \
+  php/tests/EncodeDecodeTest.php                                      \
   php/tests/gdb_test.sh                                               \
-  php/tests/generated_class_test.php                                  \
-  php/tests/generated_phpdoc_test.php                                 \
-  php/tests/generated_service_test.php                                \
-  php/tests/map_field_test.php                                        \
+  php/tests/GeneratedClassTest.php                                    \
+  php/tests/GeneratedPhpdocTest.php                                   \
+  php/tests/GeneratedServiceTest.php                                  \
+  php/tests/MapFieldTest.php                                          \
   php/tests/memory_leak_test.php                                      \
-  php/tests/php_implementation_test.php                               \
+  php/tests/PhpImplementationTest.php                                 \
+  php/tests/RepeatedFieldTest.php                                     \
   php/tests/proto/empty/echo.proto                                    \
   php/tests/proto/test.proto                                          \
   php/tests/proto/test_descriptors.proto                              \
@@ -762,11 +762,11 @@ php_EXTRA_DIST=                                                       \
   php/tests/proto/test_service_namespace.proto                        \
   php/tests/proto/test_wrapper_type_setters.proto                     \
   php/tests/test.sh                                                   \
-  php/tests/test_base.php                                             \
-  php/tests/test_util.php                                             \
-  php/tests/undefined_test.php                                        \
-  php/tests/well_known_test.php                                       \
-  php/tests/wrapper_type_setters_test.php
+  php/tests/TestBase.php                                              \
+  php/tests/TestUtil.php                                              \
+  php/tests/UndefinedTest.php                                         \
+  php/tests/WellKnownTest.php                                         \
+  php/tests/WrapperTypeSettersTest.php
 
 python_EXTRA_DIST=                                                           \
   python/MANIFEST.in                                                         \

--- a/php/composer.json
+++ b/php/composer.json
@@ -19,7 +19,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "": "tests/generated"
+      "": "tests/generated",
+      "Google\\Protobuf\\Tests\\": "tests"
     }
   },
   "scripts": {

--- a/php/phpunit.xml
+++ b/php/phpunit.xml
@@ -14,7 +14,6 @@
       <file>tests/MapFieldTest.php</file>
       <file>tests/PhpImplementationTest.php</file>
       <file>tests/RepeatedFieldTest.php</file>
-      <file>tests/UndefinedTest.php</file>
       <file>tests/WellKnownTest.php</file>
       <file>tests/WrapperTypeSettersTest.php</file>
     </testsuite>

--- a/php/phpunit.xml
+++ b/php/phpunit.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap_phpunit.php"
-         colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./tests/bootstrap_phpunit.php"
+         colors="true"
+>
   <testsuites>
     <testsuite name="protobuf-tests">
-      <file>tests/php_implementation_test.php</file>
-      <file>tests/array_test.php</file>
-      <file>tests/encode_decode_test.php</file>
-      <file>tests/generated_class_test.php</file>
-      <file>tests/generated_phpdoc_test.php</file>
-      <file>tests/map_field_test.php</file>
-      <file>tests/well_known_test.php</file>
-      <file>tests/descriptors_test.php</file>
-      <file>tests/generated_service_test.php</file>
-      <file>tests/wrapper_type_setters_test.php</file>
+      <file>tests/DescriptorsTest.php</file>
+      <file>tests/EncodeDecodeTest.php</file>
+      <file>tests/GeneratedClassTest.php</file>
+      <file>tests/GeneratedPhpdocTest.php</file>
+      <file>tests/GeneratedServiceTest.php</file>
+      <file>tests/MapFieldTest.php</file>
+      <file>tests/PhpImplementationTest.php</file>
+      <file>tests/RepeatedFieldTest.php</file>
+      <file>tests/UndefinedTest.php</file>
+      <file>tests/WellKnownTest.php</file>
+      <file>tests/WrapperTypeSettersTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/php/tests/DescriptorsTest.php
+++ b/php/tests/DescriptorsTest.php
@@ -1,9 +1,6 @@
 <?php
 
-require_once('generated/Descriptors/TestDescriptorsEnum.php');
-require_once('generated/Descriptors/TestDescriptorsMessage.php');
-require_once('test_base.php');
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
 use Google\Protobuf\DescriptorPool;
 use Google\Protobuf\Internal\RepeatedField;
@@ -12,7 +9,7 @@ use Descriptors\TestDescriptorsEnum;
 use Descriptors\TestDescriptorsMessage;
 use Descriptors\TestDescriptorsMessage\Sub;
 
-class DescriptorsTest extends TestBase
+final class DescriptorsTest extends TestBase
 {
 
     // Redefine these here for compatibility with c extension

--- a/php/tests/EncodeDecodeTest.php
+++ b/php/tests/EncodeDecodeTest.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once('test_base.php');
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
+use Google\Protobuf\Duration;
 use Google\Protobuf\RepeatedField;
 use Google\Protobuf\GPBType;
 use Foo\TestAny;
@@ -17,6 +17,7 @@ use Google\Protobuf\DoubleValue;
 use Google\Protobuf\FieldMask;
 use Google\Protobuf\FloatValue;
 use Google\Protobuf\Int32Value;
+use Google\Protobuf\Timestamp;
 use Google\Protobuf\UInt32Value;
 use Google\Protobuf\Int64Value;
 use Google\Protobuf\UInt64Value;
@@ -28,7 +29,7 @@ use Google\Protobuf\ListValue;
 use Google\Protobuf\Struct;
 use Google\Protobuf\GPBEmpty;
 
-class EncodeDecodeTest extends TestBase
+final class EncodeDecodeTest extends TestBase
 {
     public function testDecodeJsonSimple()
     {
@@ -839,7 +840,7 @@ class EncodeDecodeTest extends TestBase
 
     public function testDecodeDuration()
     {
-        $m = new Google\Protobuf\Duration();
+        $m = new Duration();
         $m->mergeFromJsonString("\"1234.5678s\"");
         $this->assertEquals(1234, $m->getSeconds());
         $this->assertEquals(567800000, $m->getNanos());
@@ -847,7 +848,7 @@ class EncodeDecodeTest extends TestBase
 
     public function testEncodeDuration()
     {
-        $m = new Google\Protobuf\Duration();
+        $m = new Duration();
         $m->setSeconds(1234);
         $m->setNanos(999999999);
         $this->assertEquals("\"1234.999999999s\"", $m->serializeToJsonString());
@@ -855,7 +856,7 @@ class EncodeDecodeTest extends TestBase
 
     public function testDecodeTimestamp()
     {
-        $m = new Google\Protobuf\Timestamp();
+        $m = new Timestamp();
         $m->mergeFromJsonString("\"2000-01-01T00:00:00.123456789Z\"");
         $this->assertEquals(946684800, $m->getSeconds());
         $this->assertEquals(123456789, $m->getNanos());
@@ -863,7 +864,7 @@ class EncodeDecodeTest extends TestBase
 
     public function testEncodeTimestamp()
     {
-        $m = new Google\Protobuf\Timestamp();
+        $m = new Timestamp();
         $m->setSeconds(946684800);
         $m->setNanos(123456789);
         $this->assertEquals("\"2000-01-01T00:00:00.123456789Z\"",
@@ -1094,7 +1095,7 @@ class EncodeDecodeTest extends TestBase
             $outer->serializeToJsonString());
 
         // Test a Timestamp message.
-        $packed = new Google\Protobuf\Timestamp();
+        $packed = new Timestamp();
         $packed->setSeconds(946684800);
         $packed->setNanos(123456789);
         $m = new Any();

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -1,9 +1,6 @@
 <?php
 
-require_once('generated/NoNamespaceEnum.php');
-require_once('generated/NoNamespaceMessage.php');
-require_once('test_base.php');
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\MapField;
@@ -21,10 +18,14 @@ use Foo\TestMessage\NestedEnum;
 use Foo\TestReverseFieldOrder;
 use Foo\testLowerCaseMessage;
 use Foo\testLowerCaseEnum;
+use NoNamespaceEnum;
+use NoNamespaceMessage;
 use PBEmpty\PBEcho\TestEmptyPackage;
 use Php\Test\TestNamespace;
+use PrefixTestPrefix;
+use TestEmptyNamespace;
 
-class GeneratedClassTest extends TestBase
+final class GeneratedClassTest extends TestBase
 {
 
     #########################################################
@@ -719,7 +720,7 @@ class GeneratedClassTest extends TestBase
     public function testEnumWithoutNamespace()
     {
         $m = new TestMessage();
-        $m->setOptionalNoNamespaceEnum(NoNameSpaceEnum::VALUE_A);
+        $m->setOptionalNoNamespaceEnum(NoNamespaceEnum::VALUE_A);
         $repeatedNoNamespaceEnum = $m->getRepeatedNoNamespaceEnum();
         $repeatedNoNamespaceEnum[] = NoNameSpaceEnum::VALUE_A;
         $m->setRepeatedNoNamespaceEnum($repeatedNoNamespaceEnum);

--- a/php/tests/GeneratedPhpdocTest.php
+++ b/php/tests/GeneratedPhpdocTest.php
@@ -1,13 +1,11 @@
 <?php
 
-require_once('generated/NoNamespaceEnum.php');
-require_once('generated/NoNamespaceMessage.php');
-require_once('test_base.php');
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
 use Foo\TestMessage;
+use ReflectionClass;
 
-class GeneratedPhpdocTest extends TestBase
+final class GeneratedPhpdocTest extends TestBase
 {
     public function testPhpDocForClass()
     {

--- a/php/tests/GeneratedServiceTest.php
+++ b/php/tests/GeneratedServiceTest.php
@@ -1,7 +1,6 @@
 <?php
 
-require_once('test_base.php');
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\MapField;
@@ -9,8 +8,9 @@ use Google\Protobuf\Internal\GPBType;
 use Foo\Greeter;
 use Foo\HelloRequest;
 use Foo\HelloReply;
+use ReflectionClass;
 
-class GeneratedServiceTest extends TestBase
+final class GeneratedServiceTest extends TestBase
 {
     /**
      * @var \ReflectionClass

--- a/php/tests/MapFieldTest.php
+++ b/php/tests/MapFieldTest.php
@@ -1,13 +1,13 @@
 <?php
 
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\MapField;
 use Foo\TestMessage;
 use Foo\TestMessage\Sub;
 
-class MapFieldTest extends \PHPUnit\Framework\TestCase {
+final class MapFieldTest extends \PHPUnit\Framework\TestCase {
 
     #########################################################
     # Test int32 field.

--- a/php/tests/PhpImplementationTest.php
+++ b/php/tests/PhpImplementationTest.php
@@ -1,7 +1,6 @@
 <?php
 
-require_once('test_base.php');
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
 use Foo\TestEnum;
 use Foo\TestMessage;
@@ -14,7 +13,7 @@ use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\GPBWire;
 use Google\Protobuf\Internal\CodedOutputStream;
 
-class ImplementationTest extends TestBase
+final class PhpImplementationTest extends TestBase
 {
     public function testReadInt32()
     {

--- a/php/tests/RepeatedFieldTest.php
+++ b/php/tests/RepeatedFieldTest.php
@@ -1,13 +1,13 @@
 <?php
 
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBType;
 use Foo\TestMessage;
 use Foo\TestMessage\Sub;
 
-class RepeatedFieldTest extends \PHPUnit\Framework\TestCase
+final class RepeatedFieldTest extends \PHPUnit\Framework\TestCase
 {
 
     #########################################################

--- a/php/tests/TestBase.php
+++ b/php/tests/TestBase.php
@@ -1,10 +1,12 @@
 <?php
 
+namespace Google\Protobuf\Tests;
+
 use Foo\TestMessage;
 use Foo\TestEnum;
 use Foo\TestMessage\Sub;
 
-class TestBase extends \PHPUnit\Framework\TestCase
+abstract class TestBase extends \PHPUnit\Framework\TestCase
 {
 
     public function setFields(TestMessage $m)

--- a/php/tests/TestUtil.php
+++ b/php/tests/TestUtil.php
@@ -1,50 +1,12 @@
 <?php
 
+namespace Google\Protobuf\Tests;
+
 use Foo\TestEnum;
 use Foo\TestMessage;
 use Foo\TestMessage\Sub;
 use Foo\TestPackedMessage;
 use Foo\TestUnpackedMessage;
-
-define('MAX_FLOAT_DIFF', 0.000001);
-
-if (PHP_INT_SIZE == 8) {
-    define('MAX_INT_STRING', '9223372036854775807');
-    define('MAX_INT_UPPER_STRING', '9223372036854775808');
-} else {
-    define('MAX_INT_STRING', '2147483647');
-    define('MAX_INT_UPPER_STRING', '2147483648');
-}
-
-define('MAX_INT32', 2147483647);
-define('MAX_INT32_FLOAT', 2147483647.0);
-define('MAX_INT32_STRING', '2147483647');
-
-define('MIN_INT32', (int)-2147483648);
-define('MIN_INT32_FLOAT', -2147483648.0);
-define('MIN_INT32_STRING', '-2147483648');
-
-define('MAX_UINT32', 4294967295);
-define('MAX_UINT32_FLOAT', 4294967295.0);
-define('MAX_UINT32_STRING', '4294967295');
-
-define('MIN_UINT32', (int)-2147483648);
-define('MIN_UINT32_FLOAT', -2147483648.0);
-define('MIN_UINT32_STRING', '-2147483648');
-
-define('MAX_INT64_STRING',  '9223372036854775807');
-define('MIN_INT64_STRING',  '-9223372036854775808');
-define('MAX_UINT64_STRING', '-9223372036854775808');
-
-if (PHP_INT_SIZE === 8) {
-    define('MAX_INT64',  (int)9223372036854775807);
-    define('MIN_INT64',  (int)-9223372036854775808);
-    define('MAX_UINT64', (int)-9223372036854775808);
-} else {
-    define('MAX_INT64', MAX_INT64_STRING);
-    define('MIN_INT64', MIN_INT64_STRING);
-    define('MAX_UINT64', MAX_UINT64_STRING);
-}
 
 class TestUtil
 {

--- a/php/tests/UndefinedTest.php
+++ b/php/tests/UndefinedTest.php
@@ -1,17 +1,21 @@
 <?php
 
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
+use Exception;
+use Google\Protobuf\Internal\MapField;
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBType;
 use Foo\TestMessage;
 use Foo\TestMessage\Sub;
+use PHPUnit_Framework_Error;
+use PHPUnit_Framework_TestCase;
 
-class UndefinedTest extends PHPUnit_Framework_TestCase
+final class UndefinedTest extends PHPUnit_Framework_TestCase
 {
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt32AppendStringFail()
     {
@@ -20,7 +24,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt32SetStringFail()
     {
@@ -30,7 +34,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt32AppendMessageFail()
     {
@@ -39,7 +43,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt32SetMessageFail()
     {
@@ -49,7 +53,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint32AppendStringFail()
     {
@@ -58,7 +62,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint32SetStringFail()
     {
@@ -68,7 +72,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint32AppendMessageFail()
     {
@@ -77,7 +81,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint32SetMessageFail()
     {
@@ -87,7 +91,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt64AppendStringFail()
     {
@@ -96,7 +100,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt64SetStringFail()
     {
@@ -106,7 +110,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt64AppendMessageFail()
     {
@@ -115,7 +119,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt64SetMessageFail()
     {
@@ -125,7 +129,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint64AppendStringFail()
     {
@@ -134,7 +138,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint64SetStringFail()
     {
@@ -144,7 +148,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint64AppendMessageFail()
     {
@@ -153,7 +157,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint64SetMessageFail()
     {
@@ -163,7 +167,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testFloatAppendStringFail()
     {
@@ -172,7 +176,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testFloatSetStringFail()
     {
@@ -182,7 +186,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testFloatAppendMessageFail()
     {
@@ -191,7 +195,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testFloatSetMessageFail()
     {
@@ -201,7 +205,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testDoubleAppendStringFail()
     {
@@ -210,7 +214,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testDoubleSetStringFail()
     {
@@ -220,7 +224,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testDoubleAppendMessageFail()
     {
@@ -229,7 +233,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testDoubleSetMessageFail()
     {
@@ -239,7 +243,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testBoolAppendMessageFail()
     {
@@ -248,7 +252,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testBoolSetMessageFail()
     {
@@ -258,7 +262,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testStringAppendMessageFail()
     {
@@ -267,7 +271,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testStringSetMessageFail()
     {
@@ -277,7 +281,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testStringAppendInvalidUTF8Fail()
     {
@@ -287,7 +291,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testStringSetInvalidUTF8Fail()
     {
@@ -298,7 +302,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMessageAppendIntFail()
     {
@@ -307,7 +311,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMessageSetIntFail()
     {
@@ -317,7 +321,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMessageAppendStringFail()
     {
@@ -326,7 +330,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMessageSetStringFail()
     {
@@ -336,7 +340,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMessageAppendOtherMessageFail()
     {
@@ -420,7 +424,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt32FieldInvalidTypeFail()
     {
@@ -429,7 +433,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt32FieldInvalidStringFail()
     {
@@ -438,7 +442,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint32FieldInvalidTypeFail()
     {
@@ -447,7 +451,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint32FieldInvalidStringFail()
     {
@@ -456,7 +460,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt64FieldInvalidTypeFail()
     {
@@ -465,7 +469,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt64FieldInvalidStringFail()
     {
@@ -474,7 +478,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint64FieldInvalidTypeFail()
     {
@@ -483,7 +487,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint64FieldInvalidStringFail()
     {
@@ -492,7 +496,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testFloatFieldInvalidTypeFail()
     {
@@ -501,7 +505,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testFloatFieldInvalidStringFail()
     {
@@ -510,7 +514,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testDoubleFieldInvalidTypeFail()
     {
@@ -519,7 +523,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testDoubleFieldInvalidStringFail()
     {
@@ -528,7 +532,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testBoolFieldInvalidStringFail()
     {
@@ -537,7 +541,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testStringFieldInvalidUTF8Fail()
     {
@@ -547,7 +551,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMessageFieldWrongTypeFail()
     {
@@ -557,7 +561,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMessageFieldWrongClassFail()
     {
@@ -566,7 +570,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testRepeatedFieldWrongTypeFail()
     {
@@ -576,7 +580,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testRepeatedFieldWrongObjectFail()
     {
@@ -585,7 +589,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testRepeatedFieldWrongRepeatedTypeFail()
     {
@@ -596,7 +600,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testRepeatedFieldWrongRepeatedMessageClassFail()
     {
@@ -608,7 +612,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMapFieldWrongTypeFail()
     {
@@ -618,7 +622,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMapFieldWrongObjectFail()
     {
@@ -627,7 +631,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMapFieldWrongRepeatedTypeFail()
     {
@@ -638,7 +642,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMapFieldWrongRepeatedMessageClassFail()
     {
@@ -661,7 +665,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt32SetStringKeyFail()
     {
@@ -670,7 +674,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt32SetStringValueFail()
     {
@@ -679,7 +683,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt32SetMessageKeyFail()
     {
@@ -688,7 +692,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt32SetMessageValueFail()
     {
@@ -697,7 +701,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint32SetStringKeyFail()
     {
@@ -706,7 +710,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint32SetStringValueFail()
     {
@@ -715,7 +719,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint32SetMessageKeyFail()
     {
@@ -724,7 +728,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint32SetMessageValueFail()
     {
@@ -733,7 +737,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt64SetStringKeyFail()
     {
@@ -742,7 +746,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt64SetStringValueFail()
     {
@@ -751,7 +755,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt64SetMessageKeyFail()
     {
@@ -760,7 +764,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testInt64SetMessageValueFail()
     {
@@ -769,7 +773,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint64SetStringKeyFail()
     {
@@ -778,7 +782,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint64SetStringValueFail()
     {
@@ -787,7 +791,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint64SetMessageKeyFail()
     {
@@ -796,7 +800,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testUint64SetMessageValueFail()
     {
@@ -805,7 +809,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testDoubleSetStringValueFail()
     {
@@ -814,7 +818,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testDoubleSetMessageValueFail()
     {
@@ -823,7 +827,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testBoolSetMessageKeyFail()
     {
@@ -832,7 +836,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testBoolSetMessageValueFail()
     {
@@ -841,7 +845,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testStringSetInvalidUTF8KeyFail()
     {
@@ -850,7 +854,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testStringSetInvalidUTF8ValueFail()
     {
@@ -859,7 +863,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testStringSetMessageKeyFail()
     {
@@ -868,7 +872,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testStringSetMessageValueFail()
     {
@@ -877,7 +881,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMessageSetIntValueFail()
     {
@@ -887,7 +891,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMessageSetStringValueFail()
     {
@@ -897,7 +901,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Exception
      */
     public function testMessageSetOtherMessageValueFail()
     {

--- a/php/tests/WellKnownTest.php
+++ b/php/tests/WellKnownTest.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once('test_base.php');
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
+use DateTime;
 use Foo\TestMessage;
 use Google\Protobuf\Any;
 use Google\Protobuf\Api;
@@ -34,10 +34,12 @@ use Google\Protobuf\Type;
 use Google\Protobuf\UInt32Value;
 use Google\Protobuf\UInt64Value;
 use Google\Protobuf\Value;
+use ReflectionClass;
+use TestImportDescriptorProto;
 
 class NotMessage {}
 
-class WellKnownTest extends TestBase {
+final class WellKnownTest extends TestBase {
 
     public function testEmpty()
     {

--- a/php/tests/WrapperTypeSettersTest.php
+++ b/php/tests/WrapperTypeSettersTest.php
@@ -1,7 +1,6 @@
 <?php
 
-require_once('test_base.php');
-require_once('test_util.php');
+namespace Google\Protobuf\Tests;
 
 use Foo\TestWrapperSetters;
 use Google\Protobuf\BoolValue;
@@ -13,8 +12,9 @@ use Google\Protobuf\Int64Value;
 use Google\Protobuf\StringValue;
 use Google\Protobuf\UInt32Value;
 use Google\Protobuf\UInt64Value;
+use stdClass;
 
-class WrapperTypeSettersTest extends TestBase
+final class WrapperTypeSettersTest extends TestBase
 {
     /**
      * @dataProvider gettersAndSettersDataProvider

--- a/php/tests/bootstrap_phpunit.php
+++ b/php/tests/bootstrap_phpunit.php
@@ -1,5 +1,45 @@
 <?php
 
-require_once("vendor/autoload.php");
+require_once __DIR__ . '/../vendor/autoload.php';
 
 error_reporting(E_ALL);
+
+define('MAX_FLOAT_DIFF', 0.000001);
+
+if (PHP_INT_SIZE == 8) {
+    define('MAX_INT_STRING', '9223372036854775807');
+    define('MAX_INT_UPPER_STRING', '9223372036854775808');
+} else {
+    define('MAX_INT_STRING', '2147483647');
+    define('MAX_INT_UPPER_STRING', '2147483648');
+}
+
+define('MAX_INT32', 2147483647);
+define('MAX_INT32_FLOAT', 2147483647.0);
+define('MAX_INT32_STRING', '2147483647');
+
+define('MIN_INT32', (int)-2147483648);
+define('MIN_INT32_FLOAT', -2147483648.0);
+define('MIN_INT32_STRING', '-2147483648');
+
+define('MAX_UINT32', 4294967295);
+define('MAX_UINT32_FLOAT', 4294967295.0);
+define('MAX_UINT32_STRING', '4294967295');
+
+define('MIN_UINT32', (int)-2147483648);
+define('MIN_UINT32_FLOAT', -2147483648.0);
+define('MIN_UINT32_STRING', '-2147483648');
+
+define('MAX_INT64_STRING',  '9223372036854775807');
+define('MIN_INT64_STRING',  '-9223372036854775808');
+define('MAX_UINT64_STRING', '-9223372036854775808');
+
+if (PHP_INT_SIZE === 8) {
+    define('MAX_INT64',  (int)9223372036854775807);
+    define('MIN_INT64',  (int)-9223372036854775808);
+    define('MAX_UINT64', (int)-9223372036854775808);
+} else {
+    define('MAX_INT64', MAX_INT64_STRING);
+    define('MIN_INT64', MIN_INT64_STRING);
+    define('MAX_UINT64', MAX_UINT64_STRING);
+}

--- a/php/tests/compatibility_test.sh
+++ b/php/tests/compatibility_test.sh
@@ -119,16 +119,16 @@ cd protobuf/php
 composer install
 
 # Remove implementation detail tests.
-tests=( array_test.php encode_decode_test.php generated_class_test.php map_field_test.php well_known_test.php )
-sed -i.bak '/php_implementation_test.php/d' phpunit.xml
-sed -i.bak '/generated_phpdoc_test.php/d' phpunit.xml
-sed -i.bak 's/generated_phpdoc_test.php//g' tests/test.sh
-sed -i.bak 's/generated_service_test.php//g' tests/test.sh
+tests=( EncodeDecodeTest.php GeneratedClassTest.php MapFieldTest.php RepeatedFieldTest.php WellKnownTest.php )
+sed -i.bak '/GeneratedPhpdocTest.php/d' phpunit.xml
+sed -i.bak 's/GeneratedPhpdocTest.php//g' tests/test.sh
+sed -i.bak 's/GeneratedServiceTest.php//g' tests/test.sh
+sed -i.bak '/PhpImplementationTest.php/d' phpunit.xml
 sed -i.bak '/memory_leak_test.php/d' tests/test.sh
-sed -i.bak '/^    public function testTimestamp()$/,/^    }$/d' tests/well_known_test.php
-sed -i.bak 's/PHPUnit_Framework_TestCase/\\PHPUnit\\Framework\\TestCase/g' tests/array_test.php
-sed -i.bak 's/PHPUnit_Framework_TestCase/\\PHPUnit\\Framework\\TestCase/g' tests/map_field_test.php
-sed -i.bak 's/PHPUnit_Framework_TestCase/\\PHPUnit\\Framework\\TestCase/g' tests/test_base.php
+sed -i.bak '/^    public function testTimestamp()$/,/^    }$/d' tests/WellKnownTest.php
+sed -i.bak 's/PHPUnit_Framework_TestCase/\\PHPUnit\\Framework\\TestCase/g' tests/MapFieldTest.php
+sed -i.bak 's/PHPUnit_Framework_TestCase/\\PHPUnit\\Framework\\TestCase/g' tests/TestBase.php
+sed -i.bak 's/PHPUnit_Framework_TestCase/\\PHPUnit\\Framework\\TestCase/g' tests/RepeatedFieldTest.php
 for t in "${tests[@]}"
 do
   remove_error_test tests/$t

--- a/php/tests/gdb_test.sh
+++ b/php/tests/gdb_test.sh
@@ -12,7 +12,7 @@ php -i | grep "Configuration"
 # phpunit` --bootstrap autoload.php tmp_test.php
 #
 # gdb --args php -dextension=../ext/google/protobuf/modules/protobuf.so `which phpunit` --bootstrap autoload.php generated_class_test.php
-gdb --args php -dextension=../ext/google/protobuf/modules/protobuf.so `which phpunit` --bootstrap autoload.php encode_decode_test.php
+gdb --args php -dextension=../ext/google/protobuf/modules/protobuf.so `which phpunit` --bootstrap autoload.php EncodeDecodeTest.php
 #
 # gdb --args php -dextension=../ext/google/protobuf/modules/protobuf.so memory_leak_test.php
 #

--- a/php/tests/memory_leak_test.php
+++ b/php/tests/memory_leak_test.php
@@ -46,13 +46,14 @@ require_once('generated/Php/Test/TestNamespace/PBEmpty/NestedEnum.php');
 require_once('generated/Php/Test/TestNamespace/PBEmpty/NestedMessage.php');
 require_once('generated/Php/Test/TestNamespace/NestedEnum.php');
 require_once('generated/Php/Test/TestNamespace/NestedMessage.php');
-require_once('test_util.php');
+require_once('TestUtil.php');
 
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBType;
 use Foo\TestAny;
 use Foo\TestMessage;
 use Foo\TestMessage\Sub;
+use Google\Protobuf\Tests\TestUtil;
 
 $from = new TestMessage();
 TestUtil::setTestMessage($from);

--- a/php/tests/test.sh
+++ b/php/tests/test.sh
@@ -14,14 +14,14 @@ set -e
 phpize && ./configure CFLAGS='-g -O0' && make
 popd
 
-tests=( array_test.php encode_decode_test.php generated_class_test.php map_field_test.php well_known_test.php descriptors_test.php wrapper_type_setters_test.php)
+tests=(DescriptorsTest.php EncodeDecodeTest.php GeneratedClassTest.php MapFieldTest.php RepeatedFieldTest.php WellKnownTest.php WrapperTypeSettersTest.php)
 
 for t in "${tests[@]}"
 do
   echo "****************************"
   echo "* $t"
   echo "****************************"
-  php -dextension=../ext/google/protobuf/modules/protobuf.so `which phpunit` --bootstrap autoload.php $t
+  php -dextension=../ext/google/protobuf/modules/protobuf.so `which phpunit` --bootstrap bootstrap_phpunit.php $t
   echo ""
 done
 


### PR DESCRIPTION
When I was creating PR for php part of this repo, test base looked a bit ancient to me. That's probably also because PHP 5.5 is supported. So I tried to clean it up a bit. Replace manually requiring files with PSR-4 autoloading for tests.