### PR TITLE
Fixed wrong counting on leap days

### DIFF
--- a/conformance/binary_json_conformance_suite.cc
+++ b/conformance/binary_json_conformance_suite.cc
@@ -2725,6 +2725,9 @@ void BinaryAndJsonConformanceSuite::RunSuiteImpl() {
   RunValidJsonTest("TimestampWithNegativeOffset", REQUIRED,
                    R"({"optionalTimestamp": "1969-12-31T16:00:01-08:00"})",
                    "optional_timestamp: {seconds: 1}");
+  RunValidJsonTest("TimestampWithYearAfterLeapYear", REQUIRED,
+                   R"({"optionalTimestamp": "1973-01-01T00:00:00Z"})",
+                   "optional_timestamp: {seconds: 94694400}");
   RunValidJsonTest(
       "TimestampNull", REQUIRED,
       R"({"optionalTimestamp": null})",

--- a/php/ext/google/protobuf/upb.c
+++ b/php/ext/google/protobuf/upb.c
@@ -10124,6 +10124,12 @@ static bool isleap(int year) {
   return (year % 4) == 0 && (year % 100 != 0 || (year % 400) == 0);
 }
 
+/* Helper: returns the number of leap days between 1 and year in the
+ * calendar year. */
+static int leap_count(int year) {
+  return year / 4 - year / 100 + year / 400;
+}
+
 const unsigned short int __mon_yday[2][13] = {
     /* Normal years.  */
     { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 },
@@ -10134,7 +10140,8 @@ const unsigned short int __mon_yday[2][13] = {
 int64_t epoch(int year, int yday, int hour, int min, int sec) {
   int64_t years = year - EPOCH_YEAR;
 
-  int64_t leap_days = years / 4 - years / 100 + years / 400;
+  /* Calculate the number of leap days between EPOCH_YEAR and year - 1. */
+  int64_t leap_days = leap_count(year - 1) - leap_count(EPOCH_YEAR - 1);
 
   int64_t days = years * 365 + yday + leap_days;
   int64_t hours = days * 24 + hour;

--- a/ruby/ext/google/protobuf_c/upb.c
+++ b/ruby/ext/google/protobuf_c/upb.c
@@ -10124,6 +10124,10 @@ static bool isleap(int year) {
   return (year % 4) == 0 && (year % 100 != 0 || (year % 400) == 0);
 }
 
+static int isleap_count(int year) {
+  return year / 4 - year / 100 + year/ 400;
+}
+
 const unsigned short int __mon_yday[2][13] = {
     /* Normal years.  */
     { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 },
@@ -10134,7 +10138,7 @@ const unsigned short int __mon_yday[2][13] = {
 int64_t epoch(int year, int yday, int hour, int min, int sec) {
   int64_t years = year - EPOCH_YEAR;
 
-  int64_t leap_days = years / 4 - years / 100 + years / 400;
+  int64_t leap_days = isleap_count(year - 1) - isleap_count(EPOCH_YEAR - 1);
 
   int64_t days = years * 365 + yday + leap_days;
   int64_t hours = days * 24 + hour;

--- a/ruby/ext/google/protobuf_c/upb.c
+++ b/ruby/ext/google/protobuf_c/upb.c
@@ -10124,8 +10124,10 @@ static bool isleap(int year) {
   return (year % 4) == 0 && (year % 100 != 0 || (year % 400) == 0);
 }
 
-static int isleap_count(int year) {
-  return year / 4 - year / 100 + year/ 400;
+/* Helper: returns the number of leap days between 1 and year in the
+ * calendar year. */
+static int leap_count(int year) {
+  return year / 4 - year / 100 + year / 400;
 }
 
 const unsigned short int __mon_yday[2][13] = {
@@ -10138,7 +10140,8 @@ const unsigned short int __mon_yday[2][13] = {
 int64_t epoch(int year, int yday, int hour, int min, int sec) {
   int64_t years = year - EPOCH_YEAR;
 
-  int64_t leap_days = isleap_count(year - 1) - isleap_count(EPOCH_YEAR - 1);
+  /* Calculate the number of leap days between EPOCH_YEAR and year - 1. */
+  int64_t leap_days = leap_count(year - 1) - leap_count(EPOCH_YEAR - 1);
 
   int64_t days = years * 365 + yday + leap_days;
   int64_t hours = days * 24 + hour;


### PR DESCRIPTION
## REF
[Google::Protobuf::Timestamp.decode_json sometimes return incorrect timestamp values in Ruby #6616](https://github.com/protocolbuffers/protobuf/issues/6616)

## WHY
In current implementation of protobuf/ruby, the result of counting leap days was wrong.
This caused the wrong result of `Google::Protobuf::Timestamp.decode_json`.

```ruby
[1] pry(main)> t = Google::Protobuf::Timestamp.decode_json('"1993-02-10T00:00:00.000+00:00"'); Time.at(t.seconds)
=> 1993-02-09 00:00:00 +0000  # This is the wrong result. The input is 1993-02-10, but the decoded value is 1993-02-09.
```

Here are some other examples.

<details>

```ruby
[2] pry(main)> [*1900..2010].each { |year| t = Google::Protobuf::Timestamp.decode_json("\"#{year}-02-10T00:00:00.000+00:00\""); print Time.at(t.seconds).to_s + "#{'  # wrong' if Time.at(t.seconds).day != 10 }\n";  }

1900-02-10 09:00:00 +0900
1901-02-10 09:00:00 +0900
1902-02-10 09:00:00 +0900
1903-02-11 09:00:00 +0900  # wrong
1904-02-11 09:00:00 +0900  # wrong
1905-02-10 09:00:00 +0900
1906-02-10 09:00:00 +0900
1907-02-11 09:00:00 +0900  # wrong
1908-02-11 09:00:00 +0900  # wrong
1909-02-10 09:00:00 +0900
1910-02-10 09:00:00 +0900
1911-02-11 09:00:00 +0900  # wrong
1912-02-11 09:00:00 +0900  # wrong
1913-02-10 09:00:00 +0900
1914-02-10 09:00:00 +0900
1915-02-11 09:00:00 +0900  # wrong
1916-02-11 09:00:00 +0900  # wrong
1917-02-10 09:00:00 +0900
1918-02-10 09:00:00 +0900
1919-02-11 09:00:00 +0900  # wrong
1920-02-11 09:00:00 +0900  # wrong
1921-02-10 09:00:00 +0900
1922-02-10 09:00:00 +0900
1923-02-11 09:00:00 +0900  # wrong
1924-02-11 09:00:00 +0900  # wrong
1925-02-10 09:00:00 +0900
1926-02-10 09:00:00 +0900
1927-02-11 09:00:00 +0900  # wrong
1928-02-11 09:00:00 +0900  # wrong
1929-02-10 09:00:00 +0900
1930-02-10 09:00:00 +0900
1931-02-11 09:00:00 +0900  # wrong
1932-02-11 09:00:00 +0900  # wrong
1933-02-10 09:00:00 +0900
1934-02-10 09:00:00 +0900
1935-02-11 09:00:00 +0900  # wrong
1936-02-11 09:00:00 +0900  # wrong
1937-02-10 09:00:00 +0900
1938-02-10 09:00:00 +0900
1939-02-11 09:00:00 +0900  # wrong
1940-02-11 09:00:00 +0900  # wrong
1941-02-10 09:00:00 +0900
1942-02-10 09:00:00 +0900
1943-02-11 09:00:00 +0900  # wrong
1944-02-11 09:00:00 +0900  # wrong
1945-02-10 09:00:00 +0900
1946-02-10 09:00:00 +0900
1947-02-11 09:00:00 +0900  # wrong
1948-02-11 09:00:00 +0900  # wrong
1949-02-10 09:00:00 +0900
1950-02-10 09:00:00 +0900
1951-02-11 09:00:00 +0900  # wrong
1952-02-11 09:00:00 +0900  # wrong
1953-02-10 09:00:00 +0900
1954-02-10 09:00:00 +0900
1955-02-11 09:00:00 +0900  # wrong
1956-02-11 09:00:00 +0900  # wrong
1957-02-10 09:00:00 +0900
1958-02-10 09:00:00 +0900
1959-02-11 09:00:00 +0900  # wrong
1960-02-11 09:00:00 +0900  # wrong
1961-02-10 09:00:00 +0900
1962-02-10 09:00:00 +0900
1963-02-11 09:00:00 +0900  # wrong
1964-02-11 09:00:00 +0900  # wrong
1965-02-10 09:00:00 +0900
1966-02-10 09:00:00 +0900
1967-02-11 09:00:00 +0900  # wrong
1968-02-11 09:00:00 +0900  # wrong
1969-02-10 09:00:00 +0900
1970-02-10 09:00:00 +0900
1971-02-10 09:00:00 +0900
1972-02-10 09:00:00 +0900
1973-02-09 09:00:00 +0900  # wrong
1974-02-10 09:00:00 +0900
1975-02-10 09:00:00 +0900
1976-02-10 09:00:00 +0900
1977-02-09 09:00:00 +0900  # wrong
1978-02-10 09:00:00 +0900
1979-02-10 09:00:00 +0900
1980-02-10 09:00:00 +0900
1981-02-09 09:00:00 +0900  # wrong
1982-02-10 09:00:00 +0900
1983-02-10 09:00:00 +0900
1984-02-10 09:00:00 +0900
1985-02-09 09:00:00 +0900  # wrong
1986-02-10 09:00:00 +0900
1987-02-10 09:00:00 +0900
1988-02-10 09:00:00 +0900
1989-02-09 09:00:00 +0900  # wrong
1990-02-10 09:00:00 +0900
1991-02-10 09:00:00 +0900
1992-02-10 09:00:00 +0900
1993-02-09 09:00:00 +0900  # wrong
1994-02-10 09:00:00 +0900
1995-02-10 09:00:00 +0900
1996-02-10 09:00:00 +0900
1997-02-09 09:00:00 +0900  # wrong
1998-02-10 09:00:00 +0900
1999-02-10 09:00:00 +0900
2000-02-10 09:00:00 +0900
2001-02-09 09:00:00 +0900  # wrong
2002-02-10 09:00:00 +0900
2003-02-10 09:00:00 +0900
2004-02-10 09:00:00 +0900
2005-02-09 09:00:00 +0900  # wrong
2006-02-10 09:00:00 +0900
2007-02-10 09:00:00 +0900
2008-02-10 09:00:00 +0900
2009-02-09 09:00:00 +0900  # wrong
2010-02-10 09:00:00 +0900
```

</details>

## WHAT
I fixed the logic to count leap days.
