### PR TITLE
Backport review comments for C# proto2 features (for 3.9.x)

### DIFF
--- a/csharp/src/Google.Protobuf/Extension.cs
+++ b/csharp/src/Google.Protobuf/Extension.cs
@@ -44,9 +44,9 @@ namespace Google.Protobuf
         /// <summary>
         /// Internal use. Creates a new extension with the specified field number.
         /// </summary>
-        protected Extension(int number)
+        protected Extension(int fieldNumber)
         {
-            FieldNumber = number;
+            FieldNumber = fieldNumber;
         }
 
         internal abstract IExtensionValue CreateValue();
@@ -69,7 +69,7 @@ namespace Google.Protobuf
         /// <summary>
         /// Creates a new extension identifier with the specified field number and codec
         /// </summary>
-        public Extension(int number, FieldCodec<TValue> codec) : base(number)
+        public Extension(int fieldNumber, FieldCodec<TValue> codec) : base(fieldNumber)
         {
             this.codec = codec;
         }
@@ -96,7 +96,7 @@ namespace Google.Protobuf
         /// <summary>
         /// Creates a new repeated extension identifier with the specified field number and codec
         /// </summary>
-        public RepeatedExtension(int number, FieldCodec<TValue> codec) : base(number)
+        public RepeatedExtension(int fieldNumber, FieldCodec<TValue> codec) : base(fieldNumber)
         {
             this.codec = codec;
         }

--- a/csharp/src/Google.Protobuf/Extension.cs
+++ b/csharp/src/Google.Protobuf/Extension.cs
@@ -35,7 +35,7 @@ using System;
 namespace Google.Protobuf
 {
     /// <summary>
-    /// Represents a non-generic extension definition
+    /// Represents a non-generic extension definition. This API is experimental and subject to change.
     /// </summary>
     public abstract class Extension
     {
@@ -58,7 +58,8 @@ namespace Google.Protobuf
     }
 
     /// <summary>
-    /// Represents a type-safe extension identifier used for getting and setting single extension values in <see cref="IExtendableMessage{T}"/> instances
+    /// Represents a type-safe extension identifier used for getting and setting single extension values in <see cref="IExtendableMessage{T}"/> instances. 
+    /// This API is experimental and subject to change.
     /// </summary>
     /// <typeparam name="TTarget">The message type this field applies to</typeparam>
     /// <typeparam name="TValue">The field value type of this extension</typeparam>
@@ -85,7 +86,8 @@ namespace Google.Protobuf
     }
 
     /// <summary>
-    /// Represents a type-safe extension identifier used for getting repeated extension values in <see cref="IExtendableMessage{T}"/> instances
+    /// Represents a type-safe extension identifier used for getting repeated extension values in <see cref="IExtendableMessage{T}"/> instances.
+    /// This API is experimental and subject to change.
     /// </summary>
     /// <typeparam name="TTarget">The message type this field applies to</typeparam>
     /// <typeparam name="TValue">The repeated field value type of this extension</typeparam>

--- a/csharp/src/Google.Protobuf/ExtensionRegistry.cs
+++ b/csharp/src/Google.Protobuf/ExtensionRegistry.cs
@@ -83,16 +83,6 @@ namespace Google.Protobuf
         }
 
         /// <summary>
-        /// Adds the specified extensions to the registry
-        /// </summary>
-        public void Add(params Extension[] newExtensions)
-        {
-            ProtoPreconditions.CheckNotNull(newExtensions, nameof(newExtensions));
-
-            Add((IEnumerable<Extension>)newExtensions);
-        }
-
-        /// <summary>
         /// Adds the specified extensions to the reigstry
         /// </summary>
         public void Add(IEnumerable<Extension> newExtensions)

--- a/csharp/src/Google.Protobuf/ExtensionRegistry.cs
+++ b/csharp/src/Google.Protobuf/ExtensionRegistry.cs
@@ -38,7 +38,7 @@ using System.Linq;
 namespace Google.Protobuf
 {
     /// <summary>
-    /// Provides extensions to messages while parsing
+    /// Provides extensions to messages while parsing. This API is experimental and subject to change.
     /// </summary>
     public sealed class ExtensionRegistry : ICollection<Extension>, IDeepCloneable<ExtensionRegistry>
     {

--- a/csharp/src/Google.Protobuf/ExtensionRegistry.cs
+++ b/csharp/src/Google.Protobuf/ExtensionRegistry.cs
@@ -85,11 +85,11 @@ namespace Google.Protobuf
         /// <summary>
         /// Adds the specified extensions to the reigstry
         /// </summary>
-        public void Add(IEnumerable<Extension> newExtensions)
+        public void AddRange(IEnumerable<Extension> extensions)
         {
-            ProtoPreconditions.CheckNotNull(newExtensions, nameof(newExtensions));
+            ProtoPreconditions.CheckNotNull(extensions, nameof(extensions));
 
-            foreach (var extension in newExtensions)
+            foreach (var extension in extensions)
                 Add(extension);
         }
 

--- a/csharp/src/Google.Protobuf/ExtensionSet.cs
+++ b/csharp/src/Google.Protobuf/ExtensionSet.cs
@@ -40,11 +40,11 @@ namespace Google.Protobuf
     /// <summary>
     /// Methods for managing <see cref="ExtensionSet{TTarget}"/>s with null checking.
     /// 
-    /// Most users will not use this class directly
+    /// Most users will not use this class directly and its API is experimental and subject to change.
     /// </summary>
     public static class ExtensionSet
     {
-        private static bool GetValue<TTarget>(ref ExtensionSet<TTarget> set, Extension extension, out IExtensionValue value) where TTarget : IExtendableMessage<TTarget>
+        private static bool TryGetValue<TTarget>(ref ExtensionSet<TTarget> set, Extension extension, out IExtensionValue value) where TTarget : IExtendableMessage<TTarget>
         {
             if (set == null)
             {
@@ -60,7 +60,7 @@ namespace Google.Protobuf
         public static TValue Get<TTarget, TValue>(ref ExtensionSet<TTarget> set, Extension<TTarget, TValue> extension) where TTarget : IExtendableMessage<TTarget>
         {
             IExtensionValue value;
-            if (GetValue(ref set, extension, out value))
+            if (TryGetValue(ref set, extension, out value))
             {
                 return ((ExtensionValue<TValue>)value).GetValue();
             }
@@ -76,7 +76,7 @@ namespace Google.Protobuf
         public static RepeatedField<TValue> Get<TTarget, TValue>(ref ExtensionSet<TTarget> set, RepeatedExtension<TTarget, TValue> extension) where TTarget : IExtendableMessage<TTarget>
         {
             IExtensionValue value;
-            if (GetValue(ref set, extension, out value))
+            if (TryGetValue(ref set, extension, out value))
             {
                 return ((RepeatedExtensionValue<TValue>)value).GetValue();
             }
@@ -111,7 +111,7 @@ namespace Google.Protobuf
         }
 
         /// <summary>
-        /// Sets the value of the specified extension
+        /// Sets the value of the specified extension. This will make a new instance of ExtensionSet if the set is null.
         /// </summary>
         public static void Set<TTarget, TValue>(ref ExtensionSet<TTarget> set, Extension<TTarget, TValue> extension, TValue value) where TTarget : IExtendableMessage<TTarget>
         {
@@ -140,14 +140,7 @@ namespace Google.Protobuf
         public static bool Has<TTarget, TValue>(ref ExtensionSet<TTarget> set, Extension<TTarget, TValue> extension) where TTarget : IExtendableMessage<TTarget>
         {
             IExtensionValue value;
-            if (GetValue(ref set, extension, out value))
-            {
-                return ((ExtensionValue<TValue>)value).HasValue;
-            }
-            else 
-            {
-                return false;
-            }
+            return TryGetValue(ref set, extension, out value);
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
@@ -407,7 +407,7 @@ namespace Google.Protobuf.Reflection
 
         private static void AddAllExtensions(FileDescriptor[] dependencies, GeneratedClrTypeInfo generatedInfo, ExtensionRegistry registry)
         {
-            registry.Add(dependencies.SelectMany(GetAllDependedExtensions).Concat(GetAllGeneratedExtensions(generatedInfo)).ToArray());
+            registry.AddRange(dependencies.SelectMany(GetAllDependedExtensions).Concat(GetAllGeneratedExtensions(generatedInfo)).ToArray());
         }
 
         private static IEnumerable<Extension> GetAllGeneratedExtensions(GeneratedClrTypeInfo generated)


### PR DESCRIPTION
- backporting some changes suggested in https://github.com/protocolbuffers/protobuf/pull/5350/files review.

Most importantly, the new extension APIs are marked as experimental so that we can do some minor adjustments in 3.10 if needed.

