### PR TITLE
Do "strict" heapcheck instead of "draconian"

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -44,7 +44,7 @@ build_cpp_tcmalloc() {
       PTHREAD_CFLAGS='-pthread -DGOOGLE_PROTOBUF_HEAP_CHECK_DRACONIAN' \
       check
   cd src
-  PPROF_PATH=/usr/bin/google-pprof HEAPCHECK=draconian ./protobuf-test
+  PPROF_PATH=/usr/bin/google-pprof HEAPCHECK=strict ./protobuf-test
 }
 
 build_cpp_distcheck() {


### PR DESCRIPTION
The draconian heapcheck turns up memory leaks outside our control, such
as ones in libc and in the heapchecker itself. I think for an automated
test it makes more sense for us to use the "strict" heapcheck, since
that already passes and should only report leaks that are within our
control.