### PR TITLE
Implement to_s for Ruby message types

### DIFF
--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -624,6 +624,7 @@ VALUE build_class_from_descriptor(Descriptor* desc) {
   rb_define_method(klass, "to_h", Message_to_h, 0);
   rb_define_method(klass, "to_hash", Message_to_h, 0);
   rb_define_method(klass, "inspect", Message_inspect, 0);
+  rb_define_method(klass, "to_s", Message_inspect, 0);
   rb_define_method(klass, "[]", Message_index, 1);
   rb_define_method(klass, "[]=", Message_index_set, 2);
   rb_define_singleton_method(klass, "decode", Message_decode, 1);

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -103,7 +103,7 @@ module CommonTests
     assert_equal 3, m.repeated_msg.first.sub_child.optional_int32
   end
 
-  def test_inspect
+  def test_inspect_eq_to_s
     m = proto_module::TestMessage.new(
       :optional_int32 => -42,
       :optional_enum => :A,
@@ -111,10 +111,12 @@ module CommonTests
       :repeated_string => ["hello", "there", "world"])
     expected = "<#{proto_module}::TestMessage: optional_int32: -42, optional_int64: 0, optional_uint32: 0, optional_uint64: 0, optional_bool: false, optional_float: 0.0, optional_double: 0.0, optional_string: \"\", optional_bytes: \"\", optional_msg: <#{proto_module}::TestMessage2: foo: 0>, optional_enum: :A, repeated_int32: [], repeated_int64: [], repeated_uint32: [], repeated_uint64: [], repeated_bool: [], repeated_float: [], repeated_double: [], repeated_string: [\"hello\", \"there\", \"world\"], repeated_bytes: [], repeated_msg: [], repeated_enum: []>"
     assert_equal expected, m.inspect
+    assert_equal expected, m.to_s
 
     m = proto_module::OneofMessage.new(:b => -42)
     expected = "<#{proto_module}::OneofMessage: a: \"\", b: -42, c: nil, d: :Default>"
     assert_equal expected, m.inspect
+    assert_equal expected, m.to_s
   end
 
   def test_hash


### PR DESCRIPTION
Resolves #3998 by adding a `to_s` method that behaves the same as `inspect`.

Originally requested here: https://github.com/googleapis/google-cloud-ruby/issues/1868