### PR TITLE
Fix issues in MessageExtensions.IsInitialized

### DIFF
--- a/csharp/src/Google.Protobuf/MessageExtensions.cs
+++ b/csharp/src/Google.Protobuf/MessageExtensions.cs
@@ -163,12 +163,12 @@ namespace Google.Protobuf
                         var map = (IDictionary)f.Accessor.GetValue(message);
                         return map.Values.OfType<IMessage>().All(IsInitialized);
                     }
-                    else if (f.IsRepeated && f.MessageType != null)
+                    else if (f.IsRepeated && f.FieldType == FieldType.Message || f.FieldType == FieldType.Group)
                     {
                         var enumerable = (IEnumerable)f.Accessor.GetValue(message);
                         return enumerable.Cast<IMessage>().All(IsInitialized);
                     }
-                    else if (f.MessageType != null)
+                    else if (f.FieldType == FieldType.Message || f.FieldType == FieldType.Group)
                     {
                         if (f.Accessor.HasValue(message))
                         {


### PR DESCRIPTION
Changes MessageType != null checks in MessageExtensions.IsInitialized to FieldType == Message || Group. This will close #5687