### PR TITLE
Add a proto_lang_toolchain for javalite (3.11.x backport)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1001,6 +1001,13 @@ proto_lang_toolchain(
     visibility = ["//visibility:public"],
 )
 
+proto_lang_toolchain(
+    name = "javalite_toolchain",
+    command_line = "--java_out=lite:$(OUT)",
+    runtime = ":protobuf_javalite",
+    visibility = ["//visibility:public"],
+)
+
 alias(
     name = "objectivec",
     actual = ":protobuf_objc",

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -21,10 +21,9 @@ local_repository(
 # Similar to com_google_protobuf but for Java lite. If you are building
 # for Android, the lite version should be prefered because it has a much
 # smaller code size.
-http_archive(
+local_repository(
     name = "com_google_protobuf_javalite",
-    strip_prefix = "protobuf-javalite",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/javalite.zip"],
+    path = "..",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
So that javalite can be used from Bazel. Related discussion: #6867

----

This is a backport of #6882