### PR TITLE
Include cmath instead of math.h

### DIFF
--- a/src/google/protobuf/text_format.cc
+++ b/src/google/protobuf/text_format.cc
@@ -35,7 +35,7 @@
 #include <google/protobuf/text_format.h>
 
 #include <float.h>
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 
 #include <algorithm>


### PR DESCRIPTION
This fixes build on, at least, NetBSD 8.1 with gcc 5.5 and SmartOS with gcc 7.