### PR TITLE
Fix scope resolution for Google namespace

### DIFF
--- a/src/google/protobuf/compiler/ruby/ruby_generated_code_pb.rb
+++ b/src/google/protobuf/compiler/ruby/ruby_generated_code_pb.rb
@@ -68,9 +68,9 @@ end
 module A
   module B
     module C
-      TestMessage = Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestMessage").msgclass
-      TestMessage::NestedMessage = Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestMessage.NestedMessage").msgclass
-      TestEnum = Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestEnum").enummodule
+      TestMessage = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestMessage").msgclass
+      TestMessage::NestedMessage = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestMessage.NestedMessage").msgclass
+      TestEnum = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestEnum").enummodule
     end
   end
 end

--- a/src/google/protobuf/compiler/ruby/ruby_generated_code_proto2_pb.rb
+++ b/src/google/protobuf/compiler/ruby/ruby_generated_code_proto2_pb.rb
@@ -69,9 +69,9 @@ end
 module A
   module B
     module C
-      TestMessage = Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestMessage").msgclass
-      TestMessage::NestedMessage = Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestMessage.NestedMessage").msgclass
-      TestEnum = Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestEnum").enummodule
+      TestMessage = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestMessage").msgclass
+      TestMessage::NestedMessage = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestMessage.NestedMessage").msgclass
+      TestEnum = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("A.B.C.TestEnum").enummodule
     end
   end
 end

--- a/src/google/protobuf/compiler/ruby/ruby_generated_pkg_explicit_legacy_pb.rb
+++ b/src/google/protobuf/compiler/ruby/ruby_generated_pkg_explicit_legacy_pb.rb
@@ -14,7 +14,7 @@ end
 module AA
   module BB
     module CC
-      Four = Google::Protobuf::DescriptorPool.generated_pool.lookup("one.two.a_three.and.Four").msgclass
+      Four = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("one.two.a_three.and.Four").msgclass
     end
   end
 end

--- a/src/google/protobuf/compiler/ruby/ruby_generated_pkg_explicit_pb.rb
+++ b/src/google/protobuf/compiler/ruby/ruby_generated_pkg_explicit_pb.rb
@@ -14,7 +14,7 @@ end
 module A
   module B
     module C
-      Four = Google::Protobuf::DescriptorPool.generated_pool.lookup("one.two.a_three.Four").msgclass
+      Four = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("one.two.a_three.Four").msgclass
     end
   end
 end

--- a/src/google/protobuf/compiler/ruby/ruby_generated_pkg_implicit_pb.rb
+++ b/src/google/protobuf/compiler/ruby/ruby_generated_pkg_implicit_pb.rb
@@ -14,7 +14,7 @@ end
 module One
   module Two
     module AThree
-      Four = Google::Protobuf::DescriptorPool.generated_pool.lookup("one.two.a_three.Four").msgclass
+      Four = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("one.two.a_three.Four").msgclass
     end
   end
 end

--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -371,7 +371,7 @@ void GenerateMessageAssignment(const std::string& prefix,
     "prefix", prefix,
     "name", RubifyConstant(message->name()));
   printer->Print(
-    "Google::Protobuf::DescriptorPool.generated_pool."
+    "::Google::Protobuf::DescriptorPool.generated_pool."
     "lookup(\"$full_name$\").msgclass\n",
     "full_name", message->full_name());
 
@@ -391,7 +391,7 @@ void GenerateEnumAssignment(const std::string& prefix, const EnumDescriptor* en,
     "prefix", prefix,
     "name", RubifyConstant(en->name()));
   printer->Print(
-    "Google::Protobuf::DescriptorPool.generated_pool."
+    "::Google::Protobuf::DescriptorPool.generated_pool."
     "lookup(\"$full_name$\").enummodule\n",
     "full_name", en->full_name());
 }


### PR DESCRIPTION
Second stab at https://github.com/protocolbuffers/protobuf/pull/4167

Having `google` in the package namespace generates unusable ruby code.

```proto
syntax = "proto3";

package foo.vendor.google;

message Bar {
  int32 baz = 1;
}
```

```ruby
# Generated by the protocol buffer compiler.  DO NOT EDIT!
# source: test.proto

require 'google/protobuf'

Google::Protobuf::DescriptorPool.generated_pool.build do
  add_message "foo.vendor.google.Bar" do
    optional :baz, :int32, 1
  end
end

module Foo
  module Vendor
    module Google
      Bar = Google::Protobuf::DescriptorPool.generated_pool.lookup("foo.vendor.google.Bar").msgclass
    end
  end
end
```

which obviously doesn't work:

```
<module:Google>: uninitialized constant Foo::Vendor::Google::Protobuf (NameError)
```

`Google::Protobuf::DescriptorPool` must be prefixed with `::` to fix this.