### PR TITLE
Revert "Fixed JS parsing of default map values"

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -465,15 +465,11 @@ jspb.Map.prototype.serializeBinary = function(
  *    entries with unset keys is required for maps to be backwards compatible
  *    with the repeated message representation described here: goo.gl/zuoLAC
  *
- * @param {V=} opt_defaultValue
- *    The default value for the type of map values.
- *
  */
 jspb.Map.deserializeBinary = function(map, reader, keyReaderFn, valueReaderFn,
-                                      opt_valueReaderCallback, opt_defaultKey,
-                                      opt_defaultValue) {
+                                      opt_valueReaderCallback, opt_defaultKey) {
   var key = opt_defaultKey;
-  var value = opt_defaultValue;
+  var value = undefined;
 
   while (reader.nextField()) {
     if (reader.isEndGroup()) {

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -3142,7 +3142,6 @@ void Generator::GenerateClassDeserializeBinaryField(
       printer->Print(", null");
     }
     printer->Print(", $defaultKey$", "defaultKey", JSFieldDefault(key_field));
-    printer->Print(", $defaultValue$", "defaultValue", JSFieldDefault(value_field));
     printer->Print(");\n");
     printer->Print("         });\n");
   } else {


### PR DESCRIPTION
Reverts protocolbuffers/protobuf#6394
We need to test this change internally, but we will make sure this is included in our next release.