### PR TITLE
Load @rules_python in six.BUILD

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -27,6 +27,7 @@ def protobuf_deps():
             name = "six",
             build_file = "@com_google_protobuf//:third_party/six.BUILD",
             sha256 = "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73",
+            strip_prefix = "six-1.12.0",
             urls = ["https://pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz"],
         )
 

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -27,7 +27,6 @@ def protobuf_deps():
             name = "six",
             build_file = "@com_google_protobuf//:third_party/six.BUILD",
             sha256 = "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73",
-            strip_prefix = "six-1.12.0",
             urls = ["https://pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz"],
         )
 

--- a/third_party/six.BUILD
+++ b/third_party/six.BUILD
@@ -5,15 +5,15 @@ load("@rules_python//python:defs.bzl", "py_library")
 # https://github.com/protocolbuffers/protobuf/pull/6795#issuecomment-546060749
 # https://github.com/bazelbuild/bazel/issues/10076
 genrule(
-  name = "copy_six",
-  srcs = ["six-1.12.0/six.py"],
-  outs = ["__init__.py"],
-  cmd = "cp $< $(@)",
+    name = "copy_six",
+    srcs = ["six-1.12.0/six.py"],
+    outs = ["__init__.py"],
+    cmd = "cp $< $(@)",
 )
 
 py_library(
-  name = "six",
-  srcs = ["__init__.py"],
-  srcs_version = "PY2AND3",
-  visibility = ["//visibility:public"],
+    name = "six",
+    srcs = ["__init__.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
 )

--- a/third_party/six.BUILD
+++ b/third_party/six.BUILD
@@ -1,8 +1,19 @@
 load("@rules_python//python:defs.bzl", "py_library")
 
+# Consume `six.py` as `__init__.py` for compatibility
+# with `--incompatible_default_to_explicit_init_py`.
+# https://github.com/protocolbuffers/protobuf/pull/6795#issuecomment-546060749
+# https://github.com/bazelbuild/bazel/issues/10076
+genrule(
+  name = "copy_six",
+  srcs = ["six-1.12.0/six.py"],
+  outs = ["__init__.py"],
+  cmd = "cp $< $(@)",
+)
+
 py_library(
-    name = "six",
-    srcs = ["six.py"],
-    srcs_version = "PY2AND3",
-    visibility = ["//visibility:public"],
+  name = "six",
+  srcs = ["__init__.py"],
+  srcs_version = "PY2AND3",
+  visibility = ["//visibility:public"],
 )

--- a/third_party/six.BUILD
+++ b/third_party/six.BUILD
@@ -1,13 +1,8 @@
-genrule(
-  name = "copy_six",
-  srcs = ["six-1.12.0/six.py"],
-  outs = ["__init__.py"],
-  cmd = "cp $< $(@)",
-)
+load("@rules_python//python:defs.bzl", "py_library")
 
 py_library(
-  name = "six",
-  srcs = ["__init__.py"],
-  srcs_version = "PY2AND3",
-  visibility = ["//visibility:public"],
+    name = "six",
+    srcs = ["six.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This PR adds a load statement for `py_library` to make `@six` compatible with https://github.com/bazelbuild/bazel/issues/9006.

//cc @aaliddell @gnossen