### PR TITLE
Update gem to 2.7.9

### DIFF
--- a/kokoro/linux/dockerfile/release/ruby_rake_compiler/Dockerfile
+++ b/kokoro/linux/dockerfile/release/ruby_rake_compiler/Dockerfile
@@ -1,3 +1,3 @@
 FROM grpctesting/rake-compiler-dock_53c22085d091183c528303791e7771359f699bcf
 
-RUN /bin/bash -l -c "gem install bundler"
+RUN /bin/bash -l -c "gem update --system '2.7.9' && gem install bundler"


### PR DESCRIPTION
New bundler doesn't work with old gem: https://github.com/rbenv/rbenv/issues/1138