### PR TITLE
Ignore RuntimeWarning from description_database.py in tests

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -11,6 +11,7 @@ setenv =
     cpp: DYLD_LIBRARY_PATH={toxinidir}/../src/.libs
     cpp: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp
     python: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+    PYTHONWARNINGS=ignore::RuntimeWarning:google.protobuf.descriptor_database
 commands =
     python setup.py -q build_py
     python: python setup.py -q build


### PR DESCRIPTION
This cuts out what is currently 209 lines of ~junk spat out while the tests are running:
```
/protobuf/python/google/protobuf/descriptor_database.py:157: RuntimeWarning: Conflict register for file "other_file": protobuf_unittest.TestAllTypes is already defined in file "google/protobuf/unittest.proto"
```
The warning is already explicitly tested for and is unaffected by this change.