### PR TITLE
Pass ctx.executable.protoc in tools

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -139,6 +139,7 @@ def _proto_gen_impl(ctx):
                 outputs = outs,
                 arguments = args + import_flags + [src.path],
                 executable = ctx.executable.protoc,
+                tools = [ctx.executable.protoc],
                 mnemonic = "ProtoCompile",
                 use_default_shell_env = True,
             )


### PR DESCRIPTION
This is another fix for `--incompatible_no_support_tools_in_action_inputs`
https://github.com/bazelbuild/bazel/issues/5826

TensorFlow is broken due to this:
https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1014#f7a58799-a361-4087-82fb-f0c54ed2be49
```
Traceback (most recent call last):
	File "/var/lib/buildkite-agent/builds/bk-docker-g96n/bazel-downstream-projects/tensorflow/tensorflow/contrib/rpc/python/kernel_tests/BUILD", line 14
		proto_gen(name = 'test_example_proto_py_genproto')
	File "/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ad505fa787dc3fe473b54762d1a7f9ae/external/protobuf_archive/protobuf.bzl", line 137, in _proto_gen_impl
		ctx.actions.run(inputs = inputs, outputs = outs, arg...]), <3 more arguments>)
Found tool(s) 'bazel-out/host/bin/external/grpc/grpc_python_plugin' in inputs. A tool is an input with executable=True set. All tools should be passed using the 'tools' argument instead of 'inputs' in order to make their runfiles available to the action. This safety check will not be performed once the action is modified to take a 'tools' argument. To temporarily disable this check, set --incompatible_no_support_tools_in_action_inputs=false.
```