### PR TITLE
Remove traces of python2.6 support

### DIFF
--- a/python/compatibility_tests/v2.5.0/setup.py
+++ b/python/compatibility_tests/v2.5.0/setup.py
@@ -52,9 +52,6 @@ class build_py(_build_py):
 if __name__ == '__main__':
   # Keep this list of dependencies in sync with tox.ini.
   install_requires = ['six>=1.9', 'setuptools']
-  if sys.version_info <= (2,7):
-    install_requires.append('ordereddict')
-    install_requires.append('unittest2')
 
   setup(
       name='protobuf',
@@ -68,7 +65,6 @@ if __name__ == '__main__':
       classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",

--- a/python/google/protobuf/internal/_parameterized.py
+++ b/python/google/protobuf/internal/_parameterized.py
@@ -148,10 +148,7 @@ __author__ = 'tmarek@google.com (Torsten Marek)'
 import functools
 import re
 import types
-try:
-  import unittest2 as unittest
-except ImportError:
-  import unittest
+import unittest
 import uuid
 
 import six

--- a/python/google/protobuf/internal/descriptor_database_test.py
+++ b/python/google/protobuf/internal/descriptor_database_test.py
@@ -34,10 +34,7 @@
 
 __author__ = 'matthewtoia@google.com (Matt Toia)'
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 import warnings
 
 from google.protobuf import unittest_pb2

--- a/python/google/protobuf/internal/descriptor_pool_test.py
+++ b/python/google/protobuf/internal/descriptor_pool_test.py
@@ -38,10 +38,7 @@ import copy
 import os
 import warnings
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import unittest_import_pb2
 from google.protobuf import unittest_import_public_pb2

--- a/python/google/protobuf/internal/descriptor_test.py
+++ b/python/google/protobuf/internal/descriptor_test.py
@@ -37,10 +37,7 @@ __author__ = 'robinson@google.com (Will Robinson)'
 import sys
 import warnings
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import unittest_custom_options_pb2
 from google.protobuf import unittest_import_pb2

--- a/python/google/protobuf/internal/generator_test.py
+++ b/python/google/protobuf/internal/generator_test.py
@@ -41,10 +41,7 @@ further ensures that we can use Python protocol message objects as we expect.
 
 __author__ = 'robinson@google.com (Will Robinson)'
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf.internal import test_bad_identifiers_pb2
 from google.protobuf import unittest_custom_options_pb2

--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -39,10 +39,7 @@ import math
 import struct
 import sys
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import any_pb2
 from google.protobuf import duration_pb2
@@ -1039,8 +1036,6 @@ class JsonFormatTest(JsonFormatBase):
         json_format.ParseError,
         'Failed to parse boolMap field: Expected "true" or "false", not null.',
         json_format.Parse, text, message)
-    if sys.version_info < (2, 7):
-      return
     text = r'{"stringMap": {"a": 3, "\u0061": 2}}'
     self.assertRaisesRegexp(
         json_format.ParseError,

--- a/python/google/protobuf/internal/message_factory_test.py
+++ b/python/google/protobuf/internal/message_factory_test.py
@@ -34,10 +34,7 @@
 
 __author__ = 'matthewtoia@google.com (Matt Toia)'
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import descriptor_pb2
 from google.protobuf.internal import api_implementation

--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -61,10 +61,7 @@ except ImportError:
   # Won't work after python 3.8
   import collections as collections_abc
 
-try:
-  import unittest2 as unittest  # PY26
-except ImportError:
-  import unittest
+import unittest
 try:
   cmp                                   # Python 2
 except NameError:
@@ -2638,9 +2635,8 @@ class PackedFieldTest(unittest.TestCase):
     self.assertEqual(golden_data, message.SerializeToString())
 
 
-@unittest.skipIf(api_implementation.Type() != 'cpp' or
-                 sys.version_info < (2, 7),
-                 'explicit tests of the C++ implementation for PY27 and above')
+@unittest.skipIf(api_implementation.Type() != 'cpp'
+                 'explicit tests of the C++ implementation')
 @testing_refleaks.TestCase
 class OversizeProtosTest(unittest.TestCase):
 

--- a/python/google/protobuf/internal/proto_builder_test.py
+++ b/python/google/protobuf/internal/proto_builder_test.py
@@ -32,14 +32,8 @@
 
 """Tests for google.protobuf.proto_builder."""
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict  #PY26
-try:
-  import unittest2 as unittest
-except ImportError:
-  import unittest
+from collections import OrderedDict
+import unittest
 
 from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool

--- a/python/google/protobuf/internal/reflection_test.py
+++ b/python/google/protobuf/internal/reflection_test.py
@@ -42,10 +42,7 @@ import six
 import struct
 import warnings
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import unittest_import_pb2
 from google.protobuf import unittest_mset_pb2

--- a/python/google/protobuf/internal/service_reflection_test.py
+++ b/python/google/protobuf/internal/service_reflection_test.py
@@ -35,10 +35,7 @@
 __author__ = 'petar@google.com (Petar Petrov)'
 
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import unittest_pb2
 from google.protobuf import service_reflection

--- a/python/google/protobuf/internal/symbol_database_test.py
+++ b/python/google/protobuf/internal/symbol_database_test.py
@@ -32,10 +32,7 @@
 
 """Tests for google.protobuf.symbol_database."""
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import unittest_pb2
 from google.protobuf import descriptor

--- a/python/google/protobuf/internal/testing_refleaks.py
+++ b/python/google/protobuf/internal/testing_refleaks.py
@@ -41,15 +41,8 @@ the Py_DEBUG option), then this module is a no-op and tests will run normally.
 import gc
 import sys
 
-try:
-  import copy_reg as copyreg  #PY26
-except ImportError:
-  import copyreg
-
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import copyreg
+import unittest
 
 
 class LocalTestResult(unittest.TestResult):

--- a/python/google/protobuf/internal/text_encoding_test.py
+++ b/python/google/protobuf/internal/text_encoding_test.py
@@ -32,10 +32,7 @@
 
 """Tests for google.protobuf.text_encoding."""
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import text_encoding
 

--- a/python/google/protobuf/internal/text_format_test.py
+++ b/python/google/protobuf/internal/text_format_test.py
@@ -42,10 +42,7 @@ import textwrap
 import six
 
 # pylint: disable=g-import-not-at-top
-try:
-  import unittest2 as unittest  # PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import any_pb2
 from google.protobuf import any_test_pb2

--- a/python/google/protobuf/internal/unknown_fields_test.py
+++ b/python/google/protobuf/internal/unknown_fields_test.py
@@ -35,10 +35,7 @@
 
 __author__ = 'bohdank@google.com (Bohdan Koval)'
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 from google.protobuf import map_unittest_pb2
 from google.protobuf import unittest_mset_pb2
 from google.protobuf import unittest_pb2

--- a/python/google/protobuf/internal/well_known_types_test.py
+++ b/python/google/protobuf/internal/well_known_types_test.py
@@ -43,10 +43,7 @@ except ImportError:
   # Won't work after python 3.8
   import collections as collections_abc
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import any_pb2
 from google.protobuf import duration_pb2

--- a/python/google/protobuf/internal/wire_format_test.py
+++ b/python/google/protobuf/internal/wire_format_test.py
@@ -34,10 +34,7 @@
 
 __author__ = 'robinson@google.com (Will Robinson)'
 
-try:
-  import unittest2 as unittest  #PY26
-except ImportError:
-  import unittest
+import unittest
 
 from google.protobuf import message
 from google.protobuf.internal import wire_format

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -42,13 +42,7 @@ Simple usage example:
 
 __author__ = 'jieluo@google.com (Jie Luo)'
 
-# pylint: disable=g-statement-before-imports,g-import-not-at-top
-try:
-  from collections import OrderedDict
-except ImportError:
-  from ordereddict import OrderedDict  # PY26
-# pylint: enable=g-statement-before-imports,g-import-not-at-top
-
+from collections import OrderedDict
 import base64
 import json
 import math

--- a/python/google/protobuf/proto_builder.py
+++ b/python/google/protobuf/proto_builder.py
@@ -30,10 +30,7 @@
 
 """Dynamic Protobuf class creator."""
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict  #PY26
+from collections import OrderedDict
 import hashlib
 import os
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -160,9 +160,6 @@ class build_py(_build_py):
 class test_conformance(_build_py):
   target = 'test_python'
   def run(self):
-    # Python 2.6 dodges these extra failures.
-    os.environ["CONFORMANCE_PYTHON_EXTRA_FAILURES"] = (
-        "--failure_list failure_list_python-post26.txt")
     cmd = 'cd ../conformance && make %s' % (test_conformance.target)
     status = subprocess.check_call(cmd, shell=True)
 
@@ -254,10 +251,7 @@ if __name__ == '__main__':
     os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'cpp'
 
   # Keep this list of dependencies in sync with tox.ini.
-  install_requires = ['six>=1.9']
-  if sys.version_info <= (2,7):
-    install_requires.append('ordereddict')
-    install_requires.append('unittest2')
+  install_requires = ['six>=1.9', 'setuptools']
 
   setup(
       name='protobuf',

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -25,5 +25,3 @@ commands =
 deps =
     # Keep this list of dependencies in sync with setup.py.
     six>=1.9
-    py26: ordereddict
-    py26: unittest2


### PR DESCRIPTION
Support for py2.6 was dropped in #4049, but the py2.6 compatible code was unfortunately not removed. 