### PR TITLE
Update "proto_gen" rule to remove duplicate includes and deps.

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -87,6 +87,8 @@ def _proto_gen_impl(ctx):
     for dep in ctx.attr.deps:
         import_flags += dep.proto.import_flags
         deps += dep.proto.deps
+    import_flags = depset(import_flags).to_list()
+    deps = depset(deps).to_list()
 
     if not ctx.attr.gen_cc and not ctx.attr.gen_py and not ctx.executable.plugin:
         return struct(


### PR DESCRIPTION
This otherwise causes problems with too-long argument lists to "protoc".

Given "foo.proto" and "bar.proto" that both depend on "baz.proto", any proto_gen rule that depends on both "foo.proto" and "bar.proto" will pull in the includes and dependencies from "baz.proto" twice. When depending on proto targets that all depend on some common, large proto target, this leads to an explosion of import flags and causes "Argument list too long" errors on some platforms (Windows has 32k, MacOS hast 256k limits).

The proposed change converts "import_flags" and "deps" from lists to sets, and back to lists again, thus removing any duplicates. I'm not sure what this does with the order of the values, but the way they are aggregated does not make it look like it's important.