### PR TITLE
add type conversions to generated code javascript setters

### DIFF
--- a/js/message_test.js
+++ b/js/message_test.js
@@ -920,6 +920,37 @@ describe('Message test suite', function() {
     assertBooleanFieldFalse(message.getRepeatedBooleanFieldList()[1]);
   });
 
+  it('testFieldsOfDifferentTypesAreConverted', function() {
+    var assertNan = function(x) {
+        assertTrue(
+            'Expected ' + x + ' (' + goog.typeOf(x) + ') to be NaN.',
+            goog.isNumber(x) && isNaN(x));
+    };
+
+    var assertArrayEqualsWithNan = function(arr1, arr2) {
+        assertTrue('Arrays are not equal. Expected [' + arr2 + '] and got [' + arr1 + ']',
+            arr1.length === arr2.length && arr1.every((element, index) => {
+                return (element === arr2[index]) || (isNaN(element) && isNaN(arr2[index]));
+            })
+        );
+    }
+    
+    var message = new proto.jspb.test.FloatingPointFields;
+
+    message.setOptionalFloatField('123');
+    message.setRequiredFloatField('12a3');
+    message.setRepeatedFloatFieldList(['aaa', '((/2*7u*', '123', '123.456789', 'Infinity']);
+    message.setOptionalDoubleField(true);
+    message.setRequiredDoubleField('-123.0000');
+    message.setRepeatedDoubleFieldList([false, null, 123.456, '5/6'])
+    assertEquals(message.getOptionalFloatField(), 123);
+    assertNan(message.getRequiredFloatField());
+    assertArrayEqualsWithNan(message.getRepeatedFloatFieldList(), [NaN, NaN, 123, 123.456789, Infinity]);
+    assertEquals(message.getOptionalDoubleField(), 1);
+    assertEquals(message.getRequiredDoubleField(), -123);
+    assertArrayEqualsWithNan(message.getRepeatedDoubleFieldList(), [0, 0, 123.456, NaN]);
+  });
+
   it('testExtensionReverseOrder', function() {
     var message2 =
         new proto.jspb.exttest.reverse.TestExtensionReverseOrderMessage2;

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -32,7 +32,6 @@
 
 #include <assert.h>
 #include <algorithm>
-#include <cctype>
 #include <limits>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Fixes #6086

Adds type conversions to the generated javascript setters for primitives & repeated primitives:

First checks if the argument is of the correct type or null (which will clear the field).
If not, convert to the correct type using the appropriate wrapper function(Number(x), String(x) or Boolean(x)).

For repeated fields, first the type of the passed variable is an array. If not, throw an error. If it is an array, iterate through the array and perform the same conversion logic as above for each element.

Examples

protofile:

message MyMessage {
    String pkid = 1;
}
after compiling:

```
> protoConfig.setPkid(123);
> protoConfig.getPkid();
123
> MyMessage.deserializeBinary((protoConfig.serializeBinary())).getPkid()
123
```

protofile:

message MyMessage {
    repeated String pkid = 1;
}

```
> protoConfig.setPkidList([true, 123]);
> protoConfig.getPkidList();
[ 'true', '123' ]
> MyMessage.deserializeBinary((protoConfig.serializeBinary())).getPkidList()
[ 'true', '123' ]
```