### PR TITLE
[Ruby] Remove to_hash methods

### DIFF
--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -847,7 +847,6 @@ void Map_register(VALUE module) {
   rb_define_method(klass, "dup", Map_dup, 0);
   rb_define_method(klass, "==", Map_eq, 1);
   rb_define_method(klass, "hash", Map_hash, 0);
-  rb_define_method(klass, "to_hash", Map_to_h, 0);
   rb_define_method(klass, "to_h", Map_to_h, 0);
   rb_define_method(klass, "inspect", Map_inspect, 0);
   rb_define_method(klass, "merge", Map_merge, 1);

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -737,7 +737,6 @@ VALUE build_class_from_descriptor(Descriptor* desc) {
   rb_define_method(klass, "eql?", Message_eq, 1);
   rb_define_method(klass, "hash", Message_hash, 0);
   rb_define_method(klass, "to_h", Message_to_h, 0);
-  rb_define_method(klass, "to_hash", Message_to_h, 0);
   rb_define_method(klass, "inspect", Message_inspect, 0);
   rb_define_method(klass, "to_s", Message_inspect, 0);
   rb_define_method(klass, "[]", Message_index, 1);

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
@@ -338,7 +338,7 @@ public class RubyMap extends RubyObject {
         return newMap;
     }
 
-    @JRubyMethod(name = {"to_h", "to_hash"})
+    @JRubyMethod(name = "to_h")
     public RubyHash toHash(ThreadContext context) {
         return RubyHash.newHash(context.runtime, table, context.runtime.getNil());
     }

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
@@ -368,7 +368,7 @@ public class RubyMessage extends RubyObject {
         return ret;
     }
 
-    @JRubyMethod(name = {"to_h", "to_hash"})
+    @JRubyMethod(name = "to_h")
     public IRubyObject toHash(ThreadContext context) {
         Ruby runtime = context.runtime;
         RubyHash ret = RubyHash.newHash(runtime);


### PR DESCRIPTION
The Ruby implementation creates the explicit coercion `#to_h` method and the implicit coercion `#to_hash` method on Message and Map. Ruby treats objects that respond to implicit coercion methods differently. I do not think Protobuf intends that Message and Map are to be treated implicitly as hashes. In fact, I think this should actually be considered a bug.

For example, here are how the explicit and implicit methods such as `#to_h` and `#to_hash` are used:

```ruby
# assuming these primitive objects
ary = [1, 2, 3]
hash = { foo: :bar }
int = 42
str = "Hello world!"

# hash has an array representation it itself
hash.to_a #=> [[:foo, :bar]]
# but that doesn't mean it _is_ an array
hash.to_ary # NoMethodError (undefined method `to_ary' for {:foo=>:bar}:Hash)

# similarily, an array doesn't know how to be a hash
ary.to_h #TypeError (wrong element type Integer at 0 (expected array))
# but an array does have a string representation
ary.to_s #=> "[1, 2, 3]"
# and a hash has a string representation
hash.to_s #=> "{:foo=>:bar}"
# and an integer has a string representation
int.to_s #=> "42"
# but none of them _are_ strings
ary.to_str # NoMethodError (undefined method `to_str' for [1, 2, 3]:Array)
hash.to_str # NoMethodError (undefined method `to_str' for {:foo=>:bar}:Hash)
int.to_str # NoMethodError (undefined method `to_str' for 42:Integer)

# and a string doesn't know how to be an array, hash, or integer
str.to_a # NoMethodError (undefined method `to_a' for "Hello world!":String)
str.to_h # NoMethodError (undefined method `to_h' for "Hello world!":String)
str.to_i # NoMethodError (undefined method `to_i' for "Hello world!":String)
```

Similarily, Protobuf Messages and Maps are not Ruby Hashes. They can generate hash representations, but they are not themselves hashes. They should not be used in place of hashes.

What does the presence of the `#to_hash` method mean? It means Ruby will treat these objects as if they were hashes. Consider the following method:

```ruby
def do_a_thing req_resource, opt_resource = nil, show_warnings: true
  p req_resource
  p opt_resource
  p show_warnings
end
```

You would expect you could pass two Protobuf objects to the method, but you cannot.

```ruby
gem "googleapis-common-protos-types"
require "google/type/color_pb"

red = Google::Type::Color.new red: 1.0
blue = Google::Type::Color.new blue: 1.0

# call the method
do_a_thing red, blue # ArgumentError (unknown keywords: red, green, blue, alpha)
```

This is because Ruby sees that the `blue` object has defined `#to_hash` and treats it as a hash, and tries to match the optional named argument instead of the positional object.

Because of this, and because there is no documentation that states that this method is intended to be part of the public API, I think these methods can and should be removed.