### PR TITLE
Fix broken ruby release test

### DIFF
--- a/kokoro/linux/dockerfile/release/ruby_rake_compiler/Dockerfile
+++ b/kokoro/linux/dockerfile/release/ruby_rake_compiler/Dockerfile
@@ -1,3 +1,3 @@
 FROM grpctesting/rake-compiler-dock_53c22085d091183c528303791e7771359f699bcf
 
-RUN /bin/bash -l -c "gem install bundler"
+RUN /bin/bash -l -c "gem install bundler -v 1.17.3"

--- a/kokoro/release/ruby/linux/ruby/ruby_build.sh
+++ b/kokoro/release/ruby/linux/ruby/ruby_build.sh
@@ -11,6 +11,7 @@ fi
 
 umask 0022
 pushd ruby
+ls
 bundle install && bundle exec rake gem:native
 ls pkg
 mv pkg/* $ARTIFACT_DIR


### PR DESCRIPTION
Bundler 2.0 requires gem 3.0. However, the upstream dockerfile is still
using gem 2.x. To fix that, we need to explicitly install lower version
of bundler.