### PR TITLE
Fix compile errors on case-sensitive APFS

### DIFF
--- a/objectivec/GPBProtocolBuffers.h
+++ b/objectivec/GPBProtocolBuffers.h
@@ -52,16 +52,16 @@
 
 // Well-known proto types
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/Any.pbobjc.h>
- #import <protobuf/Api.pbobjc.h>
- #import <protobuf/Duration.pbobjc.h>
- #import <protobuf/Empty.pbobjc.h>
- #import <protobuf/FieldMask.pbobjc.h>
- #import <protobuf/SourceContext.pbobjc.h>
- #import <protobuf/Struct.pbobjc.h>
- #import <protobuf/Timestamp.pbobjc.h>
- #import <protobuf/Type.pbobjc.h>
- #import <protobuf/Wrappers.pbobjc.h>
+ #import <Protobuf/Any.pbobjc.h>
+ #import <Protobuf/Api.pbobjc.h>
+ #import <Protobuf/Duration.pbobjc.h>
+ #import <Protobuf/Empty.pbobjc.h>
+ #import <Protobuf/FieldMask.pbobjc.h>
+ #import <Protobuf/SourceContext.pbobjc.h>
+ #import <Protobuf/Struct.pbobjc.h>
+ #import <Protobuf/Timestamp.pbobjc.h>
+ #import <Protobuf/Type.pbobjc.h>
+ #import <Protobuf/Wrappers.pbobjc.h>
 #else
  #import "google/protobuf/Any.pbobjc.h"
  #import "google/protobuf/Api.pbobjc.h"

--- a/objectivec/GPBWellKnownTypes.h
+++ b/objectivec/GPBWellKnownTypes.h
@@ -37,9 +37,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/Any.pbobjc.h>
- #import <protobuf/Duration.pbobjc.h>
- #import <protobuf/Timestamp.pbobjc.h>
+ #import <Protobuf/Any.pbobjc.h>
+ #import <Protobuf/Duration.pbobjc.h>
+ #import <Protobuf/Timestamp.pbobjc.h>
 #else
  #import "google/protobuf/Any.pbobjc.h"
  #import "google/protobuf/Duration.pbobjc.h"

--- a/objectivec/google/protobuf/Any.pbobjc.h
+++ b/objectivec/google/protobuf/Any.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBDescriptor.h>
- #import <protobuf/GPBMessage.h>
- #import <protobuf/GPBRootObject.h>
+ #import <Protobuf/GPBDescriptor.h>
+ #import <Protobuf/GPBMessage.h>
+ #import <Protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Any.pbobjc.m
+++ b/objectivec/google/protobuf/Any.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/Any.pbobjc.h>
+ #import <Protobuf/Any.pbobjc.h>
 #else
  #import "google/protobuf/Any.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Api.pbobjc.h
+++ b/objectivec/google/protobuf/Api.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBDescriptor.h>
- #import <protobuf/GPBMessage.h>
- #import <protobuf/GPBRootObject.h>
+ #import <Protobuf/GPBDescriptor.h>
+ #import <Protobuf/GPBMessage.h>
+ #import <Protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Api.pbobjc.m
+++ b/objectivec/google/protobuf/Api.pbobjc.m
@@ -8,15 +8,15 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/Api.pbobjc.h>
- #import <protobuf/SourceContext.pbobjc.h>
- #import <protobuf/Type.pbobjc.h>
+ #import <Protobuf/Api.pbobjc.h>
+ #import <Protobuf/SourceContext.pbobjc.h>
+ #import <Protobuf/Type.pbobjc.h>
 #else
  #import "google/protobuf/Api.pbobjc.h"
  #import "google/protobuf/SourceContext.pbobjc.h"

--- a/objectivec/google/protobuf/Duration.pbobjc.h
+++ b/objectivec/google/protobuf/Duration.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBDescriptor.h>
- #import <protobuf/GPBMessage.h>
- #import <protobuf/GPBRootObject.h>
+ #import <Protobuf/GPBDescriptor.h>
+ #import <Protobuf/GPBMessage.h>
+ #import <Protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Duration.pbobjc.m
+++ b/objectivec/google/protobuf/Duration.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/Duration.pbobjc.h>
+ #import <Protobuf/Duration.pbobjc.h>
 #else
  #import "google/protobuf/Duration.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Empty.pbobjc.h
+++ b/objectivec/google/protobuf/Empty.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBDescriptor.h>
- #import <protobuf/GPBMessage.h>
- #import <protobuf/GPBRootObject.h>
+ #import <Protobuf/GPBDescriptor.h>
+ #import <Protobuf/GPBMessage.h>
+ #import <Protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Empty.pbobjc.m
+++ b/objectivec/google/protobuf/Empty.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/Empty.pbobjc.h>
+ #import <Protobuf/Empty.pbobjc.h>
 #else
  #import "google/protobuf/Empty.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/FieldMask.pbobjc.h
+++ b/objectivec/google/protobuf/FieldMask.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBDescriptor.h>
- #import <protobuf/GPBMessage.h>
- #import <protobuf/GPBRootObject.h>
+ #import <Protobuf/GPBDescriptor.h>
+ #import <Protobuf/GPBMessage.h>
+ #import <Protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/FieldMask.pbobjc.m
+++ b/objectivec/google/protobuf/FieldMask.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/FieldMask.pbobjc.h>
+ #import <Protobuf/FieldMask.pbobjc.h>
 #else
  #import "google/protobuf/FieldMask.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/SourceContext.pbobjc.h
+++ b/objectivec/google/protobuf/SourceContext.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBDescriptor.h>
- #import <protobuf/GPBMessage.h>
- #import <protobuf/GPBRootObject.h>
+ #import <Protobuf/GPBDescriptor.h>
+ #import <Protobuf/GPBMessage.h>
+ #import <Protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/SourceContext.pbobjc.m
+++ b/objectivec/google/protobuf/SourceContext.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/SourceContext.pbobjc.h>
+ #import <Protobuf/SourceContext.pbobjc.h>
 #else
  #import "google/protobuf/SourceContext.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Struct.pbobjc.h
+++ b/objectivec/google/protobuf/Struct.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBDescriptor.h>
- #import <protobuf/GPBMessage.h>
- #import <protobuf/GPBRootObject.h>
+ #import <Protobuf/GPBDescriptor.h>
+ #import <Protobuf/GPBMessage.h>
+ #import <Protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Struct.pbobjc.m
+++ b/objectivec/google/protobuf/Struct.pbobjc.m
@@ -8,7 +8,7 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
@@ -16,7 +16,7 @@
 #import <stdatomic.h>
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/Struct.pbobjc.h>
+ #import <Protobuf/Struct.pbobjc.h>
 #else
  #import "google/protobuf/Struct.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Timestamp.pbobjc.h
+++ b/objectivec/google/protobuf/Timestamp.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBDescriptor.h>
- #import <protobuf/GPBMessage.h>
- #import <protobuf/GPBRootObject.h>
+ #import <Protobuf/GPBDescriptor.h>
+ #import <Protobuf/GPBMessage.h>
+ #import <Protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Timestamp.pbobjc.m
+++ b/objectivec/google/protobuf/Timestamp.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/Timestamp.pbobjc.h>
+ #import <Protobuf/Timestamp.pbobjc.h>
 #else
  #import "google/protobuf/Timestamp.pbobjc.h"
 #endif

--- a/objectivec/google/protobuf/Type.pbobjc.h
+++ b/objectivec/google/protobuf/Type.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBDescriptor.h>
- #import <protobuf/GPBMessage.h>
- #import <protobuf/GPBRootObject.h>
+ #import <Protobuf/GPBDescriptor.h>
+ #import <Protobuf/GPBMessage.h>
+ #import <Protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Type.pbobjc.m
+++ b/objectivec/google/protobuf/Type.pbobjc.m
@@ -8,7 +8,7 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
@@ -16,9 +16,9 @@
 #import <stdatomic.h>
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/Type.pbobjc.h>
- #import <protobuf/Any.pbobjc.h>
- #import <protobuf/SourceContext.pbobjc.h>
+ #import <Protobuf/Type.pbobjc.h>
+ #import <Protobuf/Any.pbobjc.h>
+ #import <Protobuf/SourceContext.pbobjc.h>
 #else
  #import "google/protobuf/Type.pbobjc.h"
  #import "google/protobuf/Any.pbobjc.h"

--- a/objectivec/google/protobuf/Wrappers.pbobjc.h
+++ b/objectivec/google/protobuf/Wrappers.pbobjc.h
@@ -8,9 +8,9 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBDescriptor.h>
- #import <protobuf/GPBMessage.h>
- #import <protobuf/GPBRootObject.h>
+ #import <Protobuf/GPBDescriptor.h>
+ #import <Protobuf/GPBMessage.h>
+ #import <Protobuf/GPBRootObject.h>
 #else
  #import "GPBDescriptor.h"
  #import "GPBMessage.h"

--- a/objectivec/google/protobuf/Wrappers.pbobjc.m
+++ b/objectivec/google/protobuf/Wrappers.pbobjc.m
@@ -8,13 +8,13 @@
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/GPBProtocolBuffers_RuntimeSupport.h>
+ #import <Protobuf/GPBProtocolBuffers_RuntimeSupport.h>
 #else
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
- #import <protobuf/Wrappers.pbobjc.h>
+ #import <Protobuf/Wrappers.pbobjc.h>
 #else
  #import "google/protobuf/Wrappers.pbobjc.h"
 #endif


### PR DESCRIPTION
Hi. I couldn't add protobuf to iOS App. using CocoaPods with compile errors:

<img width="777" alt="スクリーンショット 2019-12-11 11 43 43" src="https://user-images.githubusercontent.com/51456946/70596676-cbffd780-1c29-11ea-9a70-173a81884d6c.png">

I figured out `Any.pbobjc.h` is located on `Protobuf`, not `protobuf`, and also, my disk is formatted as case-sensitive APFS. So that the objc compiler cannot find the header.

Here is my podfile:

```
# Uncomment this line to define a global platform for your project
platform :ios, '11.0'
use_modular_headers!
inhibit_all_warnings!
# use_frameworks!

target '*****' do
    ....
    pod 'Protobuf'
    ....
end
```

This patch may also fixes: https://github.com/invertase/react-native-firebase/issues/2780