### PR TITLE
Change cerr to cout in PrintHelpText again

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -1814,7 +1814,7 @@ void CommandLineInterface::PrintHelpText() {
               << string(19 - iter->first.size(), ' ')  // Spaces for alignment.
               << iter->second.help_text << std::endl;
   }
-  std::cerr <<
+  std::cout <<
 "  @<filename>                 Read options and filenames from file. If a\n"
 "                              relative file path is specified, the file\n"
 "                              will be searched in the working directory.\n"


### PR DESCRIPTION
You can check following commits:
https://github.com/protocolbuffers/protobuf/commit/769b693564aaf8625905e5488e425d27ea123949#diff-5f83a7f49398fa05465b00c6ec8e7477
https://github.com/protocolbuffers/protobuf/commit/13fd045dbb2b4dacea32be162a41d5a4b0d1802f#diff-5f83a7f49398fa05465b00c6ec8e7477
First of them changed cerr to cout in PrintHelpText.
Second added another output to cerr. I'm changing this to cout also.