### PR TITLE
Prevent integer overflow for unknown fields in Python

### DIFF
--- a/python/google/protobuf/pyext/unknown_fields.cc
+++ b/python/google/protobuf/pyext/unknown_fields.cc
@@ -277,13 +277,13 @@ static PyObject* GetData(PyUnknownFieldRef* self, void *closure) {
   PyObject* data = NULL;
   switch (field->type()) {
     case UnknownField::TYPE_VARINT:
-      data = PyInt_FromLong(field->varint());
+      data = PyLong_FromUnsignedLongLong(field->varint());
       break;
     case UnknownField::TYPE_FIXED32:
-      data = PyInt_FromLong(field->fixed32());
+      data = PyLong_FromUnsignedLong(field->fixed32());
       break;
     case UnknownField::TYPE_FIXED64:
-      data = PyInt_FromLong(field->fixed64());
+      data = PyLong_FromUnsignedLongLong(field->fixed64());
       break;
     case UnknownField::TYPE_LENGTH_DELIMITED:
       data = PyBytes_FromStringAndSize(field->length_delimited().data(),


### PR DESCRIPTION
The PyInt_FromLong() conversion function will truncate 64 bit integer
values on 32 bit architectures. We will now use the PyLong_* functions
with the appropriate minimum size for each field.

Note that this commit also switches to the unsigned versions, since the
unknown integer fields have been declared unsigned anyway.

Fixes #6205