### PR TITLE
Fix Windows builds with future Bazel changes

### DIFF
--- a/src/google/protobuf/testing/googletest.cc
+++ b/src/google/protobuf/testing/googletest.cc
@@ -86,7 +86,11 @@ string TestSourceDir() {
   // Look for the "src" directory.
   string prefix = ".";
 
-  while (!File::Exists(prefix + "/src/google/protobuf")) {
+  // Keep looking further up the directory tree until we find
+  // src/.../descriptor.cc. It is important to look for a particular file,
+  // keeping in mind that with Bazel builds the directory structure under
+  // bazel-bin/ looks similar to the main directory tree in the Git repo.
+  while (!File::Exists(prefix + "/src/google/protobuf/descriptor.cc")) {
     if (!File::Exists(prefix)) {
       GOOGLE_LOG(FATAL)
         << "Could not find protobuf source code.  Please run tests from "


### PR DESCRIPTION
The bazel-bin/ and bazel-genfiles/ directories are going to be merged
soon. That change was causing some test failures on Windows, and I
believe it is because the logic for locating test data files was getting
confused and mistakenly looking for them under bazel-bin/. This commit
updates that logic to look for a more specific file (descriptor.cc)
which does not appear under any Bazel-related directories.

It sounds like the more official solution is to use the Bazel runfiles
library (i.e. //tools/cpp/runfiles). However, I decided not to do that
because we currently still support multiple build systems, and if we
used a separate solution for Bazel then I suspect we would need even
more #ifdefs in the code to handle the different systems.