### PR TITLE
Remove zlib copts flags when on Windows

### DIFF
--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -52,9 +52,12 @@ cc_library(
         # choice of <> or "" delimiter when including itself.
     ] + _ZLIB_HEADERS,
     hdrs = _ZLIB_PREFIXED_HEADERS,
-    copts = [
-        "-Wno-unused-variable",
-        "-Wno-implicit-function-declaration",
-    ],
+    copts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-Wno-unused-variable",
+            "-Wno-implicit-function-declaration",
+        ],
+    }),
     includes = ["zlib/include/"],
 )


### PR DESCRIPTION
Currently, when compiling on Windows in certain circumstances the `copts` flags to zlib would result in the following error, due the flags not being understood by `cl`:

```

(16:56:05) ERROR: D:/b/m3jvdz2w/external/zlib/BUILD.bazel:32:1: Couldn't build file external/zlib/_objs/zlib/zutil.obj: C++ compilation of rule '@zlib//:zlib' failed (Exit 2)
cl : Command line error D8021 : invalid numeric argument '/Wno-unused-variable'
```

This PR removes these flags when on Windows but keeps them for other platforms.

Full build error example here: https://buildkite.com/bazel/rules-proto/builds/229#a4859c25-6548-4239-a26e-57a790ff131d