### PR TITLE
Linakge Monitor fix to handle a new version of protobuf-bom not available in Maven Central

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -254,7 +254,7 @@ build_java_linkage_monitor() {
   cd bom
   # This local installation avoids the problem caused by a new version not yet in Maven Central
   # https://github.com/protocolbuffers/protobuf/issues/6627
-  mvn install
+  $MVN install
   $MVN versions:set -DnewVersion=${VERSION}-SNAPSHOT
   cd ..
   $MVN versions:set -DnewVersion=${VERSION}-SNAPSHOT

--- a/tests.sh
+++ b/tests.sh
@@ -252,6 +252,9 @@ build_java_linkage_monitor() {
   # Example: "3.9.0" (without 'rc')
   VERSION=`grep '<version>' pom.xml |head -1 |perl -nle 'print $1 if m/<version>(\d+\.\d+.\d+)/'`
   cd bom
+  # This local installation avoids the problem caused by a new version not yet in Maven Central
+  # https://github.com/protocolbuffers/protobuf/issues/6627
+  mvn install
   $MVN versions:set -DnewVersion=${VERSION}-SNAPSHOT
   cd ..
   $MVN versions:set -DnewVersion=${VERSION}-SNAPSHOT


### PR DESCRIPTION
Fixes #6627 .

The problem was that when Linkage Monitor temporarily updates the project version to "-SNAPSHOT", it needed "-rc-1" BOM in Maven Central.

```
++ mvn -e -B -Dhttps.protocols=TLSv1.2 versions:set -DnewVersion=3.10.0-SNAPSHOT
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[INFO] Downloading: https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.10.0-rc-1/protobuf-bom-3.10.0-rc-1.pom
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] Non-resolvable import POM: Could not find artifact com.google.protobuf:protobuf-bom:pom:3.10.0-rc-1 in central (https://repo.maven.apache.org/maven2) @ line 68, column 19
```

After the change (local installation of protobuf-bom before updating the version), the command stops downloading the BOM from Maven Central.

```
++ mvn -e -B -Dhttps.protocols=TLSv1.2 versions:set -DnewVersion=3.9.1-SNAPSHOT
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[INFO] Downloading: https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/3.0.1/maven-bundle-plugin-3.0.1.pom
[INFO] Downloaded: https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/3.0.1/maven-bundle-plugin-3.0.1.pom (9 KB at 27.4 KB/sec)
```
