### PR TITLE
Add more description on unspecified directory in javascript readme (release notes: no)

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -39,11 +39,8 @@ If you want, you can compile `protoc` from source instead.  To do this
 follow the instructions in [the top-level
 README](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md).
 
-Once you have `protoc` compiled, you can run the tests by typing:
+Once you have `protoc` compiled, you can run the tests provided along with our project to examine whether it can run successfully. In order to do this, you shuold download the Protocol Buffer source code from the release page with the link above. Then extract the source codes and navigate to the folder named `js` containing a `package.json` file and a series of test files. In this folder, you can run the commands below to run the tests automatically.
 
-    $ cd js
-    # Here the js folder is the working folder of your project, 
-    # it can be any other name according to your actual circumstances
     $ npm install
     $ npm test
 

--- a/js/README.md
+++ b/js/README.md
@@ -39,7 +39,7 @@ If you want, you can compile `protoc` from source instead.  To do this
 follow the instructions in [the top-level
 README](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md).
 
-Once you have `protoc` compiled, you can run the tests provided along with our project to examine whether it can run successfully. In order to do this, you shuold download the Protocol Buffer source code from the release page with the link above. Then extract the source codes and navigate to the folder named `js` containing a `package.json` file and a series of test files. In this folder, you can run the commands below to run the tests automatically.
+Once you have `protoc` compiled, you can run the tests provided along with our project to examine whether it can run successfully. In order to do this, you should download the Protocol Buffer source code from the release page with the link above. Then extract the source code and navigate to the folder named `js` containing a `package.json` file and a series of test files. In this folder, you can run the commands below to run the tests automatically.
 
     $ npm install
     $ npm test

--- a/js/README.md
+++ b/js/README.md
@@ -42,6 +42,8 @@ README](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md).
 Once you have `protoc` compiled, you can run the tests by typing:
 
     $ cd js
+    # Here the js folder is the working folder of your project, 
+    # it can be any other name according to your actual circumstances
     $ npm install
     $ npm test
 


### PR DESCRIPTION
- **Problem**: In the example code, the "js" folder appeared for the first time and there is no clue where the current folder is.

- **Consequence**: Otherwise, like me, spent a lot of time guessing what codes - some release version or the source code - should be downloaded to go to the "js" directory.

- **Solution**: Therefore, there should be some comments describing what the folder is.

- **Labels**: release notes: no  language: javascript