### PR TITLE
Make cold_threshold_ look used to fix warning

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -521,7 +521,11 @@ class ColdChunkSkipper {
 // Tuning parameters for ColdChunkSkipper.
 const double kColdRatio = 0.005;
 
-bool ColdChunkSkipper::IsColdChunk(int chunk) { return false; }
+bool ColdChunkSkipper::IsColdChunk(int chunk) {
+  // Mark this variable as used until it is actually used
+  (void) cold_threshold_;
+  return false;
+}
 
 void ColdChunkSkipper::OnStartChunk(int chunk, int cached_has_bit_index,
                                     const std::string& from,


### PR DESCRIPTION
This field isn't used yet, but it will be in the future so we don't want
to remove it. This fixes the warning in the meantime.
