### PR TITLE
c++11 option is always needed.

### DIFF
--- a/protobuf.pc.in
+++ b/protobuf.pc.in
@@ -8,5 +8,5 @@ Description: Google's Data Interchange Format
 Version: @VERSION@
 Libs: -L${libdir} -lprotobuf @PTHREAD_LIBS@
 Libs.private: @LIBS@
-Cflags: -I${includedir} @PTHREAD_CFLAGS@
+Cflags: -I${includedir} @PTHREAD_CFLAGS@ -std=c++11
 Conflicts: protobuf-lite


### PR DESCRIPTION
I run 'autogen.sh' and 'configure' as default, and then run make&make install.
And then try to build 'g++ -c addressbook.pb.cc' (example from
https://developers.google.com/protocol-buffers/docs/cpptutorial) and found errors:

In file included from /usr/include/c++/5/atomic:38:0,
                 from /usr/local/include/google/protobuf/io/coded_stream.h:113,
                 from addressbook.pb.h:23,
                 from addressbook.pb.cc:4:
/usr/include/c++/5/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standa
rd. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support \
  ^

So, I think c++11 is always needed, and should be added into .pc file.

release note: no