### PR TITLE
Optimized away the creation of empty string objects.

### DIFF
--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -592,6 +592,11 @@ const upb_pbdecodermethod *new_fillmsg_decodermethod(
 #define ENCODE_MAX_NESTING 63
 
 // -----------------------------------------------------------------------------
+// A cache of frozen string objects to use as field defaults.
+// -----------------------------------------------------------------------------
+VALUE get_frozen_string(const char* data, size_t size, bool binary);
+
+// -----------------------------------------------------------------------------
 // Global map from upb {msg,enum}defs to wrapper Descriptor/EnumDescriptor
 // instances.
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Prior to this CL, creating an empty message object would create
two empty string objects for every declared field.  First we
created a unique string object for the field's default.  Then
we created yet another string object when we assigned the
default value into the message: we called #encode to ensure
that the string would have the correct encoding and be frozen.

I optimized these unnecessary objects away with two fixes:

1. Memoize the empty string so that we don't create a new empty
   string for every field's default.
2. If we are assigning a string to a message object, avoid creating
   a new string if the assigned string has the correct encoding and
   is already frozen.