### PR TITLE
Added option --create_phony_dependencies

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.h
+++ b/src/google/protobuf/compiler/command_line_interface.h
@@ -426,6 +426,11 @@ class PROTOC_EXPORT CommandLineInterface {
   // dependency file will be written. Otherwise, empty.
   std::string dependency_out_name_;
 
+  // If --create_phony_dependencies was given a phony target for each dependency wil be added, causing each to depend on nothing.
+  // These dummy rules work around errors make gives if you remove header files without updating the Makefile to match.
+  // Like -MP in gcc. Should be used with --dependency_out.
+  bool generate_phony_target_set_;
+
   // True if --include_imports was given, meaning that we should
   // write all transitive dependencies to the DescriptorSet.  Otherwise, only
   // the .proto files listed on the command-line are added.


### PR DESCRIPTION
Added option --create_phony_dependencies that generates phony target  dependencies for .d files like -MP in gcc #