### PR TITLE
Revert "protobuf.pc.in does not reflect CXXFLAGS"

### DIFF
--- a/protobuf.pc.in
+++ b/protobuf.pc.in
@@ -8,5 +8,5 @@ Description: Google's Data Interchange Format
 Version: @VERSION@
 Libs: -L${libdir} -lprotobuf @PTHREAD_LIBS@
 Libs.private: @LIBS@
-Cflags: -I${includedir} @PTHREAD_CFLAGS@ @CXXFLAGS@
+Cflags: -I${includedir} @PTHREAD_CFLAGS@
 Conflicts: protobuf-lite


### PR DESCRIPTION
Reverts https://github.com/protocolbuffers/protobuf/pull/5755

Including `-std=c++11` in the Cflags causes compiler warnings for the reasonably common practice of leaving C++ libraries in the `pkg-config --cflags` modules list when compiling C code in mixed C and C++ projects, and projects using later versions of C++ have to be sure to include their `-std=...` argument after the pkg-config output in the compiler command line so it overrides. The first issue seems to affect gRPC:
```
cc1: error: command line option '-std=c++11' is valid for C++/ObjC++ but not for C [-Werror]
```