### PR TITLE
Fix compilation error with SDL check flag in Visual Studio

### DIFF
--- a/src/google/protobuf/generated_message_table_driven_lite.h
+++ b/src/google/protobuf/generated_message_table_driven_lite.h
@@ -237,7 +237,7 @@ static inline bool HandleString(io::CodedInputStream* input, MessageLite* msg,
 
   switch (ctype) {
     case StringType_INLINED: {
-      InlinedStringField* s;
+      InlinedStringField* s = nullptr;
       switch (cardinality) {
         case Cardinality_SINGULAR:
           // TODO(ckennelly): Is this optimal?


### PR DESCRIPTION
If you enable "SDL checks" option, you will get compilation errors:
`\src\google\protobuf\generated_message_table_driven_lite.h(254): error C4703: potentially uninitialized local pointer variable 's' used`

In classic Win32 apps, the option is disabled by default.
But in UWP apps, the option enabled by default.

I build the Visual Studio projects with the following commands (protobuf\cmake\build):
Win32 apps:
`cmake ..`
UWP apps:
`cmake -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -Dprotobuf_BUILD_SHARED_LIBS=ON ..`

You also can disable the option with the following build command:
`cmake -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -Dprotobuf_BUILD_SHARED_LIBS=ON -DCMAKE_CXX_FLAGS="/sdl-" ..`

The option located in `Project Properties -> C/C++ -> General -> SDL checks`

This issue has been raised before in [comments](https://github.com/protocolbuffers/protobuf/issues/2549#issuecomment-373869755)

Compiler info:
```
Visual Studio 16 2019
MSVC 19.20.27508.1
Windows SDK version 10.0.17763.0
```