### PR TITLE
Fixed infinite recursion problem with Java GeneratedMessageV3 (#5657)

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -710,19 +710,23 @@ public abstract class GeneratedMessageV3 extends AbstractMessage
       return (BuilderType) this;
     }
 
-    @Override
-    public BuilderType setUnknownFields(final UnknownFieldSet unknownFields) {
+    private BuilderType setUnknownFieldsInternal(final UnknownFieldSet unknownFields) {
       this.unknownFields = unknownFields;
       onChanged();
       return (BuilderType) this;
     }
 
+    @Override
+    public BuilderType setUnknownFields(final UnknownFieldSet unknownFields) {
+      return setUnknownFieldsInternal(unknownFields);
+    }
+
     /**
-     * Delegates to setUnknownFields. This method is obsolete, but we must retain it for
-     * compatibility with older generated code.
+     * This method is obsolete, but we must retain it for compatibility with
+     * older generated code.
      */
     protected BuilderType setUnknownFieldsProto3(final UnknownFieldSet unknownFields) {
-      return setUnknownFields(unknownFields);
+      return setUnknownFieldsInternal(unknownFields);
     }
 
     @Override


### PR DESCRIPTION
GeneratedMessageV3#setUnknownFieldsProto3 was trying to delegate to
setUnknownFields but was inadvertently resulting in infinite recursion.
This commit makes setUnknownFields and setUnknownFieldsProto3 delegate
to a common private method to fix the problem and avoid confusion.