### PR TITLE
[Python] Fix several DeprecationWarning: invalid escape sequence

### DIFF
--- a/benchmarks/util/result_parser.py
+++ b/benchmarks/util/result_parser.py
@@ -29,7 +29,7 @@ def __get_data_size(filename):
 
 
 def __extract_file_name(file_name):
-  name_list = re.split("[/\.]", file_name)
+  name_list = re.split(r"[/\.]", file_name)
   short_file_name = ""
   for name in name_list:
     if name[:14] == "google_message":
@@ -213,7 +213,7 @@ def __parse_go_result(filename):
     filename = os.path.dirname(os.path.abspath(__file__)) + '/' + filename
   with open(filename) as f:
     for line in f:
-      result_list = re.split("[\ \t]+", line)
+      result_list = re.split(r"[\ \t]+", line)
       if result_list[0][:9] != "Benchmark":
         continue
       first_slash_index = result_list[0].find('/')

--- a/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/text_format_test.py
+++ b/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/text_format_test.py
@@ -248,7 +248,7 @@ class TextFormatTest(unittest.TestCase):
                .replace('e-0','e-').replace('e-0','e-')
     # Floating point fields are printed with .0 suffix even if they are
     # actualy integer numbers.
-    text = re.compile('\.0$', re.MULTILINE).sub('', text)
+    text = re.compile(r'\.0$', re.MULTILINE).sub('', text)
     return text
 
   def testMergeGolden(self):


### PR DESCRIPTION
Hello,

I do not know if you are interested in fixing such warnings, but this is a little patch to fix remaining `DeprecationWarning: invalid escape sequence`.

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>