### PR TITLE
Fixed JS parsing of default map values

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -465,11 +465,15 @@ jspb.Map.prototype.serializeBinary = function(
  *    entries with unset keys is required for maps to be backwards compatible
  *    with the repeated message representation described here: goo.gl/zuoLAC
  *
+ * @param {V=} opt_defaultValue
+ *    The default value for the type of map values.
+ *
  */
 jspb.Map.deserializeBinary = function(map, reader, keyReaderFn, valueReaderFn,
-                                      opt_valueReaderCallback, opt_defaultKey) {
+                                      opt_valueReaderCallback, opt_defaultKey,
+                                      opt_defaultValue) {
   var key = opt_defaultKey;
-  var value = undefined;
+  var value = opt_defaultValue;
 
   while (reader.nextField()) {
     if (reader.isEndGroup()) {

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -3161,6 +3161,7 @@ void Generator::GenerateClassDeserializeBinaryField(
       printer->Print(", null");
     }
     printer->Print(", $defaultKey$", "defaultKey", JSFieldDefault(key_field));
+    printer->Print(", $defaultValue$", "defaultValue", JSFieldDefault(value_field));
     printer->Print(");\n");
     printer->Print("         });\n");
   } else {


### PR DESCRIPTION
We recently recently detected JS protobuf library fail to deserialize any map<uint64,double> data where value is 0. 

There has been many cases being reported:

https://github.com/protocolbuffers/protobuf/issues/3351 
https://github.com/grpc/grpc-web/issues/533
https://github.com/protocolbuffers/protobuf/issues/4500

In binary format, default map values are not sent, however this is not probably handled in JS library. 

This fix is inspired by:

https://github.com/protocolbuffers/protobuf/pull/4687