### PR TITLE
Revert "JSON string output funtions should clear() the destination fi…

### DIFF
--- a/src/google/protobuf/util/json_util.cc
+++ b/src/google/protobuf/util/json_util.cc
@@ -115,7 +115,6 @@ util::Status BinaryToJsonString(TypeResolver* resolver,
                                   const std::string& binary_input,
                                   std::string* json_output,
                                   const JsonPrintOptions& options) {
-  json_output->clear();
   io::ArrayInputStream input_stream(binary_input.data(), binary_input.size());
   io::StringOutputStream output_stream(json_output);
   return BinaryToJsonStream(resolver, type_url, &input_stream, &output_stream,
@@ -210,7 +209,6 @@ util::Status JsonToBinaryString(TypeResolver* resolver,
                                   StringPiece json_input,
                                   std::string* binary_output,
                                   const JsonParseOptions& options) {
-  binary_output->clear();
   io::ArrayInputStream input_stream(json_input.data(), json_input.size());
   io::StringOutputStream output_stream(binary_output);
   return JsonToBinaryStream(resolver, type_url, &input_stream, &output_stream,


### PR DESCRIPTION
…rst"

We found that some code depended on the behavior of appending to the
string without clearing it first. The comments in json_util.h also make
it appear that the appending behavior is intentional, so I think we need
to stick with the old behavior.

This reverts commit 3cbe45a4b55952609dff0b3a9e2e7043679af93f.