### PR TITLE
[not for merge] Checking command availability in Kokoro presubmit

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -242,6 +242,10 @@ build_java_linkage_monitor() {
   # Linkage Monitor checks compatibility with other Google libraries
   # https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/linkage-monitor
 
+  which git
+  git status
+  git remote -v
+
   use_java jdk8
   internal_build_cpp
 


### PR DESCRIPTION
@TeBoring @rafi-kamal I'm designing a new presubmit check that would use git command. (The presubmit would git-checkout our tool before running it) This PR is to confirm `git` is available when running a protobuf-java's presubmit. Would you trigger the Kokoro build?

This PR is not intended to merge.