### PR TITLE
Use proto_library in proto_lang_toolchain.blacklisted_protos

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1012,7 +1012,7 @@ cc_library(
 
 proto_lang_toolchain(
     name = "cc_toolchain",
-    blacklisted_protos = [":_internal_wkt_protos_genrule"],
+    blacklisted_protos = [proto + "_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()],
     command_line = "--cpp_out=$(OUT)",
     runtime = ":protobuf",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Support for using `proto_library` in this attribute was added in:
bazelbuild/bazel@a5ee2c4

Legacy support for using `.proto` files will be removed in a future
version of Bazel.