### PR TITLE
add Map forward declaration in arena.h

### DIFF
--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -75,6 +75,8 @@ namespace protobuf {
 class Arena;    // defined below
 class Message;  // defined in message.h
 class MessageLite;
+template <typename Key, typename T>
+class Map;
 
 namespace arena_metrics {
 


### PR DESCRIPTION
I'm currently using protobuf with godot and during compilation of godot the compiler fails because godot has a similar "Map" type.
This 2 lines of forward declaration fixes this.