### PR TITLE
Remove TODO from FieldDescriptorProto.default_value

### DIFF
--- a/src/google/protobuf/descriptor.proto
+++ b/src/google/protobuf/descriptor.proto
@@ -197,7 +197,6 @@ message FieldDescriptorProto {
   // For booleans, "true" or "false".
   // For strings, contains the default text contents (not escaped in any way).
   // For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-  // TODO(kenton):  Base-64 encode?
   optional string default_value = 7;
 
   // If set, gives the index of a oneof in the containing type's oneof_decl


### PR DESCRIPTION
While the suggested change in behavior would have been nice,
it has gone un-addressed for 11 years. At this point in time,
switching the encoding to base64 is almost certainly not going
to happen without breaking many users who already had to implement
their own C string parser.

Rather than keeping the TODO, just delete it since it does appear
in the documentation of the generated proto for most languages.