### PR TITLE
Fix RPATH when CMAKE_INSTALL_LIBDIR != lib.

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -33,7 +33,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
   if (UNIX AND NOT APPLE)
     set_property(TARGET protoc
-      PROPERTY INSTALL_RPATH "$ORIGIN/../lib")
+      PROPERTY INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
   elseif (APPLE)
     set_property(TARGET protoc
       PROPERTY INSTALL_RPATH "@loader_path/../lib")


### PR DESCRIPTION
In some platforms ${CMAKE_INSTALL_LIBDIR} expands to `lib64`. The libraries
are correctly installed in that directory, but the RPATH is set to point to
`$ORIGIN/../lib`, where it should be `$ORIGIN/../lib64`.