### PR TITLE
Include protobuf_deps.bzl in generated release archives

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1218,6 +1218,7 @@ EXTRA_DIST = $(@DIST_LANG@_EXTRA_DIST)   \
   examples/pubspec.yaml                  \
   examples/third_party/zlib.BUILD        \
   protobuf.bzl                           \
+  protobuf_deps.bzl                      \
   python/release/wheel/build_wheel_manylinux.sh  \
   python/release/wheel/Dockerfile                \
   python/release/wheel/protobuf_optimized_pip.sh \


### PR DESCRIPTION
This fixes #5918.