### PR TITLE
Add comparison of Timestamp

### DIFF
--- a/ruby/lib/google/protobuf/well_known_types.rb
+++ b/ruby/lib/google/protobuf/well_known_types.rb
@@ -72,6 +72,8 @@ module Google
     end
 
     Timestamp.class_eval do
+      include Comparable
+
       if RUBY_VERSION < "2.5"
         def to_time
           Time.at(self.to_f)
@@ -93,6 +95,10 @@ module Google
 
       def to_f
         self.seconds + (self.nanos.quo(1_000_000_000))
+      end
+
+      def <=>(target)
+        self.to_time <=> target.to_time
       end
     end
 

--- a/ruby/tests/well_known_types_test.rb
+++ b/ruby/tests/well_known_types_test.rb
@@ -25,6 +25,15 @@ class TestWellKnownTypes < Test::Unit::TestCase
     ts.from_time(time)
     assert_equal 654321321, ts.nanos
     assert_equal time, ts.to_time
+
+    # comparison
+    larger = Google::Protobuf::Timestamp.new(seconds: 123456)
+    smaller = Google::Protobuf::Timestamp.new(seconds: 12345)
+    assert( (larger <=> smaller) > 0 )
+    assert( (larger <=> larger) == 0 )
+    assert( (smaller <=> larger) < 0 )
+    assert( larger > smaller )
+    assert( !(larger < smaller))
   end
 
   def test_duration


### PR DESCRIPTION
Support comparison of `Google::Protobuf::Timestamp` in Ruby

For example, you write as follows below if you'd like to sort an array of message.

```ruby
messages.sort_by { |message| message.time.seconds }
```

You can write as follows if merge this feature.

```ruby
messages.sort_by(&:time)
```