### PR TITLE
fix a UBSAN warnings.

### DIFF
--- a/src/google/protobuf/stubs/strutil.cc
+++ b/src/google/protobuf/stubs/strutil.cc
@@ -1065,10 +1065,12 @@ done:
 }
 
 char* FastInt32ToBufferLeft(int32 i, char* buffer) {
-  uint32 u = i;
+  uint32 u = 0;
   if (i < 0) {
     *buffer++ = '-';
-    u = -i;
+    u -= i;
+  } else {
+    u = i;
   }
   return FastUInt32ToBufferLeft(u, buffer);
 }


### PR DESCRIPTION
Fixing a UBSAN error reproduced from an OSS-Fuzz testcase

* external/com_google_protobuf/src/google/protobuf/stubs/strutil.cc:1071:9: runtime error: negation of -2147483648 cannot be represented in type 'google::protobuf::int32' (aka 'int'); cast to an unsigned type to negate this value to itself

Similar to #5901 for 32-bit integers.

Signed-off-by: Asra Ali <asraa@google.com>