### PR TITLE
add test case for Generate() in the cpp_bootstrap_unittest.cc

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_bootstrap_unittest.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_bootstrap_unittest.cc
@@ -178,6 +178,19 @@ TEST(BootstrapTest, GeneratedFilesMatch) {
   }
 }
 
+//test Generate in cpp_generator.cc
+TEST(BootstrapTest, OptionNotExist)
+{
+  cpp::CppGenerator generator;
+  DescriptorPool pool;
+  GeneratorContext *generator_context = nullptr;
+  std::string parameter = "aaa";
+  string error;
+  ASSERT_FALSE(generator.Generate(pool.FindFileByName("google/protobuf/descriptor.proto"),
+                                  parameter, generator_context, &error));
+  EXPECT_EQ(error, "Unknown generator option: " + parameter);
+}
+
 }  // namespace
 
 }  // namespace cpp


### PR DESCRIPTION
i found the function Generate() in cpp_generator.cc and there are no test cases to override the exception statement. i personally think that we can supplement the test cases of the corresponding scene.