### PR TITLE
protobuf.pc.in does not reflect CXXFLAGS

### DIFF
--- a/protobuf.pc.in
+++ b/protobuf.pc.in
@@ -8,5 +8,5 @@ Description: Google's Data Interchange Format
 Version: @VERSION@
 Libs: -L${libdir} -lprotobuf @PTHREAD_CFLAGS@ @PTHREAD_LIBS@
 Libs.private: @LIBS@
-Cflags: -I${includedir} @PTHREAD_CFLAGS@
+Cflags: -I${includedir} @PTHREAD_CFLAGS@ @CXXFLAGS@
 Conflicts: protobuf-lite


### PR DESCRIPTION
Currently, downstream libraries such as RProtoBuf fail because
`-std=c++11` is required via `configure.ac`, but RProtobuf has no way
of knowing this by consulting `pkg-config --cflags protobuf`.

Cf. #5725 