### PR TITLE
Fix javalite's protobuf.bzl to be compatible with new Bazel releases

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -127,7 +127,7 @@ proto_gen = rule(
         "protoc": attr.label(
             cfg = "host",
             executable = True,
-            single_file = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "plugin": attr.label(
@@ -263,8 +263,8 @@ def internal_gen_well_known_protos_java(srcs):
   Args:
     srcs: the well known protos
   """
-  root = Label("%s//protobuf_java" % (REPOSITORY_NAME)).workspace_root
-  pkg = PACKAGE_NAME + "/" if PACKAGE_NAME else ""
+  root = Label("%s//protobuf_java" % (native.repository_name())).workspace_root
+  pkg = native.package_name() + "/" if native.package_name() else ""
   if root == "":
     include = " -I%ssrc " % pkg
   else:


### PR DESCRIPTION
This allows the `javalite` branch to be used with latest Bazel versions.

Ref: https://github.com/googlesamples/android-testing/issues/239

cc @laurentlb

