### PR TITLE
fix deprecated nodejs `Buffer(...)` calls

### DIFF
--- a/conformance/conformance_nodejs.js
+++ b/conformance/conformance_nodejs.js
@@ -117,7 +117,7 @@ function onEof(totalRead) {
 
 // Utility function to read a buffer of N bytes.
 function readBuffer(bytes) {
-  var buf = new Buffer(bytes);
+  var buf = Buffer.from(bytes);
   var totalRead = 0;
   while (totalRead < bytes) {
     var read = 0;
@@ -167,10 +167,10 @@ function doTestIo() {
 
   var serializedResponse = response.serializeBinary();
 
-  lengthBuf = new Buffer(4);
+  lengthBuf = Buffer.alloc(4);
   lengthBuf.writeInt32LE(serializedResponse.length, 0);
   writeBuffer(lengthBuf);
-  writeBuffer(new Buffer(serializedResponse));
+  writeBuffer(Buffer.from(serializedResponse));
 
   testCount += 1
 


### PR DESCRIPTION
See deprecation details here: https://nodejs.org/api/buffer.html#buffer_class_buffer

This will fix the following error message:
```
(node:30530) [DEP0005] DeprecationWarning: Buffer() is deprecated due to 
security and usability issues. Please use the Buffer.alloc(), 
Buffer.allocUnsafe(), or Buffer.from() methods instead.
```
which is seen commonly in Github issues, here and in the wild:
- #5429
- https://github.com/gatsbyjs/gatsby/issues/13094
- https://github.com/microsoft/vscode/issues/67534
