### PR TITLE
Fix incorrect field type in python JsonObjects

### DIFF
--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -292,7 +292,7 @@ class _Printer(object):
     elif field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_BOOL:
       return bool(value)
     elif field.cpp_type in _INT64_TYPES:
-      return str(value)
+      return int(value)
     elif field.cpp_type in _FLOAT_TYPES:
       if math.isinf(value):
         if value < 0.0:


### PR DESCRIPTION
google.protobuf.json_format.MessageToDict incorrectly casts ints to strs. This fixes that. 