### PR TITLE
Cleanup various bits of Google.Protobuf

### DIFF
--- a/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.Proto2.cs
+++ b/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.Proto2.cs
@@ -261,9 +261,11 @@ namespace Google.Protobuf
             Assert.True(message.IsInitialized());
         }
 
-        // Code was accidentally left in message parser that threw exceptions when missing required fields after parsing.
-        // We've decided to not throw exceptions on missing fields, instead leaving it up to the consumer how they
-        // want to check and handle missing fields.
+        /// <summary>
+        /// Code was accidentally left in message parser that threw exceptions when missing required fields after parsing.
+        /// We've decided to not throw exceptions on missing fields, instead leaving it up to the consumer how they
+        /// want to check and handle missing fields.
+        /// </summary>
         [Test]
         public void RequiredFieldsNoThrow()
         {

--- a/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.Proto2.cs
+++ b/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.Proto2.cs
@@ -261,11 +261,14 @@ namespace Google.Protobuf
             Assert.True(message.IsInitialized());
         }
 
+        // Code was accidentally left in message parser that threw exceptions when missing required fields after parsing.
+        // We've decided to not throw exceptions on missing fields, instead leaving it up to the consumer how they
+        // want to check and handle missing fields.
         [Test]
         public void RequiredFieldsNoThrow()
         {
-            TestRequired.Parser.ParseFrom(new byte[0]);
-            (TestRequired.Parser as MessageParser).ParseFrom(new byte[0]);
+            Assert.DoesNotThrow(() => TestRequired.Parser.ParseFrom(new byte[0]));
+            Assert.DoesNotThrow(() => (TestRequired.Parser as MessageParser).ParseFrom(new byte[0]));
         }
 
         [Test]

--- a/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.Proto2.cs
+++ b/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.Proto2.cs
@@ -262,6 +262,13 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void RequiredFieldsNoThrow()
+        {
+            TestRequired.Parser.ParseFrom(new byte[0]);
+            (TestRequired.Parser as MessageParser).ParseFrom(new byte[0]);
+        }
+
+        [Test]
         public void RequiredFieldsInExtensions()
         {
             var message = new TestAllExtensions();

--- a/csharp/src/Google.Protobuf/CodedOutputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedOutputStream.cs
@@ -89,7 +89,7 @@ namespace Google.Protobuf
         private CodedOutputStream(byte[] buffer, int offset, int length)
         {
             this.output = null;
-            this.buffer = buffer;
+            this.buffer = ProtoPreconditions.CheckNotNull(buffer, nameof(buffer));
             this.position = offset;
             this.limit = offset + length;
             leaveOpen = true; // Simple way of avoiding trying to dispose of a null reference

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -133,7 +133,7 @@ namespace Google.Protobuf
         /// <param name="settings">The settings.</param>
         public JsonFormatter(Settings settings)
         {
-            this.settings = settings;
+            this.settings = ProtoPreconditions.CheckNotNull(settings, nameof(settings));
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -110,7 +110,7 @@ namespace Google.Protobuf
         /// <param name="settings">The settings.</param>
         public JsonParser(Settings settings)
         {
-            this.settings = settings;
+            this.settings = ProtoPreconditions.CheckNotNull(settings, nameof(settings));
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -72,7 +72,6 @@ namespace Google.Protobuf
         {
             IMessage message = factory();
             message.MergeFrom(data, DiscardUnknownFields, Extensions);
-            CheckMergedRequiredFields(message);
             return message;
         }
 
@@ -87,7 +86,6 @@ namespace Google.Protobuf
         {
             IMessage message = factory();
             message.MergeFrom(data, offset, length, DiscardUnknownFields, Extensions);
-            CheckMergedRequiredFields(message);
             return message;
         }
 
@@ -100,7 +98,6 @@ namespace Google.Protobuf
         {
             IMessage message = factory();
             message.MergeFrom(data, DiscardUnknownFields, Extensions);
-            CheckMergedRequiredFields(message);
             return message;
         }
 
@@ -113,7 +110,6 @@ namespace Google.Protobuf
         {
             IMessage message = factory();
             message.MergeFrom(input, DiscardUnknownFields, Extensions);
-            CheckMergedRequiredFields(message);
             return message;
         }
 
@@ -130,7 +126,6 @@ namespace Google.Protobuf
         {
             IMessage message = factory();
             message.MergeDelimitedFrom(input, DiscardUnknownFields, Extensions);
-            CheckMergedRequiredFields(message);
             return message;
         }
 
@@ -143,7 +138,6 @@ namespace Google.Protobuf
         {
             IMessage message = factory();
             MergeFrom(message, input);
-            CheckMergedRequiredFields(message);
             return message;
         }
 
@@ -174,12 +168,6 @@ namespace Google.Protobuf
             {
                 codedInput.DiscardUnknownFields = originalDiscard;
             }
-        }
-
-        internal static void CheckMergedRequiredFields(IMessage message)
-        {
-            if (!message.IsInitialized())
-                throw new InvalidOperationException("Parsed message does not contain all required fields");
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/ExtensionCollection.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ExtensionCollection.cs
@@ -110,7 +110,8 @@ namespace Google.Protobuf.Reflection
                 IList<FieldDescriptor> list;
                 if (!declarationOrder.TryGetValue(descriptor.ExtendeeType, out list))
                 {
-                    declarationOrder.Add(descriptor.ExtendeeType, list = new List<FieldDescriptor>());
+                    list = new List<FieldDescriptor>();
+                    declarationOrder.Add(descriptor.ExtendeeType, list);
                 }
 
                 list.Add(descriptor);

--- a/csharp/src/Google.Protobuf/Reflection/ExtensionCollection.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ExtensionCollection.cs
@@ -109,7 +109,9 @@ namespace Google.Protobuf.Reflection
 
                 IList<FieldDescriptor> list;
                 if (!declarationOrder.TryGetValue(descriptor.ExtendeeType, out list))
+                {
                     declarationOrder.Add(descriptor.ExtendeeType, list = new List<FieldDescriptor>());
+                }
 
                 list.Add(descriptor);
             }

--- a/csharp/src/Google.Protobuf/Reflection/ExtensionCollection.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ExtensionCollection.cs
@@ -107,13 +107,11 @@ namespace Google.Protobuf.Reflection
             {
                 descriptor.CrossLink();
 
-                IList<FieldDescriptor> _;
-                if (!declarationOrder.TryGetValue(descriptor.ExtendeeType, out _))
-                {
-                    declarationOrder.Add(descriptor.ExtendeeType, new List<FieldDescriptor>());
-                }
+                IList<FieldDescriptor> list;
+                if (!declarationOrder.TryGetValue(descriptor.ExtendeeType, out list))
+                    declarationOrder.Add(descriptor.ExtendeeType, list = new List<FieldDescriptor>());
 
-                declarationOrder[descriptor.ExtendeeType].Add(descriptor);
+                list.Add(descriptor);
             }
 
             extensionsByTypeInDeclarationOrder = declarationOrder


### PR DESCRIPTION
While adding nullable annotations throughout the lib, I found a few missing null-checks and some IsInitialized checks accidentally left in MessageParser. Additionally, ExtensionCollection.CrossLink did some unnecessary things so this simplifies that.