### PR TITLE
Fix the bug for message value map

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -488,7 +488,7 @@ jspb.Map.deserializeBinary = function(map, reader, keyReaderFn, valueReaderFn,
       // Value.
       if (map.valueCtor_) {
         goog.asserts.assert(opt_valueReaderCallback);
-        value = new map.valueCtor_();
+        goog.asserts.assert(value);
         valueReaderFn.call(reader, value, opt_valueReaderCallback);
       } else {
         value =

--- a/js/maps_test.js
+++ b/js/maps_test.js
@@ -40,6 +40,13 @@ goog.require('proto.jspb.test.MapEntryOptionalKeysStringKey');
 goog.require('proto.jspb.test.MapEntryOptionalKeysInt32Key');
 goog.require('proto.jspb.test.MapEntryOptionalKeysInt64Key');
 goog.require('proto.jspb.test.MapEntryOptionalKeysBoolKey');
+goog.require('proto.jspb.test.MapEntryOptionalValuesStringValue');
+goog.require('proto.jspb.test.MapEntryOptionalValuesInt32Value');
+goog.require('proto.jspb.test.MapEntryOptionalValuesInt64Value');
+goog.require('proto.jspb.test.MapEntryOptionalValuesBoolValue');
+goog.require('proto.jspb.test.MapEntryOptionalValuesDoubleValue');
+goog.require('proto.jspb.test.MapEntryOptionalValuesEnumValue');
+goog.require('proto.jspb.test.MapEntryOptionalValuesMessageValue');
 
 // CommonJS-LoadFromFile: test_pb proto.jspb.test
 goog.require('proto.jspb.test.MapValueMessageNoBinary');
@@ -54,7 +61,12 @@ function checkMapEquals(map, entries) {
   var arr = map.toArray();
   assertEquals(arr.length, entries.length);
   for (var i = 0; i < arr.length; i++) {
-    assertElementsEquals(arr[i], entries[i]);
+    if (Array.isArray(arr[i])) {
+      assertTrue(Array.isArray(entries[i]));
+      assertArrayEquals(arr[i], entries[i]);
+    } else {
+      assertElementsEquals(arr[i], entries[i]);
+    }
   }
 }
 
@@ -265,8 +277,10 @@ function makeTests(msgInfo, submessageCtor, suffix) {
       var decoded = msgInfo.deserializeBinary(serialized);
       checkMapFields(decoded);
     });
+
     /**
-     * Tests deserialization of undefined map keys go to default values in binary format.
+     * Tests deserialization of undefined map keys go to default values in
+     * binary format.
      */
     it('testMapDeserializationForUndefinedKeys', function() {
       var testMessageOptionalKeys = new proto.jspb.test.TestMapFieldsOptionalKeys();
@@ -296,6 +310,67 @@ function makeTests(msgInfo, submessageCtor, suffix) {
       ]);
       checkMapEquals(deserializedMessage.getMapBoolStringMap(), [
         [false, 'd']
+      ]);
+    });
+
+    /**
+     * Tests deserialization of undefined map values go to default values in
+     * binary format.
+     */
+    it('testMapDeserializationForUndefinedValues', function() {
+      var testMessageOptionalValues =
+          new proto.jspb.test.TestMapFieldsOptionalValues();
+      var mapEntryStringValue =
+          new proto.jspb.test.MapEntryOptionalValuesStringValue();
+      mapEntryStringValue.setKey("a");
+      testMessageOptionalValues.setMapStringString(mapEntryStringValue);
+      var mapEntryInt32Value =
+          new proto.jspb.test.MapEntryOptionalValuesInt32Value();
+      mapEntryInt32Value.setKey("b");
+      testMessageOptionalValues.setMapStringInt32(mapEntryInt32Value);
+      var mapEntryInt64Value =
+          new proto.jspb.test.MapEntryOptionalValuesInt64Value();
+      mapEntryInt64Value.setKey("c");
+      testMessageOptionalValues.setMapStringInt64(mapEntryInt64Value);
+      var mapEntryBoolValue =
+          new proto.jspb.test.MapEntryOptionalValuesBoolValue();
+      mapEntryBoolValue.setKey("d");
+      testMessageOptionalValues.setMapStringBool(mapEntryBoolValue);
+      var mapEntryDoubleValue =
+          new proto.jspb.test.MapEntryOptionalValuesDoubleValue();
+      mapEntryDoubleValue.setKey("e");
+      testMessageOptionalValues.setMapStringDouble(mapEntryDoubleValue);
+      var mapEntryEnumValue =
+          new proto.jspb.test.MapEntryOptionalValuesEnumValue();
+      mapEntryEnumValue.setKey("f");
+      testMessageOptionalValues.setMapStringEnum(mapEntryEnumValue);
+      var mapEntryMessageValue =
+          new proto.jspb.test.MapEntryOptionalValuesMessageValue();
+      mapEntryMessageValue.setKey("g");
+      testMessageOptionalValues.setMapStringMsg(mapEntryMessageValue);
+      var deserializedMessage = msgInfo.deserializeBinary(
+        testMessageOptionalValues.serializeBinary()
+       );
+      checkMapEquals(deserializedMessage.getMapStringStringMap(), [
+        ['a', '']
+      ]);
+      checkMapEquals(deserializedMessage.getMapStringInt32Map(), [
+        ['b', 0]
+      ]);
+      checkMapEquals(deserializedMessage.getMapStringInt64Map(), [
+        ['c', 0]
+      ]);
+      checkMapEquals(deserializedMessage.getMapStringBoolMap(), [
+        ['d', false]
+      ]);
+      checkMapEquals(deserializedMessage.getMapStringDoubleMap(), [
+        ['e', 0.0]
+      ]);
+      checkMapEquals(deserializedMessage.getMapStringEnumMap(), [
+        ['f', 0]
+      ]);
+      checkMapEquals(deserializedMessage.getMapStringMsgMap(), [
+        ['g', []]
       ]);
     });
   }

--- a/js/testbinary.proto
+++ b/js/testbinary.proto
@@ -257,7 +257,7 @@ message MapEntryOptionalValuesBoolValue {
 
 message MapEntryOptionalValuesDoubleValue {
   optional string key = 1;
-  optional bool value = 2;
+  optional double value = 2;
 }
 
 message MapEntryOptionalValuesEnumValue {

--- a/js/testbinary.proto
+++ b/js/testbinary.proto
@@ -232,6 +232,56 @@ message TestMapFieldsOptionalKeys {
 
 // End mock-map entries
 
+// These proto are 'mock map' entries to test the above map deserializing with
+// undefined values. Make sure TestMapFieldsOptionalValues is written to be
+// deserialized by TestMapFields
+message MapEntryOptionalValuesStringValue {
+  optional string key = 1;
+  optional string value = 2;
+}
+
+message MapEntryOptionalValuesInt32Value {
+  optional string key = 1;
+  optional int32 value = 2;
+}
+
+message MapEntryOptionalValuesInt64Value {
+  optional string key = 1;
+  optional int64 value = 2;
+}
+
+message MapEntryOptionalValuesBoolValue {
+  optional string key = 1;
+  optional bool value = 2;
+}
+
+message MapEntryOptionalValuesDoubleValue {
+  optional string key = 1;
+  optional bool value = 2;
+}
+
+message MapEntryOptionalValuesEnumValue {
+  optional string key = 1;
+  optional MapValueEnum value = 2;
+}
+
+message MapEntryOptionalValuesMessageValue {
+  optional string key = 1;
+  optional MapValueMessage value = 2;
+}
+
+message TestMapFieldsOptionalValues {
+  optional MapEntryOptionalValuesStringValue map_string_string = 1;
+  optional MapEntryOptionalValuesInt32Value map_string_int32 = 2;
+  optional MapEntryOptionalValuesInt64Value map_string_int64 = 3;
+  optional MapEntryOptionalValuesBoolValue map_string_bool = 4;
+  optional MapEntryOptionalValuesDoubleValue map_string_double = 5;
+  optional MapEntryOptionalValuesEnumValue map_string_enum = 6;
+  optional MapEntryOptionalValuesMessageValue map_string_msg = 7;
+}
+
+// End mock-map entries
+
 enum MapValueEnum {
   MAP_VALUE_FOO = 0;
   MAP_VALUE_BAR = 1;

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -3142,7 +3142,15 @@ void Generator::GenerateClassDeserializeBinaryField(
       printer->Print(", null");
     }
     printer->Print(", $defaultKey$", "defaultKey", JSFieldDefault(key_field));
-    printer->Print(", $defaultValue$", "defaultValue", JSFieldDefault(value_field));
+    if (value_field->type() == FieldDescriptor::TYPE_MESSAGE) {
+      printer->Print(
+          ", new $messageType$()",
+	  "messageType",
+	  GetMessagePath(options, value_field->message_type()));
+    } else {
+      printer->Print(
+          ", $defaultValue$", "defaultValue", JSFieldDefault(value_field));
+    }
     printer->Print(");\n");
     printer->Print("         });\n");
   } else {


### PR DESCRIPTION
Previously, jspb.BinaryReader.prototype.readMessage complains it cannot accept null.
Also added test to it.