### PR TITLE
Fix proto3 extensions support

### DIFF
--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -537,7 +537,8 @@ bool GenerateFile(const FileDescriptor* file, io::Printer* printer,
   }
 
   // TODO: Remove this when ruby supports extensions for proto2 syntax.
-  if (file->extension_count() > 0) {
+  if (file->syntax() == FileDescriptor::SYNTAX_PROTO2 &&
+      file->extension_count() > 0) {
     *error = "Extensions are not yet supported for proto2 .proto files.";
     return false;
   }


### PR DESCRIPTION
proto3 ruby extensions have been broken by the proto2 support.

```proto
syntax = "proto3";

package test;

import "google/protobuf/descriptor.proto";

extend google.protobuf.ServiceOptions {
  bool custom_option = 12345;
}
```

will no longer compile

```
--ruby_out: test.proto: Extensions are not yet supported for proto2 .proto files.
```

Fixes https://github.com/protocolbuffers/protobuf/issues/6209
