### PR TITLE
Add missing C# windows presubmit.cfg file

### DIFF
--- a/kokoro/windows/csharp/presubmit.cfg
+++ b/kokoro/windows/csharp/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/csharp/build.bat"
+timeout_mins: 1440


### PR DESCRIPTION
We enabled Windows C# presubmit test, but I didn't realize the presubmit.cfg was missing (so currently all the Win C# tests on PR are failing).