### PR TITLE
comply with Bazel recommendations

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,7 +19,7 @@ config_setting(
 # ZLIB configuration
 ################################################################################
 
-ZLIB_DEPS = ["//external:zlib"]
+ZLIB_DEPS = ["@zlib//:zlib"]
 
 ################################################################################
 # Protobuf Runtime Library

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -5,14 +5,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def protobuf_deps():
     """Loads common dependencies needed to compile the protobuf library."""
 
-    native.bind(
-        name = "zlib",
-        actual = "@net_zlib//:zlib",
-    )
-
-    if "net_zlib" not in native.existing_rules():
+    if "zlib" not in native.existing_rules():
         http_archive(
-            name = "net_zlib",
+            name = "zlib",
             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
             sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
             strip_prefix = "zlib-1.2.11",


### PR DESCRIPTION
This brings the BUILD file into compliance with Bazel recommendations to not use bind (see [here](https://docs.bazel.build/versions/master/be/workspace.html#bind)). 

My Bazel recommendation compliant code wouldn't work with protobuf because it forced me to use bind() to remap "@zlib//:zlib" to "//external:zlib". 