### PR TITLE
javalite: don't use deprecated single_file option

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -127,7 +127,7 @@ proto_gen = rule(
         "protoc": attr.label(
             cfg = "host",
             executable = True,
-            single_file = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "plugin": attr.label(


### PR DESCRIPTION
Usage of `single_file` is not allowed by default in Bazel 0.27.0 and newer.

This change was made to the master-branch in #5050