### PR TITLE
Remove unused argument to avoid UB

### DIFF
--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -1232,7 +1232,7 @@ VALUE OneofDescriptor_name(VALUE _self) {
  *
  * Iterates through fields in this oneof, yielding to the block on each one.
  */
-VALUE OneofDescriptor_each(VALUE _self, VALUE field) {
+VALUE OneofDescriptor_each(VALUE _self) {
   DEFINE_SELF(OneofDescriptor, self, _self);
   upb_oneof_iter it;
   for (upb_oneof_begin(&it, self->oneofdef);

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -259,7 +259,7 @@ OneofDescriptor* ruby_to_OneofDescriptor(VALUE value);
 VALUE OneofDescriptor_initialize(VALUE _self, VALUE cookie,
                                  VALUE descriptor_pool, VALUE ptr);
 VALUE OneofDescriptor_name(VALUE _self);
-VALUE OneofDescriptor_each(VALUE _self, VALUE field);
+VALUE OneofDescriptor_each(VALUE _self);
 
 void EnumDescriptor_mark(void* _self);
 void EnumDescriptor_free(void* _self);


### PR DESCRIPTION
`OneOfDescriptor_each` is registered as a Ruby method which takes zero
parameters, which means it should take one argument.

When Ruby invokes `OneOfDescriptor_each`, it calls it with one parameter
only, which is one less than what `OneOfDescriptor_each` takes before
this commit. Calling a function with the wrong number of argument is
technically undefined behavior.

See also: §6.5.2.2, N1256