### PR TITLE
Add terminating character to zend_lookup_class call

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -735,6 +735,7 @@ php_EXTRA_DIST=                                                       \
   php/tests/autoload.php                                              \
   php/tests/bootstrap_phpunit.php                                     \
   php/tests/compatibility_test.sh                                     \
+  php/tests/compile_extension.sh                                      \
   php/tests/descriptors_test.php                                      \
   php/tests/encode_decode_test.php                                    \
   php/tests/gdb_test.sh                                               \

--- a/php/ext/google/protobuf/def.c
+++ b/php/ext/google/protobuf/def.c
@@ -888,6 +888,7 @@ static void fill_qualified_classname(const char *fullname,
   fill_namespace(package, namespace_given, classname);
   fill_classname(fullname, package, namespace_given, prefix,
                  classname, use_nested_submsg);
+  stringsink_string(classname, NULL, "\0", 1, NULL);
 }
 
 static void classname_no_prefix(const char *fullname, const char *package_name,
@@ -956,7 +957,7 @@ void internal_add_generated_file(const char *data, PHP_PROTO_SIZE data_len,
     fill_qualified_classname(fullname, package, php_namespace,                 \
                              prefix_given, &namesink, use_nested_submsg);      \
     PHP_PROTO_CE_DECLARE pce;                                                  \
-    if (php_proto_zend_lookup_class(namesink.ptr, namesink.len, &pce) ==       \
+    if (php_proto_zend_lookup_class(namesink.ptr, namesink.len - 1, &pce) ==   \
         FAILURE) {                                                             \
       zend_error(E_ERROR, "Generated message class %s hasn't been defined",    \
                  namesink.ptr);                                                \

--- a/php/tests/compile_extension.sh
+++ b/php/tests/compile_extension.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+EXTENSION_PATH=$1
+
+pushd $EXTENSION_PATH
+make clean || true
+set -e
+# Add following in configure for debug: --enable-debug CFLAGS='-g -O0'
+phpize && ./configure CFLAGS='-g -O0' && make
+popd

--- a/php/tests/php_implementation_test.php
+++ b/php/tests/php_implementation_test.php
@@ -14,8 +14,19 @@ use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\GPBWire;
 use Google\Protobuf\Internal\CodedOutputStream;
 
+/**
+ * Please note, this test is only intended to be run without the protobuf C
+ * extension.
+ */
 class ImplementationTest extends TestBase
 {
+    public function setUp()
+    {
+        if (extension_loaded('protobuf')) {
+            $this->markTestSkipped();
+        }
+    }
+
     public function testReadInt32()
     {
         $value = null;

--- a/php/tests/test.sh
+++ b/php/tests/test.sh
@@ -7,12 +7,7 @@ export C_INCLUDE_PATH=/usr/local/php-$VERSION/include/php/main:/usr/local/php-$V
 export CPLUS_INCLUDE_PATH=/usr/local/php-$VERSION/include/php/main:/usr/local/php-$VERSION/include/php:$CPLUS_INCLUDE_PATH
 
 # Compile c extension
-pushd ../ext/google/protobuf/
-make clean || true
-set -e
-# Add following in configure for debug: --enable-debug CFLAGS='-g -O0'
-phpize && ./configure CFLAGS='-g -O0' && make
-popd
+/bin/bash ./compile_extension.sh ../ext/google/protobuf
 
 tests=( array_test.php encode_decode_test.php generated_class_test.php map_field_test.php well_known_test.php descriptors_test.php wrapper_type_setters_test.php)
 

--- a/tests.sh
+++ b/tests.sh
@@ -439,6 +439,16 @@ build_php5.5_c() {
   # popd
 }
 
+build_php5.5_mixed() {
+  use_php 5.5
+  pushd php
+  rm -rf vendor
+  composer update
+  /bin/bash ./tests/compile_extension.sh ./ext/google/protobuf
+  php -dextension=./ext/google/protobuf/modules/protobuf.so ./vendor/bin/phpunit
+  popd
+}
+
 build_php5.5_zts_c() {
   use_php_zts 5.5
   cd php/tests && /bin/bash ./test.sh 5.5-zts && cd ../..
@@ -467,6 +477,16 @@ build_php5.6_c() {
   # pushd conformance
   # make test_php_c
   # popd
+}
+
+build_php5.6_mixed() {
+  use_php 5.6
+  pushd php
+  rm -rf vendor
+  composer update
+  /bin/bash ./tests/compile_extension.sh ./ext/google/protobuf
+  php -dextension=./ext/google/protobuf/modules/protobuf.so ./vendor/bin/phpunit
+  popd
 }
 
 build_php5.6_zts_c() {
@@ -522,6 +542,16 @@ build_php7.0_c() {
   # pushd conformance
   # make test_php_c
   # popd
+}
+
+build_php7.0_mixed() {
+  use_php 7.0
+  pushd php
+  rm -rf vendor
+  composer update
+  /bin/bash ./tests/compile_extension.sh ./ext/google/protobuf
+  php -dextension=./ext/google/protobuf/modules/protobuf.so ./vendor/bin/phpunit
+  popd
 }
 
 build_php7.0_zts_c() {
@@ -587,6 +617,16 @@ build_php7.1_c() {
   fi
 }
 
+build_php7.1_mixed() {
+  use_php 7.1
+  pushd php
+  rm -rf vendor
+  composer update
+  /bin/bash ./tests/compile_extension.sh ./ext/google/protobuf
+  php -dextension=./ext/google/protobuf/modules/protobuf.so ./vendor/bin/phpunit
+  popd
+}
+
 build_php7.1_zts_c() {
   use_php_zts 7.1
   cd php/tests && /bin/bash ./test.sh 7.1-zts && cd ../..
@@ -604,6 +644,10 @@ build_php_all_32() {
   build_php5.6_c
   build_php7.0_c
   build_php7.1_c $1
+  build_php5.5_mixed
+  build_php5.6_mixed
+  build_php7.0_mixed
+  build_php7.1_mixed
   build_php5.5_zts_c
   build_php5.6_zts_c
   build_php7.0_zts_c


### PR DESCRIPTION
Cherry pick of #5871 with a few minor adjustments as there was some refactoring done between 3.7.x and master.

/cc @TeBoring