### PR TITLE
Delete unused field in JavaType

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/WireFormat.java
+++ b/java/core/src/main/java/com/google/protobuf/WireFormat.java
@@ -77,29 +77,15 @@ public final class WireFormat {
    * only here to support the lite runtime and should not be used by users.
    */
   public enum JavaType {
-    INT(0),
-    LONG(0L),
-    FLOAT(0F),
-    DOUBLE(0D),
-    BOOLEAN(false),
-    STRING(""),
-    BYTE_STRING(ByteString.EMPTY),
-    ENUM(null),
-    MESSAGE(null);
-
-    JavaType(final Object defaultDefault) {
-      this.defaultDefault = defaultDefault;
-    }
-
-    /**
-     * The default default value for fields of this type, if it's a primitive
-     * type.
-     */
-    Object getDefaultDefault() {
-      return defaultDefault;
-    }
-
-    private final Object defaultDefault;
+    INT,
+    LONG,
+    FLOAT,
+    DOUBLE,
+    BOOLEAN,
+    STRING,
+    BYTE_STRING,
+    ENUM,
+    MESSAGE;
   }
 
   /**


### PR DESCRIPTION
First, we don't need it. Second, it avoids a bug in Proguard's `field/removal/writeonly` optimization that resulted in a crash when processing the JavaLite runtime (see https://stackoverflow.com/questions/26942430/proguard-optimization-settings-enabling-class-merging-casts-and-field-in-mod?rq=1)