### PR TITLE
Swapped libprotoc and libprotobuf to fix LNK2005 in MSVC

### DIFF
--- a/cmake/protoc.cmake
+++ b/cmake/protoc.cmake
@@ -9,7 +9,7 @@ set(protoc_rc_files
 endif()
 
 add_executable(protoc ${protoc_files} ${protoc_rc_files})
-target_link_libraries(protoc libprotobuf libprotoc)
+target_link_libraries(protoc libprotoc libprotobuf)
 add_executable(protobuf::protoc ALIAS protoc)
 
 set_target_properties(protoc PROPERTIES


### PR DESCRIPTION
Fixed problem stated in [#5384](https://github.com/protocolbuffers/protobuf/issues/5384).

The ordering of libprotobuf and libprotoc caused LNK2005 errors in MSVC builds.
The solution seems to be swapping them in cmake/protoc.cmake

Prior to this change, using cmake to create a Visual Studio 2017 x86/x64 project will succeed, but when running `cmake --build` or building in VS, you get ~193 LNK 2005 errors complaining that a symbol has already been defined in libprotobuf.