### PR TITLE
Revert "Make shared libraries be able to link to MSVC static runtime libraries, so that VC runtime is not required."

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,7 +13,6 @@
   * Skip extension tag validation for MessageSet if unknown dependencies are allowed
   * Updated deprecation macros to annotate deprecated code (#6612)
   * Remove conversion warning in MapEntryFuncs::ByteSizeLong (#6766)
-  * Make shared libraries be able to link to MSVC static runtime libraries (#6780)
 
   Java
   * Remove the usage of MethodHandle, so that Android users prior to API version 26 can use protobuf-java

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -40,6 +40,8 @@ else (BUILD_SHARED_LIBS)
 endif (BUILD_SHARED_LIBS)
 option(protobuf_BUILD_SHARED_LIBS "Build Shared Libraries" ${protobuf_BUILD_SHARED_LIBS_DEFAULT})
 include(CMakeDependentOption)
+cmake_dependent_option(protobuf_MSVC_STATIC_RUNTIME "Link static runtime libraries" ON
+  "NOT protobuf_BUILD_SHARED_LIBS" OFF)
 set(protobuf_WITH_ZLIB_DEFAULT ON)
 option(protobuf_WITH_ZLIB "Build with zlib support" ${protobuf_WITH_ZLIB_DEFAULT})
 set(protobuf_DEBUG_POSTFIX "d"
@@ -153,21 +155,21 @@ if (protobuf_BUILD_SHARED_LIBS)
   set(protobuf_SHARED_OR_STATIC "SHARED")
 else (protobuf_BUILD_SHARED_LIBS)
   set(protobuf_SHARED_OR_STATIC "STATIC")
+  # In case we are building static libraries, link also the runtime library statically
+  # so that MSVCR*.DLL is not required at runtime.
+  # https://msdn.microsoft.com/en-us/library/2kzt1wy3.aspx
+  # This is achieved by replacing msvc option /MD with /MT and /MDd with /MTd
+  # http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F
+  if (MSVC AND protobuf_MSVC_STATIC_RUNTIME)
+    foreach(flag_var
+        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+      if(${flag_var} MATCHES "/MD")
+        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+      endif(${flag_var} MATCHES "/MD")
+    endforeach(flag_var)
+  endif (MSVC AND protobuf_MSVC_STATIC_RUNTIME)
 endif (protobuf_BUILD_SHARED_LIBS)
-
-# In case we are linking the runtime library statically so that MSVCR*.DLL is not required at runtime.
-# https://msdn.microsoft.com/en-us/library/2kzt1wy3.aspx
-# This is achieved by replacing msvc option /MD with /MT and /MDd with /MTd
-# http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F
-if (MSVC AND protobuf_MSVC_STATIC_RUNTIME)
-  foreach(flag_var
-      CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-      CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-    if(${flag_var} MATCHES "/MD")
-      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-    endif(${flag_var} MATCHES "/MD")
-  endforeach(flag_var)
-endif (MSVC AND protobuf_MSVC_STATIC_RUNTIME)
 
 if (MSVC)
   # Build with multiple processes


### PR DESCRIPTION
This reverts commit 129a7c875fc89309a2ab2fbbc940268bbf42b024. We are seeing errors when building Python release artifacts in Windows:
"error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MT_StaticRelease' in descriptor.obj".
