### PR TITLE
Fix some UBsan warnings

### DIFF
--- a/src/google/protobuf/stubs/strutil.cc
+++ b/src/google/protobuf/stubs/strutil.cc
@@ -1435,32 +1435,44 @@ AlphaNum::AlphaNum(strings::Hex hex) {
 // after the area just overwritten.  It comes in multiple flavors to minimize
 // call overhead.
 static char *Append1(char *out, const AlphaNum &x) {
-  memcpy(out, x.data(), x.size());
-  return out + x.size();
+  if (x.size() > 0) {
+    memcpy(out, x.data(), x.size());
+    out += x.size();
+  }
+  return out;
 }
 
 static char *Append2(char *out, const AlphaNum &x1, const AlphaNum &x2) {
-  memcpy(out, x1.data(), x1.size());
-  out += x1.size();
-
-  memcpy(out, x2.data(), x2.size());
-  return out + x2.size();
+  if (x1.size() > 0) {
+    memcpy(out, x1.data(), x1.size());
+    out += x1.size();
+  }
+  if (x2.size() > 0) {
+    memcpy(out, x2.data(), x2.size());
+    out += x2.size();
+  }
+  return out;
 }
 
-static char *Append4(char *out,
-                     const AlphaNum &x1, const AlphaNum &x2,
+static char *Append4(char *out, const AlphaNum &x1, const AlphaNum &x2,
                      const AlphaNum &x3, const AlphaNum &x4) {
-  memcpy(out, x1.data(), x1.size());
-  out += x1.size();
-
-  memcpy(out, x2.data(), x2.size());
-  out += x2.size();
-
-  memcpy(out, x3.data(), x3.size());
-  out += x3.size();
-
-  memcpy(out, x4.data(), x4.size());
-  return out + x4.size();
+  if (x1.size() > 0) {
+    memcpy(out, x1.data(), x1.size());
+    out += x1.size();
+  }
+  if (x2.size() > 0) {
+    memcpy(out, x2.data(), x2.size());
+    out += x2.size();
+  }
+  if (x3.size() > 0) {
+    memcpy(out, x3.data(), x3.size());
+    out += x3.size();
+  }
+  if (x4.size() > 0) {
+    memcpy(out, x4.data(), x4.size());
+    out += x4.size();
+  }
+  return out;
 }
 
 string StrCat(const AlphaNum &a, const AlphaNum &b) {


### PR DESCRIPTION
Envoy's CI caught UBSan warnings with the update to 3.10:

* external/com_google_protobuf/src/google/protobuf/stubs/strutil.cc:1472:15: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:43:28: note: nonnull attribute specified here

Stack trace:
    #0 0xff9a8b5 in google::protobuf::Append4(char*, google::protobuf::strings::AlphaNum const&, google::protobuf::strings::AlphaNum const&, google::protobuf::strings::AlphaNum const&, google::protobuf::strings::AlphaNum const&) /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/stubs/strutil.cc:1472:3
    #1 0xff9a21f in google::protobuf::StrCat(google::protobuf::strings::AlphaNum const&, google::protobuf::strings::AlphaNum const&, google::protobuf::strings::AlphaNum const&, google::protobuf::strings::AlphaNum const&) /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/stubs/strutil.cc:1506:15
    #2 0xf9bc4d2 in google::protobuf::util::(anonymous namespace)::StatusErrorListener::InvalidName(google::protobuf::util::converter::LocationTrackerInterface const&, google::protobuf::StringPiece, google::protobuf::StringPiece) /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/util/json_util.cc:140:24
    #3 0xfb617d1 in google::protobuf::util::converter::ProtoWriter::InvalidName(google::protobuf::StringPiece, google::protobuf::StringPiece) /proc/self/cwd/external/com_google_protobuf/src/google/protobuf/util/internal/proto_writer.cc:442:14

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior external/com_google_protobuf/src/google/protobuf/stubs/strutil.cc:1472:15 in 

Signed-off-by: Asra Ali <asraa@google.com>