### PR TITLE
bazel: Change zlib URL to GitHub

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -17,9 +17,9 @@ def protobuf_deps():
         http_archive(
             name = "zlib",
             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-            sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+            sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
             strip_prefix = "zlib-1.2.11",
-            urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+            urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
         )
 
     if not native.existing_rule("six"):


### PR DESCRIPTION
We've notice significant issues downloading from zlib.net. Since there
are already other archives coming from GitHub, this shouldn't negatively
affect reliability.