### PR TITLE
Change "python" to "python_headers" in comment

### DIFF
--- a/util/python/BUILD
+++ b/util/python/BUILD
@@ -9,7 +9,7 @@
 # includes the following local_repository rule that points to this directory:
 #
 # new_local_repository(
-#   name = "python",
+#   name = "python_headers",
 #   path = __workspace_dir__ + "/util/python",
 # )
 cc_library(


### PR DESCRIPTION
Following the instructions as is does not work, the new_local_repository rule needs to be called "python_headers"