### PR TITLE
Add imenu support for Emacs protobuf-mode

### DIFF
--- a/editors/protobuf-mode.el
+++ b/editors/protobuf-mode.el
@@ -186,6 +186,16 @@
 (or protobuf-mode-map
     (setq protobuf-mode-map (c-make-inherited-keymap)))
 
+(defvar protobuf-imenu-generic-expression
+  `(("Message"
+     ,(rx bol (* space) bow "message" eow (+ space)
+          (group alpha (+ (any alpha num "_"))))
+     1)
+    ("Enum"
+     ,(rx bol (* space) bow "enum" eow (+ space)
+          (group alpha (+ (any alpha num "_"))))
+     1)))
+
 (easy-menu-define protobuf-menu protobuf-mode-map
   "Protocol Buffers Mode Commands"
   (cons "Protocol Buffers" (c-lang-const c-mode-menu protobuf)))
@@ -208,6 +218,7 @@ Key bindings:
         mode-name "Protocol-Buffers"
         local-abbrev-table protobuf-mode-abbrev-table
         abbrev-mode t)
+  (setq-local imenu-generic-expression protobuf-imenu-generic-expression)
   (use-local-map protobuf-mode-map)
   (c-initialize-cc-mode t)
   (if (fboundp 'c-make-emacs-variables-local)


### PR DESCRIPTION
Hello,

I found `protobuf-mode` doesn't utilize `imenu`. `imenu` is a framework for Emacs to index specific major mode buffer.

This patch will enable `protobuf-mode` to make use of  `imenu`.

<img width="692" alt="屏幕快照 2019-09-18 下午8 59 59" src="https://user-images.githubusercontent.com/10190397/65151741-4967e180-da59-11e9-93bd-b9dbdf91acf7.png">