### PR TITLE
Remove -Wall from default build options

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -49,7 +49,6 @@ COPTS = select({
     "//conditions:default": [
         "-DHAVE_PTHREAD",
         "-DHAVE_ZLIB",
-        "-Wall",
         "-Woverloaded-virtual",
         "-Wno-sign-compare",
         "-Wno-unused-function",


### PR DESCRIPTION
All bazel crosstools automatically pass -Wall to compiles. The order of
operations is:

- bazel crosstool flags
- `--host_copt` flags and other variations like `--host_cxxopt`
- the `copts` defined on the rule

Because of this when protobuf produces warnings, there's no way to
disable them from the consumer side if they are re-enabled later by
another `-Wall` flag.