### PR TITLE
fix javascript message pivot selection [javascript]

### DIFF
--- a/js/message.js
+++ b/js/message.js
@@ -470,7 +470,7 @@ jspb.Message.initPivotAndExtensionObject_ = function(msg, suggestedPivot) {
     }
   }
 
-  if (suggestedPivot > -1) {
+  if (suggestedPivot > -1 && lastIndex > -1) {
     // If a extension object is not present, set the pivot value as being
     // after the last value in the array to avoid overwriting values, etc.
     msg.pivot_ = Math.max(


### PR DESCRIPTION
I have found that protoc compiler incorrectly set suggested pivot for generated message wrappers in JavaScript. So if new message is created in JS runtime without reading of real binary data then it is created with incorrect pivot and it breaks `jspb.Message.setFieldIgnoringDefault_` and so some message properties setters calls lead to data array corruption or incorrect property value load.

I have prepared simple test case at https://github.com/artiz/google-protobuf-invalid-message-pivot-selection


