### PR TITLE
Bazel: Add dependency to error_prone_annotations

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -638,6 +638,7 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "protobuf_java",
+        "//external:error_prone_annotations",
         "//external:gson",
         "//external:guava",
     ],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -74,3 +74,13 @@ bind(
     name = "zlib",
     actual = "@net_zlib//:zlib",
 )
+
+maven_jar(
+    name = "error_prone_annotations_maven",
+    artifact = "com.google.errorprone:error_prone_annotations:2.3.2",
+)
+
+bind(
+    name = "error_prone_annotations",
+    actual = "@error_prone_annotations_maven//jar",
+)


### PR DESCRIPTION
Recently dependency to error_prone_annotations was added to the code,
but only Maven build tool chain was updated.

Closes #5795.