### PR TITLE
Java: Add Automatic-Module-Name entries to the Manifest

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -144,6 +144,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
+            <Automatic-Module-Name>com.google.protobuf</Automatic-Module-Name> <!-- Java9+ Jigsaw module name -->
             <Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
             <Bundle-SymbolicName>com.google.protobuf</Bundle-SymbolicName>
             <Export-Package>com.google.protobuf;version=${project.version}</Export-Package>

--- a/java/lite/pom.xml
+++ b/java/lite/pom.xml
@@ -324,6 +324,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
+            <Automatic-Module-Name>com.google.protobuf</Automatic-Module-Name> <!-- Java9+ Jigsaw module name -->
             <Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
             <Bundle-SymbolicName>com.google.protobuf</Bundle-SymbolicName>
             <Export-Package>com.google.protobuf;version=${project.version}</Export-Package>

--- a/java/util/pom.xml
+++ b/java/util/pom.xml
@@ -118,6 +118,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
+            <Automatic-Module-Name>com.google.protobuf.util</Automatic-Module-Name> <!-- Java9+ Jigsaw module name -->
             <Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
             <Bundle-SymbolicName>com.google.protobuf.util</Bundle-SymbolicName>
             <Export-Package>com.google.protobuf.util;version=${project.version}</Export-Package>


### PR DESCRIPTION
This PR adds `Automatic-Module-Name` entries to the Manifest files. This allows Java9+ users to depend on protobuf, without having any impact for users of earlier versions.

The module names match the OSGI symbolic names as recommended in [JLBP-20](https://github.com/GoogleCloudPlatform/cloud-opensource-java/blob/master/library-best-practices/JLBP-20.md)

This fixes #3903 and #6493
