### PR TITLE
C#: add System.Memory dependency

### DIFF
--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -7,7 +7,7 @@
     <VersionPrefix>3.7.0</VersionPrefix>
     <LangVersion>6</LangVersion>
     <Authors>Google Inc.</Authors>
-    <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../keys/Google.Protobuf.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -28,8 +28,12 @@
     - Visual Studio.
     -->
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <TargetFrameworks>netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.2" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />


### PR DESCRIPTION
Also add useful Span-based methods for ByteString

System.Memory dependency is only added for netstandard2.0 target, netstandard1.0 and net45 stay unchanged (we actually could add System.Memory dependency for net45 too, but it seems that most users that will benefit from Span optimizations will already have access to netstandard2.0).

This PR is mostly preparation for future span-based optimizations, but to make at least some use of the new dependency, two utility ByteString methods are being added.

See https://github.com/grpc/grpc-dotnet/issues/30 for more details about the planned serialization/deserialization API.