### PR TITLE
Add "src/**/*.inc" to //:protobuf_headers (again)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -219,7 +219,7 @@ cc_library(
 # TODO(keveman): Remove this target once the support gets added to Bazel.
 cc_library(
     name = "protobuf_headers",
-    hdrs = glob(["src/**/*.h"]),
+    hdrs = glob(["src/**/*.h", "src/**/*.inc"]),
     includes = ["src/"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Otherwise, sandbox and remote execution will complain `google/protobuf/port_def.inc` doesn't exist.

I fixed this at https://github.com/protocolbuffers/protobuf/commit/5902e759108d14ee8e6b0b07653dac2f4e70ac73 before, but apparently that commit is not merged into master.