### PR TITLE
Override CocoaPods module to lowercase

### DIFF
--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -5,13 +5,14 @@
 # dependent projects use the :git notation to refer to the library.
 Pod::Spec.new do |s|
   s.name     = 'Protobuf'
-  s.version  = '3.9.0-rc1'
+  s.version  = '3.9.0-rc2'
   s.summary  = 'Protocol Buffers v.3 runtime library for Objective-C.'
   s.homepage = 'https://github.com/protocolbuffers/protobuf'
   s.license  = '3-Clause BSD License'
   s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
   s.cocoapods_version = '>= 1.0'
 
+  s.module_name = 'protobuf'
   s.source = { :git => 'https://github.com/protocolbuffers/protobuf.git',
                :tag => "v#{s.version}" }
 

--- a/objectivec/GPBProtocolBuffers.h
+++ b/objectivec/GPBProtocolBuffers.h
@@ -52,16 +52,16 @@
 
 // Well-known proto types
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/Any.pbobjc.h>
- #import <Protobuf/Api.pbobjc.h>
- #import <Protobuf/Duration.pbobjc.h>
- #import <Protobuf/Empty.pbobjc.h>
- #import <Protobuf/FieldMask.pbobjc.h>
- #import <Protobuf/SourceContext.pbobjc.h>
- #import <Protobuf/Struct.pbobjc.h>
- #import <Protobuf/Timestamp.pbobjc.h>
- #import <Protobuf/Type.pbobjc.h>
- #import <Protobuf/Wrappers.pbobjc.h>
+ #import <protobuf/Any.pbobjc.h>
+ #import <protobuf/Api.pbobjc.h>
+ #import <protobuf/Duration.pbobjc.h>
+ #import <protobuf/Empty.pbobjc.h>
+ #import <protobuf/FieldMask.pbobjc.h>
+ #import <protobuf/SourceContext.pbobjc.h>
+ #import <protobuf/Struct.pbobjc.h>
+ #import <protobuf/Timestamp.pbobjc.h>
+ #import <protobuf/Type.pbobjc.h>
+ #import <protobuf/Wrappers.pbobjc.h>
 #else
  #import "google/protobuf/Any.pbobjc.h"
  #import "google/protobuf/Api.pbobjc.h"

--- a/objectivec/GPBWellKnownTypes.h
+++ b/objectivec/GPBWellKnownTypes.h
@@ -37,9 +37,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/Any.pbobjc.h>
- #import <Protobuf/Duration.pbobjc.h>
- #import <Protobuf/Timestamp.pbobjc.h>
+ #import <protobuf/Any.pbobjc.h>
+ #import <protobuf/Duration.pbobjc.h>
+ #import <protobuf/Timestamp.pbobjc.h>
 #else
  #import "google/protobuf/Any.pbobjc.h"
  #import "google/protobuf/Duration.pbobjc.h"

--- a/objectivec/google/protobuf/Any.pbobjc.h
+++ b/objectivec/google/protobuf/Any.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBDescriptor.h>
- #import <Protobuf/GPBMessage.h>
- #import <Protobuf/GPBRootObject.h>
+ #import <protobuf/GPBDescriptor.h>
+ #import <protobuf/GPBMessage.h>
+ #import <protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Any.pbobjc.m
+++ b/objectivec/google/protobuf/Any.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/Any.pbobjc.h>
+ #import <protobuf/Any.pbobjc.h>
 #else
  #import "google/protobuf/Any.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Api.pbobjc.h
+++ b/objectivec/google/protobuf/Api.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBDescriptor.h>
- #import <Protobuf/GPBMessage.h>
- #import <Protobuf/GPBRootObject.h>
+ #import <protobuf/GPBDescriptor.h>
+ #import <protobuf/GPBMessage.h>
+ #import <protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Api.pbobjc.m
+++ b/objectivec/google/protobuf/Api.pbobjc.m
@@ -8,15 +8,15 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/Api.pbobjc.h>
- #import <Protobuf/SourceContext.pbobjc.h>
- #import <Protobuf/Type.pbobjc.h>
+ #import <protobuf/Api.pbobjc.h>
+ #import <protobuf/SourceContext.pbobjc.h>
+ #import <protobuf/Type.pbobjc.h>
 #else
  #import "google/protobuf/Api.pbobjc.h"
  #import "google/protobuf/SourceContext.pbobjc.h"

--- a/objectivec/google/protobuf/Duration.pbobjc.h
+++ b/objectivec/google/protobuf/Duration.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBDescriptor.h>
- #import <Protobuf/GPBMessage.h>
- #import <Protobuf/GPBRootObject.h>
+ #import <protobuf/GPBDescriptor.h>
+ #import <protobuf/GPBMessage.h>
+ #import <protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Duration.pbobjc.m
+++ b/objectivec/google/protobuf/Duration.pbobjc.m
@@ -14,7 +14,7 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
-#import <protobuf/Duration.pbobjc.h>
+ #import <protobuf/Duration.pbobjc.h>
 #else
  #import "google/protobuf/Duration.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Duration.pbobjc.m
+++ b/objectivec/google/protobuf/Duration.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/Duration.pbobjc.h>
+#import <protobuf/Duration.pbobjc.h>
 #else
  #import "google/protobuf/Duration.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Empty.pbobjc.h
+++ b/objectivec/google/protobuf/Empty.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBDescriptor.h>
- #import <Protobuf/GPBMessage.h>
- #import <Protobuf/GPBRootObject.h>
+ #import <protobuf/GPBDescriptor.h>
+ #import <protobuf/GPBMessage.h>
+ #import <protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Empty.pbobjc.m
+++ b/objectivec/google/protobuf/Empty.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/Empty.pbobjc.h>
+ #import <protobuf/Empty.pbobjc.h>
 #else
  #import "google/protobuf/Empty.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/FieldMask.pbobjc.h
+++ b/objectivec/google/protobuf/FieldMask.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBDescriptor.h>
- #import <Protobuf/GPBMessage.h>
- #import <Protobuf/GPBRootObject.h>
+ #import <protobuf/GPBDescriptor.h>
+ #import <protobuf/GPBMessage.h>
+ #import <protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/FieldMask.pbobjc.m
+++ b/objectivec/google/protobuf/FieldMask.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/FieldMask.pbobjc.h>
+ #import <protobuf/FieldMask.pbobjc.h>
 #else
  #import "google/protobuf/FieldMask.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/SourceContext.pbobjc.h
+++ b/objectivec/google/protobuf/SourceContext.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBDescriptor.h>
- #import <Protobuf/GPBMessage.h>
- #import <Protobuf/GPBRootObject.h>
+ #import <protobuf/GPBDescriptor.h>
+ #import <protobuf/GPBMessage.h>
+ #import <protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/SourceContext.pbobjc.m
+++ b/objectivec/google/protobuf/SourceContext.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/SourceContext.pbobjc.h>
+ #import <protobuf/SourceContext.pbobjc.h>
 #else
  #import "google/protobuf/SourceContext.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Struct.pbobjc.h
+++ b/objectivec/google/protobuf/Struct.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBDescriptor.h>
- #import <Protobuf/GPBMessage.h>
- #import <Protobuf/GPBRootObject.h>
+ #import <protobuf/GPBDescriptor.h>
+ #import <protobuf/GPBMessage.h>
+ #import <protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Struct.pbobjc.m
+++ b/objectivec/google/protobuf/Struct.pbobjc.m
@@ -8,7 +8,7 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
@@ -16,7 +16,7 @@
 #import <stdatomic.h>
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/Struct.pbobjc.h>
+ #import <protobuf/Struct.pbobjc.h>
 #else
  #import "google/protobuf/Struct.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Timestamp.pbobjc.h
+++ b/objectivec/google/protobuf/Timestamp.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBDescriptor.h>
- #import <Protobuf/GPBMessage.h>
- #import <Protobuf/GPBRootObject.h>
+ #import <protobuf/GPBDescriptor.h>
+ #import <protobuf/GPBMessage.h>
+ #import <protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Timestamp.pbobjc.m
+++ b/objectivec/google/protobuf/Timestamp.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/Timestamp.pbobjc.h>
+ #import <protobuf/Timestamp.pbobjc.h>
 #else
  #import "google/protobuf/Timestamp.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Type.pbobjc.h
+++ b/objectivec/google/protobuf/Type.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBDescriptor.h>
- #import <Protobuf/GPBMessage.h>
- #import <Protobuf/GPBRootObject.h>
+ #import <protobuf/GPBDescriptor.h>
+ #import <protobuf/GPBMessage.h>
+ #import <protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Type.pbobjc.m
+++ b/objectivec/google/protobuf/Type.pbobjc.m
@@ -8,7 +8,7 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
@@ -16,9 +16,9 @@
 #import <stdatomic.h>
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/Type.pbobjc.h>
- #import <Protobuf/Any.pbobjc.h>
- #import <Protobuf/SourceContext.pbobjc.h>
+ #import <protobuf/Type.pbobjc.h>
+ #import <protobuf/Any.pbobjc.h>
+ #import <protobuf/SourceContext.pbobjc.h>
 #else
  #import "google/protobuf/Type.pbobjc.h"
  #import "google/protobuf/Any.pbobjc.h"

--- a/objectivec/google/protobuf/Wrappers.pbobjc.h
+++ b/objectivec/google/protobuf/Wrappers.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBDescriptor.h>
- #import <Protobuf/GPBMessage.h>
- #import <Protobuf/GPBRootObject.h>
+ #import <protobuf/GPBDescriptor.h>
+ #import <protobuf/GPBMessage.h>
+ #import <protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Wrappers.pbobjc.m
+++ b/objectivec/google/protobuf/Wrappers.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <Protobuf/Wrappers.pbobjc.h>
+ #import <protobuf/Wrappers.pbobjc.h>
 #else
  #import "google/protobuf/Wrappers.pbobjc.h"
 #endif

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -981,7 +981,7 @@ string BuildCommentsString(const SourceLocation& location,
 // want to put the library in a framework is an interesting question. The
 // problem is it means changing sources shipped with the library to actually
 // use a different value; so it isn't as simple as a option.
-const char* const ProtobufLibraryFrameworkName = "Protobuf";
+const char* const ProtobufLibraryFrameworkName = "protobuf";
 
 string ProtobufFrameworkImportSymbol(const string& framework_name) {
   // GPB_USE_[framework_name]_FRAMEWORK_IMPORTS


### PR DESCRIPTION
Fix #3218 

Implement suggestion from @BugsBunnyBR at https://github.com/protocolbuffers/protobuf/issues/3218#issuecomment-517643842 to use `module_name` in podspec to make the module name consistent with the directory structure.

Presumably another change is needed to create the generated files properly?