### PR TITLE
PHP: Exclude repeated and map fields from normalization in constructor

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -294,6 +294,58 @@ void build_class_from_descriptor(
 // PHP Methods
 // -----------------------------------------------------------------------------
 
+static bool is_wrapper_msg(const upb_msgdef* m) {
+  upb_wellknowntype_t type = upb_msgdef_wellknowntype(m);
+  return type >= UPB_WELLKNOWN_DOUBLEVALUE &&
+         type <= UPB_WELLKNOWN_BOOLVALUE;
+}
+
+static void append_wrapper_message(
+    zend_class_entry* subklass, RepeatedField* intern, zval* value TSRMLS_DC) {
+  MessageHeader* submsg;
+  const upb_fielddef* field;
+#if PHP_MAJOR_VERSION < 7
+  zval* val = NULL;
+  MAKE_STD_ZVAL(val);
+  ZVAL_OBJ(val, subklass->create_object(subklass TSRMLS_CC));
+  repeated_field_push_native(intern, &val);
+  submsg = UNBOX(MessageHeader, val);
+#else
+  zend_object* obj = subklass->create_object(subklass TSRMLS_CC);
+  repeated_field_push_native(intern, &obj);
+  submsg = (MessageHeader*)((char*)obj - XtOffsetOf(MessageHeader, std));
+#endif
+  custom_data_init(subklass, submsg PHP_PROTO_TSRMLS_CC);
+
+  field = upb_msgdef_itof(submsg->descriptor->msgdef, 1);
+  layout_set(submsg->descriptor->layout, submsg, field, value TSRMLS_CC);
+}
+
+static void set_wrapper_message_as_map_value(
+    zend_class_entry* subklass, zval* map, zval* key,  zval* value TSRMLS_DC) {
+  MessageHeader* submsg;
+  const upb_fielddef* field;
+#if PHP_MAJOR_VERSION < 7
+  zval* val = NULL;
+  MAKE_STD_ZVAL(val);
+  ZVAL_OBJ(val, subklass->create_object(subklass TSRMLS_CC));
+  repeated_field_push_native(intern, &val);
+  map_field_handlers->write_dimension(
+      map, key, val TSRMLS_CC);
+  submsg = UNBOX(MessageHeader, val);
+#else
+  zval val;
+  zend_object* obj = subklass->create_object(subklass TSRMLS_CC);
+  ZVAL_OBJ(&val, obj);
+  map_field_handlers->write_dimension(map, key, &val TSRMLS_CC);
+  submsg = (MessageHeader*)((char*)obj - XtOffsetOf(MessageHeader, std));
+#endif
+  custom_data_init(subklass, submsg PHP_PROTO_TSRMLS_CC);
+
+  field = upb_msgdef_itof(submsg->descriptor->msgdef, 1);
+  layout_set(submsg->descriptor->layout, submsg, field, value TSRMLS_CC);
+}
+
 void Message_construct(zval* msg, zval* array_wrapper) {
   TSRMLS_FETCH();
   zend_class_entry* ce = Z_OBJCE_P(msg);
@@ -336,14 +388,38 @@ void Message_construct(zval* msg, zval* array_wrapper) {
       HashPosition subpointer;
       zval subkey;
       void* memory;
+      bool is_wrapper = false;
+      zend_class_entry* subklass = NULL;
+      const upb_msgdef* mapentry = upb_fielddef_msgsubdef(field);
+      const upb_fielddef *value_field = upb_msgdef_itof(mapentry, 2);
+
+      if (upb_fielddef_issubmsg(value_field)) {
+        const upb_msgdef* submsgdef = upb_fielddef_msgsubdef(value_field);
+        upb_wellknowntype_t type = upb_msgdef_wellknowntype(submsgdef);
+        is_wrapper = is_wrapper_msg(submsgdef);
+
+        if (is_wrapper) {
+          PHP_PROTO_HASHTABLE_VALUE subdesc_php = get_def_obj(submsgdef);
+          Descriptor* subdesc = UNBOX_HASHTABLE_VALUE(Descriptor, subdesc_php);
+          subklass = subdesc->klass;
+        }
+      }
+
       for (zend_hash_internal_pointer_reset_ex(subtable, &subpointer);
            php_proto_zend_hash_get_current_data_ex(subtable, (void**)&memory,
                                                    &subpointer) == SUCCESS;
            zend_hash_move_forward_ex(subtable, &subpointer)) {
         zend_hash_get_current_key_zval_ex(subtable, &subkey, &subpointer);
-        map_field_handlers->write_dimension(
-            submap, &subkey,
-            CACHED_PTR_TO_ZVAL_PTR((CACHED_VALUE*)memory) TSRMLS_CC);
+        if (is_wrapper &&
+            Z_TYPE_P(CACHED_PTR_TO_ZVAL_PTR((CACHED_VALUE*)memory)) != IS_OBJECT) {
+          set_wrapper_message_as_map_value(
+              subklass, submap, &subkey,
+              CACHED_PTR_TO_ZVAL_PTR((CACHED_VALUE*)memory) TSRMLS_CC);
+        } else {
+          map_field_handlers->write_dimension(
+              submap, &subkey,
+              CACHED_PTR_TO_ZVAL_PTR((CACHED_VALUE*)memory) TSRMLS_CC);
+        }
         zval_dtor(&subkey);
       }
     } else if (upb_fielddef_isseq(field)) {
@@ -354,13 +430,36 @@ void Message_construct(zval* msg, zval* array_wrapper) {
           CACHED_PTR_TO_ZVAL_PTR((CACHED_VALUE*)value));
       HashPosition subpointer;
       void* memory;
+      bool is_wrapper = false;
+      zend_class_entry* subklass = NULL;
+
+      if (upb_fielddef_issubmsg(field)) {
+        const upb_msgdef* submsgdef = upb_fielddef_msgsubdef(field);
+        upb_wellknowntype_t type = upb_msgdef_wellknowntype(submsgdef);
+        is_wrapper = is_wrapper_msg(submsgdef);
+
+        if (is_wrapper) {
+          PHP_PROTO_HASHTABLE_VALUE subdesc_php = get_def_obj(submsgdef);
+          Descriptor* subdesc = UNBOX_HASHTABLE_VALUE(Descriptor, subdesc_php);
+          subklass = subdesc->klass;
+        }
+      }
+
       for (zend_hash_internal_pointer_reset_ex(subtable, &subpointer);
            php_proto_zend_hash_get_current_data_ex(subtable, (void**)&memory,
                                                    &subpointer) == SUCCESS;
            zend_hash_move_forward_ex(subtable, &subpointer)) {
-        repeated_field_handlers->write_dimension(
-            subarray, NULL,
-            CACHED_PTR_TO_ZVAL_PTR((CACHED_VALUE*)memory) TSRMLS_CC);
+        if (is_wrapper &&
+            Z_TYPE_P(CACHED_PTR_TO_ZVAL_PTR((CACHED_VALUE*)memory)) != IS_OBJECT) {
+          RepeatedField* intern = UNBOX(RepeatedField, subarray);
+          append_wrapper_message(
+              subklass, intern,
+              CACHED_PTR_TO_ZVAL_PTR((CACHED_VALUE*)memory) TSRMLS_CC);
+        } else {
+          repeated_field_handlers->write_dimension(
+              subarray, NULL,
+              CACHED_PTR_TO_ZVAL_PTR((CACHED_VALUE*)memory) TSRMLS_CC);
+        }
       }
     } else if (upb_fielddef_issubmsg(field)) {
       const upb_msgdef* submsgdef = upb_fielddef_msgsubdef(field);

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -329,7 +329,6 @@ static void set_wrapper_message_as_map_value(
   zval* val = NULL;
   MAKE_STD_ZVAL(val);
   ZVAL_OBJ(val, subklass->create_object(subklass TSRMLS_CC));
-  repeated_field_push_native(intern, &val);
   map_field_handlers->write_dimension(
       map, key, val TSRMLS_CC);
   submsg = UNBOX(MessageHeader, val);

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -987,7 +987,7 @@ class Message
                     'Invalid message property: ' . $key);
             }
             $setter = $field->getSetter();
-            if ($field->isWrapperType() && !($field->isRepeated() || $field->isMap())) {
+            if ($field->isWrapperType() && !$field->isRepeated()) {
                 self::normalizeToMessageType($value, $field->getMessageType()->getClass());
             }
             $this->$setter($value);

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -973,9 +973,12 @@ class Message
      * ]);
      * ```
      *
+     * This method will trigger an error if it is passed data that cannot
+     * be converted to the correct type. For example, a StringValue field
+     * must receive data that is either a string or a StringValue object.
+     *
      * @param array $array An array containing message properties and values.
      * @return null.
-     * @throws \Exception Invalid data.
      */
     protected function mergeFromArray(array $array)
     {
@@ -1013,7 +1016,6 @@ class Message
      *
      * @param mixed $value The array of values to normalize.
      * @param string $class The expected wrapper class name
-     * @throws \Exception If an element of $value cannot be converted
      */
     private static function normalizeArrayElementsToMessageType(&$value, $class)
     {
@@ -1038,9 +1040,11 @@ class Message
      * instance of $class and assign $value to it using the setValue method
      * shared by all wrapper types.
      *
+     * This method will raise an error if it receives a type that cannot be
+     * assigned to the wrapper type via setValue.
+     *
      * @param mixed $value The value to normalize.
      * @param string $class The expected wrapper class name
-     * @throws \Exception If $value cannot be converted to a wrapper type
      */
     private static function normalizeToMessageType(&$value, $class)
     {

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -987,7 +987,7 @@ class Message
                     'Invalid message property: ' . $key);
             }
             $setter = $field->getSetter();
-            if ($field->isWrapperType()) {
+            if ($field->isWrapperType() && !($field->isRepeated() || $field->isMap())) {
                 self::normalizeToMessageType($value, $field->getMessageType()->getClass());
             }
             $this->$setter($value);

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -1025,17 +1025,9 @@ class Message
             // already be the correct types.
             return;
         } else {
-            // Try to instantiate $class and set the value
-            try {
-                foreach ($value as $key => &$elementValue) {
-                  self::normalizeToMessageType($elementValue, $class);
-                }
-            } catch (\Exception $exception) {
-                throw new \Exception(
-                    "Error normalizing element to type '$class': " . $exception->getMessage(),
-                    $exception->getCode(),
-                    $exception
-                );
+            // Normalize each element in the array.
+            foreach ($value as $key => &$elementValue) {
+              self::normalizeToMessageType($elementValue, $class);
             }
         }
     }
@@ -1065,10 +1057,9 @@ class Message
                 $value = $msg;
                 return;
             } catch (\Exception $exception) {
-                throw new \Exception(
+                trigger_error(
                     "Error normalizing value to type '$class': " . $exception->getMessage(),
-                    $exception->getCode(),
-                    $exception
+                    E_USER_ERROR
                 );
             }
         }

--- a/php/tests/proto/test_wrapper_type_setters.proto
+++ b/php/tests/proto/test_wrapper_type_setters.proto
@@ -19,4 +19,8 @@ message TestWrapperSetters {
     google.protobuf.DoubleValue double_value_oneof = 10;
     google.protobuf.StringValue string_value_oneof = 11;
   }
+
+  repeated google.protobuf.StringValue repeated_string_value = 12;
+
+  map<string, google.protobuf.StringValue> map_string_value = 13;
 }

--- a/php/tests/wrapper_type_setters_test.php
+++ b/php/tests/wrapper_type_setters_test.php
@@ -225,4 +225,43 @@ class WrapperTypeSettersTest extends TestBase
             [TestWrapperSetters::class, BytesValue::class, 'bytes_value', 'getBytesValue', "nine"],
         ];
     }
+
+    /**
+     * @dataProvider invalidConstructorWithWrapperTypeDataProvider
+     * @expectedException \Exception
+     */
+    public function testInvalidConstructorWithWrapperType($class, $wrapperField, $value)
+    {
+        new $class([$wrapperField => $value]);
+    }
+
+    public function invalidConstructorWithWrapperTypeDataProvider()
+    {
+        return [
+            [TestWrapperSetters::class, 'repeated_string_value', ['eight']],
+            [TestWrapperSetters::class, 'map_string_value', ['key' => 'eight']],
+        ];
+    }
+
+    /**
+     * @dataProvider constructorWithRepeatedWrapperTypeDataProvider
+     */
+    public function testConstructorWithRepeatedWrapperType($class, $wrapperField, $getter, $value)
+    {
+        $actualInstance = new $class([$wrapperField => $value]);
+        $this->assertEquals($value, iterator_to_array($actualInstance->$getter()));
+    }
+
+    public function constructorWithRepeatedWrapperTypeDataProvider()
+    {
+        return [
+            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', [new StringValue(['value' => 'eight'])]],
+            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', ['key' => new StringValue(['value' => 'eight'])]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidConstructorWithWrapperTypeDataProvider
+     * @expectedException \Exception
+     */
 }

--- a/php/tests/wrapper_type_setters_test.php
+++ b/php/tests/wrapper_type_setters_test.php
@@ -259,9 +259,4 @@ class WrapperTypeSettersTest extends TestBase
             [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', ['key' => new StringValue(['value' => 'eight'])]],
         ];
     }
-
-    /**
-     * @dataProvider invalidConstructorWithWrapperTypeDataProvider
-     * @expectedException \Exception
-     */
 }

--- a/php/tests/wrapper_type_setters_test.php
+++ b/php/tests/wrapper_type_setters_test.php
@@ -226,37 +226,12 @@ class WrapperTypeSettersTest extends TestBase
         ];
     }
 
-    // /**
-    //  * @dataProvider invalidConstructorWithWrapperTypeDataProvider
-    //  * @expectedException \Exception
-    //  */
-    // public function testInvalidConstructorWithWrapperType($class, $wrapperField, $value)
-    // {
-    //     new $class([$wrapperField => $value]);
-    // }
-
-    // public function invalidConstructorWithWrapperTypeDataProvider()
-    // {
-    //     return [
-    //         [TestWrapperSetters::class, 'repeated_string_value', null],
-    //         // The below is an error case, but we can't test it as the RepeatedField
-    //         // class uses trigger_error in this case.
-    //         // [TestWrapperSetters::class, 'repeated_string_value', [null]],
-    //         [TestWrapperSetters::class, 'repeated_string_value', [new stdClass()]],
-    //         [TestWrapperSetters::class, 'map_string_value', null],
-    //         // The below is an error case, but we can't test it as the MapField
-    //         // class uses trigger_error in this case.
-    //         //[TestWrapperSetters::class, 'map_string_value', ['key' => null]],
-    //         [TestWrapperSetters::class, 'map_string_value', ['key' => new stdClass()]],
-    //     ];
-    // }
-
     /**
      * @dataProvider constructorWithRepeatedWrapperTypeDataProvider
      */
-    public function testConstructorWithRepeatedWrapperType($class, $wrapperField, $getter, $value)
+    public function testConstructorWithRepeatedWrapperType($wrapperField, $getter, $value)
     {
-        $actualInstance = new $class([$wrapperField => $value]);
+        $actualInstance = new TestWrapperSetters([$wrapperField => $value]);
         foreach ($actualInstance->$getter() as $key => $actualWrapperValue) {
             $actualInnerValue = $actualWrapperValue->getValue();
             $expectedElement = $value[$key];
@@ -279,25 +254,25 @@ class WrapperTypeSettersTest extends TestBase
         $repeatedField = $testWrapperSetters->getRepeatedStringValue();
 
         return [
-            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', []],
-            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', [$sv7]],
-            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', [$sv7, $sv8]],
-            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', ['seven']],
-            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', [7]],
-            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', [7.7]],
-            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', ['seven', 'eight']],
-            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', [$sv7, 'eight']],
-            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', ['seven', $sv8]],
-            [TestWrapperSetters::class, 'repeated_string_value', 'getRepeatedStringValue', $repeatedField],
+            ['repeated_string_value', 'getRepeatedStringValue', []],
+            ['repeated_string_value', 'getRepeatedStringValue', [$sv7]],
+            ['repeated_string_value', 'getRepeatedStringValue', [$sv7, $sv8]],
+            ['repeated_string_value', 'getRepeatedStringValue', ['seven']],
+            ['repeated_string_value', 'getRepeatedStringValue', [7]],
+            ['repeated_string_value', 'getRepeatedStringValue', [7.7]],
+            ['repeated_string_value', 'getRepeatedStringValue', ['seven', 'eight']],
+            ['repeated_string_value', 'getRepeatedStringValue', [$sv7, 'eight']],
+            ['repeated_string_value', 'getRepeatedStringValue', ['seven', $sv8]],
+            ['repeated_string_value', 'getRepeatedStringValue', $repeatedField],
         ];
     }
 
     /**
      * @dataProvider constructorWithMapWrapperTypeDataProvider
      */
-    public function testConstructorWithMapWrapperType($class, $wrapperField, $getter, $value)
+    public function testConstructorWithMapWrapperType($wrapperField, $getter, $value)
     {
-        $actualInstance = new $class([$wrapperField => $value]);
+        $actualInstance = new TestWrapperSetters([$wrapperField => $value]);
         foreach ($actualInstance->$getter() as $key => $actualWrapperValue) {
             $actualInnerValue = $actualWrapperValue->getValue();
             $expectedElement = $value[$key];
@@ -322,16 +297,16 @@ class WrapperTypeSettersTest extends TestBase
         $mapField = $testWrapperSetters->getMapStringValue();
 
         return [
-            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', []],
-            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', ['key' => $sv7]],
-            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', ['key' => $sv7, 'key2' => $sv8]],
-            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', ['key' => 'seven']],
-            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', ['key' => 7]],
-            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', ['key' => 7.7]],
-            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', ['key' => 'seven', 'key2' => 'eight']],
-            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', ['key' => $sv7, 'key2' => 'eight']],
-            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', ['key' => 'seven', 'key2' => $sv8]],
-            [TestWrapperSetters::class, 'map_string_value', 'getMapStringValue', $mapField],
+            ['map_string_value', 'getMapStringValue', []],
+            ['map_string_value', 'getMapStringValue', ['key' => $sv7]],
+            ['map_string_value', 'getMapStringValue', ['key' => $sv7, 'key2' => $sv8]],
+            ['map_string_value', 'getMapStringValue', ['key' => 'seven']],
+            ['map_string_value', 'getMapStringValue', ['key' => 7]],
+            ['map_string_value', 'getMapStringValue', ['key' => 7.7]],
+            ['map_string_value', 'getMapStringValue', ['key' => 'seven', 'key2' => 'eight']],
+            ['map_string_value', 'getMapStringValue', ['key' => $sv7, 'key2' => 'eight']],
+            ['map_string_value', 'getMapStringValue', ['key' => 'seven', 'key2' => $sv8]],
+            ['map_string_value', 'getMapStringValue', $mapField],
         ];
     }
 }

--- a/php/tests/wrapper_type_setters_test.php
+++ b/php/tests/wrapper_type_setters_test.php
@@ -226,30 +226,30 @@ class WrapperTypeSettersTest extends TestBase
         ];
     }
 
-    /**
-     * @dataProvider invalidConstructorWithWrapperTypeDataProvider
-     * @expectedException \Exception
-     */
-    public function testInvalidConstructorWithWrapperType($class, $wrapperField, $value)
-    {
-        new $class([$wrapperField => $value]);
-    }
+    // /**
+    //  * @dataProvider invalidConstructorWithWrapperTypeDataProvider
+    //  * @expectedException \Exception
+    //  */
+    // public function testInvalidConstructorWithWrapperType($class, $wrapperField, $value)
+    // {
+    //     new $class([$wrapperField => $value]);
+    // }
 
-    public function invalidConstructorWithWrapperTypeDataProvider()
-    {
-        return [
-            [TestWrapperSetters::class, 'repeated_string_value', null],
-            // The below is an error case, but we can't test it as the RepeatedField
-            // class uses trigger_error in this case.
-            // [TestWrapperSetters::class, 'repeated_string_value', [null]],
-            [TestWrapperSetters::class, 'repeated_string_value', [new stdClass()]],
-            [TestWrapperSetters::class, 'map_string_value', null],
-            // The below is an error case, but we can't test it as the MapField
-            // class uses trigger_error in this case.
-            //[TestWrapperSetters::class, 'map_string_value', ['key' => null]],
-            [TestWrapperSetters::class, 'map_string_value', ['key' => new stdClass()]],
-        ];
-    }
+    // public function invalidConstructorWithWrapperTypeDataProvider()
+    // {
+    //     return [
+    //         [TestWrapperSetters::class, 'repeated_string_value', null],
+    //         // The below is an error case, but we can't test it as the RepeatedField
+    //         // class uses trigger_error in this case.
+    //         // [TestWrapperSetters::class, 'repeated_string_value', [null]],
+    //         [TestWrapperSetters::class, 'repeated_string_value', [new stdClass()]],
+    //         [TestWrapperSetters::class, 'map_string_value', null],
+    //         // The below is an error case, but we can't test it as the MapField
+    //         // class uses trigger_error in this case.
+    //         //[TestWrapperSetters::class, 'map_string_value', ['key' => null]],
+    //         [TestWrapperSetters::class, 'map_string_value', ['key' => new stdClass()]],
+    //     ];
+    // }
 
     /**
      * @dataProvider constructorWithRepeatedWrapperTypeDataProvider


### PR DESCRIPTION
This PR:
- Exclude repeated and map fields over wrapper types from trying to convert a primitive value to a wrapper type in the protobuf message constructor
- Adds tests

cc @TeBoring 