### PR TITLE
C#: Optimize parsing of some primitive and wrapper types

### DIFF
--- a/csharp/src/Google.Protobuf/FieldCodec.cs
+++ b/csharp/src/Google.Protobuf/FieldCodec.cs
@@ -507,7 +507,7 @@ namespace Google.Protobuf
         {
             var nestedCodec = WrapperCodecs.GetCodec<T>();
             return new FieldCodec<T?>(
-                input => WrapperCodecs.Read<T>(input, nestedCodec),
+                WrapperCodecs.GetReader<T>(),
                 (output, value) => WrapperCodecs.Write<T>(output, value.Value, nestedCodec),
                 (CodedInputStream i, ref T? v) => v = WrapperCodecs.Read<T>(i, nestedCodec),
                 (ref T? v, T? v2) => { if (v2.HasValue) { v = v2; } return v.HasValue; },
@@ -539,6 +539,22 @@ namespace Google.Protobuf
                 { typeof(ByteString), ForBytes(WireFormat.MakeTag(WrappersReflection.WrapperValueFieldNumber, WireFormat.WireType.LengthDelimited)) }
             };
 
+            private static readonly Dictionary<System.Type, Func<object>> Readers = new Dictionary<System.Type, Func<object>>
+            {
+                // TODO: Provide more optimized readers.
+                { typeof(bool), null },
+                { typeof(int), null },
+                { typeof(long), () => (Func<CodedInputStream, long?>)CodedInputStream.ReadInt64Wrapper },
+                { typeof(uint), null },
+                { typeof(ulong), null },
+                { typeof(float), null },
+                { typeof(double), () => BitConverter.IsLittleEndian ?
+                    (Func<CodedInputStream, double?>)CodedInputStream.ReadDoubleWrapperLittleEndian :
+                    (Func<CodedInputStream, double?>)CodedInputStream.ReadDoubleWrapperBigEndian },
+                { typeof(string), null },
+                { typeof(ByteString), null },
+            };
+
             /// <summary>
             /// Returns a field codec which effectively wraps a value of type T in a message.
             ///
@@ -551,6 +567,23 @@ namespace Google.Protobuf
                     throw new InvalidOperationException("Invalid type argument requested for wrapper codec: " + typeof(T));
                 }
                 return (FieldCodec<T>) value;
+            }
+
+            internal static Func<CodedInputStream, T?> GetReader<T>() where T : struct
+            {
+                Func<object> value;
+                if (!Readers.TryGetValue(typeof(T), out value))
+                {
+                    throw new InvalidOperationException("Invalid type argument requested for wrapper reader: " + typeof(T));
+                }
+                if (value == null)
+                {
+                    // Return default unoptimized reader for the wrapper type.
+                    var nestedCoded = GetCodec<T>();
+                    return input => Read<T>(input, nestedCoded);
+                }
+                // Return optimized read for the wrapper type.
+                return (Func<CodedInputStream, T?>)value();
             }
 
             internal static T Read<T>(CodedInputStream input, FieldCodec<T> codec)

--- a/csharp/src/Google.Protobuf/InvalidProtocolBufferException.cs
+++ b/csharp/src/Google.Protobuf/InvalidProtocolBufferException.cs
@@ -136,20 +136,5 @@ namespace Google.Protobuf
         {
             return new InvalidProtocolBufferException("Message was missing required fields");
         }
-
-        internal static InvalidProtocolBufferException InvalidWrapperMessageLength()
-        {
-            return new InvalidProtocolBufferException("Wrapper type message length is incorrect.");
-        }
-
-        internal static InvalidProtocolBufferException InvalidWrapperMessageTag()
-        {
-            return new InvalidProtocolBufferException("Wrapper type message tag is incorrect.");
-        }
-
-        internal static InvalidProtocolBufferException InvalidWrapperMessageExtraFields()
-        {
-            return new InvalidProtocolBufferException("Wrapper type message contains invalid extra field(s).");
-        }
-    }
+}
 }

--- a/csharp/src/Google.Protobuf/InvalidProtocolBufferException.cs
+++ b/csharp/src/Google.Protobuf/InvalidProtocolBufferException.cs
@@ -136,5 +136,20 @@ namespace Google.Protobuf
         {
             return new InvalidProtocolBufferException("Message was missing required fields");
         }
-}
+
+        internal static InvalidProtocolBufferException InvalidWrapperMessageLength()
+        {
+            return new InvalidProtocolBufferException("Wrapper type message length is incorrect.");
+        }
+
+        internal static InvalidProtocolBufferException InvalidWrapperMessageTag()
+        {
+            return new InvalidProtocolBufferException("Wrapper type message tag is incorrect.");
+        }
+
+        internal static InvalidProtocolBufferException InvalidWrapperMessageExtraFields()
+        {
+            return new InvalidProtocolBufferException("Wrapper type message contains invalid extra field(s).");
+        }
+    }
 }


### PR DESCRIPTION
Benchmark on my Windows 10 machine.

Before:
```
|               Method |     Mean |    Error |    StdDev |   Median | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------------- |---------:|---------:|----------:|---------:|------------:|------------:|------------:|--------------------:|
|   ParseWrapperFields | 965.8 ns | 61.36 ns | 180.91 ns | 884.7 ns |      0.8869 |           - |           - |             1.82 KB |
| ParsePrimitiveFields | 409.3 ns | 14.55 ns |  41.98 ns | 393.8 ns |      0.4873 |           - |           - |                1 KB |
```

After:
```
|               Method |     Mean |     Error |    StdDev |   Median | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------------- |---------:|----------:|----------:|---------:|------------:|------------:|------------:|--------------------:|
|   ParseWrapperFields | 692.2 ns | 40.284 ns | 118.78 ns | 660.4 ns |      0.8879 |           - |           - |             1.82 KB |
| ParsePrimitiveFields | 325.9 ns |  6.636 ns |  12.63 ns | 324.8 ns |      0.4878 |           - |           - |                1 KB |
```