### PR TITLE
Fix incorrect Proto2 C# doc comments

### DIFF
--- a/csharp/src/Google.Protobuf/Reflection/EnumValueDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/EnumValueDescriptor.cs
@@ -77,7 +77,7 @@ namespace Google.Protobuf.Reflection
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options._extensions?.ValuesByNumber);
 
         /// <summary>
-        /// Gets a single value enum option for this descriptor
+        /// Gets a single value enum value option for this descriptor
         /// </summary>
         public T GetOption<T>(Extension<EnumValueOptions, T> extension)
         {
@@ -86,7 +86,7 @@ namespace Google.Protobuf.Reflection
         }
 
         /// <summary>
-        /// Gets a repeated value enum option for this descriptor
+        /// Gets a repeated value enum value option for this descriptor
         /// </summary>
         public RepeatedField<T> GetOption<T>(RepeatedExtension<EnumValueOptions, T> extension)
         {

--- a/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
@@ -302,7 +302,7 @@ namespace Google.Protobuf.Reflection
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options._extensions?.ValuesByNumber);
 
         /// <summary>
-        /// Gets a single value enum option for this descriptor
+        /// Gets a single value field option for this descriptor
         /// </summary>
         public T GetOption<T>(Extension<FieldOptions, T> extension)
         {
@@ -311,7 +311,7 @@ namespace Google.Protobuf.Reflection
         }
 
         /// <summary>
-        /// Gets a repeated value enum option for this descriptor
+        /// Gets a repeated value field option for this descriptor
         /// </summary>
         public RepeatedField<T> GetOption<T>(RepeatedExtension<FieldOptions, T> extension)
         {

--- a/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
@@ -545,7 +545,7 @@ namespace Google.Protobuf.Reflection
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options._extensions?.ValuesByNumber);
 
         /// <summary>
-        /// Gets a single value enum option for this descriptor
+        /// Gets a single value file option for this descriptor
         /// </summary>
         public T GetOption<T>(Extension<FileOptions, T> extension)
         {
@@ -554,7 +554,7 @@ namespace Google.Protobuf.Reflection
         }
 
         /// <summary>
-        /// Gets a repeated value enum option for this descriptor
+        /// Gets a repeated value file option for this descriptor
         /// </summary>
         public RepeatedField<T> GetOption<T>(RepeatedExtension<FileOptions, T> extension)
         {

--- a/csharp/src/Google.Protobuf/Reflection/MessageDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/MessageDescriptor.cs
@@ -264,7 +264,7 @@ namespace Google.Protobuf.Reflection
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options._extensions?.ValuesByNumber);
 
         /// <summary>
-        /// Gets a single value enum option for this descriptor
+        /// Gets a single value message option for this descriptor
         /// </summary>
         public T GetOption<T>(Extension<MessageOptions, T> extension)
         {
@@ -273,7 +273,7 @@ namespace Google.Protobuf.Reflection
         }
 
         /// <summary>
-        /// Gets a repeated value enum option for this descriptor
+        /// Gets a repeated value message option for this descriptor
         /// </summary>
         public Collections.RepeatedField<T> GetOption<T>(RepeatedExtension<MessageOptions, T> extension)
         {

--- a/csharp/src/Google.Protobuf/Reflection/MethodDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/MethodDescriptor.cs
@@ -77,7 +77,7 @@ namespace Google.Protobuf.Reflection
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options._extensions?.ValuesByNumber);
 
         /// <summary>
-        /// Gets a single value enum option for this descriptor
+        /// Gets a single value method option for this descriptor
         /// </summary>
         public T GetOption<T>(Extension<MethodOptions, T> extension)
         {
@@ -86,7 +86,7 @@ namespace Google.Protobuf.Reflection
         }
 
         /// <summary>
-        /// Gets a repeated value enum option for this descriptor
+        /// Gets a repeated value method option for this descriptor
         /// </summary>
         public RepeatedField<T> GetOption<T>(RepeatedExtension<MethodOptions, T> extension)
         {

--- a/csharp/src/Google.Protobuf/Reflection/OneofDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/OneofDescriptor.cs
@@ -109,7 +109,7 @@ namespace Google.Protobuf.Reflection
         public CustomOptions CustomOptions => new CustomOptions(proto.Options._extensions?.ValuesByNumber);
 
         /// <summary>
-        /// Gets a single value enum option for this descriptor
+        /// Gets a single value oneof option for this descriptor
         /// </summary>
         public T GetOption<T>(Extension<OneofOptions, T> extension)
         {
@@ -118,7 +118,7 @@ namespace Google.Protobuf.Reflection
         }
 
         /// <summary>
-        /// Gets a repeated value enum option for this descriptor
+        /// Gets a repeated value oneof option for this descriptor
         /// </summary>
         public RepeatedField<T> GetOption<T>(RepeatedExtension<OneofOptions, T> extension)
         {

--- a/csharp/src/Google.Protobuf/Reflection/ServiceDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ServiceDescriptor.cs
@@ -98,7 +98,7 @@ namespace Google.Protobuf.Reflection
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options._extensions?.ValuesByNumber);
 
         /// <summary>
-        /// Gets a single value enum option for this descriptor
+        /// Gets a single value service option for this descriptor
         /// </summary>
         public T GetOption<T>(Extension<ServiceOptions, T> extension)
         {
@@ -107,7 +107,7 @@ namespace Google.Protobuf.Reflection
         }
 
         /// <summary>
-        /// Gets a repeated value enum option for this descriptor
+        /// Gets a repeated value service option for this descriptor
         /// </summary>
         public RepeatedField<T> GetOption<T>(RepeatedExtension<ServiceOptions, T> extension)
         {


### PR DESCRIPTION
Always remember to copy-paste responsibly.