### PR TITLE
Revert bad change to objc conformance test in #6199

### DIFF
--- a/conformance/conformance_objc.m
+++ b/conformance/conformance_objc.m
@@ -68,7 +68,8 @@ static ConformanceResponse *DoTest(ConformanceRequest *request) {
 
   switch (request.payloadOneOfCase) {
     case ConformanceRequest_Payload_OneOfCase_GPBUnsetOneOfCase:
-      Die(@"Request didn't have a payload: %@", request);
+      response.runtimeError =
+          [NSString stringWithFormat:@"Request didn't have a payload: %@", request];
       break;
 
     case ConformanceRequest_Payload_OneOfCase_ProtobufPayload: {
@@ -78,7 +79,10 @@ static ConformanceResponse *DoTest(ConformanceRequest *request) {
       } else if ([request.messageType isEqual:@"protobuf_test_messages.proto2.TestAllTypesProto2"]) {
         msgClass = [TestAllTypesProto2 class];
       } else {
-        Die(@"Protobuf request had an unknown message_type: %@", request.messageType);
+        response.runtimeError =
+            [NSString stringWithFormat:
+                @"Protobuf request had an unknown message_type: %@", request.messageType];
+        break;
       }
       NSError *error = nil;
       testMessage = [msgClass parseFromData:request.protobufPayload error:&error];
@@ -108,7 +112,8 @@ static ConformanceResponse *DoTest(ConformanceRequest *request) {
     switch (request.requestedOutputFormat) {
       case WireFormat_GPBUnrecognizedEnumeratorValue:
       case WireFormat_Unspecified:
-        Die(@"Unrecognized/unspecified output format: %@", request);
+        response.runtimeError =
+            [NSString stringWithFormat:@"Unrecognized/unspecified output format: %@", request];
         break;
 
       case WireFormat_Protobuf:


### PR DESCRIPTION
Since true for objc is external, changes should always start on the github
side, so the fact that something got pushed out is a sign something was
broken in the process.