### PR TITLE
Fix usage of six in //:protobuf_python rule and add import

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -871,7 +871,7 @@ py_proto_library(
     protoc = ":protoc",
     py_libs = [
         ":python_srcs",
-        "//external:six",
+        "@six//:six",
     ],
     py_extra_srcs = glob(["python/**/__init__.py"]),
     srcs_version = "PY2AND3",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@ new_local_repository(
 )
 
 http_archive(
-    name = "six_archive",
+    name = "six",
     build_file = "@//:six.BUILD",
     sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
     urls = ["https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55"],
@@ -39,11 +39,6 @@ bind(
 bind(
     name = "gtest_main",
     actual = "@submodule_gmock//:gtest_main",
-)
-
-bind(
-    name = "six",
-    actual = "@six_archive//:six",
 )
 
 maven_jar(

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -13,3 +13,11 @@ def protobuf_deps():
             strip_prefix = "zlib-1.2.11",
             urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
         )
+
+    if "six" not in native.existing_rules():
+        http_archive(
+            name = "six",
+            build_file = "@//:six.BUILD",
+            sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+            urls = ["https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55"],
+        )


### PR DESCRIPTION
Using `//external:six` works when protobuf is the root repo, but fails when protobuf is a third party dependency of another workspace. `@six//:six` works in both situations once the relevant workspace rule has been updated to match.

Also added six to the protobuf_deps.bzl file.