### PR TITLE
Replaced unnecessary include with struct definition

### DIFF
--- a/src/google/protobuf/io/io_win32.cc
+++ b/src/google/protobuf/io/io_win32.cc
@@ -42,7 +42,7 @@
 //
 // This file is only used on Windows, it's empty on other platforms.
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(_XBOX_ONE)
 
 // Comment this out to fall back to using the ANSI versions (open, mkdir, ...)
 // instead of the Unicode ones (_wopen, _wmkdir, ...). Doing so can be useful to

--- a/src/google/protobuf/util/time_util.h
+++ b/src/google/protobuf/util/time_util.h
@@ -37,7 +37,14 @@
 #include <ostream>
 #include <string>
 #ifdef _MSC_VER
+#ifdef _XBOX_ONE
+struct timeval {
+	long    tv_sec;         /* seconds */
+	long    tv_usec;        /* and microseconds */
+};
+#else
 #include <winsock2.h>
+#endif // _XBOX_ONE
 #else
 #include <sys/time.h>
 #endif


### PR DESCRIPTION
It appears this file was including winsock2.h just to get the timeval struct definition. There are platforms, such as Xbox One, that don't use winsock but do compile with _MSC_VER set, so just drop in the struct definition we needed instead of including all of winsock. This fixes compilation of this file for Xbox One. Without this change, there were numerous `timeval` complaints such as
```
1>c:\dev\protobuf\src\google\protobuf\util\time_util.h(153): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file C:\dev\protobuf\src\google\protobuf\util\time_util.cc)
1>c:\dev\protobuf\src\google\protobuf\util\time_util.h(153): error C2143: syntax error: missing ',' before '&' (compiling source file C:\dev\protobuf\src\google\protobuf\util\time_util.cc)
```
etc.