### PR TITLE
Split libprotoc by generator language

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -319,11 +319,27 @@ cc_proto_library(
 ################################################################################
 
 cc_library(
-    name = "protoc_lib",
+    name = "protoc_base",
     srcs = [
-        # AUTOGEN(protoc_lib_srcs)
+        # AUTOGEN(protoc_base_srcs)
         "src/google/protobuf/compiler/code_generator.cc",
         "src/google/protobuf/compiler/command_line_interface.cc",
+        "src/google/protobuf/compiler/plugin.cc",
+        "src/google/protobuf/compiler/plugin.pb.cc",
+        "src/google/protobuf/compiler/subprocess.cc",
+        "src/google/protobuf/compiler/zip_writer.cc",
+    ],
+    copts = COPTS,
+    includes = ["src/"],
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [":protobuf"],
+)
+
+cc_library(
+    name = "protoc_cpp",
+    srcs = [
+        # AUTOGEN(protoc_cpp_srcs)
         "src/google/protobuf/compiler/cpp/cpp_enum.cc",
         "src/google/protobuf/compiler/cpp/cpp_enum_field.cc",
         "src/google/protobuf/compiler/cpp/cpp_extension.cc",
@@ -338,6 +354,21 @@ cc_library(
         "src/google/protobuf/compiler/cpp/cpp_primitive_field.cc",
         "src/google/protobuf/compiler/cpp/cpp_service.cc",
         "src/google/protobuf/compiler/cpp/cpp_string_field.cc",
+    ],
+    copts = COPTS,
+    includes = ["src/"],
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protobuf",
+        ":protoc_base",
+    ],
+)
+
+cc_library(
+    name = "protoc_csharp",
+    srcs = [
+        # AUTOGEN(protoc_csharp_srcs)
         "src/google/protobuf/compiler/csharp/csharp_doc_comment.cc",
         "src/google/protobuf/compiler/csharp/csharp_enum.cc",
         "src/google/protobuf/compiler/csharp/csharp_enum_field.cc",
@@ -354,6 +385,21 @@ cc_library(
         "src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc",
         "src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc",
         "src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc",
+    ],
+    copts = COPTS,
+    includes = ["src/"],
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protobuf",
+        ":protoc_base",
+    ],
+)
+
+cc_library(
+    name = "protoc_java",
+    srcs = [
+        # AUTOGEN(protoc_java_srcs)
         "src/google/protobuf/compiler/java/java_context.cc",
         "src/google/protobuf/compiler/java/java_doc_comment.cc",
         "src/google/protobuf/compiler/java/java_enum.cc",
@@ -382,8 +428,38 @@ cc_library(
         "src/google/protobuf/compiler/java/java_shared_code_generator.cc",
         "src/google/protobuf/compiler/java/java_string_field.cc",
         "src/google/protobuf/compiler/java/java_string_field_lite.cc",
+    ],
+    copts = COPTS,
+    includes = ["src/"],
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protobuf",
+        ":protoc_base",
+    ],
+)
+
+cc_library(
+    name = "protoc_js",
+    srcs = [
+        # AUTOGEN(protoc_js_srcs)
         "src/google/protobuf/compiler/js/js_generator.cc",
         "src/google/protobuf/compiler/js/well_known_types_embed.cc",
+    ],
+    copts = COPTS,
+    includes = ["src/"],
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protobuf",
+        ":protoc_base",
+    ],
+)
+
+cc_library(
+    name = "protoc_objectivec",
+    srcs = [
+        # AUTOGEN(protoc_objectivec_srcs)
         "src/google/protobuf/compiler/objectivec/objectivec_enum.cc",
         "src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc",
         "src/google/protobuf/compiler/objectivec/objectivec_extension.cc",
@@ -396,19 +472,82 @@ cc_library(
         "src/google/protobuf/compiler/objectivec/objectivec_message_field.cc",
         "src/google/protobuf/compiler/objectivec/objectivec_oneof.cc",
         "src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc",
-        "src/google/protobuf/compiler/php/php_generator.cc",
-        "src/google/protobuf/compiler/plugin.cc",
-        "src/google/protobuf/compiler/plugin.pb.cc",
-        "src/google/protobuf/compiler/python/python_generator.cc",
-        "src/google/protobuf/compiler/ruby/ruby_generator.cc",
-        "src/google/protobuf/compiler/subprocess.cc",
-        "src/google/protobuf/compiler/zip_writer.cc",
     ],
     copts = COPTS,
     includes = ["src/"],
     linkopts = LINK_OPTS,
     visibility = ["//visibility:public"],
-    deps = [":protobuf"],
+    deps = [
+        ":protobuf",
+        ":protoc_base",
+    ],
+)
+
+cc_library(
+    name = "protoc_php",
+    srcs = [
+        # AUTOGEN(protoc_php_srcs)
+        "src/google/protobuf/compiler/php/php_generator.cc",
+    ],
+    copts = COPTS,
+    includes = ["src/"],
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protobuf",
+        ":protoc_base",
+    ],
+)
+
+cc_library(
+    name = "protoc_python",
+    srcs = [
+        # AUTOGEN(protoc_python_srcs)
+        "src/google/protobuf/compiler/python/python_generator.cc",
+    ],
+    copts = COPTS,
+    includes = ["src/"],
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protobuf",
+        ":protoc_base",
+    ],
+)
+
+cc_library(
+    name = "protoc_ruby",
+    srcs = [
+        # AUTOGEN(protoc_ruby_srcs)
+        "src/google/protobuf/compiler/ruby/ruby_generator.cc",
+    ],
+    copts = COPTS,
+    includes = ["src/"],
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protobuf",
+        ":protoc_base",
+    ],
+)
+
+cc_library(
+    name = "protoc_lib",
+    copts = COPTS,
+    includes = ["src/"],
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protoc_base",
+        ":protoc_cpp",
+        ":protoc_csharp",
+        ":protoc_java",
+        ":protoc_js",
+        ":protoc_objectivec",
+        ":protoc_php",
+        ":protoc_python",
+        ":protoc_ruby",
+    ],
 )
 
 cc_binary(

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -1,6 +1,19 @@
-set(libprotoc_files
+set(libprotoc_base_srcs
   ${protobuf_source_dir}/src/google/protobuf/compiler/code_generator.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/command_line_interface.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.pb.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/subprocess.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.cc
+)
+
+set(libprotoc_base_hdrs
+  ${protobuf_source_dir}/src/google/protobuf/compiler/scc.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/subprocess.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.h
+)
+
+set(libprotoc_cpp_srcs
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_enum.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_enum_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_extension.cc
@@ -15,6 +28,27 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_service.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_string_field.cc
+)
+
+set(libprotoc_cpp_hdrs
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_enum.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_enum_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_extension.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_file.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_helpers.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_map_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_message.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_message_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_message_layout_helper.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_options.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_padding_optimizer.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_primitive_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_service.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_string_field.h
+)
+
+set(libprotoc_csharp_srcs
   ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum_field.cc
@@ -31,6 +65,28 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc
+)
+
+set(libprotoc_csharp_hdrs
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_doc_comment.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_field_base.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_helpers.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_map_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_options.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_primitive_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_reflection_class.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_source_generator_base.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_wrapper_field.h
+)
+
+set(libprotoc_java_srcs
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_context.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_doc_comment.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum.cc
@@ -59,61 +115,9 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_shared_code_generator.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field_lite.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/js/js_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types_embed.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_file.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_map_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_message.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_message_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_oneof.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/php/php_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.pb.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/python/python_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/ruby/ruby_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/subprocess.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.cc
 )
 
-set(libprotoc_headers
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_enum.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_enum_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_extension.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_file.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_helpers.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_map_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_message.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_message_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_message_layout_helper.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_options.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_padding_optimizer.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_primitive_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_service.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_string_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_doc_comment.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_field_base.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_helpers.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_map_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_options.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_primitive_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_reflection_class.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_source_generator_base.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_wrapper_field.h
+set(libprotoc_java_hdrs
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_context.h
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_doc_comment.h
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum.h
@@ -142,6 +146,32 @@ set(libprotoc_headers
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_shared_code_generator.h
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field.h
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field_lite.h
+)
+
+set(libprotoc_js_srcs
+  ${protobuf_source_dir}/src/google/protobuf/compiler/js/js_generator.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types_embed.cc
+)
+
+set(libprotoc_js_hdrs
+)
+
+set(libprotoc_objectivec_srcs
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_file.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_map_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_message.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_message_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_oneof.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc
+)
+
+set(libprotoc_objectivec_hdrs
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum.h
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum_field.h
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_extension.h
@@ -154,9 +184,51 @@ set(libprotoc_headers
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_nsobject_methods.h
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_oneof.h
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/scc.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/subprocess.h
-  ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.h
+)
+
+set(libprotoc_php_srcs
+  ${protobuf_source_dir}/src/google/protobuf/compiler/php/php_generator.cc
+)
+
+set(libprotoc_php_hdrs
+)
+
+set(libprotoc_python_srcs
+  ${protobuf_source_dir}/src/google/protobuf/compiler/python/python_generator.cc
+)
+
+set(libprotoc_python_hdrs
+)
+
+set(libprotoc_ruby_srcs
+  ${protobuf_source_dir}/src/google/protobuf/compiler/ruby/ruby_generator.cc
+)
+
+set(libprotoc_ruby_hdrs
+)
+
+set(libprotoc_files
+  ${libprotoc_base_srcs}
+  ${libprotoc_cpp_srcs}
+  ${libprotoc_csharp_srcs}
+  ${libprotoc_java_srcs}
+  ${libprotoc_js_srcs}
+  ${libprotoc_objectivec_srcs}
+  ${libprotoc_php_srcs}
+  ${libprotoc_python_srcs}
+  ${libprotoc_ruby_srcs}
+)
+
+set(libprotoc_headers
+  ${libprotoc_base_hdrs}
+  ${libprotoc_cpp_hdrs}
+  ${libprotoc_csharp_hdrs}
+  ${libprotoc_java_hdrs}
+  ${libprotoc_js_hdrs}
+  ${libprotoc_objectivec_hdrs}
+  ${libprotoc_php_hdrs}
+  ${libprotoc_python_hdrs}
+  ${libprotoc_ruby_hdrs}
 )
 
 if (MSVC)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -313,7 +313,8 @@ if HAVE_LD_VERSION_SCRIPT
 libprotoc_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libprotoc.map
 EXTRA_libprotoc_la_DEPENDENCIES = libprotoc.map
 endif
-libprotoc_la_SOURCES =                                         \
+
+libprotoc_base_SOURCES =                                       \
   google/protobuf/compiler/code_generator.cc                   \
   google/protobuf/compiler/command_line_interface.cc           \
   google/protobuf/compiler/plugin.cc                           \
@@ -322,7 +323,9 @@ libprotoc_la_SOURCES =                                         \
   google/protobuf/compiler/subprocess.cc                       \
   google/protobuf/compiler/subprocess.h                        \
   google/protobuf/compiler/zip_writer.cc                       \
-  google/protobuf/compiler/zip_writer.h                        \
+  google/protobuf/compiler/zip_writer.h
+
+libprotoc_cpp_SOURCES =                                        \
   google/protobuf/compiler/cpp/cpp_enum.cc                     \
   google/protobuf/compiler/cpp/cpp_enum.h                      \
   google/protobuf/compiler/cpp/cpp_enum_field.cc               \
@@ -351,7 +354,43 @@ libprotoc_la_SOURCES =                                         \
   google/protobuf/compiler/cpp/cpp_service.cc                  \
   google/protobuf/compiler/cpp/cpp_service.h                   \
   google/protobuf/compiler/cpp/cpp_string_field.cc             \
-  google/protobuf/compiler/cpp/cpp_string_field.h              \
+  google/protobuf/compiler/cpp/cpp_string_field.h
+
+libprotoc_csharp_SOURCES =                                     \
+  google/protobuf/compiler/csharp/csharp_doc_comment.cc        \
+  google/protobuf/compiler/csharp/csharp_doc_comment.h         \
+  google/protobuf/compiler/csharp/csharp_enum.cc               \
+  google/protobuf/compiler/csharp/csharp_enum.h                \
+  google/protobuf/compiler/csharp/csharp_enum_field.cc         \
+  google/protobuf/compiler/csharp/csharp_enum_field.h          \
+  google/protobuf/compiler/csharp/csharp_field_base.cc         \
+  google/protobuf/compiler/csharp/csharp_field_base.h          \
+  google/protobuf/compiler/csharp/csharp_generator.cc          \
+  google/protobuf/compiler/csharp/csharp_helpers.cc            \
+  google/protobuf/compiler/csharp/csharp_helpers.h             \
+  google/protobuf/compiler/csharp/csharp_map_field.cc          \
+  google/protobuf/compiler/csharp/csharp_map_field.h           \
+  google/protobuf/compiler/csharp/csharp_message.cc            \
+  google/protobuf/compiler/csharp/csharp_message.h             \
+  google/protobuf/compiler/csharp/csharp_message_field.cc      \
+  google/protobuf/compiler/csharp/csharp_message_field.h       \
+  google/protobuf/compiler/csharp/csharp_options.h             \
+  google/protobuf/compiler/csharp/csharp_primitive_field.cc    \
+  google/protobuf/compiler/csharp/csharp_primitive_field.h     \
+  google/protobuf/compiler/csharp/csharp_reflection_class.cc     \
+  google/protobuf/compiler/csharp/csharp_reflection_class.h      \
+  google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc \
+  google/protobuf/compiler/csharp/csharp_repeated_enum_field.h \
+  google/protobuf/compiler/csharp/csharp_repeated_message_field.cc \
+  google/protobuf/compiler/csharp/csharp_repeated_message_field.h \
+  google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc \
+  google/protobuf/compiler/csharp/csharp_repeated_primitive_field.h \
+  google/protobuf/compiler/csharp/csharp_source_generator_base.cc \
+  google/protobuf/compiler/csharp/csharp_source_generator_base.h \
+  google/protobuf/compiler/csharp/csharp_wrapper_field.cc      \
+  google/protobuf/compiler/csharp/csharp_wrapper_field.h
+
+libprotoc_java_SOURCES =                                       \
   google/protobuf/compiler/java/java_context.cc                \
   google/protobuf/compiler/java/java_context.h                 \
   google/protobuf/compiler/java/java_enum.cc                   \
@@ -407,9 +446,13 @@ libprotoc_la_SOURCES =                                         \
   google/protobuf/compiler/java/java_string_field_lite.cc      \
   google/protobuf/compiler/java/java_string_field_lite.h       \
   google/protobuf/compiler/java/java_doc_comment.cc            \
-  google/protobuf/compiler/java/java_doc_comment.h             \
+  google/protobuf/compiler/java/java_doc_comment.h
+
+libprotoc_js_SOURCES =                                         \
   google/protobuf/compiler/js/js_generator.cc                  \
-  google/protobuf/compiler/js/well_known_types_embed.cc        \
+  google/protobuf/compiler/js/well_known_types_embed.cc
+
+libprotoc_objectivec_SOURCES =                                 \
   google/protobuf/compiler/objectivec/objectivec_enum.cc       \
   google/protobuf/compiler/objectivec/objectivec_enum.h        \
   google/protobuf/compiler/objectivec/objectivec_enum_field.cc \
@@ -427,48 +470,33 @@ libprotoc_la_SOURCES =                                         \
   google/protobuf/compiler/objectivec/objectivec_map_field.h   \
   google/protobuf/compiler/objectivec/objectivec_message.cc    \
   google/protobuf/compiler/objectivec/objectivec_message.h     \
-  google/protobuf/compiler/objectivec/objectivec_message_field.cc \
-  google/protobuf/compiler/objectivec/objectivec_message_field.h \
+  google/protobuf/compiler/objectivec/objectivec_message_field.cc  \
+  google/protobuf/compiler/objectivec/objectivec_message_field.h  \
   google/protobuf/compiler/objectivec/objectivec_nsobject_methods.h  \
   google/protobuf/compiler/objectivec/objectivec_oneof.cc      \
   google/protobuf/compiler/objectivec/objectivec_oneof.h       \
-  google/protobuf/compiler/objectivec/objectivec_primitive_field.cc \
-  google/protobuf/compiler/objectivec/objectivec_primitive_field.h \
-  google/protobuf/compiler/php/php_generator.cc                \
-  google/protobuf/compiler/python/python_generator.cc          \
-  google/protobuf/compiler/ruby/ruby_generator.cc              \
-  google/protobuf/compiler/csharp/csharp_doc_comment.cc        \
-  google/protobuf/compiler/csharp/csharp_doc_comment.h         \
-  google/protobuf/compiler/csharp/csharp_enum.cc               \
-  google/protobuf/compiler/csharp/csharp_enum.h                \
-  google/protobuf/compiler/csharp/csharp_enum_field.cc         \
-  google/protobuf/compiler/csharp/csharp_enum_field.h          \
-  google/protobuf/compiler/csharp/csharp_field_base.cc         \
-  google/protobuf/compiler/csharp/csharp_field_base.h          \
-  google/protobuf/compiler/csharp/csharp_generator.cc          \
-  google/protobuf/compiler/csharp/csharp_helpers.cc            \
-  google/protobuf/compiler/csharp/csharp_helpers.h             \
-  google/protobuf/compiler/csharp/csharp_map_field.cc          \
-  google/protobuf/compiler/csharp/csharp_map_field.h           \
-  google/protobuf/compiler/csharp/csharp_message.cc            \
-  google/protobuf/compiler/csharp/csharp_message.h             \
-  google/protobuf/compiler/csharp/csharp_message_field.cc      \
-  google/protobuf/compiler/csharp/csharp_message_field.h       \
-  google/protobuf/compiler/csharp/csharp_options.h             \
-  google/protobuf/compiler/csharp/csharp_primitive_field.cc    \
-  google/protobuf/compiler/csharp/csharp_primitive_field.h     \
-  google/protobuf/compiler/csharp/csharp_reflection_class.cc     \
-  google/protobuf/compiler/csharp/csharp_reflection_class.h      \
-  google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc \
-  google/protobuf/compiler/csharp/csharp_repeated_enum_field.h \
-  google/protobuf/compiler/csharp/csharp_repeated_message_field.cc \
-  google/protobuf/compiler/csharp/csharp_repeated_message_field.h \
-  google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc \
-  google/protobuf/compiler/csharp/csharp_repeated_primitive_field.h \
-  google/protobuf/compiler/csharp/csharp_source_generator_base.cc \
-  google/protobuf/compiler/csharp/csharp_source_generator_base.h \
-  google/protobuf/compiler/csharp/csharp_wrapper_field.cc      \
-  google/protobuf/compiler/csharp/csharp_wrapper_field.h
+  google/protobuf/compiler/objectivec/objectivec_primitive_field.cc  \
+  google/protobuf/compiler/objectivec/objectivec_primitive_field.h
+
+libprotoc_php_SOURCES =                                        \
+  google/protobuf/compiler/php/php_generator.cc
+
+libprotoc_python_SOURCES =                                     \
+  google/protobuf/compiler/python/python_generator.cc
+
+libprotoc_ruby_SOURCES =                                       \
+  google/protobuf/compiler/ruby/ruby_generator.cc
+
+libprotoc_la_SOURCES =                                         \
+  $(libprotoc_base_SOURCES)                                    \
+  $(libprotoc_cpp_SOURCES)                                     \
+  $(libprotoc_csharp_SOURCES)                                  \
+  $(libprotoc_java_SOURCES)                                    \
+  $(libprotoc_js_SOURCES)                                      \
+  $(libprotoc_objectivec_SOURCES)                              \
+  $(libprotoc_php_SOURCES)                                     \
+  $(libprotoc_python_SOURCES)                                  \
+  $(libprotoc_ruby_SOURCES)
 
 bin_PROGRAMS = protoc
 protoc_LDADD = $(PTHREAD_LIBS) libprotobuf.la libprotoc.la

--- a/update_file_lists.sh
+++ b/update_file_lists.sh
@@ -54,8 +54,24 @@ HEADERS=$(get_variable_value $MAKEFILE nobase_include_HEADERS)
 PUBLIC_HEADERS=$(sort_files $GZHEADERS $HEADERS)
 LIBPROTOBUF_LITE_SOURCES=$(get_source_files $MAKEFILE libprotobuf_lite_la_SOURCES)
 LIBPROTOBUF_SOURCES=$(get_source_files $MAKEFILE libprotobuf_la_SOURCES)
-LIBPROTOC_SOURCES=$(get_source_files $MAKEFILE libprotoc_la_SOURCES)
-LIBPROTOC_HEADERS=$(get_header_files $MAKEFILE libprotoc_la_SOURCES)
+LIBPROTOC_BASE_SOURCES=$(get_source_files $MAKEFILE libprotoc_base_SOURCES)
+LIBPROTOC_BASE_HEADERS=$(get_header_files $MAKEFILE libprotoc_base_SOURCES)
+LIBPROTOC_CPP_SOURCES=$(get_source_files $MAKEFILE libprotoc_cpp_SOURCES)
+LIBPROTOC_CPP_HEADERS=$(get_header_files $MAKEFILE libprotoc_cpp_SOURCES)
+LIBPROTOC_CSHARP_SOURCES=$(get_source_files $MAKEFILE libprotoc_csharp_SOURCES)
+LIBPROTOC_CSHARP_HEADERS=$(get_header_files $MAKEFILE libprotoc_csharp_SOURCES)
+LIBPROTOC_JAVA_SOURCES=$(get_source_files $MAKEFILE libprotoc_java_SOURCES)
+LIBPROTOC_JAVA_HEADERS=$(get_header_files $MAKEFILE libprotoc_java_SOURCES)
+LIBPROTOC_JS_SOURCES=$(get_source_files $MAKEFILE libprotoc_js_SOURCES)
+LIBPROTOC_JS_HEADERS=$(get_header_files $MAKEFILE libprotoc_js_SOURCES)
+LIBPROTOC_OBJECTIVEC_SOURCES=$(get_source_files $MAKEFILE libprotoc_objectivec_SOURCES)
+LIBPROTOC_OBJECTIVEC_HEADERS=$(get_header_files $MAKEFILE libprotoc_objectivec_SOURCES)
+LIBPROTOC_PHP_SOURCES=$(get_source_files $MAKEFILE libprotoc_php_SOURCES)
+LIBPROTOC_PHP_HEADERS=$(get_header_files $MAKEFILE libprotoc_php_SOURCES)
+LIBPROTOC_PYTHON_SOURCES=$(get_source_files $MAKEFILE libprotoc_python_SOURCES)
+LIBPROTOC_PYTHON_HEADERS=$(get_header_files $MAKEFILE libprotoc_python_SOURCES)
+LIBPROTOC_RUBY_SOURCES=$(get_source_files $MAKEFILE libprotoc_ruby_SOURCES)
+LIBPROTOC_RUBY_HEADERS=$(get_header_files $MAKEFILE libprotoc_ruby_SOURCES)
 LITE_PROTOS=$(get_proto_files $MAKEFILE protoc_lite_outputs)
 PROTOS=$(get_proto_files $MAKEFILE protoc_outputs)
 PROTOS_BLACKLISTED=$(get_proto_files_blacklisted $MAKEFILE protoc_outputs)
@@ -117,8 +133,24 @@ set_cmake_value() {
 CMAKE_PREFIX="\${protobuf_source_dir}/src/"
 set_cmake_value $CMAKE_DIR/libprotobuf-lite.cmake libprotobuf_lite_files $CMAKE_PREFIX $LIBPROTOBUF_LITE_SOURCES
 set_cmake_value $CMAKE_DIR/libprotobuf.cmake libprotobuf_files $CMAKE_PREFIX $LIBPROTOBUF_SOURCES
-set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_files $CMAKE_PREFIX $LIBPROTOC_SOURCES
-set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_headers $CMAKE_PREFIX $LIBPROTOC_HEADERS
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_base_srcs $CMAKE_PREFIX $LIBPROTOC_BASE_SOURCES
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_base_hdrs $CMAKE_PREFIX $LIBPROTOC_BASE_HEADERS
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_cpp_srcs $CMAKE_PREFIX $LIBPROTOC_CPP_SOURCES
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_cpp_hdrs $CMAKE_PREFIX $LIBPROTOC_CPP_HEADERS
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_csharp_srcs $CMAKE_PREFIX $LIBPROTOC_CSHARP_SOURCES
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_csharp_hdrs $CMAKE_PREFIX $LIBPROTOC_CSHARP_HEADERS
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_java_srcs $CMAKE_PREFIX $LIBPROTOC_JAVA_SOURCES
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_java_hdrs $CMAKE_PREFIX $LIBPROTOC_JAVA_HEADERS
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_js_srcs $CMAKE_PREFIX $LIBPROTOC_JS_SOURCES
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_js_hdrs $CMAKE_PREFIX $LIBPROTOC_JS_HEADERS
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_objectivec_srcs $CMAKE_PREFIX $LIBPROTOC_OBJECTIVEC_SOURCES
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_objectivec_hdrs $CMAKE_PREFIX $LIBPROTOC_OBJECTIVEC_HEADERS
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_php_srcs $CMAKE_PREFIX $LIBPROTOC_PHP_SOURCES
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_php_hdrs $CMAKE_PREFIX $LIBPROTOC_PHP_HEADERS
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_python_srcs $CMAKE_PREFIX $LIBPROTOC_PYTHON_SOURCES
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_python_hdrs $CMAKE_PREFIX $LIBPROTOC_PYTHON_HEADERS
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_ruby_srcs $CMAKE_PREFIX $LIBPROTOC_RUBY_SOURCES
+set_cmake_value $CMAKE_DIR/libprotoc.cmake libprotoc_ruby_hdrs $CMAKE_PREFIX $LIBPROTOC_RUBY_HEADERS
 set_cmake_value $CMAKE_DIR/tests.cmake lite_test_protos "" $LITE_PROTOS
 set_cmake_value $CMAKE_DIR/tests.cmake tests_protos "" $PROTOS_BLACKLISTED
 set_cmake_value $CMAKE_DIR/tests.cmake common_test_files $CMAKE_PREFIX $COMMON_TEST_SOURCES
@@ -182,7 +214,15 @@ BAZEL_PREFIX="src/"
 if [ -f "$BAZEL_BUILD" ]; then
   set_bazel_value $BAZEL_BUILD protobuf_lite_srcs $BAZEL_PREFIX $LIBPROTOBUF_LITE_SOURCES
   set_bazel_value $BAZEL_BUILD protobuf_srcs $BAZEL_PREFIX $LIBPROTOBUF_SOURCES
-  set_bazel_value $BAZEL_BUILD protoc_lib_srcs $BAZEL_PREFIX $LIBPROTOC_SOURCES
+  set_bazel_value $BAZEL_BUILD protoc_base_srcs $BAZEL_PREFIX $LIBPROTOC_BASE_SOURCES
+  set_bazel_value $BAZEL_BUILD protoc_cpp_srcs $BAZEL_PREFIX $LIBPROTOC_CPP_SOURCES
+  set_bazel_value $BAZEL_BUILD protoc_csharp_srcs $BAZEL_PREFIX $LIBPROTOC_CSHARP_SOURCES
+  set_bazel_value $BAZEL_BUILD protoc_java_srcs $BAZEL_PREFIX $LIBPROTOC_JAVA_SOURCES
+  set_bazel_value $BAZEL_BUILD protoc_js_srcs $BAZEL_PREFIX $LIBPROTOC_JS_SOURCES
+  set_bazel_value $BAZEL_BUILD protoc_objectivec_srcs $BAZEL_PREFIX $LIBPROTOC_OBJECTIVEC_SOURCES
+  set_bazel_value $BAZEL_BUILD protoc_php_srcs $BAZEL_PREFIX $LIBPROTOC_PHP_SOURCES
+  set_bazel_value $BAZEL_BUILD protoc_python_srcs $BAZEL_PREFIX $LIBPROTOC_PYTHON_SOURCES
+  set_bazel_value $BAZEL_BUILD protoc_ruby_srcs $BAZEL_PREFIX $LIBPROTOC_RUBY_SOURCES
   set_bazel_value $BAZEL_BUILD lite_test_protos "" $LITE_PROTOS
   set_bazel_value $BAZEL_BUILD well_known_protos "" $WKT_PROTOS
   set_bazel_value $BAZEL_BUILD test_protos "" $PROTOS


### PR DESCRIPTION
In a future version of Bazel, all languages will require
a protoc plugin instead of having some of them built
directly into protoc [1]. This change prepares Protobuf
for that by splitting //:protoc_lib into language-specific
targets. For other build-systems, this is effectively a no-op.

By exporting all language-specific targets as //:protoc_lib,
this remains fully compatible with previous versions.

[1] https://docs.google.com/document/d/1u95vlQ1lWeQNR4bUw5T4cMeHTGJla2_e1dHHx7v4Dvg/edit