### PR TITLE
Add ocaml-protoc-plugin option extension

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -212,3 +212,8 @@ with info about your project (name and website) so we can add an entry for you.
 1. Dart port of protocol buffers
    * Website https://github.com/dart-lang/protobuf
    * Extensions: 1073
+   
+1. Ocaml-protoc-plugin
+   * Website https://github.com/issuu/ocaml-protoc-plugin
+   * Extensions: 1074
+   


### PR DESCRIPTION
Reserve an option extension number for Ocaml protoc plugin, to be used for extending FileOptions and ServiceOptions