### PR TITLE
[bazel] Add fixes for --incompatible_load_{cc,java,proto}_rules_from_bzl (Part 2)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -805,12 +805,9 @@ py_library(
     name = "python_srcs",
     srcs = glob(
         [
-            "python/google/__init__.py",
-            "python/google/protobuf/*.py",
-            "python/google/protobuf/**/*.py",
+            "python/google/**/*.py",
         ],
         exclude = [
-            "python/google/protobuf/__init__.py",
             "python/google/protobuf/**/__init__.py",
             "python/google/protobuf/internal/*_test.py",
             "python/google/protobuf/internal/test_util.py",

--- a/Makefile.am
+++ b/Makefile.am
@@ -1230,7 +1230,6 @@ EXTRA_DIST = $(@DIST_LANG@_EXTRA_DIST)   \
   examples/list_people.py                \
   examples/list_people_test.go           \
   examples/pubspec.yaml                  \
-  examples/third_party/zlib.BUILD        \
   protobuf.bzl                           \
   protobuf_deps.bzl                      \
   python/release/wheel/build_wheel_manylinux.sh  \

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,10 @@
 workspace(name = "com_google_protobuf")
 
+local_repository(
+    name = "com_google_protobuf_examples",
+    path = "examples",
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//:protobuf_deps.bzl", "protobuf_deps")
 
@@ -17,13 +22,6 @@ http_archive(
     build_file = "@//:six.BUILD",
     sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
     urls = ["https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55"],
-)
-
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
-    strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
 )
 
 bind(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -4,6 +4,10 @@
 # the WORKSPACE file in the same directory with this BUILD file for an
 # example.
 
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_java//java:defs.bzl", "java_binary", "java_lite_proto_library", "java_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_proto_library")
+
 # For each .proto file, a proto_library target should be defined. This target
 # is not bound to any particular language. Instead, it defines the dependency
 # graph of the .proto files (i.e., proto imports) and serves as the provider

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -1,31 +1,24 @@
+workspace(name = "com_google_protobuf_examples")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # This com_google_protobuf repository is required for proto_library rule.
 # It provides the protocol compiler binary (i.e., protoc).
-http_archive(
+#
+# We declare it as local_repository so we can test changes
+# before they get merged. You'll want to use the following instead:
+#
+# http_archive(
+#     name = "com_google_protobuf",
+#     strip_prefix = "protobuf-master",
+#     urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+# )
+local_repository(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+    path = "..",
 )
 
-# This com_google_protobuf_cc repository is required for cc_proto_library
-# rule. It provides protobuf C++ runtime. Note that it actually is the same
-# repo as com_google_protobuf but has to be given a different name as
-# required by bazel.
-http_archive(
-    name = "com_google_protobuf_cc",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
-)
-
-# Similar to com_google_protobuf_cc but for Java (i.e., java_proto_library).
-http_archive(
-    name = "com_google_protobuf_java",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
-)
-
-# Similar to com_google_protobuf_cc but for Java lite. If you are building
+# Similar to com_google_protobuf but for Java lite. If you are building
 # for Android, the lite version should be prefered because it has a much
 # smaller code size.
 http_archive(
@@ -34,17 +27,6 @@ http_archive(
     urls = ["https://github.com/protocolbuffers/protobuf/archive/javalite.zip"],
 )
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
-    strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
-)
-
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-load("@bazel_skylib//lib:versions.bzl", "versions")
-
-versions.check(minimum_bazel_version = "0.5.4")

--- a/examples/third_party/zlib.BUILD
+++ b/examples/third_party/zlib.BUILD
@@ -1,1 +1,0 @@
-../../third_party/zlib.BUILD

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
 def _GetPath(ctx, path):
@@ -276,7 +277,7 @@ def cc_proto_library(
         )
 
         # An empty cc_library to make rule dependency consistent.
-        native.cc_library(
+        cc_library(
             name = name,
             **kargs
         )
@@ -307,8 +308,7 @@ def cc_proto_library(
         cc_libs = cc_libs + [default_runtime]
     if use_grpc_plugin:
         cc_libs = cc_libs + ["//external:grpc_lib"]
-
-    native.cc_library(
+    cc_library(
         name = name,
         srcs = gen_srcs,
         hdrs = gen_hdrs,

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -5,6 +5,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def protobuf_deps():
     """Loads common dependencies needed to compile the protobuf library."""
 
+    if not native.existing_rule("bazel_skylib"):
+        http_archive(
+            name = "bazel_skylib",
+            sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
+            strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
+            urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+        )
+
     if not native.existing_rule("zlib"):
         http_archive(
             name = "zlib",

--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 licenses(["notice"])  # BSD/MIT-like license (for zlib)
 
@@ -26,7 +26,6 @@ genrule(
     srcs = _ZLIB_HEADERS,
     outs = _ZLIB_PREFIXED_HEADERS,
     cmd = "cp $(SRCS) $(@D)/zlib/include/",
-    visibility = ["//visibility:private"],
 )
 
 cc_library(
@@ -60,4 +59,5 @@ cc_library(
         ],
     }),
     includes = ["zlib/include/"],
+    visibility = ["//visibility:public"],
 )

--- a/util/python/BUILD
+++ b/util/python/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 # This is a placeholder for python headers. Projects needing to use
 # fast cpp protos in protobuf's python interface should build with
 # --define=use_fast_cpp_protos=true, and in addition, provide


### PR DESCRIPTION
This change adds the required loads to examples and zlib. Sorry for missing them in the first PR.
For full compatibility with --incompatible_load_{cc,java,proto}_rules_from_bzl,
we will need to roll gtest to a newer version.