### PR TITLE
Fix the issue for parsing zero length message

### DIFF
--- a/php/src/Google/Protobuf/Internal/CodedInputStream.php
+++ b/php/src/Google/Protobuf/Internal/CodedInputStream.php
@@ -299,8 +299,12 @@ class CodedInputStream
             return false;
         }
 
-        $buffer = substr($this->buffer, $this->current, $size);
-        $this->advance($size);
+        if ($size === 0) {
+          $buffer = "";
+        } else {
+          $buffer = substr($this->buffer, $this->current, $size);
+          $this->advance($size);
+        }
 
         return true;
     }


### PR DESCRIPTION
* When length is zero, substr returns null instead of emptry string, which breaks the invariable for message.
* Tested in https://github.com/protocolbuffers/protobuf/pull/6560