### PR TITLE
Convert integer to string if field is string field in json

### DIFF
--- a/conformance/failure_list_php.txt
+++ b/conformance/failure_list_php.txt
@@ -13,6 +13,8 @@ Required.Proto3.JsonInput.FloatFieldTooSmall
 Required.Proto3.JsonInput.DoubleFieldTooSmall
 Required.Proto3.JsonInput.Int32FieldNotInteger
 Required.Proto3.JsonInput.Int64FieldNotInteger
+Required.Proto3.JsonInput.RepeatedFieldWrongElementTypeExpectingStringsGotInt
+Required.Proto3.JsonInput.StringFieldNotAString
 Required.Proto3.JsonInput.Uint32FieldNotInteger
 Required.Proto3.JsonInput.Uint64FieldNotInteger
 Required.Proto3.JsonInput.Int32FieldLeadingSpace

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -832,6 +832,9 @@ class Message
                 if (is_null($value)) {
                     return $this->defaultValue($field);
                 }
+                if (is_numeric($value)) {
+                    return strval($value);
+                }
                 if (!is_string($value)) {
                     throw new GPBDecodeException(
                         "String field only accepts string value");

--- a/php/tests/encode_decode_test.php
+++ b/php/tests/encode_decode_test.php
@@ -1148,4 +1148,14 @@ class EncodeDecodeTest extends TestBase
                           $m->serializeToJsonString());
     }
 
+    public function testJsonDecodeNumericStringMapKey()
+    {
+        $m = new TestMessage();
+        $m->getMapStringString()["1"] = "1";
+        $data = $m->serializeToJsonString();
+        $this->assertSame("{\"mapStringString\":{\"1\":\"1\"}}", $data);
+        $n = new TestMessage();
+        $n->mergeFromJsonString($data);
+    }
+
 }

--- a/tests.sh
+++ b/tests.sh
@@ -482,8 +482,7 @@ build_php5.6_mac() {
   export PATH="$PHP_FOLDER/bin:$PATH"
 
   # Install phpunit
-  curl https://phar.phpunit.de/phpunit-5.6.10.phar -L -o phpunit.phar
-  chmod +x phpunit.phar
+  curl https://phar.phpunit.de/phpunit-5.6.8.phar -L -o phpunit.phar chmod +x phpunit.phar
   sudo mv phpunit.phar /usr/local/bin/phpunit
 
   # Install valgrind

--- a/tests.sh
+++ b/tests.sh
@@ -482,7 +482,8 @@ build_php5.6_mac() {
   export PATH="$PHP_FOLDER/bin:$PATH"
 
   # Install phpunit
-  curl https://phar.phpunit.de/phpunit-5.6.8.phar -L -o phpunit.phar chmod +x phpunit.phar
+  curl https://phar.phpunit.de/phpunit-5.6.8.phar -L -o phpunit.phar
+  chmod +x phpunit.phar
   sudo mv phpunit.phar /usr/local/bin/phpunit
 
   # Install valgrind


### PR DESCRIPTION
json_decode automatically convert numeric string to integer, so that
we need to convert it back. However, this will suceed to parse invalid
json data with string field set as integer even though it should have failed.
Because, the failure case is less often than the succeeding case, we decided
to make this change. Users should make sure their data don't use integer for
string fields by themselves.

Fix #4765 