### PR TITLE
Updated issue templates to remove question form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,17 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
 
 ---
+
+<!--
+
+NOTE: this form is for bug reports only. For questions or troubleshooting, please see the protobuf mailing list: https://groups.google.com/forum/#!forum/protobuf
+
+-->
 
 **What version of protobuf and what language are you using?**
 Version: master/v3.6.0/v3.5.0 etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,18 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
 
 ---
+
+<!--
+
+NOTE: this form is for feature requests (including cleanup requests) only. For questions or troubleshooting, please see the protobuf mailing list: https://groups.google.com/forum/#!forum/protobuf
+
+-->
+
 
 **What language does this apply to?**
 If it's a proto syntax change, is it for proto2 or proto3?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,0 @@
----
-name: Question
-about: Questions and troubleshooting
-
----
-
-


### PR DESCRIPTION
This commit removes the question template. It also updates the bug report and feature request templates to direct questions to the mailing list.