### PR TITLE
Fixed errors with type declarations on some versions of clang

### DIFF
--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -33,6 +33,7 @@
 
 #include <cstring>
 #include <string>
+#include <cstdint>
 
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream.h>


### PR DESCRIPTION
Some versions of clang report an error such as
```
C:\dev\protobuf\src\google/protobuf/parse_context.h(227,5): error : no type named 'uintptr_t' in namespace 'std'; did you mean simply 'uintptr_t'?
```
protobufs had mixed usage of plain `uintptr_t` and `std::uintptr_t` (and others such as `uint32_t`). This removes all instances of the leading namespace which allows compilation to succeed under MSVC and clang.