### PR TITLE
Remove hiding generic types from createBuilder()

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java
@@ -170,16 +170,12 @@ public abstract class GeneratedMessageLite<
     Protobuf.getInstance().schemaFor(this).makeImmutable(this);
   }
 
-  protected final <
-          MessageType extends GeneratedMessageLite<MessageType, BuilderType>,
-          BuilderType extends GeneratedMessageLite.Builder<MessageType, BuilderType>>
+  protected final
       BuilderType createBuilder() {
     return (BuilderType) dynamicMethod(MethodToInvoke.NEW_BUILDER);
   }
 
-  protected final <
-          MessageType extends GeneratedMessageLite<MessageType, BuilderType>,
-          BuilderType extends GeneratedMessageLite.Builder<MessageType, BuilderType>>
+  protected final
       BuilderType createBuilder(MessageType prototype) {
     return ((BuilderType) createBuilder()).mergeFrom(prototype);
   }


### PR DESCRIPTION
I recently upgraded to the latest `protobuf-javalite` in a project that used a version prior to 3.4.1 before. After upgrading and regenerating the protobuf Java source files from the `*.proto` files, the resulting code fails to compile with the Eclipse compiler. Any place the method `createBuilder()` is used, appears this type of error message:

    Cannot cast from GeneratedMessageLite.Builder<GeneratedMessageLite<MessageType,BuilderType>,GeneratedMessageLite.Builder<MessageType,BuilderType>> to Fileformat.Blob.Builder

The ordinary `javac` compiles the code fine. Digging into this, I found that the two versions of `createBuilder()` were introduced in 1a7a7fca804afa1c which is between version 3.4.0 and 3.4.1. Looking at the code in `GeneratedMessageLite` closely, it appears that there are generic type arguments on some methods that have the same name of the type arguments on the main class and hence hide the outer type argument. Seems to me like this is not good practice in general because it is confusing. Specifically with the methods `createBuilder()` I think the additional type arguments aren't necessary at all and correctly lead to an error. I haven't been able to run the tests (`mvn package` fails on my setup here on the master branch). Maybe somebody else can check whether the changes I suggest break anything. Thanks!