### PR TITLE
avoid potential c++ macro redefinition on windows [release notes: no] [c++]

### DIFF
--- a/src/google/protobuf/compiler/subprocess.h
+++ b/src/google/protobuf/compiler/subprocess.h
@@ -34,7 +34,9 @@
 #define GOOGLE_PROTOBUF_COMPILER_SUBPROCESS_H__
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN  // right...
+#endif
 #include <windows.h>
 #else  // _WIN32
 #include <sys/types.h>

--- a/src/google/protobuf/stubs/common.cc
+++ b/src/google/protobuf/stubs/common.cc
@@ -39,7 +39,9 @@
 #include <vector>
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN  // We only need minimal includes
+#endif
 #include <windows.h>
 #define snprintf _snprintf    // see comment in strutil.cc
 #elif defined(HAVE_PTHREAD)


### PR DESCRIPTION
In my windows project, i build protobuf from source using the WIN32_LEAN_AND_MEAN define via cmake flags.
But: common.cc also defines this macro, causing MSVC to warn about macro redifinition
Solution: only define the macro when it's not already defined