### PR TITLE
No define strtoll/strtoull for VS2013 and above

### DIFF
--- a/src/google/protobuf/stubs/strutil.h
+++ b/src/google/protobuf/stubs/strutil.h
@@ -43,7 +43,7 @@
 namespace google {
 namespace protobuf {
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1800
 #define strtoll  _strtoi64
 #define strtoull _strtoui64
 #elif defined(__DECCXX) && defined(__osf__)


### PR DESCRIPTION
Problem
=====

I am trying to update `vcpkg`'s `protobuf` to v3.7.0 recently: https://github.com/Microsoft/vcpkg/pull/5502, and encountered a strange error when I tried to install `google-cloud-cpp` with this new version of `protobuf`: https://github.com/Microsoft/vcpkg/pull/5502#issuecomment-471164970

In VS2013 and after, `stdlib.h` already have `strtoll` and `strtoull` in it. Redefining them will cause an error if the users use `std::strtoull` in their code:

>error C2039: '_strtoui64': is not a member of 'std'

How to reproduce?
=====

```cpp
#include <fstream>
#include <iostream>

#include "person.pb.h"


int main()
{
    std::cout << std::strtoull("12345678", nullptr, 0) << std::endl;

    {
        Person person;
        person.set_name("John Doe");
        person.set_id(1234);
        person.set_email("jdoe@example.com");

        std::ofstream out_stream("person.dat", std::ios::binary);
        if (out_stream.is_open())
           person.SerializeToOstream(&out_stream);
   }

   {
        std::ifstream in_stream("person.dat", std::ios::binary);
        if (in_stream.is_open())
        {
            Person person;
            person.ParseFromIstream(&in_stream);
    
            std::cout << "Name: " << person.name() << std::endl;
            std::cout << "Email: " << person.email() << std::endl;
        }
    }

    return 0;
}
```

>1>ongoing-study\cpp\protobuf\person_example\person.cpp(9): error C2039: '_strtoui64': is not a member of 'std'

References
=====
https://stackoverflow.com/questions/21911652/c-strtoull-function-undefined
https://github.com/SOCI/soci/pull/217
[_MSC_VER](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2017)
https://github.com/flavio/qjson/issues/23