### PR TITLE
Fix compilation on clang-cl

### DIFF
--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -2655,14 +2655,14 @@ UnsafeArenaAllocatedRepeatedPtrFieldBackInserter(
 }
 
 // Extern declarations of common instantiations to reduce libray bloat.
-extern template class PROTOBUF_EXPORT RepeatedField<bool>;
-extern template class PROTOBUF_EXPORT RepeatedField<int32>;
-extern template class PROTOBUF_EXPORT RepeatedField<uint32>;
-extern template class PROTOBUF_EXPORT RepeatedField<int64>;
-extern template class PROTOBUF_EXPORT RepeatedField<uint64>;
-extern template class PROTOBUF_EXPORT RepeatedField<float>;
-extern template class PROTOBUF_EXPORT RepeatedField<double>;
-extern template class PROTOBUF_EXPORT RepeatedPtrField<std::string>;
+extern template class RepeatedField<bool>;
+extern template class RepeatedField<int32>;
+extern template class RepeatedField<uint32>;
+extern template class RepeatedField<int64>;
+extern template class RepeatedField<uint64>;
+extern template class RepeatedField<float>;
+extern template class RepeatedField<double>;
+extern template class RepeatedPtrField<std::string>;
 
 }  // namespace protobuf
 }  // namespace google

--- a/src/google/protobuf/stubs/mutex.h
+++ b/src/google/protobuf/stubs/mutex.h
@@ -93,7 +93,7 @@ class PROTOBUF_EXPORT CriticalSectionLock {
 // Mutex is a natural type to wrap. As both google and other organization have
 // specialized mutexes. gRPC also provides an injection mechanism for custom
 // mutexes.
-class PROTOBUF_EXPORT GOOGLE_PROTOBUF_CAPABILITY("mutex") WrappedMutex {
+class GOOGLE_PROTOBUF_CAPABILITY("mutex") PROTOBUF_EXPORT WrappedMutex {
  public:
   WrappedMutex() = default;
   void Lock() GOOGLE_PROTOBUF_ACQUIRE() { mu_.lock(); }


### PR DESCRIPTION
For RepeatedPtrField<> `explicit instantiation declaration should not be
'dllexport'` (you cant put dllexport in the declaration of templated types only the definition)

For WrappedMutex `__attribute__(())` must come before `__declspec()`