### PR TITLE
C# testing improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ csharp_EXTRA_DIST=                                                           \
   csharp/README.md                                                           \
   csharp/build_packages.bat                                                  \
   csharp/build_tools.sh                                                      \
+  csharp/buildall.bat                                                        \
   csharp/buildall.sh                                                         \
   csharp/generate_protos.sh                                                  \
   csharp/install_dotnet_sdk.ps1                                              \

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -38,7 +38,7 @@ dotnet restore
 dotnet build -c %configuration% || goto error
 
 echo Testing C#
-dotnet test -c %configuration% -f netcoreapp1.0 Google.Protobuf.Test\Google.Protobuf.Test.csproj || goto error
+dotnet test -c %configuration% -f netcoreapp2.1 Google.Protobuf.Test\Google.Protobuf.Test.csproj || goto error
 dotnet test -c %configuration% -f net451 Google.Protobuf.Test\Google.Protobuf.Test.csproj || goto error
 
 goto :EOF

--- a/csharp/buildall.bat
+++ b/csharp/buildall.bat
@@ -4,7 +4,7 @@ dotnet build src/Google.Protobuf.sln || goto :error
 
 echo Running tests.
 
-dotnet test -f netcoreapp2.1 src/Google.Protobuf.Test/Google.Protobuf.Test.csproj || goto :error
+dotnet test src/Google.Protobuf.Test/Google.Protobuf.Test.csproj || goto :error
 
 goto :EOF
 

--- a/csharp/buildall.bat
+++ b/csharp/buildall.bat
@@ -4,7 +4,7 @@ dotnet build src/Google.Protobuf.sln || goto :error
 
 echo Running tests.
 
-dotnet test -f netcoreapp1.0 src/Google.Protobuf.Test/Google.Protobuf.Test.csproj || goto :error
+dotnet test -f netcoreapp2.1 src/Google.Protobuf.Test/Google.Protobuf.Test.csproj || goto :error
 
 goto :EOF
 

--- a/csharp/buildall.bat
+++ b/csharp/buildall.bat
@@ -1,0 +1,13 @@
+@rem Builds Google.Protobuf and runs the tests
+
+dotnet build src/Google.Protobuf.sln || goto :error
+
+echo Running tests.
+
+dotnet test -f netcoreapp1.0 src/Google.Protobuf.Test/Google.Protobuf.Test.csproj || goto :error
+
+goto :EOF
+
+:error
+echo Failed!
+exit /b %errorlevel%

--- a/csharp/buildall.sh
+++ b/csharp/buildall.sh
@@ -10,8 +10,8 @@ dotnet restore $SRC/Google.Protobuf.sln
 dotnet build -c $CONFIG $SRC/Google.Protobuf.sln
 
 echo Running tests.
-# Only test netcoreapp1.0, which uses the .NET Core runtime.
+# Only test netcoreapp2.1, which uses the .NET Core runtime.
 # If we want to test the .NET 4.5 version separately, we could
 # run Mono explicitly. However, we don't have any differences between
-# the .NET 4.5 and netstandard1.0 assemblies.
-dotnet test -c $CONFIG -f netcoreapp1.0 $SRC/Google.Protobuf.Test/Google.Protobuf.Test.csproj
+# the .NET 4.5 and netstandard2.1 assemblies.
+dotnet test -c $CONFIG -f netcoreapp2.1 $SRC/Google.Protobuf.Test/Google.Protobuf.Test.csproj

--- a/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
@@ -750,7 +750,8 @@ namespace Google.Protobuf.Collections
             var list2 = new RepeatedField<double> { SampleNaNs.Regular, SampleNaNs.PayloadFlipped };
             var list3 = new RepeatedField<double> { SampleNaNs.Regular, SampleNaNs.SignallingFlipped };
 
-            EqualityTester.AssertInequality(list1, list2);
+            // All SampleNaNs have the same hashcode under certain targets (e.g. netcoreapp2.1)
+            EqualityTester.AssertInequality(list1, list2, checkHashcode: false);
             EqualityTester.AssertEquality(list1, list3);
             Assert.True(list1.Contains(SampleNaNs.SignallingFlipped));
             Assert.False(list2.Contains(SampleNaNs.SignallingFlipped));

--- a/csharp/src/Google.Protobuf.Test/EqualityTester.cs
+++ b/csharp/src/Google.Protobuf.Test/EqualityTester.cs
@@ -49,13 +49,14 @@ namespace Google.Protobuf
             Assert.AreEqual(first.GetHashCode(), second.GetHashCode());
         }
 
-        public static void AssertInequality<T>(T first, T second) where T : IEquatable<T>
+        public static void AssertInequality<T>(T first, T second, bool checkHashcode = true) where T : IEquatable<T>
         {
             Assert.IsFalse(first.Equals(second));
             Assert.IsFalse(first.Equals((object) second));
             // While this isn't a requirement, the chances of this test failing due to
             // coincidence rather than a bug are very small.
-            if (first != null && second != null)
+            // For such rare cases, an argument can be used to disable the check.
+            if (checkHashcode && first != null && second != null)
             {
                 Assert.AreNotEqual(first.GetHashCode(), second.GetHashCode());
             }

--- a/kokoro/release/csharp/windows/build_nuget.bat
+++ b/kokoro/release/csharp/windows/build_nuget.bat
@@ -7,4 +7,8 @@ cd csharp
 powershell -File install_dotnet_sdk.ps1
 set PATH=%LOCALAPPDATA%\Microsoft\dotnet;%PATH%
 
+@rem Disable some unwanted dotnet options
+set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+set DOTNET_CLI_TELEMETRY_OPTOUT=true
+
 call build_packages.bat

--- a/kokoro/windows/csharp/build.bat
+++ b/kokoro/windows/csharp/build.bat
@@ -7,4 +7,8 @@ cd csharp
 powershell -File install_dotnet_sdk.ps1
 set PATH=%LOCALAPPDATA%\Microsoft\dotnet;%PATH%
 
+@rem Disable some unwanted dotnet options
+set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+set DOTNET_CLI_TELEMETRY_OPTOUT=true
+
 call buildall.bat

--- a/kokoro/windows/csharp/build.bat
+++ b/kokoro/windows/csharp/build.bat
@@ -1,0 +1,10 @@
+@rem enter repo root
+cd /d %~dp0\..\..\..
+
+cd csharp
+
+@rem Install dotnet SDK
+powershell -File install_dotnet_sdk.ps1
+set PATH=%LOCALAPPDATA%\Microsoft\dotnet;%PATH%
+
+call buildall.bat

--- a/kokoro/windows/csharp/continuous.cfg
+++ b/kokoro/windows/csharp/continuous.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/csharp/build.bat"
+timeout_mins: 1440

--- a/tests.sh
+++ b/tests.sh
@@ -117,6 +117,12 @@ build_csharp() {
   internal_build_cpp
   NUGET=/usr/local/bin/nuget.exe
 
+  # Disable some unwanted dotnet options
+  export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+  export DOTNET_CLI_TELEMETRY_OPTOUT=true
+
+  # TODO(jtattermusch): is this still needed with "first time experience"
+  # disabled?
   # Perform "dotnet new" once to get the setup preprocessing out of the
   # way. That spews a lot of output (including backspaces) into logs
   # otherwise, and can cause problems. It doesn't matter if this step


### PR DESCRIPTION
- linux: switch tests to use netcoreapp2.1 (**currently some tests are being skipped due to the failure to update buildall.sh in #5838**)
- add kokoro testing scripts for windows (will be enabled on pull requests later)
- a bit more cleanup

