### PR TITLE
export third_party BUILD files so they are accessible to users

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,0 +1,1 @@
+exports_files(["six.BUILD", "zlib.BUILD"])


### PR DESCRIPTION
When importing dependencies of `com_google_protobuf` with `protobuf_deps`

```bzl
load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

protobuf_deps()
```

It currently gives an error because the associated build files are not exported:

```plaintext
ERROR: /var/lib/jenkins/.cache/bazel/_bazel_jenkins/de8446692c11da2ee9ac26006b0c07ab/external/com_google_protobuf/protobuf_deps.bzl:9:9: no such target '@com_google_protobuf//:third_party/zlib.BUILD': target 'third_party/zlib.BUILD' not declared in package ''; however, a source file of this name exists.  (Perhaps add 'exports_files(["third_party/zlib.BUILD"])' to /BUILD?) defined by /var/lib/jenkins/.cache/bazel/_bazel_jenkins/de8446692c11da2ee9ac26006b0c07ab/external/com_google_protobuf/BUILD and referenced by '//external:zlib'
```

This PR exports the build files so they can be accessible by external consumers.