### PR TITLE
c# feature: new method AsSpan() on RepeatedField<T>

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
@@ -756,5 +756,33 @@ namespace Google.Protobuf.Collections
             Assert.True(list1.Contains(SampleNaNs.SignallingFlipped));
             Assert.False(list2.Contains(SampleNaNs.SignallingFlipped));
         }
+
+#if NETCOREAPP2_1
+        [Test]
+        public void AsSpan_BasicUsage()
+        {
+            var list = new RepeatedField<int> { 10, 11 };
+            var span = list.AsSpan();
+
+            // Span was constructed correctly
+            Assert.AreEqual(2, span.Length);
+            Assert.AreEqual(10, span[0]);
+            Assert.AreEqual(11, span[1]);
+
+            // Writing to span writes to RepeatedField
+            span[0] = 100;
+            Assert.AreEqual(100, list[0]);
+        }
+
+        [Test]
+        public void AsSpan_Empty()
+        {
+            var list = new RepeatedField<int>();
+            var span = list.AsSpan();
+
+            // Empty Span was constructed correctly
+            Assert.AreEqual(0, span.Length);
+        }
+#endif
     }
 }

--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -543,6 +543,20 @@ namespace Google.Protobuf.Collections
             }
         }
 
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Creates a new span over the RepeatedField.  This is the most
+        /// efficient way to read and write values to the RepeatedField because
+        /// there are no internal null or bounds checks.  You are responsible
+        /// for ensuring no null values are written to the span.
+        /// </summary>
+        /// <returns>Span representation of the RepeatedField</returns>
+        public Span<T> AsSpan()
+        {
+            return array.AsSpan(0, count);
+        }
+#endif
+
         #region Explicit interface implementation for IList and ICollection.
         bool IList.IsFixedSize => false;
 


### PR DESCRIPTION
Provides very efficient access to the underlying data at the expense of foregoing null checks.

#6217