### PR TITLE
Fix builtin_atomics check in CMakeLists.txt

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -137,6 +137,8 @@ endif (HAVE_ZLIB)
 set(protobuf_LINK_LIBATOMIC false)
 if (NOT MSVC)
   include(CheckCXXSourceCompiles)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} -std=c++11)
   check_cxx_source_compiles("
     #include <atomic>
     int main() {
@@ -146,6 +148,7 @@ if (NOT MSVC)
   if (NOT protobuf_HAVE_BUILTIN_ATOMICS)
     set(protobuf_LINK_LIBATOMIC true)
   endif (NOT protobuf_HAVE_BUILTIN_ATOMICS)
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 endif (NOT MSVC)
 
 if (protobuf_BUILD_SHARED_LIBS)


### PR DESCRIPTION
The check for builtin atomics, added in #6337, was incorrect in that it relied on universal initialization (c++11) without including a compiler flag specifying c++11.  Consequently the check always fails, resulting in the linker getting a `-latomic` argument that breaks builds (for me, at least, on macOS 10.14, with a compiler that definitely has builtin atomics).

The fix here is to provide `-std=c++11` in `CMAKE_REQUIRED_FLAGS` just prior to executing the check.  Because it's cmake, of course this is a global variable so we need to take care to reset it to its old value.

LLVM itself does the same thing here: https://llvm.org/svn/llvm-project/libcxx/trunk/cmake/Modules/CheckLibcxxAtomic.cmake

Fixes #6349 
