### PR TITLE
Use proper log channel for compiling issues

### DIFF
--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -105,6 +105,12 @@ class SourceTreeDescriptorDatabase::SingleFileErrorCollector
     had_errors_ = true;
   }
 
+  void AddWarning(int line, int column, const std::string& message) override {
+    if (multi_file_error_collector_ != NULL) {
+      multi_file_error_collector_->AddWarning(filename_, line, column, message);
+    }
+  }
+
  private:
   std::string filename_;
   MultiFileErrorCollector* multi_file_error_collector_;

--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -643,10 +643,11 @@ bool Parser::Parse(io::Tokenizer* input, FileDescriptorProto* file) {
       // Store the syntax into the file.
       if (file != NULL) file->set_syntax(syntax_identifier_);
     } else if (!stop_after_syntax_identifier_) {
-      GOOGLE_LOG(WARNING) << "No syntax specified for the proto file: " << file->name()
-                   << ". Please use 'syntax = \"proto2\";' "
-                   << "or 'syntax = \"proto3\";' to specify a syntax "
-                   << "version. (Defaulted to proto2 syntax.)";
+      AddWarning(
+          "No syntax specified for the proto file: " + file->name() +
+          ". Please use 'syntax = \"proto2\";' " +
+          "or 'syntax = \"proto3\";' to specify a syntax " +
+          "version. (Defaulted to proto2 syntax.)");
       syntax_identifier_ = "proto2";
     }
 


### PR DESCRIPTION
`GOOGLE_LOG` had been used for reporting of a specific input file related warning. Use error collector instead and fix `SingleFileErrorCollector` to allow propagation of warnings.