### PR TITLE
Revert "Remove unused f expression from jscode gen."

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -2272,7 +2272,7 @@ void Generator::GenerateClassToObject(const GeneratorOptions& options,
       " * @suppress {unusedLocalVariables} f is only used for nested messages\n"
       " */\n"
       "$classname$.toObject = function(includeInstance, msg) {\n"
-      "  var obj = {",
+      "  var f, obj = {",
       "classname", GetMessagePath(options, desc));
 
   bool first = true;


### PR DESCRIPTION
We need to revert the following changes: 
https://github.com/protocolbuffers/protobuf/commit/94a1819c7ae8509ab6ad37d867d3ea60a5809aaa#diff-99c613b6f4f530783572bbbffc822412

  [Generator::GenerateClassFieldToObject](https://github.com/protocolbuffers/protobuf/blob/94a1819c7ae8509ab6ad37d867d3ea60a5809aaa/src/google/protobuf/compiler/js/js_generator.cc#L2387) generate a code which use _f_ variable in cases when class contains a complex type fields.

For example for the following .proto message definition:

`message MyMessage {
	google.protobuf.Timestamp timestamp = 1;
}` 

it will produce following output: 

`proto.MyMessage.toObject = function(includeInstance, msg) {
  var obj = {
    timestamp: (f = msg.getTimestamp()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f)
  };
};`

and here we get `ReferenceError: f is not defined`