### PR TITLE
Avoid passing -Og flag to C++ compiler

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -888,7 +888,7 @@ no_warning_test.cc:
 
 no_warning_test_LDADD = $(PTHREAD_LIBS) libprotobuf.la libprotoc.la
 no_warning_test_CXXFLAGS = $(PTHREAD_CFLAGS) $(PTHREAD_DEF) $(ZLIB_DEF) \
-                           -Wall -Wextra -Werror -Wno-unused-parameter -Og
+                           -Wall -Wextra -Werror -Wno-unused-parameter
 nodist_no_warning_test_SOURCES = no_warning_test.cc $(protoc_outputs)
 
 TESTS = protobuf-test protobuf-lazy-descriptor-test protobuf-lite-test \

--- a/tests.sh
+++ b/tests.sh
@@ -48,6 +48,10 @@ build_cpp_tcmalloc() {
 }
 
 build_cpp_distcheck() {
+  grep -q -- "-Og" src/Makefile.am &&
+    echo "The -Og flag is incompatible with Clang versions older than 4.0." &&
+    exit 1
+
   # Initialize any submodules.
   git submodule update --init --recursive
   ./autogen.sh


### PR DESCRIPTION
It appears that some versions of Clang do not support this flag, and
this came up as a problem for Homebrew builds in issue #5815.