### PR TITLE
JSON string output functions should clear() the destination first

### DIFF
--- a/src/google/protobuf/util/json_util.cc
+++ b/src/google/protobuf/util/json_util.cc
@@ -115,6 +115,7 @@ util::Status BinaryToJsonString(TypeResolver* resolver,
                                   const std::string& binary_input,
                                   std::string* json_output,
                                   const JsonPrintOptions& options) {
+  json_output->clear();
   io::ArrayInputStream input_stream(binary_input.data(), binary_input.size());
   io::StringOutputStream output_stream(json_output);
   return BinaryToJsonStream(resolver, type_url, &input_stream, &output_stream,
@@ -209,6 +210,7 @@ util::Status JsonToBinaryString(TypeResolver* resolver,
                                   StringPiece json_input,
                                   std::string* binary_output,
                                   const JsonParseOptions& options) {
+  binary_output->clear();
   io::ArrayInputStream input_stream(json_input.data(), json_input.size());
   io::StringOutputStream output_stream(binary_output);
   return JsonToBinaryStream(resolver, type_url, &input_stream, &output_stream,


### PR DESCRIPTION
Make the JSON util string output functions match the Message::SerializeToString() behavior.  This is helpful when packing the output into string fields of reused protobuf messages.