### PR TITLE
Make use of RDTSC optional as it may not be available

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -937,7 +937,7 @@ class Map {
     // Return a randomish value.
     size_type Seed() const {
       size_type s = static_cast<size_type>(reinterpret_cast<uintptr_t>(this));
-#if defined(__x86_64__) && defined(__GNUC__)
+#if defined(__x86_64__) && defined(__GNUC__) && !defined(GOOGLE_PROTOBUF_NO_RDTSC)
       uint32 hi, lo;
       asm("rdtsc" : "=a"(lo), "=d"(hi));
       s += ((static_cast<uint64>(hi) << 32) | lo);


### PR DESCRIPTION
`RDTSC` is unavailable when using [seccomp](https://en.wikipedia.org/wiki/Seccomp) while setting  `PR_SET_TSC` to `PR_TSC_SIGSEGV`. There may be other odd cases as well.

Since the value of `RDTSC` is only used conditionally anyway (`#if defined(__x86_64__) && defined(__GNUC__)`) I suggest simply removing the relevant code. It's used for making a random seed more random, but I doubt this is really necessary.

EDIT: See discussion below. `RDTSC` is disabled optionally by macro.