### PR TITLE
Add kotlin kroto plus to third party add-ons

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -60,6 +60,7 @@ These are projects we know about implementing Protocol Buffers for other program
 * Javascript: http://code.google.com/p/protobuf-for-node/
 * Javascript: http://code.google.com/p/protostuff/
 * Julia: https://github.com/tanmaykm/ProtoBuf.jl
+* Kotlin: https://github.com/marcoferrer/kroto-plus
 * Kotlin: https://github.com/Kotlin/kotlinx.serialization
 * Lua: http://code.google.com/p/protoc-gen-lua/
 * Lua: http://github.com/indygreg/lua-protobuf


### PR DESCRIPTION
Submitting [Kroto plus](https://github.com/marcoferrer/kroto-plus) as a third party add-on.
Kroto is a protoc plugin which produces type safe Kotlin DSLs from proto definitions. It also performs DSL marker annotation insertions for generated java classes. 