### PR TITLE
Update for new bazel proto API

### DIFF
--- a/kokoro/linux/bazel/build.sh
+++ b/kokoro/linux/bazel/build.sh
@@ -7,6 +7,7 @@ set -ex
 cd $(dirname $0)/../../..
 
 git submodule update --init --recursive
+use_bazel.sh 0.25.3
 bazel test :protobuf_test --copt=-Werror --host_copt=-Werror
 
 cd examples

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -83,8 +83,8 @@ def _proto_gen_impl(ctx):
         import_flags = ["-I."]
 
     for dep in ctx.attr.deps:
-        import_flags += dep.proto.import_flags
-        deps += dep.proto.deps
+        import_flags += dep[ProtoInfo].import_flags
+        deps += dep[ProtoInfo].deps
 
     if not ctx.attr.gen_cc and not ctx.attr.gen_py and not ctx.executable.plugin:
         return struct(
@@ -177,7 +177,7 @@ def _proto_gen_impl(ctx):
 proto_gen = rule(
     attrs = {
         "srcs": attr.label_list(allow_files = True),
-        "deps": attr.label_list(providers = ["proto"]),
+        "deps": attr.label_list(providers = [ProtoInfo]),
         "includes": attr.string_list(),
         "protoc": attr.label(
             cfg = "host",


### PR DESCRIPTION
This fixes issues if you build a `proto_gen` rule with the
`--incompatible_disable_legacy_proto_provider` flag that will be enabled
with an upcoming bazel release. https://github.com/bazelbuild/bazel/issues/7152