### PR TITLE
Installing BOM before running Java test

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -213,6 +213,9 @@ build_java() {
 build_java_with_conformance_tests() {
   # Java build needs `protoc`.
   internal_build_cpp
+  # This local installation avoids the problem caused by a new version not yet in Maven Central
+  cd java/bom && $MVN install
+  cd ../..
   cd java && $MVN test && $MVN install
   cd util && $MVN package assembly:single
   cd ../..


### PR DESCRIPTION
There is a problem in current test script related to protobuf-java BOM such as https://github.com/protocolbuffers/protobuf/pull/6752 in https://source.cloud.google.com/results/invocations/44587680-210c-4cdc-aa0b-fb1559e0e798/targets/protobuf%2Fgithub%2Fmaster%2Fubuntu%2Fjava_jdk7%2Fpresubmit/log .

> [DEBUG] Using connector WagonRepositoryConnector with priority 0 for https://repo.maven.apache.org/maven2
Downloading: https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-bom/3.11.0-rc-0/protobuf-bom-3.11.0-rc-0.pom
> [DEBUG] Writing resolution tracking file /var/maven_local_repository/com/google/protobuf/protobuf-bom/3.11.0-rc-0/protobuf-bom-3.11.0-rc-0.pom.lastUpdated
> [ERROR] The build could not read 1 project -> [Help 1]
org.apache.maven.project.ProjectBuildingException: Some problems were encountered while processing the POMs:
> [ERROR] Non-resolvable import POM: Could not find artifact com.google.protobuf:protobuf-bom:pom:3.11.0-rc-0 in central (https://repo.maven.apache.org/maven2) @ com.google.protobuf:protobuf-parent:3.11.0-rc-0, /tmp/protobuf/protobuf/java/pom.xml, line 68, column 19
> [ERROR] 'dependencies.dependency.version' for com.google.protobuf:protobuf-java:jar is missing. @ line 17, column 17

This PR fixes the problem by installing the BOM locally before running the Java tests.

Note: when releasing artifacts, please ensure that the BOM is also released.
