### PR TITLE
[Ruby] Add Google::Protobuf::Timestamp.from_time

### DIFF
--- a/ruby/lib/google/protobuf/well_known_types.rb
+++ b/ruby/lib/google/protobuf/well_known_types.rb
@@ -82,6 +82,10 @@ module Google
         end
       end
 
+      def self.from_time(time)
+        new(seconds: time.to_i, nanos: time.nsec)
+      end
+
       def from_time(time)
         self.seconds = time.to_i
         self.nanos = time.nsec

--- a/ruby/tests/well_known_types_test.rb
+++ b/ruby/tests/well_known_types_test.rb
@@ -25,6 +25,11 @@ class TestWellKnownTypes < Test::Unit::TestCase
     ts.from_time(time)
     assert_equal 654321321, ts.nanos
     assert_equal time, ts.to_time
+
+    timestamp = Google::Protobuf::Timestamp.from_time(Time.at(123456, Rational(654321321, 1000)))
+    ts.from_time(time)
+    assert_equal 654321321, timestamp.nanos
+    assert_equal ts, timestamp
   end
 
   def test_duration


### PR DESCRIPTION
Previously, you would have to instantiate a timestamp class then call #from_time on that object to mutate its state. Instead provides a mechanism to instantiate the object with the correct state.