### PR TITLE
Fix a bytes vs. strings bug in FileDescriptor

### DIFF
--- a/python/google/protobuf/descriptor.py
+++ b/python/google/protobuf/descriptor.py
@@ -874,7 +874,7 @@ class FileDescriptor(DescriptorBase):
       # FileDescriptor() is called from various places, not only from generated
       # files, to register dynamic proto files and messages.
       # pylint: disable=g-explicit-bool-comparison
-      if serialized_pb == '':
+      if serialized_pb == b'':
         # Cpp generated code must be linked in if serialized_pb is ''
         try:
           return _message.default_pool.FindFileByName(name)

--- a/python/google/protobuf/descriptor.py
+++ b/python/google/protobuf/descriptor.py
@@ -874,8 +874,10 @@ class FileDescriptor(DescriptorBase):
       # FileDescriptor() is called from various places, not only from generated
       # files, to register dynamic proto files and messages.
       # pylint: disable=g-explicit-bool-comparison
-      if serialized_pb == b'':
-        # Cpp generated code must be linked in if serialized_pb is ''
+      if len(serialized_pb) == 0:
+        # Cpp generated code must be linked in if serialized_pb is ''.
+        # Explicity check length as this can be either of type `bytes` or `str`
+        # and this is the fastest method for checking for either an empty bytes.
         try:
           return _message.default_pool.FindFileByName(name)
         except KeyError:

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -15,10 +15,10 @@ commands =
     python setup.py -q build_py
     python: python setup.py -q build
     cpp: python setup.py -q build --cpp_implementation --warnings_as_errors --compile_static_extension
-    python: python setup.py -q test -q
-    cpp: python setup.py -q test -q --cpp_implementation
-    python: python setup.py -q test_conformance
-    cpp: python setup.py -q test_conformance --cpp_implementation
+    python: python -bb setup.py -q test -q
+    cpp: python -bb setup.py -q test -q --cpp_implementation
+    python: python -bb setup.py -q test_conformance
+    cpp: python -bb setup.py -q test_conformance --cpp_implementation
 deps =
     # Keep this list of dependencies in sync with setup.py.
     six>=1.9

--- a/src/google/protobuf/compiler/python/python_generator.cc
+++ b/src/google/protobuf/compiler/python/python_generator.cc
@@ -467,7 +467,7 @@ void Generator::PrintFileDescriptor() const {
       printer_->Print("]");
     }
   } else {
-    printer_->Print("serialized_pb=''\n");
+    printer_->Print("serialized_pb=b''\n");
   }
 
   // TODO(falk): Also print options and fix the message_type, enum_type,


### PR DESCRIPTION
It appears this was broken in:
https://github.com/protocolbuffers/protobuf/pull/6893/files#r351384126

This is an actual bug, not just a warning issue:

```python
In [1]: '' == b''
Out[1]: False
```

This can be caught by adding the `-bb` flag to CI:

```
rwilliams at rwilliams-mbp114 in ~
$ python3 -c '"" == b""'

rwilliams at rwilliams-mbp114 in ~
$ python3 -bb -c '"" == b""'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
BytesWarning: Comparison between bytes and string
```
Lyft runs all Python 3 CI jobs with this flag to catch just such issues.

Lyft has signed the Google CLA.