### PR TITLE
Revert "Remove unused f expression from jscode gen. (#5573)"

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -2272,7 +2272,7 @@ void Generator::GenerateClassToObject(const GeneratorOptions& options,
       " * @suppress {unusedLocalVariables} f is only used for nested messages\n"
       " */\n"
       "$classname$.toObject = function(includeInstance, msg) {\n"
-      "  var obj = {",
+      "  var f, obj = {",
       "classname", GetMessagePath(options, desc));
 
   bool first = true;


### PR DESCRIPTION
The removed variable here is actually used breaking downstream bazel
builds.