### PR TITLE
Emit annotations for generated C++ extension identifiers

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_extension.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_extension.cc
@@ -133,8 +133,8 @@ void ExtensionGenerator::GenerateDeclaration(io::Printer* printer) const {
       "static const int $constant_name$ = $number$;\n"
       "$1$ ::$proto_ns$::internal::ExtensionIdentifier< $extendee$,\n"
       "    ::$proto_ns$::internal::$type_traits$, $field_type$, $packed$ >\n"
-      "  $name$;\n",
-      qualifier);
+      "  ${2$$name$$}$;\n",
+      qualifier, descriptor_);
 }
 
 void ExtensionGenerator::GenerateDefinition(io::Printer* printer) {


### PR DESCRIPTION
This will enable [kythe](https://github.com/kythe/kythe) to associate the generated extension id in C++ with the definition in the proto file.

Note that this annotation is already added for generated java code:
https://github.com/justbuchanan/protobuf/blob/8c3d0f4806f9e8ca7c2046ff0066dc737f70d4a8/src/google/protobuf/compiler/java/java_extension.cc#L145