### PR TITLE
Fix usage of deprecated single_file attribute

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -127,7 +127,7 @@ proto_gen = rule(
         "protoc": attr.label(
             cfg = "host",
             executable = True,
-            single_file = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "plugin": attr.label(


### PR DESCRIPTION
This removes the need to use --incompatible_disable_deprecated_attr_params when using protobuf.