### PR TITLE
[WIP] Improve C# serialization performance - ArrayValueWriter 

### DIFF
--- a/csharp/src/Google.Protobuf.Test/FieldCodecTest.cs
+++ b/csharp/src/Google.Protobuf.Test/FieldCodecTest.cs
@@ -43,7 +43,7 @@ namespace Google.Protobuf
 #pragma warning disable 0414 // Used by tests via reflection - do not remove!
         private static readonly List<ICodecTestData> Codecs = new List<ICodecTestData>
         {
-            new FieldCodecTestData<bool>(FieldCodec.ForBool(100), true, "Bool"),
+            new FieldCodecTestData<bool>(FieldCodec.ForBool(100), true, "FixedBool"),
             new FieldCodecTestData<string>(FieldCodec.ForString(100), "sample", "String"),
             new FieldCodecTestData<ByteString>(FieldCodec.ForBytes(100), ByteString.CopyFrom(1, 2, 3), "Bytes"),
             new FieldCodecTestData<int>(FieldCodec.ForInt32(100), -1000, "Int32"),
@@ -56,8 +56,8 @@ namespace Google.Protobuf
             new FieldCodecTestData<long>(FieldCodec.ForSFixed64(100), -1000, "SFixed64"),
             new FieldCodecTestData<ulong>(FieldCodec.ForUInt64(100), 1234, "UInt64"),
             new FieldCodecTestData<ulong>(FieldCodec.ForFixed64(100), 1234, "Fixed64"),
-            new FieldCodecTestData<float>(FieldCodec.ForFloat(100), 1234.5f, "Float"),
-            new FieldCodecTestData<double>(FieldCodec.ForDouble(100), 1234567890.5d, "Double"),
+            new FieldCodecTestData<float>(FieldCodec.ForFloat(100), 1234.5f, "FixedFloat"),
+            new FieldCodecTestData<double>(FieldCodec.ForDouble(100), 1234567890.5d, "FixedDouble"),
             new FieldCodecTestData<ForeignEnum>(
                 FieldCodec.ForEnum(100, t => (int) t, t => (ForeignEnum) t), ForeignEnum.ForeignBaz, "Enum"),
             new FieldCodecTestData<ForeignMessage>(

--- a/csharp/src/Google.Protobuf/CodedOutputStream.ComputeSize.cs
+++ b/csharp/src/Google.Protobuf/CodedOutputStream.ComputeSize.cs
@@ -46,7 +46,7 @@ namespace Google.Protobuf
         /// Computes the number of bytes that would be needed to encode a
         /// double field, including the tag.
         /// </summary>
-        public static int ComputeFixedDoubleSize(double value)
+        public static int ComputeDoubleSize(double value)
         {
             return LittleEndian64Size;
         }
@@ -55,7 +55,7 @@ namespace Google.Protobuf
         /// Computes the number of bytes that would be needed to encode a
         /// float field, including the tag.
         /// </summary>
-        public static int ComputeFixedFloatSize(float value)
+        public static int ComputeFloatSize(float value)
         {
             return LittleEndian32Size;
         }
@@ -117,7 +117,7 @@ namespace Google.Protobuf
         /// Computes the number of bytes that would be needed to encode a
         /// bool field, including the tag.
         /// </summary>
-        public static int ComputeFixedBoolSize(bool value)
+        public static int ComputeBoolSize(bool value)
         {
             return 1;
         }

--- a/csharp/src/Google.Protobuf/CodedOutputStream.ComputeSize.cs
+++ b/csharp/src/Google.Protobuf/CodedOutputStream.ComputeSize.cs
@@ -46,7 +46,7 @@ namespace Google.Protobuf
         /// Computes the number of bytes that would be needed to encode a
         /// double field, including the tag.
         /// </summary>
-        public static int ComputeDoubleSize(double value)
+        public static int ComputeFixedDoubleSize(double value)
         {
             return LittleEndian64Size;
         }
@@ -55,7 +55,7 @@ namespace Google.Protobuf
         /// Computes the number of bytes that would be needed to encode a
         /// float field, including the tag.
         /// </summary>
-        public static int ComputeFloatSize(float value)
+        public static int ComputeFixedFloatSize(float value)
         {
             return LittleEndian32Size;
         }
@@ -117,7 +117,7 @@ namespace Google.Protobuf
         /// Computes the number of bytes that would be needed to encode a
         /// bool field, including the tag.
         /// </summary>
-        public static int ComputeBoolSize(bool value)
+        public static int ComputeFixedBoolSize(bool value)
         {
             return 1;
         }

--- a/csharp/src/Google.Protobuf/CodedOutputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedOutputStream.cs
@@ -172,6 +172,34 @@ namespace Google.Protobuf
             WriteRawLittleEndian64((ulong)BitConverter.DoubleToInt64Bits(value));
         }
 
+        public void WriteDoubleArray(double[] values, int count)
+        {
+            if(position + 8 * count > limit)
+            {
+                for(int i = 0; i < count; ++i)
+                {
+                    WriteDouble(values[i]);
+                }
+            }
+            else
+            {
+                long d;
+                for(int i = 0; i < count; ++i)
+                {
+                    d = BitConverter.DoubleToInt64Bits(values[i]);
+                    buffer[position + i * 8] = (byte)(d);
+                    buffer[position + i * 8 + 1] = (byte)(d >> 8);
+                    buffer[position + i * 8 + 2] = (byte)(d >> 16);
+                    buffer[position + i * 8 + 3] = (byte)(d >> 24);
+                    buffer[position + i * 8 + 4] = (byte)(d >> 32);
+                    buffer[position + i * 8 + 5] = (byte)(d >> 40);
+                    buffer[position + i * 8 + 6] = (byte)(d >> 48);
+                    buffer[position + i * 8 + 7] = (byte)(d >> 56);
+                }
+                position += count * 8;
+            }
+        }
+
         /// <summary>
         /// Writes a float field value, without a tag, to the stream.
         /// </summary>
@@ -194,6 +222,14 @@ namespace Google.Protobuf
             else
             {
                 WriteRawBytes(rawBytes, 0, 4);
+            }
+        }
+
+        public void WriteFloatArray(float[] values, int count)
+        {
+            for(int i = 0; i < count; ++i)
+            {
+                WriteFloat(values[i]);
             }
         }
 
@@ -241,6 +277,11 @@ namespace Google.Protobuf
             WriteRawLittleEndian64(value);
         }
 
+        public void WriteFixed64Array(ulong[] values, int count)
+        {
+            WriteRawLittleEndian64Array(values, count);
+        }
+
         /// <summary>
         /// Writes a fixed32 field value, without a tag, to the stream.
         /// </summary>
@@ -248,6 +289,32 @@ namespace Google.Protobuf
         public void WriteFixed32(uint value)
         {
             WriteRawLittleEndian32(value);
+        }
+    
+        /// <summary>
+        /// Writes an array of fixed32 field values, without tags, to the stream.
+        /// </summary>
+        /// <param name="values">The values to write</param>
+        public void WriteFixed32Array(uint[] values, int count)
+        {
+            if (position + 4 * count > limit)
+            {
+                for(int i = 0; i < count; ++i)
+                {
+                    WriteRawLittleEndian32(values[i]);
+                }
+            }
+            else
+            {
+                for(int i = 0; i < count; ++i)
+                {
+                    buffer[position + i * 4] = ((byte)values[i]);
+                    buffer[position + i * 4 + 1] = ((byte)(values[i] >> 8));
+                    buffer[position + i * 4 + 2] = ((byte)(values[i] >> 16));
+                    buffer[position + i * 4 + 3] = ((byte)(values[i] >> 24));
+                }
+                position += count * 4;
+            }
         }
 
         /// <summary>
@@ -257,6 +324,28 @@ namespace Google.Protobuf
         public void WriteBool(bool value)
         {
             WriteRawByte(value ? (byte) 1 : (byte) 0);
+        }
+
+        internal readonly byte trueByte = (byte)1;
+        internal readonly byte falseByte = (byte)0;
+
+        /// <summary>
+        /// Writes an array of bool field values, without tags, to the stream. 
+        /// </summary>
+        /// <param name="values">The array of values to write</param>
+        public void WriteBoolArray(bool[] values, int count)
+        {
+            if(position + count > limit)
+            { 
+                for (int i = 0; i < count; ++i)
+                    WriteBool(values[i]);
+            }
+            else
+            {
+                for (int i = 0; i < count; ++i)
+                    buffer[position + i] = (values[i] ? trueByte : falseByte);
+                position += count;
+            }
         }
 
         /// <summary>
@@ -351,12 +440,26 @@ namespace Google.Protobuf
         }
 
         /// <summary>
+        /// Writes an array of sfixed32 values, without tags, to the stream.
+        /// </summary>
+        /// <param name="value">The values to write.</param>
+        public void WriteSFixed32Array(int[] values, int count)
+        {
+            WriteFixed32Array((uint[])(object)values, count);
+        }
+
+        /// <summary>
         /// Writes an sfixed64 value, without a tag, to the stream.
         /// </summary>
         /// <param name="value">The value to write</param>
         public void WriteSFixed64(long value)
         {
             WriteRawLittleEndian64((ulong) value);
+        }
+
+        public void WriteSFixed64Array(long[] values, int count)
+        {
+            WriteRawLittleEndian64Array((ulong[])(object)values, count);
         }
 
         /// <summary>
@@ -575,6 +678,32 @@ namespace Google.Protobuf
                 buffer[position++] = ((byte) (value >> 40));
                 buffer[position++] = ((byte) (value >> 48));
                 buffer[position++] = ((byte) (value >> 56));
+            }
+        }
+
+        internal void WriteRawLittleEndian64Array(ulong[] values, int count)
+        {
+            if (position + 8 * count > limit)
+            {
+                for(int i = 0; i < count; ++i)
+                {
+                    WriteRawLittleEndian64(values[i]);
+                }
+            }
+            else
+            {
+                for(int i = 0; i < count; ++i)
+                {
+                    buffer[position + i * 8] = ((byte) values[i]);
+                    buffer[position + i * 8 + 1] = ((byte) (values[i] >> 8));
+                    buffer[position + i * 8 + 2] = ((byte) (values[i] >> 16));
+                    buffer[position + i * 8 + 3] = ((byte) (values[i] >> 24));
+                    buffer[position + i * 8 + 4] = ((byte) (values[i] >> 32));
+                    buffer[position + i * 8 + 5] = ((byte) (values[i] >> 40));
+                    buffer[position + i * 8 + 6] = ((byte) (values[i] >> 48));
+                    buffer[position + i * 8 + 7] = ((byte) (values[i] >> 56));
+                }
+                position += count * 8;
             }
         }
 

--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -195,10 +195,7 @@ namespace Google.Protobuf.Collections
                 uint size = (uint)CalculatePackedDataSize(codec);
                 output.WriteTag(tag);
                 output.WriteRawVarint32(size);
-                for (int i = 0; i < count; i++)
-                {
-                    writer(output, array[i]);
-                }
+                codec.ArrayValueWriter(output, array, count);
             }
             else
             {

--- a/csharp/src/Google.Protobuf/FieldCodec.cs
+++ b/csharp/src/Google.Protobuf/FieldCodec.cs
@@ -72,7 +72,7 @@ namespace Google.Protobuf
         /// <returns>A codec for the given tag.</returns>
         public static FieldCodec<bool> ForBool(uint tag)
         {
-            return new FieldCodec<bool>(input => input.ReadBool(), (output, value) => output.WriteBool(value), CodedOutputStream.ComputeBoolSize, tag);
+            return new FieldCodec<bool>(input => input.ReadBool(), (output, value) => output.WriteBool(value), CodedOutputStream.ComputeFixedBoolSize(true), tag);
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Google.Protobuf
         /// <returns>A codec for the given tag.</returns>
         public static FieldCodec<float> ForFloat(uint tag)
         {
-            return new FieldCodec<float>(input => input.ReadFloat(), (output, value) => output.WriteFloat(value), CodedOutputStream.ComputeFloatSize, tag);
+            return new FieldCodec<float>(input => input.ReadFloat(), (output, value) => output.WriteFloat(value), CodedOutputStream.ComputeFixedFloatSize(0f), tag);
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Google.Protobuf
         /// <returns>A codec for the given tag.</returns>
         public static FieldCodec<double> ForDouble(uint tag)
         {
-            return new FieldCodec<double>(input => input.ReadDouble(), (output, value) => output.WriteDouble(value), CodedOutputStream.ComputeDoubleSize, tag);
+            return new FieldCodec<double>(input => input.ReadDouble(), (output, value) => output.WriteDouble(value), CodedOutputStream.ComputeFixedDoubleSize(0.0), tag);
         }
 
         // Enums are tricky. We can probably use expression trees to build these delegates automatically,

--- a/csharp/src/Google.Protobuf/FieldCodec.cs
+++ b/csharp/src/Google.Protobuf/FieldCodec.cs
@@ -455,10 +455,9 @@ namespace Google.Protobuf
                 Action<CodedOutputStream, T> writer,
                 Action<CodedOutputStream, T[], int> arrayWriter,
                 int fixedSize,
-                uint tag) : this(reader, writer, _ => fixedSize, tag)
+                uint tag) : this(reader, writer, arrayWriter, _ => fixedSize, tag, 0, DefaultDefault)
         {
             FixedSize = fixedSize;
-            ArrayValueWriter = arrayWriter;
         }
 
         internal FieldCodec(

--- a/csharp/src/Google.Protobuf/FieldCodec.cs
+++ b/csharp/src/Google.Protobuf/FieldCodec.cs
@@ -72,7 +72,7 @@ namespace Google.Protobuf
         /// <returns>A codec for the given tag.</returns>
         public static FieldCodec<bool> ForBool(uint tag)
         {
-            return new FieldCodec<bool>(input => input.ReadBool(), (output, value) => output.WriteBool(value), CodedOutputStream.ComputeFixedBoolSize(true), tag);
+            return new FieldCodec<bool>(input => input.ReadBool(), (output, value) => output.WriteBool(value), 1, tag);
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Google.Protobuf
         /// <returns>A codec for the given tag.</returns>
         public static FieldCodec<float> ForFloat(uint tag)
         {
-            return new FieldCodec<float>(input => input.ReadFloat(), (output, value) => output.WriteFloat(value), CodedOutputStream.ComputeFixedFloatSize(0f), tag);
+            return new FieldCodec<float>(input => input.ReadFloat(), (output, value) => output.WriteFloat(value), 4, tag);
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Google.Protobuf
         /// <returns>A codec for the given tag.</returns>
         public static FieldCodec<double> ForDouble(uint tag)
         {
-            return new FieldCodec<double>(input => input.ReadDouble(), (output, value) => output.WriteDouble(value), CodedOutputStream.ComputeFixedDoubleSize(0.0), tag);
+            return new FieldCodec<double>(input => input.ReadDouble(), (output, value) => output.WriteDouble(value), 8, tag);
         }
 
         // Enums are tricky. We can probably use expression trees to build these delegates automatically,


### PR DESCRIPTION
this fixes issue #5822

This applies the same style optimizations that are done in WriteString, handling the "common case".
I need to sort out indentation to match the project. I'm opening this up for initial feedback. I've moved incrementing the position member variable to outside of the loops as I saw it generated less assembly and appeared to perform better on Release builds for my profiling.

I'm seeing about 100% speed improvements for repeated fields on primitives, so I'd be curious if others see the same too. These optimizations are applied only if the entire array fits within the buffer, otherwise performance should be the same. This optimization should be covered by the existing unit tests which test varying buffer sizes, but the test data could be added to providing longer repeated fields.