### PR TITLE
Allow repeated fields in Ruby to accept multiple arguments on push

### DIFF
--- a/ruby/ext/google/protobuf_c/repeated_field.c
+++ b/ruby/ext/google/protobuf_c/repeated_field.c
@@ -30,6 +30,8 @@
 
 #include "protobuf.h"
 
+VALUE RepeatedField_concat(VALUE _self, VALUE list);
+
 // -----------------------------------------------------------------------------
 // Repeated field container type.
 // -----------------------------------------------------------------------------
@@ -210,6 +212,10 @@ void RepeatedField_reserve(RepeatedField* self, int new_size) {
  * Adds a new element to the repeated field.
  */
 VALUE RepeatedField_push(VALUE _self, VALUE val) {
+  if (TYPE(val) == T_ARRAY) {
+    return RepeatedField_concat(_self, val);
+  }
+
   RepeatedField* self = ruby_to_RepeatedField(_self);
   upb_fieldtype_t field_type = self->field_type;
   int element_size = native_slot_size(field_type);

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -708,6 +708,28 @@ module CommonTests
     assert proto_module::TestEnum::resolve(:C) == 3
   end
 
+  def test_repeated_push
+    m = proto_module::TestMessage.new
+
+    m.repeated_string << "one"
+    m.repeated_string.push "two"
+    assert_equal ["one", "two"], m.repeated_string
+
+    m.repeated_string.push ["three", "four"]
+    assert_equal ["one", "two", "three", "four"], m.repeated_string
+
+    m.repeated_string << ["five"]
+    assert_equal ["one", "two", "three", "four", "five"], m.repeated_string
+
+    m = proto_module::TestMessage.new
+
+    m.repeated_msg << proto_module::TestMessage2.new(:foo => 1)
+    m.repeated_msg.push proto_module::TestMessage2.new(:foo => 2)
+    m.repeated_msg << [proto_module::TestMessage2.new(:foo => 3)]
+    m.repeated_msg.push [proto_module::TestMessage2.new(:foo => 4)]
+    assert_equal [1, 2, 3, 4], m.repeated_msg.map {|x| x.foo}
+  end
+
   def test_parse_serialize
     m = proto_module::TestMessage.new(:optional_int32 => 42,
                                       :optional_string => "hello world",

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -711,22 +711,21 @@ module CommonTests
   def test_repeated_push
     m = proto_module::TestMessage.new
 
-    m.repeated_string << "one"
-    m.repeated_string.push "two"
-    assert_equal ["one", "two"], m.repeated_string
+    m.repeated_string += ['one']
+    m.repeated_string += %w[two three]
+    assert_equal %w[one two three], m.repeated_string
 
-    m.repeated_string.push ["three", "four"]
-    assert_equal ["one", "two", "three", "four"], m.repeated_string
+    m.repeated_string.push *['four', 'five']
+    assert_equal %w[one two three four five], m.repeated_string
 
-    m.repeated_string << ["five"]
-    assert_equal ["one", "two", "three", "four", "five"], m.repeated_string
+    m.repeated_string.push 'six', 'seven'
+    assert_equal %w[one two three four five six seven], m.repeated_string
 
     m = proto_module::TestMessage.new
 
-    m.repeated_msg << proto_module::TestMessage2.new(:foo => 1)
-    m.repeated_msg.push proto_module::TestMessage2.new(:foo => 2)
-    m.repeated_msg << [proto_module::TestMessage2.new(:foo => 3)]
-    m.repeated_msg.push [proto_module::TestMessage2.new(:foo => 4)]
+    m.repeated_msg += [proto_module::TestMessage2.new(:foo => 1), proto_module::TestMessage2.new(:foo => 2)]
+    m.repeated_msg += [proto_module::TestMessage2.new(:foo => 3)]
+    m.repeated_msg.push proto_module::TestMessage2.new(:foo => 4)
     assert_equal [1, 2, 3, 4], m.repeated_msg.map {|x| x.foo}
   end
 

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -725,8 +725,8 @@ module CommonTests
 
     m.repeated_msg += [proto_module::TestMessage2.new(:foo => 1), proto_module::TestMessage2.new(:foo => 2)]
     m.repeated_msg += [proto_module::TestMessage2.new(:foo => 3)]
-    m.repeated_msg.push proto_module::TestMessage2.new(:foo => 4)
-    assert_equal [1, 2, 3, 4], m.repeated_msg.map {|x| x.foo}
+    m.repeated_msg.push proto_module::TestMessage2.new(:foo => 4), proto_module::TestMessage2.new(:foo => 5)
+    assert_equal [1, 2, 3, 4, 5], m.repeated_msg.map {|x| x.foo}
   end
 
   def test_parse_serialize

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -221,7 +221,7 @@ class RepeatedFieldTest < Test::Unit::TestCase
 
   def test_push
     m = TestMessage.new
-    reference_arr = %w(foo bar baz)
+    reference_arr = %w[foo bar baz]
     m.repeated_string += reference_arr.clone
 
     check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
@@ -230,10 +230,9 @@ class RepeatedFieldTest < Test::Unit::TestCase
     check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
       arr << 'fizz'
     end
-    #TODO: push should support multiple
-    # check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
-    #   arr.push('fizz', 'buzz')
-    # end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      arr.push('fizz', 'buzz')
+    end
   end
 
   def test_clear


### PR DESCRIPTION
Allow the `push` method on repeated fields to accept multiple values and resolve #4278.