### PR TITLE
OpenJDK 7 docker file

### DIFF
--- a/kokoro/linux/dockerfile/test/java_jessie/Dockerfile
+++ b/kokoro/linux/dockerfile/test/java_jessie/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:jessie
+
+# Install dependencies.  We start with the basic ones require to build protoc
+# and the C++ build
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  bzip2 \
+  ccache \
+  curl \
+  gcc \
+  git \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libtool \
+  make \
+  parallel \
+  time \
+  wget \
+  && apt-get clean
+
+# Apt source for Oracle Java 7 is no longer available in webupd8
+# https://launchpad.net/~webupd8team/+archive/ubuntu/java
+
+# Java dependencies
+RUN apt-get install -y \
+  # -- For all Java builds -- \
+  maven \
+  # -- For java_jdk7 -- \
+  openjdk-7-jdk \
+  && apt-get clean

--- a/kokoro/linux/java_jdk7/build.sh
+++ b/kokoro/linux/java_jdk7/build.sh
@@ -10,7 +10,8 @@
 # Change to repo root
 cd $(dirname $0)/../../..
 
-export DOCKERFILE_DIR=kokoro/linux/64-bit
+export DOCKERHUB_ORGANIZATION=protobuftesting
+export DOCKERFILE_DIR=kokoro/linux/dockerfile/test/java_jessie
 export DOCKER_RUN_SCRIPT=kokoro/linux/pull_request_in_docker.sh
 export OUTPUT_DIR=testoutput
 export TEST_SET="java_jdk7"


### PR DESCRIPTION
Fixes #6353 

- [openjdk-7-jdk](https://packages.debian.org/search?keywords=openjdk-7-jdk) is available in Debian Jessie.
- Because of [Oracle Java (JDK) 8 Installer PPA (DISCONTINUED) via WebUpd8 team](https://launchpad.net/~webupd8team/+archive/ubuntu/java), not touching Oracle JDK 7 test image with this PR.

@TeBoring Would you publish the image to DockerHub?