### PR TITLE
Avoid marking generated C++ messages as final for now

### DIFF
--- a/src/google/protobuf/any.pb.h
+++ b/src/google/protobuf/any.pb.h
@@ -62,7 +62,7 @@ namespace protobuf {
 
 // ===================================================================
 
-class PROTOBUF_EXPORT Any final :
+class PROTOBUF_EXPORT Any :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Any) */ {
  public:
   Any();

--- a/src/google/protobuf/api.pb.h
+++ b/src/google/protobuf/api.pb.h
@@ -71,7 +71,7 @@ namespace protobuf {
 
 // ===================================================================
 
-class PROTOBUF_EXPORT Api final :
+class PROTOBUF_EXPORT Api :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Api) */ {
  public:
   Api();
@@ -262,7 +262,7 @@ class PROTOBUF_EXPORT Api final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT Method final :
+class PROTOBUF_EXPORT Method :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Method) */ {
  public:
   Method();
@@ -446,7 +446,7 @@ class PROTOBUF_EXPORT Method final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT Mixin final :
+class PROTOBUF_EXPORT Mixin :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Mixin) */ {
  public:
   Mixin();

--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -246,7 +246,7 @@ bool HasPrivateHasMethod(const FieldDescriptor* field) {
 
 bool ShouldMarkClassAsFinal(const Descriptor* descriptor,
                             const Options& options) {
-  return true;
+  return false;
 }
 
 bool ShouldMarkClearAsFinal(const Descriptor* descriptor,

--- a/src/google/protobuf/compiler/plugin.pb.h
+++ b/src/google/protobuf/compiler/plugin.pb.h
@@ -83,7 +83,7 @@ namespace compiler {
 
 // ===================================================================
 
-class PROTOC_EXPORT Version final :
+class PROTOC_EXPORT Version :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.Version) */ {
  public:
   Version();
@@ -236,7 +236,7 @@ class PROTOC_EXPORT Version final :
 };
 // -------------------------------------------------------------------
 
-class PROTOC_EXPORT CodeGeneratorRequest final :
+class PROTOC_EXPORT CodeGeneratorRequest :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorRequest) */ {
  public:
   CodeGeneratorRequest();
@@ -411,7 +411,7 @@ class PROTOC_EXPORT CodeGeneratorRequest final :
 };
 // -------------------------------------------------------------------
 
-class PROTOC_EXPORT CodeGeneratorResponse_File final :
+class PROTOC_EXPORT CodeGeneratorResponse_File :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorResponse.File) */ {
  public:
   CodeGeneratorResponse_File();
@@ -572,7 +572,7 @@ class PROTOC_EXPORT CodeGeneratorResponse_File final :
 };
 // -------------------------------------------------------------------
 
-class PROTOC_EXPORT CodeGeneratorResponse final :
+class PROTOC_EXPORT CodeGeneratorResponse :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorResponse) */ {
  public:
   CodeGeneratorResponse();

--- a/src/google/protobuf/descriptor.pb.h
+++ b/src/google/protobuf/descriptor.pb.h
@@ -301,7 +301,7 @@ inline bool MethodOptions_IdempotencyLevel_Parse(
 }
 // ===================================================================
 
-class PROTOBUF_EXPORT FileDescriptorSet final :
+class PROTOBUF_EXPORT FileDescriptorSet :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FileDescriptorSet) */ {
  public:
   FileDescriptorSet();
@@ -442,7 +442,7 @@ class PROTOBUF_EXPORT FileDescriptorSet final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT FileDescriptorProto final :
+class PROTOBUF_EXPORT FileDescriptorProto :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FileDescriptorProto) */ {
  public:
   FileDescriptorProto();
@@ -772,7 +772,7 @@ class PROTOBUF_EXPORT FileDescriptorProto final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT DescriptorProto_ExtensionRange final :
+class PROTOBUF_EXPORT DescriptorProto_ExtensionRange :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.DescriptorProto.ExtensionRange) */ {
  public:
   DescriptorProto_ExtensionRange();
@@ -929,7 +929,7 @@ class PROTOBUF_EXPORT DescriptorProto_ExtensionRange final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT DescriptorProto_ReservedRange final :
+class PROTOBUF_EXPORT DescriptorProto_ReservedRange :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.DescriptorProto.ReservedRange) */ {
  public:
   DescriptorProto_ReservedRange();
@@ -1073,7 +1073,7 @@ class PROTOBUF_EXPORT DescriptorProto_ReservedRange final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT DescriptorProto final :
+class PROTOBUF_EXPORT DescriptorProto :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.DescriptorProto) */ {
  public:
   DescriptorProto();
@@ -1356,7 +1356,7 @@ class PROTOBUF_EXPORT DescriptorProto final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT ExtensionRangeOptions final :
+class PROTOBUF_EXPORT ExtensionRangeOptions :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.ExtensionRangeOptions) */ {
  public:
   ExtensionRangeOptions();
@@ -1500,7 +1500,7 @@ class PROTOBUF_EXPORT ExtensionRangeOptions final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT FieldDescriptorProto final :
+class PROTOBUF_EXPORT FieldDescriptorProto :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FieldDescriptorProto) */ {
  public:
   FieldDescriptorProto();
@@ -1884,7 +1884,7 @@ class PROTOBUF_EXPORT FieldDescriptorProto final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT OneofDescriptorProto final :
+class PROTOBUF_EXPORT OneofDescriptorProto :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.OneofDescriptorProto) */ {
  public:
   OneofDescriptorProto();
@@ -2050,7 +2050,7 @@ class PROTOBUF_EXPORT OneofDescriptorProto final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT EnumDescriptorProto_EnumReservedRange final :
+class PROTOBUF_EXPORT EnumDescriptorProto_EnumReservedRange :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumDescriptorProto.EnumReservedRange) */ {
  public:
   EnumDescriptorProto_EnumReservedRange();
@@ -2194,7 +2194,7 @@ class PROTOBUF_EXPORT EnumDescriptorProto_EnumReservedRange final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT EnumDescriptorProto final :
+class PROTOBUF_EXPORT EnumDescriptorProto :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumDescriptorProto) */ {
  public:
   EnumDescriptorProto();
@@ -2411,7 +2411,7 @@ class PROTOBUF_EXPORT EnumDescriptorProto final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT EnumValueDescriptorProto final :
+class PROTOBUF_EXPORT EnumValueDescriptorProto :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumValueDescriptorProto) */ {
  public:
   EnumValueDescriptorProto();
@@ -2585,7 +2585,7 @@ class PROTOBUF_EXPORT EnumValueDescriptorProto final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT ServiceDescriptorProto final :
+class PROTOBUF_EXPORT ServiceDescriptorProto :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.ServiceDescriptorProto) */ {
  public:
   ServiceDescriptorProto();
@@ -2764,7 +2764,7 @@ class PROTOBUF_EXPORT ServiceDescriptorProto final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT MethodDescriptorProto final :
+class PROTOBUF_EXPORT MethodDescriptorProto :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.MethodDescriptorProto) */ {
  public:
   MethodDescriptorProto();
@@ -2996,7 +2996,7 @@ class PROTOBUF_EXPORT MethodDescriptorProto final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT FileOptions final :
+class PROTOBUF_EXPORT FileOptions :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FileOptions) */ {
  public:
   FileOptions();
@@ -3498,7 +3498,7 @@ class PROTOBUF_EXPORT FileOptions final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT MessageOptions final :
+class PROTOBUF_EXPORT MessageOptions :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.MessageOptions) */ {
  public:
   MessageOptions();
@@ -3674,7 +3674,7 @@ class PROTOBUF_EXPORT MessageOptions final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT FieldOptions final :
+class PROTOBUF_EXPORT FieldOptions :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FieldOptions) */ {
  public:
   FieldOptions();
@@ -3922,7 +3922,7 @@ class PROTOBUF_EXPORT FieldOptions final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT OneofOptions final :
+class PROTOBUF_EXPORT OneofOptions :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.OneofOptions) */ {
  public:
   OneofOptions();
@@ -4066,7 +4066,7 @@ class PROTOBUF_EXPORT OneofOptions final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT EnumOptions final :
+class PROTOBUF_EXPORT EnumOptions :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumOptions) */ {
  public:
   EnumOptions();
@@ -4226,7 +4226,7 @@ class PROTOBUF_EXPORT EnumOptions final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT EnumValueOptions final :
+class PROTOBUF_EXPORT EnumValueOptions :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumValueOptions) */ {
  public:
   EnumValueOptions();
@@ -4378,7 +4378,7 @@ class PROTOBUF_EXPORT EnumValueOptions final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT ServiceOptions final :
+class PROTOBUF_EXPORT ServiceOptions :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.ServiceOptions) */ {
  public:
   ServiceOptions();
@@ -4530,7 +4530,7 @@ class PROTOBUF_EXPORT ServiceOptions final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT MethodOptions final :
+class PROTOBUF_EXPORT MethodOptions :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.MethodOptions) */ {
  public:
   MethodOptions();
@@ -4718,7 +4718,7 @@ class PROTOBUF_EXPORT MethodOptions final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT UninterpretedOption_NamePart final :
+class PROTOBUF_EXPORT UninterpretedOption_NamePart :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.UninterpretedOption.NamePart) */ {
  public:
   UninterpretedOption_NamePart();
@@ -4882,7 +4882,7 @@ class PROTOBUF_EXPORT UninterpretedOption_NamePart final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT UninterpretedOption final :
+class PROTOBUF_EXPORT UninterpretedOption :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.UninterpretedOption) */ {
  public:
   UninterpretedOption();
@@ -5124,7 +5124,7 @@ class PROTOBUF_EXPORT UninterpretedOption final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT SourceCodeInfo_Location final :
+class PROTOBUF_EXPORT SourceCodeInfo_Location :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.SourceCodeInfo.Location) */ {
  public:
   SourceCodeInfo_Location();
@@ -5353,7 +5353,7 @@ class PROTOBUF_EXPORT SourceCodeInfo_Location final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT SourceCodeInfo final :
+class PROTOBUF_EXPORT SourceCodeInfo :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.SourceCodeInfo) */ {
  public:
   SourceCodeInfo();
@@ -5496,7 +5496,7 @@ class PROTOBUF_EXPORT SourceCodeInfo final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT GeneratedCodeInfo_Annotation final :
+class PROTOBUF_EXPORT GeneratedCodeInfo_Annotation :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.GeneratedCodeInfo.Annotation) */ {
  public:
   GeneratedCodeInfo_Annotation();
@@ -5679,7 +5679,7 @@ class PROTOBUF_EXPORT GeneratedCodeInfo_Annotation final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT GeneratedCodeInfo final :
+class PROTOBUF_EXPORT GeneratedCodeInfo :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.GeneratedCodeInfo) */ {
  public:
   GeneratedCodeInfo();

--- a/src/google/protobuf/duration.pb.h
+++ b/src/google/protobuf/duration.pb.h
@@ -61,7 +61,7 @@ namespace protobuf {
 
 // ===================================================================
 
-class PROTOBUF_EXPORT Duration final :
+class PROTOBUF_EXPORT Duration :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Duration) */ {
  public:
   Duration();

--- a/src/google/protobuf/empty.pb.h
+++ b/src/google/protobuf/empty.pb.h
@@ -61,7 +61,7 @@ namespace protobuf {
 
 // ===================================================================
 
-class PROTOBUF_EXPORT Empty final :
+class PROTOBUF_EXPORT Empty :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Empty) */ {
  public:
   Empty();

--- a/src/google/protobuf/field_mask.pb.h
+++ b/src/google/protobuf/field_mask.pb.h
@@ -61,7 +61,7 @@ namespace protobuf {
 
 // ===================================================================
 
-class PROTOBUF_EXPORT FieldMask final :
+class PROTOBUF_EXPORT FieldMask :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FieldMask) */ {
  public:
   FieldMask();

--- a/src/google/protobuf/source_context.pb.h
+++ b/src/google/protobuf/source_context.pb.h
@@ -61,7 +61,7 @@ namespace protobuf {
 
 // ===================================================================
 
-class PROTOBUF_EXPORT SourceContext final :
+class PROTOBUF_EXPORT SourceContext :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.SourceContext) */ {
  public:
   SourceContext();

--- a/src/google/protobuf/struct.pb.h
+++ b/src/google/protobuf/struct.pb.h
@@ -121,7 +121,7 @@ static bool _ParseMap(const char* begin, const char* end, void* object, ::google
 
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT Struct final :
+class PROTOBUF_EXPORT Struct :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Struct) */ {
  public:
   Struct();
@@ -257,7 +257,7 @@ class PROTOBUF_EXPORT Struct final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT Value final :
+class PROTOBUF_EXPORT Value :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Value) */ {
  public:
   Value();
@@ -486,7 +486,7 @@ class PROTOBUF_EXPORT Value final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT ListValue final :
+class PROTOBUF_EXPORT ListValue :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.ListValue) */ {
  public:
   ListValue();

--- a/src/google/protobuf/timestamp.pb.h
+++ b/src/google/protobuf/timestamp.pb.h
@@ -61,7 +61,7 @@ namespace protobuf {
 
 // ===================================================================
 
-class PROTOBUF_EXPORT Timestamp final :
+class PROTOBUF_EXPORT Timestamp :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Timestamp) */ {
  public:
   Timestamp();

--- a/src/google/protobuf/type.pb.h
+++ b/src/google/protobuf/type.pb.h
@@ -162,7 +162,7 @@ inline bool Syntax_Parse(
 }
 // ===================================================================
 
-class PROTOBUF_EXPORT Type final :
+class PROTOBUF_EXPORT Type :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Type) */ {
  public:
   Type();
@@ -375,7 +375,7 @@ class PROTOBUF_EXPORT Type final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT Field final :
+class PROTOBUF_EXPORT Field :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Field) */ {
  public:
   Field();
@@ -729,7 +729,7 @@ class PROTOBUF_EXPORT Field final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT Enum final :
+class PROTOBUF_EXPORT Enum :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Enum) */ {
  public:
   Enum();
@@ -919,7 +919,7 @@ class PROTOBUF_EXPORT Enum final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT EnumValue final :
+class PROTOBUF_EXPORT EnumValue :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumValue) */ {
  public:
   EnumValue();
@@ -1083,7 +1083,7 @@ class PROTOBUF_EXPORT EnumValue final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT Option final :
+class PROTOBUF_EXPORT Option :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Option) */ {
  public:
   Option();

--- a/src/google/protobuf/wrappers.pb.h
+++ b/src/google/protobuf/wrappers.pb.h
@@ -93,7 +93,7 @@ namespace protobuf {
 
 // ===================================================================
 
-class PROTOBUF_EXPORT DoubleValue final :
+class PROTOBUF_EXPORT DoubleValue :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.DoubleValue) */ {
  public:
   DoubleValue();
@@ -220,7 +220,7 @@ class PROTOBUF_EXPORT DoubleValue final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT FloatValue final :
+class PROTOBUF_EXPORT FloatValue :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FloatValue) */ {
  public:
   FloatValue();
@@ -347,7 +347,7 @@ class PROTOBUF_EXPORT FloatValue final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT Int64Value final :
+class PROTOBUF_EXPORT Int64Value :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Int64Value) */ {
  public:
   Int64Value();
@@ -474,7 +474,7 @@ class PROTOBUF_EXPORT Int64Value final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT UInt64Value final :
+class PROTOBUF_EXPORT UInt64Value :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.UInt64Value) */ {
  public:
   UInt64Value();
@@ -601,7 +601,7 @@ class PROTOBUF_EXPORT UInt64Value final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT Int32Value final :
+class PROTOBUF_EXPORT Int32Value :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Int32Value) */ {
  public:
   Int32Value();
@@ -728,7 +728,7 @@ class PROTOBUF_EXPORT Int32Value final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT UInt32Value final :
+class PROTOBUF_EXPORT UInt32Value :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.UInt32Value) */ {
  public:
   UInt32Value();
@@ -855,7 +855,7 @@ class PROTOBUF_EXPORT UInt32Value final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT BoolValue final :
+class PROTOBUF_EXPORT BoolValue :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.BoolValue) */ {
  public:
   BoolValue();
@@ -982,7 +982,7 @@ class PROTOBUF_EXPORT BoolValue final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT StringValue final :
+class PROTOBUF_EXPORT StringValue :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.StringValue) */ {
  public:
   StringValue();
@@ -1126,7 +1126,7 @@ class PROTOBUF_EXPORT StringValue final :
 };
 // -------------------------------------------------------------------
 
-class PROTOBUF_EXPORT BytesValue final :
+class PROTOBUF_EXPORT BytesValue :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.BytesValue) */ {
  public:
   BytesValue();


### PR DESCRIPTION
We need to mark messages as final soon, but before we do that we need to
provide a temporary opt-out mechanism to accommodate existing code that
inherits from generated messages. For 3.7.1 let's stop marking messages
final but in 3.8 we can reintroduce "final" with an opt-out option.