### PR TITLE
Ruby - Add failing tests for issue with deserializing wrapped values

### DIFF
--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -318,6 +318,43 @@ module BasicTest
       assert_equal m5, m
     end
 
+    def test_map_wrappers_with_no_value
+      run_asserts = ->(m) {
+        assert_equal nil, m.map_double[0]
+        assert_equal nil, m.map_float[0]
+        assert_equal nil, m.map_int32[0]
+        assert_equal nil, m.map_int64[0]
+        assert_equal nil, m.map_uint32[0]
+        assert_equal nil, m.map_uint64[0]
+        assert_equal nil, m.map_bool[0]
+        assert_equal nil, m.map_string[0]
+        assert_equal nil, m.map_bytes[0]
+      }
+
+      m = proto_module::Wrapper.new(
+        map_double: {0 => Google::Protobuf::DoubleValue.new()},
+        map_float: {0 => Google::Protobuf::FloatValue.new()},
+        map_int32: {0 => Google::Protobuf::Int32Value.new()},
+        map_int64: {0 => Google::Protobuf::Int64Value.new()},
+        map_uint32: {0 => Google::Protobuf::UInt32Value.new()},
+        map_uint64: {0 => Google::Protobuf::UInt64Value.new()},
+        map_bool: {0 => Google::Protobuf::BoolValue.new()},
+        map_string: {0 => Google::Protobuf::StringValue.new()},
+        map_bytes: {0 => Google::Protobuf::BytesValue.new()},
+      )
+
+      serialized = proto_module::Wrapper::encode(m)
+      m2 = proto_module::Wrapper::decode(serialized)
+      run_asserts.call(m2)
+
+      # Test the case where we are serializing directly from the parsed form
+      # (before anything lazy is materialized).
+      m3 = proto_module::Wrapper::decode(serialized)
+      serialized2 = proto_module::Wrapper::encode(m3)
+      m4 = proto_module::Wrapper::decode(serialized2)
+      run_asserts.call(m4)
+    end
+
     def test_concurrent_decoding
       o = Outer.new
       o.items[0] = Inner.new

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -276,6 +276,48 @@ module BasicTest
       assert_equal m5, m
     end
 
+    def test_map_wrappers_with_default_values
+      run_asserts = ->(m) {
+        assert_equal 0.0, m.map_double[0].value
+        assert_equal 0.0, m.map_float[0].value
+        assert_equal 0, m.map_int32[0].value
+        assert_equal 0, m.map_int64[0].value
+        assert_equal 0, m.map_uint32[0].value
+        assert_equal 0, m.map_uint64[0].value
+        assert_equal false, m.map_bool[0].value
+        assert_equal '', m.map_string[0].value
+        assert_equal '', m.map_bytes[0].value
+      }
+
+      m = proto_module::Wrapper.new(
+        map_double: {0 => Google::Protobuf::DoubleValue.new(value: 0.0)},
+        map_float: {0 => Google::Protobuf::FloatValue.new(value: 0.0)},
+        map_int32: {0 => Google::Protobuf::Int32Value.new(value: 0)},
+        map_int64: {0 => Google::Protobuf::Int64Value.new(value: 0)},
+        map_uint32: {0 => Google::Protobuf::UInt32Value.new(value: 0)},
+        map_uint64: {0 => Google::Protobuf::UInt64Value.new(value: 0)},
+        map_bool: {0 => Google::Protobuf::BoolValue.new(value: false)},
+        map_string: {0 => Google::Protobuf::StringValue.new(value: '')},
+        map_bytes: {0 => Google::Protobuf::BytesValue.new(value: '')},
+      )
+
+      run_asserts.call(m)
+      serialized = proto_module::Wrapper::encode(m)
+      m2 = proto_module::Wrapper::decode(serialized)
+      run_asserts.call(m2)
+
+      # Test the case where we are serializing directly from the parsed form
+      # (before anything lazy is materialized).
+      m3 = proto_module::Wrapper::decode(serialized)
+      serialized2 = proto_module::Wrapper::encode(m3)
+      m4 = proto_module::Wrapper::decode(serialized2)
+      run_asserts.call(m4)
+
+      # Test that the lazy form compares equal to the expanded form.
+      m5 = proto_module::Wrapper::decode(serialized2)
+      assert_equal m5, m
+    end
+
     def test_concurrent_decoding
       o = Outer.new
       o.items[0] = Inner.new


### PR DESCRIPTION
This is in reference to https://github.com/protocolbuffers/protobuf/issues/7029.

The expected behavior is 
1.) wrapped values with the default value set should deserialize to a wrapped value with the default value set, but instead, they are being set to nil.

The first test fails with:
`Error: test_map_wrappers_with_default_values(BasicTest::MessageContainerTest): NoMethodError: undefined method value for nil:NilClass`, which matches what https://github.com/protocolbuffers/protobuf/issues/7029 is seeing.

2.) The second test I added for completeness.  A test that asserts the correct behavior for wrapped values with no value set.

The test structure followed the test introduced by @haberman  here, https://github.com/protocolbuffers/protobuf/pull/6797.  My understanding of C is limited, but that PR seems to be  one of the PRs that touched the Ruby code between the upgrade from 3.10.1 to 3.11.0, where this issue was introduced.  