### PR TITLE
Use -std=gnu99

### DIFF
--- a/ruby/ext/google/protobuf_c/extconf.rb
+++ b/ruby/ext/google/protobuf_c/extconf.rb
@@ -3,9 +3,9 @@
 require 'mkmf'
 
 if RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
-  $CFLAGS += " -std=gnu90 -O3 -DNDEBUG -Wall -Wdeclaration-after-statement -Wsign-compare"
+  $CFLAGS += " -std=gnu99 -O3 -DNDEBUG -Wall -Wdeclaration-after-statement -Wsign-compare"
 else
-  $CFLAGS += " -std=gnu90 -O3 -DNDEBUG"
+  $CFLAGS += " -std=gnu99 -O3 -DNDEBUG"
 end
 
 


### PR DESCRIPTION
Alpine linux (at least in 3.10) does not have __va_copy, so it is not possible to use google-protobuf without some really ugly hack around build process. c99 is 20 years old and should be fine to use.