### PR TITLE
Fix ArgumentException in C# when any proto file with extension is imported multiple times

### DIFF
--- a/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
@@ -98,5 +98,18 @@ namespace Google.Protobuf
             Assert.AreEqual(message, other);
             Assert.AreEqual(message.CalculateSize(), message.CalculateSize());
         }
+
+        [Test]
+        public void TestImportedMultipleTImes()
+        {
+            var descriptor = UnittestWithExtension1Proto3Reflection.Descriptor.FindTypeByName<Google.Protobuf.Reflection.MessageDescriptor>("TestMessageWithExtension1");
+
+            Assert.IsNotNull(descriptor);
+            var extensionData = descriptor.GetOption(UnittestImportExtensionProto3Extensions.UnittestExtension);
+            Assert.IsNotNull(extensionData);
+
+            Assert.AreEqual(extensionData, "TestMessageWithExtension1");
+            Assert.AreEqual(descriptor.Name, "TestMessageWithExtension1");
+        }
     }
 }

--- a/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
@@ -98,18 +98,5 @@ namespace Google.Protobuf
             Assert.AreEqual(message, other);
             Assert.AreEqual(message.CalculateSize(), message.CalculateSize());
         }
-
-        [Test]
-        public void TestImportedMultipleTImes()
-        {
-            var descriptor = UnittestWithExtension1Proto3Reflection.Descriptor.FindTypeByName<Google.Protobuf.Reflection.MessageDescriptor>("TestMessageWithExtension1");
-
-            Assert.IsNotNull(descriptor);
-            var extensionData = descriptor.GetOption(UnittestImportExtensionProto3Extensions.UnittestExtension);
-            Assert.IsNotNull(extensionData);
-
-            Assert.AreEqual(extensionData, "TestMessageWithExtension1");
-            Assert.AreEqual(descriptor.Name, "TestMessageWithExtension1");
-        }
     }
 }

--- a/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
@@ -448,7 +448,7 @@ namespace Google.Protobuf.Reflection
 
         private static IEnumerable<Extension> GetAllExtensions(FileDescriptor[] dependencies, GeneratedClrTypeInfo generatedInfo)
         {
-            return dependencies.SelectMany(GetAllDependedExtensions).Distinct(ExtensionRegistry.ExtensionComparer.Instance).Concat(GetAllGeneratedExtensions(generatedInfo));
+            return BuildDependedFileDescriptors(dependencies).SelectMany(GetAllDependedExtensions).Distinct(ExtensionRegistry.ExtensionComparer.Instance).Concat(GetAllGeneratedExtensions(generatedInfo));
         }
 
         private static IEnumerable<FileDescriptor> BuildDependedFileDescriptors(IEnumerable<FileDescriptor> dependencies)


### PR DESCRIPTION
Fix ```ArgumentException: An item with the same key has already been added. Key: Google.Protobuf.ObjectIntPair``` when using Descriptor with proto file with any proto file with extensions is imported multiple times(imported directly or imported by dependencies proto files).

I think this PR is related to #6936 #6938 . The latest release (by now) [v3.11.0](https://github.com/protocolbuffers/protobuf/releases/tag/v3.11.0) also has this problem.

Here is a simple sample to reproduction this problem:

**test-a.proto**

```protobuf
syntax = "proto3";

import "test-ext.proto";
import "test-b.proto";

message TestMessageA {
    option (msg_description_1) = "description of TestMessageA";
    
    string id      = 1;
    TestMessageB b = 2;
}
```

**test-b.proto**

```protobuf
syntax = "proto3";

import "test-ext.proto";

message TestMessageB {
    option (msg_description_1) = "description of TestMessageB";
    
    string id = 1;
}
```


**test-ext.proto**

```protobuf
syntax = "proto3";

import "google/protobuf/descriptor.proto";

extend google.protobuf.MessageOptions {
    string msg_description_1         = 1001; // description 1
    // other options 2000 to max;
}
```

**Generate csharp code with** ```protoc -I./extensions ./extensions/test-a.proto ./extensions/test-b.proto ./extensions/test-ext.proto ./extensions/google/protobuf/descriptor.proto --csharp_out=.```

**Ant then run these codes below:**

```csharp
using System;

namespace DotnetCoreConsoleApp2
{
    class Program
    {
        static void Main(string[] args)
        {
            // protoc -I./extensions ./extensions/test-a.proto ./extensions/test-b.proto ./extensions/test-ext.proto ./extensions/google/protobuf/descriptor.proto --csharp_out=.
            var desc = TestAReflection.Descriptor.FindTypeByName<Google.Protobuf.Reflection.MessageDescriptor>("TestMessageA");
            Console.WriteLine(desc.FullName);
        }
    }
}
```

We will got a exception like this:

```bash
Unhandled exception. System.TypeInitializationException: The type initializer for 'TestAReflection' threw an exception.
 ---> System.ArgumentException: An item with the same key has already been added. Key: Google.Protobuf.ObjectIntPair`1[System.Type]
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Google.Protobuf.ExtensionRegistry.Add(Extension extension) in D:\prebuilt\protobuf\protobuf-3.11.0\csharp\src\Google.Protobuf\ExtensionRegistry.cs:line 83
   at Google.Protobuf.ExtensionRegistry.AddRange(IEnumerable`1 extensions) in D:\prebuilt\protobuf\protobuf-3.11.0\csharp\src\Google.Protobuf\ExtensionRegistry.cs:line 92
   at Google.Protobuf.Reflection.FileDescriptor.AddAllExtensions(FileDescriptor[] dependencies, GeneratedClrTypeInfo generatedInfo, ExtensionRegistry registry) in D:\prebuilt\protobuf\protobuf-3.11.0\csharp\src\Google.Protobuf\Reflection\FileDescriptor.cs:line 451
   at Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode(Byte[] descriptorData, FileDescriptor[] dependencies, GeneratedClrTypeInfo generatedCodeInfo) in D:\prebuilt\protobuf\protobuf-3.11.0\csharp\src\Google.Protobuf\Reflection\FileDescriptor.cs:line 425
   at TestAReflection..cctor() in D:\workspace\test\DotnetCoreConsoleApp2\TestA.cs:line 29
   --- End of inner exception stack trace ---
   at TestAReflection.get_Descriptor() in D:\workspace\test\DotnetCoreConsoleApp2\TestA.cs:line 18
   at DotnetCoreConsoleApp2.Program.Main(String[] args) in D:\workspace\test\DotnetCoreConsoleApp2\Program.cs:line 10
```

We find the problem is in the call ```Google.Protobuf.Reflection.FileDescriptor.AddAllExtensions(...)```  when generate extensions for ```test-a.proto``` . ```msg_description_1``` is added twice from ```test-a.proto/test-ext.proto/descriptor.proto``` and ```test-a.proto/test-b.proto/test-ext.proto/descriptor.proto``` .


If ```test-a.proto``` import ```test-b.proto``` and ```test-c.proto``` when both ```test-b.proto``` and ```test-c.proto``` import ```test-ext.proto``` with extensions in it. The same problem happens.