### PR TITLE
Backport null checks for custom options

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Reflection/CustomOptionsTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Reflection/CustomOptionsTest.cs
@@ -40,6 +40,7 @@ using static Google.Protobuf.WireFormat;
 using static UnitTest.Issues.TestProtos.ComplexOptionType2.Types;
 using static UnitTest.Issues.TestProtos.DummyMessageContainingEnum.Types;
 using static Google.Protobuf.Test.Reflection.CustomOptionNumber;
+using Google.Protobuf.TestProtos;
 
 namespace Google.Protobuf.Test.Reflection
 {
@@ -200,6 +201,21 @@ namespace Google.Protobuf.Test.Reflection
 
             var fieldOptions = AggregateMessage.Descriptor.Fields["fieldname"].CustomOptions;
             AssertOption(new Aggregate { S = "FieldAnnotation" }, fieldOptions.TryGetMessage, AggregateFieldOpt);
+        }
+
+        [Test]
+        public void NoOptions()
+        {
+            var fileDescriptor = UnittestProto3Reflection.Descriptor;
+            var messageDescriptor = TestAllTypes.Descriptor;
+            Assert.NotNull(fileDescriptor.CustomOptions);
+            Assert.NotNull(messageDescriptor.CustomOptions);
+            Assert.NotNull(messageDescriptor.Fields[1].CustomOptions);
+            Assert.NotNull(fileDescriptor.Services[0].CustomOptions);
+            Assert.NotNull(fileDescriptor.Services[0].Methods[0].CustomOptions);
+            Assert.NotNull(fileDescriptor.EnumTypes[0].CustomOptions);
+            Assert.NotNull(fileDescriptor.EnumTypes[0].Values[0].CustomOptions);
+            Assert.NotNull(TestAllTypes.Descriptor.Oneofs[0].CustomOptions);
         }
 
         private void AssertOption<T>(T expected, OptionFetcher<T> fetcher, CustomOptionNumber field)

--- a/csharp/src/Google.Protobuf/Reflection/EnumDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/EnumDescriptor.cs
@@ -129,7 +129,7 @@ namespace Google.Protobuf.Reflection
         /// The (possibly empty) set of custom options for this enum.
         /// </summary>
         //[Obsolete("CustomOptions are obsolete. Use GetOption")]
-        public CustomOptions CustomOptions => Proto.Options.CustomOptions;
+        public CustomOptions CustomOptions => Proto.Options?.CustomOptions ?? CustomOptions.Empty;
 
         /* // uncomment this in the full proto2 support PR
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/EnumValueDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/EnumValueDescriptor.cs
@@ -74,7 +74,7 @@ namespace Google.Protobuf.Reflection
         /// The (possibly empty) set of custom options for this enum value.
         /// </summary>
         //[Obsolete("CustomOptions are obsolete. Use GetOption")]
-        public CustomOptions CustomOptions => Proto.Options.CustomOptions;
+        public CustomOptions CustomOptions => Proto.Options?.CustomOptions ?? CustomOptions.Empty;
 
         /* // uncomment this in the full proto2 support PR
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
@@ -278,7 +278,7 @@ namespace Google.Protobuf.Reflection
         /// The (possibly empty) set of custom options for this field.
         /// </summary>
         //[Obsolete("CustomOptions are obsolete. Use GetOption")]
-        public CustomOptions CustomOptions => Proto.Options.CustomOptions;
+        public CustomOptions CustomOptions => Proto.Options?.CustomOptions ?? CustomOptions.Empty;
 
         /* // uncomment this in the full proto2 support PR
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
@@ -505,7 +505,7 @@ namespace Google.Protobuf.Reflection
         /// The (possibly empty) set of custom options for this file.
         /// </summary>
         //[Obsolete("CustomOptions are obsolete. Use GetOption")]
-        public CustomOptions CustomOptions => Proto.Options.CustomOptions;
+        public CustomOptions CustomOptions => Proto.Options?.CustomOptions ?? CustomOptions.Empty;
 
         /* // uncomment this in the full proto2 support PR
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/MessageDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/MessageDescriptor.cs
@@ -244,7 +244,7 @@ namespace Google.Protobuf.Reflection
         /// The (possibly empty) set of custom options for this message.
         /// </summary>
         //[Obsolete("CustomOptions are obsolete. Use GetOption")]
-        public CustomOptions CustomOptions => Proto.Options.CustomOptions;
+        public CustomOptions CustomOptions => Proto.Options?.CustomOptions ?? CustomOptions.Empty;
 
         /* // uncomment this in the full proto2 support PR
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/MethodDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/MethodDescriptor.cs
@@ -74,7 +74,7 @@ namespace Google.Protobuf.Reflection
         /// The (possibly empty) set of custom options for this method.
         /// </summary>
         //[Obsolete("CustomOptions are obsolete. Use GetOption")]
-        public CustomOptions CustomOptions => Proto.Options.CustomOptions;
+        public CustomOptions CustomOptions => Proto.Options?.CustomOptions ?? CustomOptions.Empty;
 
         /* // uncomment this in the full proto2 support PR
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/OneofDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/OneofDescriptor.cs
@@ -106,7 +106,7 @@ namespace Google.Protobuf.Reflection
         /// The (possibly empty) set of custom options for this oneof.
         /// </summary>
         //[Obsolete("CustomOptions are obsolete. Use GetOption")]
-        public CustomOptions CustomOptions => proto.Options.CustomOptions;
+        public CustomOptions CustomOptions => proto.Options?.CustomOptions ?? CustomOptions.Empty;
 
         /* // uncomment this in the full proto2 support PR
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/ServiceDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ServiceDescriptor.cs
@@ -95,7 +95,7 @@ namespace Google.Protobuf.Reflection
         /// The (possibly empty) set of custom options for this service.
         /// </summary>
         //[Obsolete("CustomOptions are obsolete. Use GetOption")]
-        public CustomOptions CustomOptions => Proto.Options.CustomOptions;
+        public CustomOptions CustomOptions => Proto.Options?.CustomOptions ?? CustomOptions.Empty;
 
         /* // uncomment this in the full proto2 support PR
         /// <summary>


### PR DESCRIPTION
Forgot to reintroduce them when writing #6760 and that's my bad. This also adds tests from #6826.