### PR TITLE
c++ remove conversion warning in MapEntryFuncs::ByteSizeLong

### DIFF
--- a/src/google/protobuf/map_entry_lite.h
+++ b/src/google/protobuf/map_entry_lite.h
@@ -128,7 +128,7 @@ struct MapEntryFuncs {
     // Tags for key and value will both be one byte (field numbers 1 and 2).
     size_t inner_length =
         2 + KeyTypeHandler::ByteSize(key) + ValueTypeHandler::ByteSize(value);
-    return inner_length + io::CodedOutputStream::VarintSize32(inner_length);
+    return inner_length + io::CodedOutputStream::VarintSize32(static_cast<uint32>(inner_length));
   }
 
   static int GetCachedSize(const Key& key, const Value& value) {


### PR DESCRIPTION
Removes following conversion warning:

```
google/protobuf/map_entry_lite.h(131): warning C4267: 'argument': conversion from 'size_t' to 'google::protobuf::uint32', possible loss of data
google/protobuf/map_entry_lite.h(127): note: while compiling class template member function 'size_t google::protobuf::internal::MapEntryFuncs<Key,Value,google::protobuf::internal::WireFormatLite::TYPE_STRING,google::protobuf::internal::WireFormatLite::TYPE_BYTES>::ByteSizeLong(const Key &,const Value &)'
        with
       [
            Key=std::string,
            Value=std::string
        ]
note: see reference to function template instantiation 'size_t google::protobuf::internal::MapEntryFuncs<Key,Value,google::protobuf::internal::WireFormatLite::TYPE_STRING,google::protobuf::internal::WireFormatLite::TYPE_BYTES>::ByteSizeLong(const Key &,const Value &)' being compiled
        with
        [
            Key=std::string,
            Value=std::string
        ]
note: see reference to class template instantiation 'google::protobuf::internal::MapEntryFuncs<Key,Value,google::protobuf::internal::WireFormatLite::TYPE_STRING,google::protobuf::internal::WireFormatLite::TYPE_BYTES>' being compiled
        with
        [
            Key=std::string,
            Value=std::string
        ]
```
