### PR TITLE
No define strtoll/strtoull for VS2013 and above

### DIFF
--- a/src/google/protobuf/stubs/strutil.h
+++ b/src/google/protobuf/stubs/strutil.h
@@ -43,7 +43,7 @@
 namespace google {
 namespace protobuf {
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1800
 #define strtoll  _strtoi64
 #define strtoull _strtoui64
 #elif defined(__DECCXX) && defined(__osf__)


### PR DESCRIPTION
This is a cherry-pick of #5864 from `master` branch.