### PR TITLE
Enable mock for proto message

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -382,8 +382,6 @@ void Message_construct(zval* msg, zval* array_wrapper) {
   if (EXPECTED(class_added(ce))) {
     intern = UNBOX(MessageHeader, msg);
     custom_data_init(ce, intern PHP_PROTO_TSRMLS_CC);
-  } else {
-    intern = UNBOX(MessageHeader, msg);
   }
 
   if (array_wrapper == NULL) {

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -255,6 +255,9 @@
 #define php_proto_zend_lookup_class(name, name_length, ce) \
   zend_lookup_class(name, name_length, ce TSRMLS_CC)
 
+#define php_instanceof_function(instance_ce, class_ce) \
+  instanceof_function(instance_ce, class_ce TSRMLS_CC)
+
 #define PHP_PROTO_RETVAL_ZVAL(value) ZVAL_ZVAL(return_value, value, 1, 0)
 
 #else  // PHP_MAJOR_VERSION >= 7
@@ -522,6 +525,9 @@ static inline int php_proto_zend_lookup_class(
   zend_string_release(zstr_name);
   return *ce != NULL ? SUCCESS : FAILURE;
 }
+
+#define php_instanceof_function(instance_ce, class_ce) \
+  instanceof_function(instance_ce, class_ce)
 
 #define PHP_PROTO_RETVAL_ZVAL(value) ZVAL_COPY(return_value, value)
 

--- a/php/ext/google/protobuf/storage.c
+++ b/php/ext/google/protobuf/storage.c
@@ -114,7 +114,7 @@ bool native_slot_set(upb_fieldtype_t type, const zend_class_entry* klass,
         return false;
       }
       if (Z_TYPE_P(value) == IS_OBJECT &&
-          !instanceof_function(Z_OBJCE_P(value), klass)) {
+          !php_instanceof_function(Z_OBJCE_P(value), klass)) {
         zend_error(E_USER_ERROR, "Given message does not have correct class.");
         return false;
       }
@@ -197,7 +197,7 @@ bool native_slot_set_by_array(upb_fieldtype_t type,
         return false;
       }
       if (Z_TYPE_P(value) == IS_OBJECT &&
-          !instanceof_function(Z_OBJCE_P(value), klass)) {
+          !php_instanceof_function(Z_OBJCE_P(value), klass)) {
         zend_error(E_USER_ERROR, "Given message does not have correct class.");
         return false;
       }
@@ -255,7 +255,7 @@ bool native_slot_set_by_map(upb_fieldtype_t type, const zend_class_entry* klass,
         return false;
       }
       if (Z_TYPE_P(value) == IS_OBJECT &&
-          !instanceof_function(Z_OBJCE_P(value), klass)) {
+          !php_instanceof_function(Z_OBJCE_P(value), klass)) {
         zend_error(E_USER_ERROR, "Given message does not have correct class.");
         return false;
       }

--- a/php/ext/google/protobuf/storage.c
+++ b/php/ext/google/protobuf/storage.c
@@ -113,7 +113,8 @@ bool native_slot_set(upb_fieldtype_t type, const zend_class_entry* klass,
         zend_error(E_USER_ERROR, "Given value is not message.");
         return false;
       }
-      if (Z_TYPE_P(value) == IS_OBJECT && klass != Z_OBJCE_P(value)) {
+      if (Z_TYPE_P(value) == IS_OBJECT &&
+          !instanceof_function(Z_OBJCE_P(value), klass)) {
         zend_error(E_USER_ERROR, "Given message does not have correct class.");
         return false;
       }
@@ -195,7 +196,8 @@ bool native_slot_set_by_array(upb_fieldtype_t type,
         zend_error(E_USER_ERROR, "Given value is not message.");
         return false;
       }
-      if (Z_TYPE_P(value) == IS_OBJECT && klass != Z_OBJCE_P(value)) {
+      if (Z_TYPE_P(value) == IS_OBJECT &&
+          !instanceof_function(Z_OBJCE_P(value), klass)) {
         zend_error(E_USER_ERROR, "Given message does not have correct class.");
         return false;
       }
@@ -252,7 +254,8 @@ bool native_slot_set_by_map(upb_fieldtype_t type, const zend_class_entry* klass,
         zend_error(E_USER_ERROR, "Given value is not message.");
         return false;
       }
-      if (Z_TYPE_P(value) == IS_OBJECT && klass != Z_OBJCE_P(value)) {
+      if (Z_TYPE_P(value) == IS_OBJECT &&
+          !instanceof_function(Z_OBJCE_P(value), klass)) {
         zend_error(E_USER_ERROR, "Given message does not have correct class.");
         return false;
       }

--- a/php/tests/generated_class_test.php
+++ b/php/tests/generated_class_test.php
@@ -1509,12 +1509,25 @@ class GeneratedClassTest extends TestBase
     # Test Mock
     #########################################################
 
-    public function testMock()
+    public function testMessageMock()
     {
         if (method_exists(\PHPUnit\Framework\TestCase::class,'createMock')) {
             $m = $this->createMock(TestMessage::class);
             $m->method("getOptionalInt32")->willReturn(1);
             $this->assertEquals(1, $m->getOptionalInt32());
+        } else {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function testSubMessageMock()
+    {
+        if (method_exists(\PHPUnit\Framework\TestCase::class,'createMock')) {
+            $m = new TestMessage();
+            $subm = $this->createMock(Sub::class);
+            $m->setOptionalMessage($subm);
+            $m->setRepeatedMessage([$subm]);
+            $m->setMapInt32Message([1 => $subm]);
         } else {
             $this->assertTrue(true);
         }

--- a/php/tests/generated_class_test.php
+++ b/php/tests/generated_class_test.php
@@ -1511,9 +1511,12 @@ class GeneratedClassTest extends TestBase
 
     public function testMock()
     {
-        $m = $this->createMock(TestMessage::class);
-        $m->method("getOptionalInt32")->willReturn(1);
-
-        $this->assertEquals(1, $m->getOptionalInt32());
+        if (method_exists(\PHPUnit\Framework\TestCase::class,'createMock')) {
+            $m = $this->createMock(TestMessage::class);
+            $m->method("getOptionalInt32")->willReturn(1);
+            $this->assertEquals(1, $m->getOptionalInt32());
+        } else {
+            $this->assertTrue(true);
+        }
     }
 }

--- a/php/tests/generated_class_test.php
+++ b/php/tests/generated_class_test.php
@@ -24,6 +24,9 @@ use Foo\testLowerCaseEnum;
 use PBEmpty\PBEcho\TestEmptyPackage;
 use Php\Test\TestNamespace;
 
+class ExtendTestMessage extends TestMessage {
+}
+
 class GeneratedClassTest extends TestBase
 {
 
@@ -1503,5 +1506,17 @@ class GeneratedClassTest extends TestBase
         array_walk($values, function (&$value) {});
         $m = new TestMessage();
         $m->setOptionalString($values[0]);
+    }
+
+    #########################################################
+    # Test Mock
+    #########################################################
+
+    public function testMock()
+    {
+        $m = $this->createMock(TestMessage::class);
+        $m->method("getOptionalInt32")->willReturn(1);
+
+        $this->assertEquals(1, $m->getOptionalInt32());
     }
 }

--- a/php/tests/generated_class_test.php
+++ b/php/tests/generated_class_test.php
@@ -24,9 +24,6 @@ use Foo\testLowerCaseEnum;
 use PBEmpty\PBEcho\TestEmptyPackage;
 use Php\Test\TestNamespace;
 
-class ExtendTestMessage extends TestMessage {
-}
-
 class GeneratedClassTest extends TestBase
 {
 


### PR DESCRIPTION
Previously mock cannot be used for proto message because it cannot be extended.
Now, it can be extended by doing:
1) Avoid freeing internal data, since it was not initialized for subclass
2) Resort to standard handlers for subclass's properties