### PR TITLE
Update third_party.md

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -78,7 +78,7 @@ These are projects we know about implementing Protocol Buffers for other program
 * PHP: http://drslump.github.com/Protobuf-PHP
 * Prolog: http://www.swi-prolog.org/pldoc/package/protobufs.html
 * Python: https://github.com/google/protobuf (Google-official implementation)
-* Python: http://eigenein.github.com/protobuf/
+* Python: https://github.com/eigenein/protobuf
 * R: http://cran.r-project.org/package=RProtoBuf
 * Ruby: http://code.google.com/p/ruby-protobuf/
 * Ruby: http://github.com/mozy/ruby-protocol-buffers


### PR DESCRIPTION
I've deprecated the separate web page for the project and moved everything to `README.md`, so for now it's better to point to the GitHub project page.