### PR TITLE
Update addressbook.proto

### DIFF
--- a/examples/addressbook.proto
+++ b/examples/addressbook.proto
@@ -29,9 +29,11 @@ message Person {
   string email = 3;
 
   enum PhoneType {
-    MOBILE = 0;
-    HOME = 1;
-    WORK = 2;
+    // Allways use the 0 for UNKNOWN in enums!!!
+    PT_UNKNOWN = 0; 
+    PT_MOBILE = 1;
+    PT_HOME = 2;
+    PT_WORK = 3;
   }
 
   message PhoneNumber {


### PR DESCRIPTION
changed the example a little bit to follow the design guide.
Additionally on enums it is a good practice to use 0 for the unknown and use prefixes.
