### PR TITLE
compelete fix issue 5060: change CodedOutputStream to CodedOutputStream*

### DIFF
--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -664,7 +664,7 @@ class PROTOBUF_EXPORT CodedInputStream {
 // individual value.
 // i.e., in the example above:
 //
-//   CodedOutputStream coded_output = new CodedOutputStream(raw_output);
+//   CodedOutputStream* coded_output = new CodedOutputStream(raw_output);
 //   int magic_number = 1234;
 //   char text[] = "Hello world!";
 //


### PR DESCRIPTION
In issue #5060 ,  there is a typo about `CodedInputStream`,  and it has been fixed in the current version.
But there is still an item missing, this PR fix `CodedOutputStream`   