### PR TITLE
Fix MacOS protoc release

### DIFF
--- a/kokoro/release/protoc/macos/build.sh
+++ b/kokoro/release/protoc/macos/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-CXXFLAGS_COMMON="-DNDEBUG -mmacosx-version-min=10.9"
+CXXFLAGS_COMMON="-std=c++14 -DNDEBUG -mmacosx-version-min=10.9"
 
 cd github/protobuf
 ./autogen.sh

--- a/kokoro/release/protoc/macos/build.sh
+++ b/kokoro/release/protoc/macos/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -ex
 CXXFLAGS_COMMON="-DNDEBUG -mmacosx-version-min=10.9"
 
 cd github/protobuf


### PR DESCRIPTION
Make the test fail if any command returns non-zero.
Use -std=c++14 to -latomic would work.