### PR TITLE
Updated Bazel test script to use most recent Bazel version (#6413)

### DIFF
--- a/kokoro/linux/bazel/build.sh
+++ b/kokoro/linux/bazel/build.sh
@@ -3,6 +3,10 @@
 # Build file to set up and run tests
 set -ex
 
+# Install the latest Bazel version available
+use_bazel.sh latest
+bazel version
+
 # Change to repo root
 cd $(dirname $0)/../../..
 


### PR DESCRIPTION
I'm not exactly sure why, but this fixes the failing Bazel presubmit
test. Using the most recent version seems like a good idea anyway so
that we can make sure we're compatible with any new Bazel changes.

Cherry Pick