### PR TITLE
protoc: Add --python_opt.

### DIFF
--- a/src/google/protobuf/compiler/main.cc
+++ b/src/google/protobuf/compiler/main.cc
@@ -69,7 +69,7 @@ int ProtobufMain(int argc, char* argv[]) {
 
   // Proto2 Python
   python::Generator py_generator;
-  cli.RegisterGenerator("--python_out", &py_generator,
+  cli.RegisterGenerator("--python_out", "--python_opt", &py_generator,
                         "Generate Python source file.");
 
   // PHP


### PR DESCRIPTION
Now that there's something interesting to pass to the Python generator (cpp_generated_lib_linked), add the option flag to allow it.