### PR TITLE
Implement the done method on JsonObjectWriter

### DIFF
--- a/src/google/protobuf/util/internal/json_objectwriter.cc
+++ b/src/google/protobuf/util/internal/json_objectwriter.cc
@@ -65,7 +65,10 @@ JsonObjectWriter* JsonObjectWriter::StartObject(StringPiece name) {
 JsonObjectWriter* JsonObjectWriter::EndObject() {
   Pop();
   WriteChar('}');
-  if (element() && element()->is_root()) NewLine();
+  if (element() && element()->is_root()) {
+    NewLine();
+    done_ = true;
+  }
   return this;
 }
 

--- a/src/google/protobuf/util/internal/json_objectwriter.h
+++ b/src/google/protobuf/util/internal/json_objectwriter.h
@@ -91,6 +91,7 @@ class PROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
         stream_(out),
         sink_(out),
         indent_string_(indent_string),
+        done_(false),
         use_websafe_base64_for_bytes_(false) {}
   virtual ~JsonObjectWriter();
 
@@ -115,6 +116,9 @@ class PROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
   void set_use_websafe_base64_for_bytes(bool value) {
     use_websafe_base64_for_bytes_ = value;
   }
+
+  // We report as done if we're not in the middle of an element and we have emitted at least one
+  bool done() override { return element()->is_root() && done_; }
 
  protected:
   class PROTOBUF_EXPORT Element : public BaseElement {
@@ -214,6 +218,8 @@ class PROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
   io::CodedOutputStream* stream_;
   ByteSinkWrapper sink_;
   const std::string indent_string_;
+  // True if we have emitted at least one object
+  bool done_;
 
   // Whether to use regular or websafe base64 encoding for byte fields. Defaults
   // to regular base64 encoding.

--- a/src/google/protobuf/util/internal/json_objectwriter_test.cc
+++ b/src/google/protobuf/util/internal/json_objectwriter_test.cc
@@ -313,6 +313,23 @@ TEST_F(JsonObjectWriterTest, TestWebsafeByteEncoding) {
             output_.substr(0, out_stream_->ByteCount()));
 }
 
+TEST_F(JsonObjectWriterTest, DoneAfterEmptyObject) {
+  ow_ = new JsonObjectWriter("", out_stream_);
+  ow_->StartObject("")->EndObject();
+  EXPECT_EQ(true, ow_->done());
+}
+
+TEST_F(JsonObjectWriterTest, NotDoneWithoutObject) {
+  ow_ = new JsonObjectWriter("", out_stream_);
+  EXPECT_EQ(false, ow_->done());
+}
+
+TEST_F(JsonObjectWriterTest, NotDoneInsideObject) {
+  ow_ = new JsonObjectWriter("", out_stream_);
+  ow_->StartObject("");
+  EXPECT_EQ(false, ow_->done());
+}
+
 }  // namespace converter
 }  // namespace util
 }  // namespace protobuf


### PR DESCRIPTION
This makes JsonObjectWriter fit the ObjectWriter interface, mirroring the behaviour of ProtoWriter.