### PR TITLE
protoc-java: Fix broken javadoc generation

### DIFF
--- a/src/google/protobuf/compiler/java/java_enum_field.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field.cc
@@ -656,7 +656,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateMembers(
       "      java.lang.Integer, $type$>($name$_, $name$_converter_);\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
-  WriteFieldAccessorDocComment(printer, descriptor_, LIST_ADDER);
+  WriteFieldAccessorDocComment(printer, descriptor_, LIST_COUNT);
   printer->Print(
       variables_,
       "$deprecation$public int ${$get$capitalized_name$Count$}$() {\n"


### PR DESCRIPTION
protoc-3.10.0 generates broken javadocs for repeated enum values:

````java
/**
 * <pre>
 * A list of types.
 * </pre>
 * <code>repeated .foo.bar.ItemType types = 1;</code>
 * @param value The types to add.
 */
public int getTypesCount() {
    return types_.size();
}
````

which causes an `error` during javadoc generation.

This PR fixes that issue by using the correct parameter.
The error was accidentally added by me in #6231

Maybe this fix could be added to a 3.10.1 release.