### PR TITLE
Fix a Python extension crash in descriptor's nested types container

### DIFF
--- a/python/google/protobuf/internal/descriptor_test.py
+++ b/python/google/protobuf/internal/descriptor_test.py
@@ -650,6 +650,13 @@ class GeneratedDescriptorTest(unittest.TestCase):
     del enum
     self.assertEqual('FOO', next(values_iter).name)
 
+  def testDescriptorNestedTypesContainer(self):
+    message_descriptor = unittest_pb2.TestAllTypes.DESCRIPTOR
+    nested_message_descriptor = unittest_pb2.TestAllTypes.NestedMessage.DESCRIPTOR
+    self.assertEqual(len(message_descriptor.nested_types), 3)
+    self.assertFalse(None in message_descriptor.nested_types)
+    self.assertTrue(nested_message_descriptor in message_descriptor.nested_types)
+
   def testServiceDescriptor(self):
     service_descriptor = unittest_pb2.DESCRIPTOR.services_by_name['TestService']
     self.assertEqual(service_descriptor.name, 'TestService')

--- a/python/google/protobuf/pyext/descriptor_containers.cc
+++ b/python/google/protobuf/pyext/descriptor_containers.cc
@@ -639,6 +639,7 @@ int Find(PyContainer* self, PyObject* item) {
   // the .proto file definition.
   const void* descriptor_ptr = PyDescriptor_AsVoidPtr(item);
   if (descriptor_ptr == NULL) {
+    PyErr_Clear();
     // Not a descriptor, it cannot be in the list.
     return -1;
   }


### PR DESCRIPTION
This PR adds tests to check some basic behavior of a descriptor's nested types container.
It fixes a bug that appear in the C++ implementation (Python extension) when trying to check if an object with an invalid (non-descriptor) type is present in the nested_types container :

======================================================================
ERROR: testDescriptorNestedTypesContainer (google.protobuf.internal.descriptor_test.GeneratedDescriptorTest)
----------------------------------------------------------------------
TypeError: Not a BaseDescriptor

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/protobuf/python/google/protobuf/internal/descriptor_test.py", line 657, in testDescriptorNestedTypesContainer
    self.assertFalse(None in message_descriptor.nested_types)
SystemError: PyEval_EvalFrameEx returned a result with an error set

----------------------------------------------------------------------