### PR TITLE
Simplifying Linkage Monitor test setup

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -248,16 +248,6 @@ build_java_linkage_monitor() {
   # Linkage Monitor uses $HOME/.m2 local repository
   MVN="mvn -e -B -Dhttps.protocols=TLSv1.2"
   cd java
-  # Sets java artifact version with SNAPSHOT, as Linkage Monitor looks for SNAPSHOT versions.
-  # Example: "3.9.0" (without 'rc')
-  VERSION=`grep '<version>' pom.xml |head -1 |perl -nle 'print $1 if m/<version>(\d+\.\d+.\d+)/'`
-  cd bom
-  # This local installation avoids the problem caused by a new version not yet in Maven Central
-  # https://github.com/protocolbuffers/protobuf/issues/6627
-  $MVN install
-  $MVN versions:set -DnewVersion=${VERSION}-SNAPSHOT
-  cd ..
-  $MVN versions:set -DnewVersion=${VERSION}-SNAPSHOT
   # Installs the snapshot version locally
   $MVN install -Dmaven.test.skip=true
 


### PR DESCRIPTION
[Linkage Monitor](https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/linkage-monitor) checks compatibility with other Google libraries. It recently got an enhancement to avoid relying on "snapshot" version. With that, the test script for Linkage Monitor does not need to modify the version of checkout repository copy.

