### PR TITLE
Fix unused-parameter clang warnings in arena.h and map_type_handler.h

### DIFF
--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -688,6 +688,7 @@ class PROTOBUF_EXPORT alignas(8) Arena final {
                                         !has_get_arena<T>::value,
                                     int>::type = 0>
   PROTOBUF_ALWAYS_INLINE static Arena* GetArenaInternal(const T* value) {
+    (void) value;
     return nullptr;
   }
 

--- a/src/google/protobuf/map_type_handler.h
+++ b/src/google/protobuf/map_type_handler.h
@@ -524,6 +524,7 @@ inline const char* ReadSFIXED32(const char* ptr, int32* value) {
   template <typename Type>                                                  \
   const char* MapTypeHandler<WireFormatLite::TYPE_##FieldType, Type>::Read( \
       const char* begin, ParseContext* ctx, MapEntryAccessorType* value) {  \
+    (void) ctx;                                                             \
     return Read##FieldType(begin, value);                                   \
   }
 


### PR DESCRIPTION
I'm using protobuf in a Qt project, and (using clang++ on macOS) see a number of unused-parameter warnings in generated code coming from two places; `GetArenaInternal` in arena.h, and in methods generated by `READ_METHOD` in `map_type_handler.h`.  In both cases, there is indeed a parameter that goes unused.

The fix here is dumb and simple - just a plain `(void) param` statement.  I noticed that there's a `PROTOBUF_UNUSED` macro, which I didn't use because it seemed to break the `READ_METHOD` macro, and in any case is not defined for clang.  In fact, the `PROTOBUF_UNUSED` macro itself seems to be entirely unused outside of `port_def.inc` and `port_undef.inc`.

It's certainly possible for me to ignore these warnings in my project, but a) that requires silencing them for _my_ code, too, and b) it seems simple and inoffensive to just fix this here.  Please let me know if there's a better approach here.

Here's an example of the kinds of warnings I'm seeing:
<img width="1255" alt="image" src="https://user-images.githubusercontent.com/512212/60840651-d6064180-a184-11e9-9fe1-a89223e55c36.png">
