### PR TITLE
Treat plugins as host tools.

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -117,6 +117,7 @@ def _proto_gen_impl(ctx):
 
         outs = [ctx.actions.declare_file(out, sibling = src) for out in outs]
         inputs = [src] + deps
+        tools = [ctx.executable.protoc]
         if ctx.executable.plugin:
             plugin = ctx.executable.plugin
             lang = ctx.attr.plugin_language
@@ -131,11 +132,12 @@ def _proto_gen_impl(ctx):
                 outdir = ",".join(ctx.attr.plugin_options) + ":" + outdir
             args += [("--plugin=protoc-gen-%s=" + path_tpl) % (lang, plugin.path)]
             args += ["--%s_out=%s" % (lang, outdir)]
-            inputs += [plugin]
+            tools.append(plugin)
 
         if not in_gen_dir:
             ctx.actions.run(
                 inputs = inputs,
+                tools = tools,
                 outputs = outs,
                 arguments = args + import_flags + [src.path],
                 executable = ctx.executable.protoc,
@@ -162,7 +164,7 @@ def _proto_gen_impl(ctx):
                     outputs = [out],
                     command = command,
                     mnemonic = "ProtoCompile",
-                    tools = [ctx.executable.protoc],
+                    tools = tools,
                     use_default_shell_env = True,
                 )
 


### PR DESCRIPTION
As a followup to ca3ead7745581b24d9e84471b5dee6921fcd369d, treat plugin executables as well as protoc as host tools.