### PR TITLE
[bazel] Load python rules from @rules_python

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,6 +3,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test", "objc_library")
 load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
+load("@rules_python//python:defs.bzl", "py_library")
 
 licenses(["notice"])
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,17 +5,16 @@ local_repository(
     path = "examples",
 )
 
+local_repository(
+    name = "submodule_gmock",
+    path = "third_party/googletest",
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//:protobuf_deps.bzl", "protobuf_deps")
 
 # Load common dependencies.
 protobuf_deps()
-
-new_local_repository(
-    name = "submodule_gmock",
-    build_file = "@//:third_party/googletest/BUILD.bazel",
-    path = "third_party/googletest",
-)
 
 http_archive(
     name = "six",

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -4,9 +4,9 @@
 # the WORKSPACE file in the same directory with this BUILD file for an
 # example.
 
-load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_binary", "java_lite_proto_library", "java_proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_proto_library")
+load("@rules_java//java:defs.bzl", "java_binary", "java_lite_proto_library", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # For each .proto file, a proto_library target should be defined. This target
 # is not bound to any particular language. Instead, it defines the dependency

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -1,5 +1,6 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@bazel_skylib//lib:versions.bzl", "versions")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 def _GetPath(ctx, path):
     if ctx.label.workspace_root:
@@ -434,8 +435,7 @@ def py_proto_library(
 
     if default_runtime and not default_runtime in py_libs + deps:
         py_libs = py_libs + [default_runtime]
-
-    native.py_library(
+    py_library(
         name = name,
         srcs = outs + py_extra_srcs,
         deps = py_libs + deps,
@@ -458,7 +458,7 @@ def internal_protobuf_py_tests(
     """
     for m in modules:
         s = "python/google/protobuf/internal/%s.py" % m
-        native.py_test(
+        py_test(
             name = "py_%s" % m,
             srcs = [s],
             main = s,

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -49,7 +49,15 @@ def protobuf_deps():
     if not native.existing_rule("rules_proto"):
         http_archive(
             name = "rules_proto",
-            sha256 = "88b0a90433866b44bb4450d4c30bc5738b8c4f9c9ba14e9661deb123f56a833d",
-            strip_prefix = "rules_proto-b0cc14be5da05168b01db282fe93bdf17aa2b9f4",
-            urls = ["https://github.com/bazelbuild/rules_proto/archive/b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz"],
+            sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+            strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+            urls = ["https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz"],
+        )
+
+    if not native.existing_rule("rules_python"):
+        http_archive(
+            name = "rules_python",
+            sha256 = "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
+            strip_prefix = "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
+            urls = ["https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz"],
         )


### PR DESCRIPTION
This should be the last change to make Protobuf compatible with `--incompatible_load_*_rules_from_bzl`. For full compatibility, we'll have to update third_party/googletest after https://github.com/google/googletest/pull/2364 has landed.