### PR TITLE
Emit annotations for oneof field accessors in c++

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_helpers.h
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.h
@@ -647,6 +647,7 @@ class PROTOC_EXPORT Formatter {
   static std::string ToString(const EnumValueDescriptor* d) {
     return Payload(d);
   }
+  static std::string ToString(const OneofDescriptor* d) { return Payload(d); }
 
   template <typename Descriptor>
   static std::string Payload(const Descriptor* descriptor) {

--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -768,8 +768,8 @@ void MessageGenerator::GenerateFieldAccessorDeclarations(io::Printer* printer) {
     format.Set("oneof_name", oneof->name());
     format.Set("camel_oneof_name", UnderscoresToCamelCase(oneof->name(), true));
     format(
-        "void clear_$oneof_name$();\n"
-        "$camel_oneof_name$Case $oneof_name$_case() const;\n");
+        "void ${1$clear_$oneof_name$$}$();\n"
+        "$camel_oneof_name$Case $oneof_name$_case() const;\n", oneof);
   }
 }
 
@@ -1527,10 +1527,10 @@ void MessageGenerator::GenerateInlineMethods(io::Printer* printer) {
     format.Set("oneof_index", oneof->index());
     format(
         "inline $classname$::$camel_oneof_name$Case $classname$::"
-        "$oneof_name$_case() const {\n"
+        "${1$$oneof_name$_case$}$() const {\n"
         "  return $classname$::$camel_oneof_name$Case("
         "_oneof_case_[$oneof_index$]);\n"
-        "}\n");
+        "}\n", oneof);
   }
 }
 


### PR DESCRIPTION
This will enable [kythe](https://github.com/kythe/kythe) to associate the generated accessors in C++ with the definition in the proto file.