### PR TITLE
Remove unused-parameter warnings

### DIFF
--- a/src/google/protobuf/descriptor_database.h
+++ b/src/google/protobuf/descriptor_database.h
@@ -116,7 +116,7 @@ class PROTOBUF_EXPORT DescriptorDatabase {
   //
   // This method has a default implementation that always returns
   // false.
-  virtual bool FindAllFileNames(std::vector<std::string>* output) {
+  virtual bool FindAllFileNames(std::vector<std::string>* /*output*/) {
     return false;
   }
 

--- a/src/google/protobuf/stubs/bytestream.h
+++ b/src/google/protobuf/stubs/bytestream.h
@@ -274,7 +274,7 @@ class PROTOBUF_EXPORT StringByteSink : public ByteSink {
 class PROTOBUF_EXPORT NullByteSink : public ByteSink {
  public:
   NullByteSink() {}
-  virtual void Append(const char *data, size_t n) override {}
+  virtual void Append(const char* /*data*/, size_t /*n*/) override {}
 
  private:
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(NullByteSink);


### PR DESCRIPTION
The parameters in these two functions are not used and trigger corresponding warnings.

This PR comments out the parameter-names according to the Google C++ Style Guide ( section: Function_Declarations_and_Definitions ).