### PR TITLE
avoid error when compiling with MSVC2010

### DIFF
--- a/src/google/protobuf/map_field.cc
+++ b/src/google/protobuf/map_field.cc
@@ -281,7 +281,7 @@ void DynamicMapField::MergeFrom(const MapFieldBase& other) {
   Map<MapKey, MapValueRef>* map = MutableMap();
   const DynamicMapField& other_field =
       reinterpret_cast<const DynamicMapField&>(other);
-  for (typename Map<MapKey, MapValueRef>::const_iterator other_it =
+  for (Map<MapKey, MapValueRef>::const_iterator other_it =
            other_field.map_.begin();
        other_it != other_field.map_.end(); ++other_it) {
     Map<MapKey, MapValueRef>::iterator iter = map->find(other_it->first);


### PR DESCRIPTION
I'm getting `src/google/protobuf/map_field.cc(284): error C2899: typename cannot be used outside a template declaration`

removing `typename` fixes the issue