### PR TITLE
C#: Allow readonly view of byteString's data with ByteString.Memory property

### DIFF
--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -116,6 +116,12 @@ namespace Google.Protobuf
         /// No data is copied so this is the most efficient way of accessing.
         /// </summary>
         public ReadOnlySpan<byte> Span => new ReadOnlySpan<byte>(bytes);
+
+        /// <summary>
+        /// Provides read-only access to the data of this <see cref="ByteString"/>.
+        /// No data is copied so this is the most efficient way of accessing.
+        /// </summary>
+        public ReadOnlyMemory<byte> Memory => new ReadOnlyMemory<byte>(bytes);
 #endif
 
         /// <summary>


### PR DESCRIPTION
To allow calling e.g. FileStream.WriteAsync() that requires ReadOnlyMemory<byte>.
You can go from a Memory<T> to a Span<T> but not vice versa.