### PR TITLE
Simplify holding copies of strings in default_value_objectwriter

### DIFF
--- a/src/google/protobuf/util/internal/default_value_objectwriter.cc
+++ b/src/google/protobuf/util/internal/default_value_objectwriter.cc
@@ -71,9 +71,6 @@ DefaultValueObjectWriter::DefaultValueObjectWriter(
       ow_(ow) {}
 
 DefaultValueObjectWriter::~DefaultValueObjectWriter() {
-  for (int i = 0; i < string_values_.size(); ++i) {
-    delete string_values_[i];
-  }
   if (own_typeinfo_) {
     delete typeinfo_;
   }
@@ -156,7 +153,7 @@ DefaultValueObjectWriter* DefaultValueObjectWriter::RenderString(
   } else {
     // Since StringPiece is essentially a pointer, takes a copy of "value" to
     // avoid ownership issues.
-    string_values_.push_back(new string(value));
+    string_values_.emplace_back(new string(value));
     RenderDataPiece(name, DataPiece(*string_values_.back(), true));
   }
   return this;
@@ -169,7 +166,7 @@ DefaultValueObjectWriter* DefaultValueObjectWriter::RenderBytes(
   } else {
     // Since StringPiece is essentially a pointer, takes a copy of "value" to
     // avoid ownership issues.
-    string_values_.push_back(new string(value.ToString()));
+    string_values_.emplace_back(new string(value));
     RenderDataPiece(name, DataPiece(*string_values_.back(), false, true));
   }
   return this;

--- a/src/google/protobuf/util/internal/default_value_objectwriter.h
+++ b/src/google/protobuf/util/internal/default_value_objectwriter.h
@@ -299,7 +299,7 @@ class PROTOBUF_EXPORT DefaultValueObjectWriter : public ObjectWriter {
   // google::protobuf::Type of the root message type.
   const google::protobuf::Type& type_;
   // Holds copies of strings passed to RenderString.
-  std::vector<std::string*> string_values_;
+  std::vector<std::unique_ptr<std::string>> string_values_;
 
   // The current Node. Owned by its parents.
   Node* current_;


### PR DESCRIPTION
If you don't mind, i propose to improve the implementation of `default_value_objectwriter` with smart pointer for `string_values_`.