### PR TITLE
Small patch to handle -Wfloat-equal warnings

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -178,6 +178,10 @@ bool EmitFieldNonDefaultCondition(io::Printer* printer,
     } else if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
       // Message fields still have has_$name$() methods.
       format("if ($prefix$has_$name$()) {\n");
+    } else if (field->cpp_type() == FieldDescriptor::CPPTYPE_DOUBLE 
+               || field->cpp_type() == FieldDescriptor::CPPTYPE_FLOAT) {
+      // Handle float comparison to prevent -Wfloat-equal warnings
+      format("if (!($prefix$$name$() <= 0 && $prefix$$name$() >= 0)) {\n");
     } else {
       format("if ($prefix$$name$() != 0) {\n");
     }


### PR DESCRIPTION
To check whether a field is set, we make "field != 0" comparisons; however, this makes the generated *.pb.cc files to throw the following warning if float-equal flag is set:

```
file.pb.cc:494:34:  warning: comparing floating point with == or != is unsafe [-Wfloat-equal]
   // float field_name = 10;
   if (this->field_name() != 0) {
                             ^
```

In case of a float, we can can avoid the float-equal warnings by using `<=` and `>=` to handle `==`.

https://groups.google.com/d/msg/protobuf/H8_D1hfg3p4/mSJKQB75AAAJ