### PR TITLE
Swapped libprotoc and libprotobuf

### DIFF
--- a/cmake/protoc.cmake
+++ b/cmake/protoc.cmake
@@ -9,7 +9,7 @@ set(protoc_rc_files
 endif()
 
 add_executable(protoc ${protoc_files} ${protoc_rc_files})
-target_link_libraries(protoc libprotobuf libprotoc)
+target_link_libraries(protoc libprotoc libprotobuf)
 add_executable(protobuf::protoc ALIAS protoc)
 
 set_target_properties(protoc PROPERTIES


### PR DESCRIPTION
libprotobuf being targeted before libprotoc was causing Visual Studio to fail in linking protoc.

This fix addresses the issue in [#5384](https://github.com/protocolbuffers/protobuf/issues/5384).