### PR TITLE
Optimization for layout_init()

### DIFF
--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -487,6 +487,9 @@ void Descriptor_mark(void* _self) {
   Descriptor* self = _self;
   rb_gc_mark(self->klass);
   rb_gc_mark(self->descriptor_pool);
+  if (self->layout && self->layout->empty_template) {
+    layout_mark(self->layout, self->layout->empty_template);
+  }
 }
 
 void Descriptor_free(void* _self) {

--- a/ruby/ext/google/protobuf_c/encode_decode.c
+++ b/ruby/ext/google/protobuf_c/encode_decode.c
@@ -690,7 +690,7 @@ void add_handlers_for_message(const void *closure, upb_handlers *h) {
   // class is actually built, so to work around this, we just create the layout
   // (and handlers, in the class-building function) on-demand.
   if (desc->layout == NULL) {
-    desc->layout = create_layout(desc);
+    create_layout(desc);
   }
 
   // If this is a mapentry message type, set up a special set of handlers and

--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -495,7 +495,7 @@ VALUE Map_length(VALUE _self) {
   return ULL2NUM(upb_strtable_count(&self->table));
 }
 
-static VALUE Map_new_this_type(VALUE _self) {
+VALUE Map_new_this_type(VALUE _self) {
   Map* self = ruby_to_Map(_self);
   VALUE new_map = Qnil;
   VALUE key_type = fieldtype_to_ruby(self->key_type);

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -70,8 +70,6 @@ VALUE Message_alloc(VALUE klass) {
   msg = (MessageHeader*)ALLOC_N(uint8_t,
                                 sizeof(MessageHeader) + desc->layout->size);
 
-  memset(Message_data(msg), 0, desc->layout->size);
-
   // We wrap first so that everything in the message object is GC-rooted in case
   // a collection happens during object creation in layout_init().
   ret = TypedData_Wrap_Struct(klass, &Message_type, msg);

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -64,7 +64,7 @@ VALUE Message_alloc(VALUE klass) {
   VALUE ret;
 
   if (desc->layout == NULL) {
-    desc->layout = create_layout(desc);
+    create_layout(desc);
   }
 
   msg = (MessageHeader*)ALLOC_N(uint8_t,

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -62,26 +62,19 @@ VALUE Message_alloc(VALUE klass) {
   Descriptor* desc = ruby_to_Descriptor(descriptor);
   MessageHeader* msg;
   VALUE ret;
+  size_t size;
 
   if (desc->layout == NULL) {
     create_layout(desc);
   }
 
-  msg = (MessageHeader*)ALLOC_N(uint8_t,
-                                sizeof(MessageHeader) + desc->layout->size);
-
-  // Required in case a GC happens before layout_init().
-  memset(msg, 0, desc->layout->size);
-
-  // We wrap first so that everything in the message object is GC-rooted in case
-  // a collection happens during object creation in layout_init().
-  ret = TypedData_Wrap_Struct(klass, &Message_type, msg);
+  msg = ALLOC_N(uint8_t, sizeof(MessageHeader) + desc->layout->size);
   msg->descriptor = desc;
-  rb_ivar_set(ret, descriptor_instancevar_interned, descriptor);
-
   msg->unknown_fields = NULL;
+  memcpy(Message_data(msg), desc->layout->empty_template, desc->layout->size);
 
-  layout_init(desc->layout, Message_data(msg));
+  ret = TypedData_Wrap_Struct(klass, &Message_type, msg);
+  rb_ivar_set(ret, descriptor_instancevar_interned, descriptor);
 
   return ret;
 }
@@ -473,7 +466,11 @@ int Message_initialize_kwarg(VALUE key, VALUE val, VALUE _self) {
  * Message class are provided on each concrete message class.
  */
 VALUE Message_initialize(int argc, VALUE* argv, VALUE _self) {
+  MessageHeader* self;
   VALUE hash_args;
+  TypedData_Get_Struct(_self, MessageHeader, &Message_type, self);
+
+  layout_init(self->descriptor->layout, Message_data(self));
 
   if (argc == 0) {
     return Qnil;

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -70,6 +70,9 @@ VALUE Message_alloc(VALUE klass) {
   msg = (MessageHeader*)ALLOC_N(uint8_t,
                                 sizeof(MessageHeader) + desc->layout->size);
 
+  // Required in case a GC happens before layout_init().
+  memset(msg, 0, desc->layout->size);
+
   // We wrap first so that everything in the message object is GC-rooted in case
   // a collection happens during object creation in layout_init().
   ret = TypedData_Wrap_Struct(klass, &Message_type, msg);

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -419,6 +419,7 @@ extern VALUE cRepeatedField;
 
 RepeatedField* ruby_to_RepeatedField(VALUE value);
 
+VALUE RepeatedField_new_this_type(VALUE _self);
 VALUE RepeatedField_each(VALUE _self);
 VALUE RepeatedField_index(int argc, VALUE* argv, VALUE _self);
 void* RepeatedField_index_native(VALUE _self, int index);
@@ -467,6 +468,7 @@ extern VALUE cMap;
 
 Map* ruby_to_Map(VALUE value);
 
+VALUE Map_new_this_type(VALUE _self);
 VALUE Map_each(VALUE _self);
 VALUE Map_keys(VALUE _self);
 VALUE Map_values(VALUE _self);
@@ -522,11 +524,13 @@ struct MessageLayout {
   uint32_t size;
   uint32_t value_offset;
   int value_count;
+  int repeated_count;
+  int map_count;
 };
 
 #define ONEOF_CASE_MASK 0x80000000
 
-MessageLayout* create_layout(Descriptor* desc);
+void create_layout(Descriptor* desc);
 void free_layout(MessageLayout* layout);
 bool field_contains_hasbit(MessageLayout* layout,
                  const upb_fielddef* field);

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -509,11 +509,12 @@ struct MessageField {
 struct MessageLayout {
   const Descriptor* desc;
   const upb_msgdef* msgdef;
+  void* empty_template;  // Can memcpy() onto a layout to clear it.
   MessageField* fields;
   size_t size;
 };
 
-MessageLayout* create_layout(const Descriptor* desc);
+void create_layout(Descriptor* desc);
 void free_layout(MessageLayout* layout);
 bool field_contains_hasbit(MessageLayout* layout,
                  const upb_fielddef* field);

--- a/ruby/ext/google/protobuf_c/repeated_field.c
+++ b/ruby/ext/google/protobuf_c/repeated_field.c
@@ -323,7 +323,7 @@ VALUE RepeatedField_length(VALUE _self) {
   return INT2NUM(self->size);
 }
 
-static VALUE RepeatedField_new_this_type(VALUE _self) {
+VALUE RepeatedField_new_this_type(VALUE _self) {
   RepeatedField* self = ruby_to_RepeatedField(_self);
   VALUE new_rptfield = Qnil;
   VALUE element_type = fieldtype_to_ruby(self->field_type);

--- a/ruby/ext/google/protobuf_c/storage.c
+++ b/ruby/ext/google/protobuf_c/storage.c
@@ -947,8 +947,6 @@ void layout_init(MessageLayout* layout, void* storage) {
   VALUE* value = (VALUE*)CHARPTR_AT(storage, layout->value_offset);
   int i;
 
-  memcpy(storage, layout->empty_template, layout->size);
-
   for (i = 0; i < layout->repeated_count; i++, value++) {
     *value = RepeatedField_new_this_type(*value);
   }

--- a/ruby/ext/google/protobuf_c/storage.c
+++ b/ruby/ext/google/protobuf_c/storage.c
@@ -956,15 +956,6 @@ void layout_init(MessageLayout* layout, void* storage) {
   for (i = 0; i < layout->map_count; i++, value++) {
     *value = Map_new_this_type(*value);
   }
-
-  /*
-  upb_msg_field_iter it;
-  for (upb_msg_field_begin(&it, layout->msgdef);
-       !upb_msg_field_done(&it);
-       upb_msg_field_next(&it)) {
-    layout_clear(layout, storage, upb_msg_iter_field(&it));
-  }
-  */
 }
 
 void layout_mark(MessageLayout* layout, void* storage) {


### PR DESCRIPTION
This avoids most of the work of layout_init() by creating a template object we can `memcpy()` from when initializing a new object.

There is a bit of complication since we must eagerly allocate maps and repeated fields. So we have to `dup` these still in `layout_init()`.

In the benchmark on my machine this takes us from 8 seconds to 2.3 seconds, or a 70% reduction in runtime overall.