### PR TITLE
Removed all use of STLDelete*() in ObjC and C# Generators.

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_file.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.cc
@@ -192,27 +192,21 @@ FileGenerator::FileGenerator(const FileDescriptor *file, const Options& options)
       options_(options) {
   for (int i = 0; i < file_->enum_type_count(); i++) {
     EnumGenerator *generator = new EnumGenerator(file_->enum_type(i));
-    enum_generators_.push_back(generator);
+    enum_generators_.emplace_back(generator);
   }
   for (int i = 0; i < file_->message_type_count(); i++) {
     MessageGenerator *generator =
         new MessageGenerator(root_class_name_, file_->message_type(i), options_);
-    message_generators_.push_back(generator);
+    message_generators_.emplace_back(generator);
   }
   for (int i = 0; i < file_->extension_count(); i++) {
     ExtensionGenerator *generator =
         new ExtensionGenerator(root_class_name_, file_->extension(i));
-    extension_generators_.push_back(generator);
+    extension_generators_.emplace_back(generator);
   }
 }
 
-FileGenerator::~FileGenerator() {
-  STLDeleteContainerPointers(enum_generators_.begin(), enum_generators_.end());
-  STLDeleteContainerPointers(message_generators_.begin(),
-                             message_generators_.end());
-  STLDeleteContainerPointers(extension_generators_.begin(),
-                             extension_generators_.end());
-}
+FileGenerator::~FileGenerator() {}
 
 void FileGenerator::GenerateHeader(io::Printer *printer) {
   std::set<string> headers;
@@ -270,9 +264,8 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
       "\n");
 
   std::set<string> fwd_decls;
-  for (std::vector<MessageGenerator *>::iterator iter = message_generators_.begin();
-       iter != message_generators_.end(); ++iter) {
-    (*iter)->DetermineForwardDeclarations(&fwd_decls);
+  for (const auto& generator : message_generators_) {
+    generator->DetermineForwardDeclarations(&fwd_decls);
   }
   for (std::set<string>::const_iterator i(fwd_decls.begin());
        i != fwd_decls.end(); ++i) {
@@ -287,14 +280,12 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
       "\n");
 
   // need to write out all enums first
-  for (std::vector<EnumGenerator *>::iterator iter = enum_generators_.begin();
-       iter != enum_generators_.end(); ++iter) {
-    (*iter)->GenerateHeader(printer);
+  for (const auto& generator : enum_generators_) {
+    generator->GenerateHeader(printer);
   }
 
-  for (std::vector<MessageGenerator *>::iterator iter = message_generators_.begin();
-       iter != message_generators_.end(); ++iter) {
-    (*iter)->GenerateEnumHeader(printer);
+  for (const auto& generator : message_generators_) {
+    generator->GenerateEnumHeader(printer);
   }
 
   // For extensions to chain together, the Root gets created even if there
@@ -323,18 +314,15 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
         "@interface $root_class_name$ (DynamicMethods)\n",
         "root_class_name", root_class_name_);
 
-    for (std::vector<ExtensionGenerator *>::iterator iter =
-             extension_generators_.begin();
-         iter != extension_generators_.end(); ++iter) {
-      (*iter)->GenerateMembersHeader(printer);
+    for (const auto& generator : extension_generators_) {
+      generator->GenerateMembersHeader(printer);
     }
 
     printer->Print("@end\n\n");
   }  // extension_generators_.size() > 0
 
-  for (std::vector<MessageGenerator *>::iterator iter = message_generators_.begin();
-       iter != message_generators_.end(); ++iter) {
-    (*iter)->GenerateMessageHeader(printer);
+  for (const auto& generator : message_generators_) {
+    generator->GenerateMessageHeader(printer);
   }
 
   printer->Print(
@@ -403,9 +391,8 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
   }
 
   bool includes_oneof = false;
-  for (std::vector<MessageGenerator *>::iterator iter = message_generators_.begin();
-       iter != message_generators_.end(); ++iter) {
-    if ((*iter)->IncludesOneOfDefinition()) {
+  for (const auto& generator : message_generators_) {
+    if (generator->IncludesOneOfDefinition()) {
       includes_oneof = true;
       break;
     }
@@ -456,15 +443,11 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
       printer->Print(
           "static GPBExtensionDescription descriptions[] = {\n");
       printer->Indent();
-      for (std::vector<ExtensionGenerator *>::iterator iter =
-               extension_generators_.begin();
-           iter != extension_generators_.end(); ++iter) {
-        (*iter)->GenerateStaticVariablesInitialization(printer);
+      for (const auto& generator : extension_generators_) {
+        generator->GenerateStaticVariablesInitialization(printer);
       }
-      for (std::vector<MessageGenerator *>::iterator iter =
-               message_generators_.begin();
-           iter != message_generators_.end(); ++iter) {
-        (*iter)->GenerateStaticVariablesInitialization(printer);
+      for (const auto& generator : message_generators_) {
+        generator->GenerateStaticVariablesInitialization(printer);
       }
       printer->Outdent();
       printer->Print(
@@ -561,13 +544,11 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
         "\n");
   }
 
-  for (std::vector<EnumGenerator *>::iterator iter = enum_generators_.begin();
-       iter != enum_generators_.end(); ++iter) {
-    (*iter)->GenerateSource(printer);
+  for (const auto& generator : enum_generators_) {
+    generator->GenerateSource(printer);
   }
-  for (std::vector<MessageGenerator *>::iterator iter = message_generators_.begin();
-       iter != message_generators_.end(); ++iter) {
-    (*iter)->GenerateSource(printer);
+  for (const auto& generator : message_generators_) {
+    generator->GenerateSource(printer);
   }
 
   printer->Print(

--- a/src/google/protobuf/compiler/objectivec/objectivec_file.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.h
@@ -65,9 +65,9 @@ class FileGenerator {
   string root_class_name_;
   bool is_bundled_proto_;
 
-  std::vector<EnumGenerator*> enum_generators_;
-  std::vector<MessageGenerator*> message_generators_;
-  std::vector<ExtensionGenerator*> extension_generators_;
+  std::vector<std::unique_ptr<EnumGenerator>> enum_generators_;
+  std::vector<std::unique_ptr<MessageGenerator>> message_generators_;
+  std::vector<std::unique_ptr<ExtensionGenerator>> extension_generators_;
 
   const Options options_;
 

--- a/src/google/protobuf/compiler/objectivec/objectivec_message.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message.h
@@ -85,10 +85,10 @@ class MessageGenerator {
   FieldGeneratorMap field_generators_;
   const string class_name_;
   const string deprecated_attribute_;
-  std::vector<ExtensionGenerator*> extension_generators_;
-  std::vector<EnumGenerator*> enum_generators_;
-  std::vector<MessageGenerator*> nested_message_generators_;
-  std::vector<OneofGenerator*> oneof_generators_;
+  std::vector<std::unique_ptr<ExtensionGenerator>> extension_generators_;
+  std::vector<std::unique_ptr<EnumGenerator>> enum_generators_;
+  std::vector<std::unique_ptr<MessageGenerator>> nested_message_generators_;
+  std::vector<std::unique_ptr<OneofGenerator>> oneof_generators_;
 };
 
 }  // namespace objectivec


### PR DESCRIPTION
Other languages will have this removed inside Google first.
These functions are subject to ADL and cause problems.