### PR TITLE
Add missing declaration in protobuf_headers

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -203,7 +203,7 @@ cc_library(
 # TODO(keveman): Remove this target once the support gets added to Bazel.
 cc_library(
     name = "protobuf_headers",
-    hdrs = glob(["src/**/*.h"]),
+    hdrs = glob(["src/**/*.h", "src/**/*.inc"]),
     includes = ["src/"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
To prevent us from getting such error with sandbox or remote execution:
```
bazel-out/k8-opt/genfiles/tensorflow/core/lib/core/error_codes.pb.h:10:40: fatal error: google/protobuf/port_def.inc: No such file or directory
 #include <google/protobuf/port_def.inc>
                                        ^
```