### PR TITLE
Fix decoding of overencoded booleans.

### DIFF
--- a/objectivec/GPBCodedInputStream.m
+++ b/objectivec/GPBCodedInputStream.m
@@ -203,7 +203,7 @@ int64_t GPBCodedInputStreamReadSInt64(GPBCodedInputStreamState *state) {
 }
 
 BOOL GPBCodedInputStreamReadBool(GPBCodedInputStreamState *state) {
-  return ReadRawVarint32(state) != 0;
+  return ReadRawVarint64(state) != 0;
 }
 
 int32_t GPBCodedInputStreamReadTag(GPBCodedInputStreamState *state) {


### PR DESCRIPTION
if the value was >32bit with the low bits all being zero, it was decoded as
false instead of as true.

Fixes #6863