### PR TITLE
remove comment about wire_format_lite_inl.h

### DIFF
--- a/src/google/protobuf/wire_format_lite.h
+++ b/src/google/protobuf/wire_format_lite.h
@@ -244,9 +244,7 @@ class PROTOBUF_EXPORT WireFormatLite {
   static int64 ZigZagDecode64(uint64 n);
 
   // =================================================================
-  // Methods for reading/writing individual field.  The implementations
-  // of these methods are defined in wire_format_lite_inl.h; you must #include
-  // that file to use these.
+  // Methods for reading/writing individual field.
 
   // Read fields, not including tags.  The assumption is that you already
   // read the tag to determine what field to read.


### PR DESCRIPTION
The wire_format_lite_inl.h header file was made unnecessary in #5839
and deleted in #5921, so remove the comment about it.