### PR TITLE
fix typo in io/printer.h

### DIFF
--- a/src/google/protobuf/io/printer.h
+++ b/src/google/protobuf/io/printer.h
@@ -53,7 +53,7 @@ class ZeroCopyOutputStream;  // zero_copy_stream.h
 // Records annotations about a Printer's output.
 class PROTOBUF_EXPORT AnnotationCollector {
  public:
-  // Annotation is a ofset range and a payload pair.
+  // Annotation is a offset range and a payload pair.
   typedef std::pair<std::pair<size_t, size_t>, std::string> Annotation;
 
   // Records that the bytes in file_path beginning with begin_offset and ending


### PR DESCRIPTION
fix typo in io/printer.h
change `ofset` to `offset`