### PR TITLE
Remove win64 conversion warnings in generated code

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -1030,7 +1030,7 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
         format(
             "  static bool ValidateKey(std::string* s) {\n"
             "    return ::$proto_ns$::internal::WireFormatLite::"
-            "VerifyUtf8String(s->data(), s->size(), "
+            "VerifyUtf8String(s->data(), static_cast<int>(s->size()), "
             "::$proto_ns$::internal::WireFormatLite::PARSE, \"$1$\");\n"
             " }\n",
             descriptor_->field(0)->full_name());
@@ -1040,7 +1040,7 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
             "  static bool ValidateKey(std::string* s) {\n"
             "#ifndef NDEBUG\n"
             "    ::$proto_ns$::internal::WireFormatLite::VerifyUtf8String(\n"
-            "       s->data(), s->size(), ::$proto_ns$::internal::"
+            "       s->data(), static_cast<int>(s->size()), ::$proto_ns$::internal::"
             "WireFormatLite::PARSE, \"$1$\");\n"
             "#endif\n"
             "    return true;\n"
@@ -1056,7 +1056,7 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
         format(
             "  static bool ValidateValue(std::string* s) {\n"
             "    return ::$proto_ns$::internal::WireFormatLite::"
-            "VerifyUtf8String(s->data(), s->size(), "
+            "VerifyUtf8String(s->data(), static_cast<int>(s->size()), "
             "::$proto_ns$::internal::WireFormatLite::PARSE, \"$1$\");\n"
             " }\n",
             descriptor_->field(1)->full_name());
@@ -1066,7 +1066,7 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
             "  static bool ValidateValue(std::string* s) {\n"
             "#ifndef NDEBUG\n"
             "    ::$proto_ns$::internal::WireFormatLite::VerifyUtf8String(\n"
-            "       s->data(), s->size(), ::$proto_ns$::internal::"
+            "       s->data(), static_cast<int>(s->size()), ::$proto_ns$::internal::"
             "WireFormatLite::PARSE, \"$1$\");\n"
             "#endif\n"
             "    return true;\n"


### PR DESCRIPTION
When compiling protoc generated code in 64bit windows, we get conversion warnings.

The reason being, that the size method of std::string returns a size_t, while VerifyUtf8String accepts an int.

```
"  static bool ValidateKey(std::string* s) {\n"
             "    return ::$proto_ns$::internal::WireFormatLite::"
-            "VerifyUtf8String(s->data(), s->size(), "
```

Motivated by _cpp_string_field.cc(call of GenerateUtf8CheckCodeForString)_ this PR solves the issue by static-casting the return value of the size method to int.

By approving this PR protobuf will get rid of these warnings:

```
File: XyzProto.pb.h, Line: xxx
Message: 'argument': conversion from 'size_t' to 'int', possible loss of data

```
