### PR TITLE
Remove namespace package boilerplate from google.protobuf and google.protobuf.pyext.

### DIFF
--- a/python/google/protobuf/__init__.py
+++ b/python/google/protobuf/__init__.py
@@ -31,9 +31,3 @@
 # Copyright 2007 Google Inc. All Rights Reserved.
 
 __version__ = '3.11.0rc0'
-
-if __name__ != '__main__':
-  try:
-    __import__('pkg_resources').declare_namespace(__name__)
-  except ImportError:
-    __path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/google/protobuf/pyext/__init__.py
+++ b/python/google/protobuf/pyext/__init__.py
@@ -1,4 +1,0 @@
-try:
-  __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-  __path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
setup.py does not declare these packages to be namespace packages, so they shouldn't have the boilerplate.

Fixes https://github.com/protocolbuffers/protobuf/issues/5194.