### PR TITLE
c++ avoid potential macro redifinition on windows

### DIFF
--- a/src/google/protobuf/stubs/common.cc
+++ b/src/google/protobuf/stubs/common.cc
@@ -39,7 +39,9 @@
 #include <vector>
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN  // We only need minimal includes
+#endif
 #include <windows.h>
 #define snprintf _snprintf    // see comment in strutil.cc
 #elif defined(HAVE_PTHREAD)


### PR DESCRIPTION
In my build environment WIN32_LEAN_AND_MEAN is always defined
This gives a macro-redifition warning when compiling protobuf from source
Thus: define the macro only if it's not already defined