### PR TITLE
Fix order of export and capability macros on WrappedMutex

### DIFF
--- a/src/google/protobuf/stubs/mutex.h
+++ b/src/google/protobuf/stubs/mutex.h
@@ -93,7 +93,7 @@ class PROTOBUF_EXPORT CriticalSectionLock {
 // Mutex is a natural type to wrap. As both google and other organization have
 // specialized mutexes. gRPC also provides an injection mechanism for custom
 // mutexes.
-class PROTOBUF_EXPORT GOOGLE_PROTOBUF_CAPABILITY("mutex") WrappedMutex {
+class GOOGLE_PROTOBUF_CAPABILITY("mutex") PROTOBUF_EXPORT WrappedMutex {
  public:
   WrappedMutex() = default;
   void Lock() GOOGLE_PROTOBUF_ACQUIRE() { mu_.lock(); }


### PR DESCRIPTION
clang-cl requires the order to be the opposite of what it currently is.
It should not affect other compilers since this is the only compiler
that has both macros defined.