### PR TITLE
Avoid linking against libatomic when building protoc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,6 +165,10 @@ AS_IF([test "$with_zlib" != no], [
 ])
 AM_CONDITIONAL([HAVE_ZLIB], [test $HAVE_ZLIB = 1])
 
+# Add -std=c++11 if necesssary. It is important for us to do this before the
+# libatomic check below, since that also depends on C++11.
+AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+
 dnl On some platforms, std::atomic needs a helper library
 AC_MSG_CHECKING(whether -latomic is needed)
 AC_LINK_IFELSE([AC_LANG_SOURCE([[
@@ -213,8 +217,6 @@ case "$target_os" in
     ;;
 esac
 AM_CONDITIONAL([OBJC_CONFORMANCE_TEST], [test $OBJC_CONFORMANCE_TEST = 1])
-
-AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 
 # HACK:  Make gmock's configure script pick up our copy of CFLAGS and CXXFLAGS,
 #   since the flags added by ACX_CHECK_SUNCC must be used when compiling gmock

--- a/protoc-artifacts/build-protoc.sh
+++ b/protoc-artifacts/build-protoc.sh
@@ -140,9 +140,9 @@ checkDependencies ()
     host_machine="$(uname -m)";
     dump_cmd='ldd '"$1"
     if [[ "$ARCH" == x86_32 ]]; then
-      white_list="linux-gate\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux\.so\.2\|libatomic\.so\.1"
+      white_list="linux-gate\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux\.so\.2"
     elif [[ "$ARCH" == x86_64 ]]; then
-      white_list="linux-vdso\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux-x86-64\.so\.2\|libatomic\.so\.1"
+      white_list="linux-vdso\.so\.1\|libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux-x86-64\.so\.2"
     elif [[ "$ARCH" == ppcle_64 ]]; then
       if [[ $host_machine != ppc64le ]];then
         dump_cmd='objdump -p '"$1"' | grep NEEDED'


### PR DESCRIPTION
We ran into problems with precompiled protoc binaries not working on
some systems because of the dependence on a dynamically linked
libatomic. However, I found that linking against libatomic is not
actually necessary in our protoc build environment. Inside configure.ac
there's a test which figures out if we need to pass -latomic, and it
does this by attempting to build a test binary. That binary was failing
to build, but it turns out this was because we need to pass -std=c++11,
not -latomic.

This fixes #5875.