### PR TITLE
c++ remove unused parameters

### DIFF
--- a/src/google/protobuf/extension_set.h
+++ b/src/google/protobuf/extension_set.h
@@ -760,7 +760,7 @@ class PROTOBUF_EXPORT ExtensionSet {
 
   bool FindExtension(int wire_type, uint32 field,
                      const MessageLite* containing_type,
-                     const internal::ParseContext* ctx,
+                     const internal::ParseContext* /*ctx*/,
                      ExtensionInfo* extension, bool* was_packed_on_wire) {
     GeneratedExtensionFinder finder(containing_type);
     return FindExtensionInfoFromFieldNumber(wire_type, field, &finder,

--- a/src/google/protobuf/message_lite.h
+++ b/src/google/protobuf/message_lite.h
@@ -434,8 +434,8 @@ class PROTOBUF_EXPORT MessageLite {
   // method.)
   virtual int GetCachedSize() const = 0;
 
-  virtual const char* _InternalParse(const char* ptr,
-                                     internal::ParseContext* ctx) {
+  virtual const char* _InternalParse(const char* /*ptr*/,
+                                     internal::ParseContext* /*ctx*/) {
     return nullptr;
   }
 

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -491,7 +491,7 @@ PROTOBUF_EXPORT
 std::pair<const char*, uint32> ReadTagFallback(const char* p, uint32 res);
 
 // Same as ParseVarint but only accept 5 bytes at most.
-inline const char* ReadTag(const char* p, uint32* out, uint32 max_tag = 0) {
+inline const char* ReadTag(const char* p, uint32* out, uint32 /*max_tag*/ = 0) {
   uint32 res = static_cast<uint8>(p[0]);
   if (res < 128) {
     *out = res;


### PR DESCRIPTION
This PR removes the following unused parameter warnings.

```
google/protobuf/message_lite.h:437:50: warning: unused parameter 'ptr' [-Wunused-parameter]
  virtual const char* _InternalParse(const char* ptr,
                                                 ^

google/protobuf/message_lite.h:438:62: warning: unused parameter 'ctx' [-Wunused-parameter]
                                     internal::ParseContext* ctx) {
                                                             ^

google/protobuf/parse_context.h:494:63: warning: unused parameter 'max_tag' [-Wunused-parameter]
inline const char* ReadTag(const char* p, uint32* out, uint32 max_tag = 0) {
                                                              ^

google/protobuf/extension_set.h:763:52: warning: unused parameter 'ctx' [-Wunused-parameter]
                     const internal::ParseContext* ctx,
                                                   ^
```

