### PR TITLE
Fix #6548: add check for null pointer in encode_decode.c

### DIFF
--- a/php/ext/google/protobuf/encode_decode.c
+++ b/php/ext/google/protobuf/encode_decode.c
@@ -74,6 +74,7 @@ void stringsink_init(stringsink *sink) {
 
   sink->size = 32;
   sink->ptr = malloc(sink->size);
+  PHP_PROTO_ASSERT(sink->ptr != NULL);
   sink->len = 0;
 }
 
@@ -132,6 +133,7 @@ static bool is_wrapper_msg(const upb_msgdef *msg) {
 // Creates a handlerdata that simply contains the offset for this field.
 static const void* newhandlerdata(upb_handlers* h, uint32_t ofs) {
   size_t* hd_ofs = (size_t*)malloc(sizeof(size_t));
+  PHP_PROTO_ASSERT(hd_ofs != NULL);
   *hd_ofs = ofs;
   upb_handlers_addcleanup(h, hd_ofs, free);
   return hd_ofs;
@@ -154,6 +156,7 @@ typedef struct {
 static const void *newunknownfieldshandlerdata(upb_handlers* h) {
   unknownfields_handlerdata_t* hd =
       (unknownfields_handlerdata_t*)malloc(sizeof(unknownfields_handlerdata_t));
+  PHP_PROTO_ASSERT(hd != NULL);
   hd->handler = stringsink_string;
   upb_handlers_addcleanup(h, hd, free);
   return hd;
@@ -169,6 +172,7 @@ static const void *newsubmsghandlerdata(upb_handlers* h, uint32_t ofs,
                                         const upb_fielddef* f) {
   submsg_handlerdata_t* hd =
       (submsg_handlerdata_t*)malloc(sizeof(submsg_handlerdata_t));
+  PHP_PROTO_ASSERT(hd != NULL);
   hd->ofs = ofs;
   hd->md = upb_fielddef_msgsubdef(f);
   upb_handlers_addcleanup(h, hd, free);
@@ -192,6 +196,7 @@ static const void *newoneofhandlerdata(upb_handlers *h,
                                        const upb_fielddef *f) {
   oneof_handlerdata_t* hd =
       (oneof_handlerdata_t*)malloc(sizeof(oneof_handlerdata_t));
+  PHP_PROTO_ASSERT(hd != NULL);
   hd->ofs = ofs;
   hd->case_ofs = case_ofs;
   hd->property_ofs = property_ofs;
@@ -247,6 +252,7 @@ static void* appendstr_handler(void *closure,
 
   stringfields_parseframe_t* frame =
       (stringfields_parseframe_t*)malloc(sizeof(stringfields_parseframe_t));
+  PHP_PROTO_ASSERT(frame != NULL);
   frame->closure = closure;
   stringsink_init(&frame->sink);
 
@@ -358,6 +364,7 @@ static void* str_handler(void *closure,
 
   stringfields_parseframe_t* frame =
       (stringfields_parseframe_t*)malloc(sizeof(stringfields_parseframe_t));
+  PHP_PROTO_ASSERT(frame != NULL);
   frame->closure = closure;
   stringsink_init(&frame->sink);
 
@@ -650,13 +657,13 @@ static map_handlerdata_t* new_map_handlerdata(
   // TODO(teboring): Use emalloc and efree.
   map_handlerdata_t* hd =
       (map_handlerdata_t*)malloc(sizeof(map_handlerdata_t));
-
+  PHP_PROTO_ASSERT(hd != NULL);
   hd->ofs = ofs;
   key_field = upb_msgdef_itof(mapentry_def, MAP_KEY_FIELD);
-  assert(key_field != NULL);
+  PHP_PROTO_ASSERT(key_field != NULL);
   hd->key_field_type = upb_fielddef_type(key_field);
   value_field = upb_msgdef_itof(mapentry_def, MAP_VALUE_FIELD);
-  assert(value_field != NULL);
+  PHP_PROTO_ASSERT(value_field != NULL);
   hd->value_field_type = upb_fielddef_type(value_field);
 
   return hd;
@@ -767,6 +774,7 @@ static void *oneofstr_handler(void *closure,
 
   stringfields_parseframe_t* frame =
       (stringfields_parseframe_t*)malloc(sizeof(stringfields_parseframe_t));
+  PHP_PROTO_ASSERT(frame != NULL);
   frame->closure = closure;
   stringsink_init(&frame->sink);
 
@@ -1101,7 +1109,7 @@ static void put_optional_value(const void* memory, int len,
                                const upb_fielddef* f,
                                int depth, upb_sink sink,
                                bool is_json TSRMLS_DC) {
-  assert(upb_fielddef_label(f) == UPB_LABEL_OPTIONAL);
+  PHP_PROTO_ASSERT(upb_fielddef_label(f) == UPB_LABEL_OPTIONAL);
 
   switch (upb_fielddef_type(f)) {
 #define T(upbtypeconst, upbtype, ctype, default_value)                         \
@@ -1139,7 +1147,7 @@ static void put_optional_value(const void* memory, int len,
       break;
     }
     default:
-      assert(false);
+      PHP_PROTO_ASSERT(false);
   }
 }
 
@@ -1181,14 +1189,14 @@ static void putmap(zval* map, const upb_fielddef* f, upb_sink sink,
   MapIter it;
   int len, size;
 
-  assert(map != NULL);
+  PHP_PROTO_ASSERT(map != NULL);
   Map* intern = UNBOX(Map, map);
   size = upb_strtable_count(&intern->table);
   if (size == 0) return;
 
   upb_sink_startseq(sink, getsel(f, UPB_HANDLER_STARTSEQ), &subsink);
 
-  assert(upb_fielddef_type(f) == UPB_TYPE_MESSAGE);
+  PHP_PROTO_ASSERT(upb_fielddef_type(f) == UPB_TYPE_MESSAGE);
   key_field = map_field_key(f);
   value_field = map_field_value(f);
 
@@ -1500,7 +1508,7 @@ static void putstr(zval* str, const upb_fielddef *f,
 
   if (ZVAL_IS_NULL(str)) return;
 
-  assert(Z_TYPE_P(str) == IS_STRING);
+  PHP_PROTO_ASSERT(Z_TYPE_P(str) == IS_STRING);
 
   upb_sink_startstr(sink, getsel(f, UPB_HANDLER_STARTSTR), Z_STRLEN_P(str),
                     &subsink);
@@ -1568,7 +1576,7 @@ static void putarray(zval* array, const upb_fielddef* f, upb_sink sink,
   upb_selector_t sel = 0;
   int size, i;
 
-  assert(array != NULL);
+  PHP_PROTO_ASSERT(array != NULL);
   RepeatedField* intern = UNBOX(RepeatedField, array);
   HashTable *ht = PHP_PROTO_HASH_OF(intern->array);
   size = zend_hash_num_elements(ht);


### PR DESCRIPTION
 This PR fix #6548 ,  add NULL pointer checks in `encode_decode.c`