### PR TITLE
Fix typos

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -265,7 +265,7 @@
   * Introduce Proto C API.
   * FindFileContainingSymbol in descriptor pool is now able to find field and enum values.
   * reflection.MakeClass()  and  reflection.ParseMessage() are deprecated.
-  * Added DescriptorPool.FindMethodByName() method in pure python (c extension alreay has it)
+  * Added DescriptorPool.FindMethodByName() method in pure python (c extension already has it)
   * Flipped proto3 to preserve unknown fields by default.
   * Added support for memoryview in python3 proto message parsing.
   * Added MergeFrom for repeated scalar fields in c extension (pure python already has it)
@@ -428,7 +428,7 @@
   PHP
   * Fixed memory leak in C-extension implementation.
   * Added discardUnknokwnFields API.
-  * Removed duplicatd typedef in C-extension headers.
+  * Removed duplicated typedef in C-extension headers.
   * Avoided calling private php methods (timelib_update_ts).
   * Fixed Any.php to use fully-qualified name for DescriptorPool.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -168,7 +168,7 @@ $ ./cpp-benchmark $(specific generated dataset file name) [$(benchmark options)]
 
 ### Python:
 
-For Python benchmark we have `--json` for outputing the json result
+For Python benchmark we have `--json` for outputting the json result
 
 #### Pure Python:
 

--- a/conformance/Makefile.am
+++ b/conformance/Makefile.am
@@ -218,7 +218,7 @@ conformance_test_runner_SOURCES = conformance_test.h conformance_test.cc \
 nodist_conformance_test_runner_SOURCES = conformance.pb.cc google/protobuf/test_messages_proto3.pb.cc google/protobuf/test_messages_proto2.pb.cc
 conformance_test_runner_CPPFLAGS = -I$(top_srcdir)/src -I$(srcdir)
 conformance_test_runner_CXXFLAGS = -std=c++11
-# Explicit deps beacuse BUILT_SOURCES are only done before a "make all/check"
+# Explicit deps because BUILT_SOURCES are only done before a "make all/check"
 # so a direct "make test_cpp" could fail if parallel enough.
 conformance_test_runner-conformance_test.$(OBJEXT): conformance.pb.h
 conformance_test_runner-conformance_test_runner.$(OBJEXT): conformance.pb.h
@@ -227,7 +227,7 @@ conformance_cpp_LDADD = $(top_srcdir)/src/libprotobuf.la
 conformance_cpp_SOURCES = conformance_cpp.cc
 nodist_conformance_cpp_SOURCES = conformance.pb.cc google/protobuf/test_messages_proto3.pb.cc google/protobuf/test_messages_proto2.pb.cc
 conformance_cpp_CPPFLAGS = -I$(top_srcdir)/src
-# Explicit dep beacuse BUILT_SOURCES are only done before a "make all/check"
+# Explicit dep because BUILT_SOURCES are only done before a "make all/check"
 # so a direct "make test_cpp" could fail if parallel enough.
 conformance_cpp-conformance_cpp.$(OBJEXT): conformance.pb.h
 
@@ -243,7 +243,7 @@ nodist_conformance_objc_SOURCES = Conformance.pbobjc.m google/protobuf/TestMessa
 # setup for Xcode and old frameworks are being found.
 conformance_objc_CPPFLAGS = -I$(top_srcdir)/objectivec -isysroot `xcrun --sdk macosx --show-sdk-path`
 conformance_objc_LDFLAGS = -framework Foundation
-# Explicit dep beacuse BUILT_SOURCES are only done before a "make all/check"
+# Explicit dep because BUILT_SOURCES are only done before a "make all/check"
 # so a direct "make test_objc" could fail if parallel enough.
 conformance_objc-conformance_objc.$(OBJEXT): Conformance.pbobjc.h google/protobuf/TestMessagesProto2.pbobjc.h google/protobuf/TestMessagesProto3.pbobjc.h
 

--- a/conformance/binary_json_conformance_suite.cc
+++ b/conformance/binary_json_conformance_suite.cc
@@ -1973,7 +1973,7 @@ void BinaryAndJsonConformanceSuite::RunJsonTestsForNonRepeatedTypes() {
   ExpectParseFailureForJson(
       "Uint64FieldNotNumber", REQUIRED,
       R"({"optionalUint64": "3x3"})");
-  // JSON does not allow "+" on numric values.
+  // JSON does not allow "+" on numeric values.
   ExpectParseFailureForJson(
       "Int32FieldPlusSign", REQUIRED,
       R"({"optionalInt32": +1})");
@@ -2080,7 +2080,7 @@ void BinaryAndJsonConformanceSuite::RunJsonTestsForNonRepeatedTypes() {
       "FloatFieldNegativeInfinity", REQUIRED,
       R"({"optionalFloat": "-Infinity"})",
       "optional_float: -inf");
-  // Non-cannonical Nan will be correctly normalized.
+  // Non-canonical Nan will be correctly normalized.
   {
     TestAllTypesProto3 message;
     // IEEE floating-point standard 32-bit quiet NaN:
@@ -2139,7 +2139,7 @@ void BinaryAndJsonConformanceSuite::RunJsonTestsForNonRepeatedTypes() {
       "DoubleFieldQuotedValue", REQUIRED,
       R"({"optionalDouble": "1"})",
       "optional_double: 1");
-  // Speical values.
+  // Special values.
   RunValidJsonTest(
       "DoubleFieldNan", REQUIRED,
       R"({"optionalDouble": "NaN"})",
@@ -2152,7 +2152,7 @@ void BinaryAndJsonConformanceSuite::RunJsonTestsForNonRepeatedTypes() {
       "DoubleFieldNegativeInfinity", REQUIRED,
       R"({"optionalDouble": "-Infinity"})",
       "optional_double: -inf");
-  // Non-cannonical Nan will be correctly normalized.
+  // Non-canonical Nan will be correctly normalized.
   {
     TestAllTypesProto3 message;
     message.set_optional_double(

--- a/conformance/conformance.proto
+++ b/conformance/conformance.proto
@@ -113,7 +113,7 @@ message ConformanceRequest {
   string message_type = 4;
 
   // Each test is given a specific test category. Some category may need
-  // spedific support in testee programs. Refer to the defintion of TestCategory
+  // spedific support in testee programs. Refer to the definition of TestCategory
   // for more information.
   TestCategory test_category = 5;
 
@@ -170,7 +170,7 @@ message ConformanceResponse {
 
 // Encoding options for jspb format.
 message JspbEncodingConfig {
-  // Encode the value field of Any as jspb array if ture, otherwise binary.
+  // Encode the value field of Any as jspb array if true, otherwise binary.
   bool use_jspb_array_any_format = 1;
 }
 

--- a/conformance/conformance_test.h
+++ b/conformance/conformance_test.h
@@ -191,7 +191,7 @@ class ConformanceTestSuite {
   // Test cases are classified into a few categories:
   //   REQUIRED: the test case must be passed for an implementation to be
   //             interoperable with other implementations. For example, a
-  //             parser implementaiton must accept both packed and unpacked
+  //             parser implementation must accept both packed and unpacked
   //             form of repeated primitive fields.
   //   RECOMMENDED: the test case is not required for the implementation to
   //                be interoperable with other implementations, but is

--- a/conformance/third_party/jsoncpp/json.h
+++ b/conformance/third_party/jsoncpp/json.h
@@ -1019,7 +1019,7 @@ private:
  * - ".name1.name2.name3"
  * - ".[0][1][2].name1[3]"
  * - ".%" => member name is provided as parameter
- * - ".[%]" => index is provied as parameter
+ * - ".[%]" => index is provided as parameter
  */
 class JSON_API Path {
 public:
@@ -1371,7 +1371,7 @@ public:
    */
   std::string getFormattedErrorMessages() const;
 
-  /** \brief Returns a vector of structured erros encounted while parsing.
+  /** \brief Returns a vector of structured errors encounted while parsing.
    * \return A (possibly empty) vector of StructuredError objects. Currently
    *         only one error can be returned, but the caller should tolerate
    * multiple
@@ -1816,7 +1816,7 @@ public:
  *
  * The JSON document is written in a single line. It is not intended for 'human'
  *consumption,
- * but may be usefull to support feature such as RPC where bandwith is limited.
+ * but may be useful to support feature such as RPC where bandwidth is limited.
  * \sa Reader, Value
  * \deprecated Use StreamWriterBuilder.
  */

--- a/conformance/third_party/jsoncpp/jsoncpp.cpp
+++ b/conformance/third_party/jsoncpp/jsoncpp.cpp
@@ -4112,7 +4112,7 @@ std::string valueToString(double value, bool useSpecialFloats, unsigned int prec
   sprintf(formatString, "%%.%dg", precision);
 
   // Print into the buffer. We need not request the alternative representation
-  // that always has a decimal point because JSON doesn't distingish the
+  // that always has a decimal point because JSON doesn't distinguish the
   // concepts of reals and integers.
   if (isfinite(value)) {
     len = snprintf(buffer, sizeof(buffer), formatString, value);

--- a/csharp/compatibility_tests/v3.0.0/protos/src/google/protobuf/unittest_proto3.proto
+++ b/csharp/compatibility_tests/v3.0.0/protos/src/google/protobuf/unittest_proto3.proto
@@ -142,7 +142,7 @@ message TestAllTypes {
   }
 }
 
-// This proto includes a recusively nested message.
+// This proto includes a recursively nested message.
 message NestedTestAllTypes {
   NestedTestAllTypes child = 1;
   TestAllTypes payload = 2;

--- a/csharp/compatibility_tests/v3.0.0/test.sh
+++ b/csharp/compatibility_tests/v3.0.0/test.sh
@@ -37,7 +37,7 @@ TEST_VERSION=3.0.0
 # The old version of protobuf that we are testing compatibility against. This
 # is usually the same as TEST_VERSION (i.e., we use the tests extracted from
 # that version to test compatibility of the newest runtime against it), but it
-# is also possible to use this same test set to test the compatibiilty of the
+# is also possible to use this same test set to test the compatibility of the
 # latest version against other versions.
 OLD_VERSION=$1
 OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/$OLD_VERSION/protoc-$OLD_VERSION-linux-x86_64.exe

--- a/csharp/protos/unittest.proto
+++ b/csharp/protos/unittest.proto
@@ -182,7 +182,7 @@ message TestAllTypes {
   }
 }
 
-// This proto includes a recusively nested message.
+// This proto includes a recursively nested message.
 message NestedTestAllTypes {
   optional NestedTestAllTypes child = 1;
   optional TestAllTypes payload = 2;

--- a/csharp/protos/unittest_custom_options_proto3.proto
+++ b/csharp/protos/unittest_custom_options_proto3.proto
@@ -286,7 +286,7 @@ message Aggregate {
 }
 
 // Allow Aggregate to be used as an option at all possible locations
-// in the .proto grammer.
+// in the .proto grammar.
 extend google.protobuf.FileOptions      { Aggregate fileopt    = 15478479; }
 extend google.protobuf.MessageOptions   { Aggregate msgopt     = 15480088; }
 extend google.protobuf.FieldOptions     { Aggregate fieldopt   = 15481374; }

--- a/csharp/protos/unittest_proto3.proto
+++ b/csharp/protos/unittest_proto3.proto
@@ -130,7 +130,7 @@ message TestAllTypes {
   }
 }
 
-// This proto includes a recusively nested message.
+// This proto includes a recursively nested message.
 message NestedTestAllTypes {
   NestedTestAllTypes child = 1;
   TestAllTypes payload = 2;

--- a/csharp/src/Google.Protobuf.Conformance/Conformance.cs
+++ b/csharp/src/Google.Protobuf.Conformance/Conformance.cs
@@ -370,7 +370,7 @@ namespace Conformance {
     private global::Conformance.TestCategory testCategory_ = global::Conformance.TestCategory.UnspecifiedTest;
     /// <summary>
     /// Each test is given a specific test category. Some category may need
-    /// spedific support in testee programs. Refer to the defintion of TestCategory
+    /// spedific support in testee programs. Refer to the definition of TestCategory
     /// for more information.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1110,7 +1110,7 @@ namespace Conformance {
     public const int UseJspbArrayAnyFormatFieldNumber = 1;
     private bool useJspbArrayAnyFormat_;
     /// <summary>
-    /// Encode the value field of Any as jspb array if ture, otherwise binary.
+    /// Encode the value field of Any as jspb array if true, otherwise binary.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public bool UseJspbArrayAnyFormat {

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestProto3.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestProto3.cs
@@ -1773,7 +1773,7 @@ namespace Google.Protobuf.TestProtos {
   }
 
   /// <summary>
-  /// This proto includes a recusively nested message.
+  /// This proto includes a recursively nested message.
   /// </summary>
   public sealed partial class NestedTestAllTypes : pb::IMessage<NestedTestAllTypes> {
     private static readonly pb::MessageParser<NestedTestAllTypes> _parser = new pb::MessageParser<NestedTestAllTypes>(() => new NestedTestAllTypes());

--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -248,7 +248,7 @@ namespace Google.Protobuf
         }
 
         /// <summary>
-        /// Returns the byte at the given index.
+        /// Retuns the byte at the given index.
         /// </summary>
         public byte this[int index]
         {

--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -248,7 +248,7 @@ namespace Google.Protobuf
         }
 
         /// <summary>
-        /// Retuns the byte at the given index.
+        /// Returns the byte at the given index.
         /// </summary>
         public byte this[int index]
         {

--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -1381,7 +1381,7 @@ namespace Google.Protobuf
 
         /// <summary>
         /// Called when buffer is empty to read more bytes from the
-        /// input.  If <paramref name="mustSucceed"/> is true, RefillBuffer() guarantees that
+        /// input.  If <paramref name="mustSucceed"/> is true, RefillBuffer() gurantees that
         /// either there will be at least one byte in the buffer when it returns
         /// or it will throw an exception.  If <paramref name="mustSucceed"/> is false,
         /// RefillBuffer() returns false if no more bytes were available.

--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -1381,7 +1381,7 @@ namespace Google.Protobuf
 
         /// <summary>
         /// Called when buffer is empty to read more bytes from the
-        /// input.  If <paramref name="mustSucceed"/> is true, RefillBuffer() gurantees that
+        /// input.  If <paramref name="mustSucceed"/> is true, RefillBuffer() guarantees that
         /// either there will be at least one byte in the buffer when it returns
         /// or it will throw an exception.  If <paramref name="mustSucceed"/> is false,
         /// RefillBuffer() returns false if no more bytes were available.

--- a/csharp/src/Google.Protobuf/ExtensionRegistry.cs
+++ b/csharp/src/Google.Protobuf/ExtensionRegistry.cs
@@ -96,7 +96,7 @@ namespace Google.Protobuf
         }
 
         /// <summary>
-        /// Adds the specified extensions to the reigstry
+        /// Adds the specified extensions to the registry
         /// </summary>
         public void AddRange(IEnumerable<Extension> extensions)
         {

--- a/csharp/src/Google.Protobuf/Reflection/ServiceDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ServiceDescriptor.cs
@@ -85,7 +85,7 @@ namespace Google.Protobuf.Reflection
         /// Finds a method by name.
         /// </summary>
         /// <param name="name">The unqualified name of the method (e.g. "Foo").</param>
-        /// <returns>The method's decsriptor, or null if not found.</returns>
+        /// <returns>The method's descriptor, or null if not found.</returns>
         public MethodDescriptor FindMethodByName(String name)
         {
             return File.DescriptorPool.FindSymbol<MethodDescriptor>(FullName + "." + name);

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -19,7 +19,7 @@ local_repository(
 )
 
 # Similar to com_google_protobuf but for Java lite. If you are building
-# for Android, the lite version should be prefered because it has a much
+# for Android, the lite version should be preferred because it has a much
 # smaller code size.
 local_repository(
     name = "com_google_protobuf_javalite",

--- a/java/README.md
+++ b/java/README.md
@@ -146,7 +146,7 @@ library (without the util package).
   are guaranteed for minor version releases if the user follows the guideline
   described in this section.
 
-* Protobuf major version releases may also be backwards-compatbile with the
+* Protobuf major version releases may also be backwards-compatible with the
   last release of the previous major version. See the release notice for more
   details.
 

--- a/java/compatibility_tests/v2.5.0/more_protos/src/proto/google/protobuf/descriptor.proto
+++ b/java/compatibility_tests/v2.5.0/more_protos/src/proto/google/protobuf/descriptor.proto
@@ -228,7 +228,7 @@ message MethodDescriptorProto {
 // * For options which will be published and used publicly by multiple
 //   independent entities, e-mail protobuf-global-extension-registry@google.com
 //   to reserve extension numbers. Simply provide your project name (e.g.
-//   Object-C plugin) and your porject website (if available) -- there's no need
+//   Object-C plugin) and your project website (if available) -- there's no need
 //   to explain how you intend to use them. Usually you only need one extension
 //   number. You can declare multiple options with only one extension number by
 //   putting them in a sub-message. See the Custom Options section of the docs

--- a/java/compatibility_tests/v2.5.0/more_protos/src/proto/google/protobuf/unittest_custom_options.proto
+++ b/java/compatibility_tests/v2.5.0/more_protos/src/proto/google/protobuf/unittest_custom_options.proto
@@ -321,7 +321,7 @@ message Aggregate {
 }
 
 // Allow Aggregate to be used as an option at all possible locations
-// in the .proto grammer.
+// in the .proto grammar.
 extend google.protobuf.FileOptions      { optional Aggregate fileopt    = 15478479; }
 extend google.protobuf.MessageOptions   { optional Aggregate msgopt     = 15480088; }
 extend google.protobuf.FieldOptions     { optional Aggregate fieldopt   = 15481374; }

--- a/java/compatibility_tests/v2.5.0/more_protos/src/proto/google/protobuf/unittest_import.proto
+++ b/java/compatibility_tests/v2.5.0/more_protos/src/proto/google/protobuf/unittest_import.proto
@@ -43,7 +43,7 @@ package protobuf_unittest_import;
 
 option optimize_for = SPEED;
 
-// Excercise the java_package option.
+// Exercise the java_package option.
 option java_package = "com.google.protobuf.test";
 
 // Do not set a java_outer_classname here to verify that Proto2 works without

--- a/java/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/descriptor.proto
+++ b/java/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/descriptor.proto
@@ -228,7 +228,7 @@ message MethodDescriptorProto {
 // * For options which will be published and used publicly by multiple
 //   independent entities, e-mail protobuf-global-extension-registry@google.com
 //   to reserve extension numbers. Simply provide your project name (e.g.
-//   Object-C plugin) and your porject website (if available) -- there's no need
+//   Object-C plugin) and your project website (if available) -- there's no need
 //   to explain how you intend to use them. Usually you only need one extension
 //   number. You can declare multiple options with only one extension number by
 //   putting them in a sub-message. See the Custom Options section of the docs

--- a/java/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/unittest_custom_options.proto
+++ b/java/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/unittest_custom_options.proto
@@ -321,7 +321,7 @@ message Aggregate {
 }
 
 // Allow Aggregate to be used as an option at all possible locations
-// in the .proto grammer.
+// in the .proto grammar.
 extend google.protobuf.FileOptions      { optional Aggregate fileopt    = 15478479; }
 extend google.protobuf.MessageOptions   { optional Aggregate msgopt     = 15480088; }
 extend google.protobuf.FieldOptions     { optional Aggregate fieldopt   = 15481374; }

--- a/java/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/unittest_import.proto
+++ b/java/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/unittest_import.proto
@@ -43,7 +43,7 @@ package protobuf_unittest_import;
 
 option optimize_for = SPEED;
 
-// Excercise the java_package option.
+// Exercise the java_package option.
 option java_package = "com.google.protobuf.test";
 
 // Do not set a java_outer_classname here to verify that Proto2 works without

--- a/java/compatibility_tests/v2.5.0/test.sh
+++ b/java/compatibility_tests/v2.5.0/test.sh
@@ -15,7 +15,7 @@ TEST_VERSION=`grep "^  <version>.*</version>" pom.xml | sed "s|  <version>\(.*\)
 # The old version of protobuf that we are testing compatibility against. This
 # is usually the same as TEST_VERSION (i.e., we use the tests extracted from
 # that version to test compatibility of the newest runtime against it), but it
-# is also possible to use this same test set to test the compatibiilty of the
+# is also possible to use this same test set to test the compatibility of the
 # latest version against other versions.
 OLD_VERSION=$1
 OLD_VERSION_PROTOC=https://repo1.maven.org/maven2/com/google/protobuf/protoc/$OLD_VERSION/protoc-$OLD_VERSION-linux-x86_64.exe

--- a/java/compatibility_tests/v2.5.0/tests/src/main/java/com/google/protobuf/test/LiteralByteStringTest.java
+++ b/java/compatibility_tests/v2.5.0/tests/src/main/java/com/google/protobuf/test/LiteralByteStringTest.java
@@ -87,7 +87,7 @@ public class LiteralByteStringTest extends TestCase {
       stillEqual = (iter.hasNext() && referenceBytes[i] == iter.nextByte());
     }
     assertTrue(classUnderTest + " must capture the right bytes", stillEqual);
-    assertFalse(classUnderTest + " must have exhausted the itertor", iter.hasNext());
+    assertFalse(classUnderTest + " must have exhausted the iterator", iter.hasNext());
 
     try {
       iter.nextByte();
@@ -317,7 +317,7 @@ public class LiteralByteStringTest extends TestCase {
     assertEquals("InputStream.skip(), no more input", 0, input.available());
     assertEquals("InputStream.skip(), no more input", -1, input.read());
     input.reset();
-    assertEquals("InputStream.reset() succeded",
+    assertEquals("InputStream.reset() succeeded",
                  stringSize - skipped1, input.available());
     assertEquals("InputStream.reset(), read()",
         stringUnderTest.byteAt(nearEndIndex) & 0xFF, input.read());

--- a/java/core/src/main/java/com/google/protobuf/ArrayDecoders.java
+++ b/java/core/src/main/java/com/google/protobuf/ArrayDecoders.java
@@ -873,7 +873,7 @@ final class ArrayDecoders {
       }
     } else {
       Object value = null;
-      // Enum is a special case becasue unknown enum values will be put into UnknownFieldSetLite.
+      // Enum is a special case because unknown enum values will be put into UnknownFieldSetLite.
       if (extension.getLiteType() == WireFormat.FieldType.ENUM) {
         position = decodeVarint32(data, position, registers);
         Object enumValue = extension.descriptor.getEnumType().findValueByNumber(registers.int1);

--- a/java/core/src/main/java/com/google/protobuf/ExtensionSchemaLite.java
+++ b/java/core/src/main/java/com/google/protobuf/ExtensionSchemaLite.java
@@ -193,7 +193,7 @@ final class ExtensionSchemaLite extends ExtensionSchema<ExtensionDescriptor> {
       extensions.setField(extension.descriptor, value);
     } else {
       Object value = null;
-      // Enum is a special case becasue unknown enum values will be put into UnknownFieldSetLite.
+      // Enum is a special case because unknown enum values will be put into UnknownFieldSetLite.
       if (extension.getLiteType() == WireFormat.FieldType.ENUM) {
         int number = reader.readInt32();
         Object enumValue = extension.descriptor.getEnumType().findValueByNumber(number);

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -359,7 +359,7 @@ public abstract class GeneratedMessage extends AbstractMessage
    * TODO(xiaofeng): remove this after b/29368482 is fixed. We need to move this
    * interface to AbstractMessage in order to versioning GeneratedMessage but
    * this move breaks binary compatibility for AppEngine. After AppEngine is
-   * fixed we can exlude this from google3.
+   * fixed we can exclude this from google3.
    */
   protected interface BuilderParent extends AbstractMessage.BuilderParent {}
 

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -515,7 +515,7 @@ public abstract class GeneratedMessageV3 extends AbstractMessage
    * TODO(xiaofeng): remove this after b/29368482 is fixed. We need to move this
    * interface to AbstractMessage in order to versioning GeneratedMessageV3 but
    * this move breaks binary compatibility for AppEngine. After AppEngine is
-   * fixed we can exlude this from google3.
+   * fixed we can exclude this from google3.
    */
   protected interface BuilderParent extends AbstractMessage.BuilderParent {}
 
@@ -3086,7 +3086,7 @@ public abstract class GeneratedMessageV3 extends AbstractMessage
       serializeMapTo(out, m, defaultEntry, fieldNumber);
       return;
     }
-    // Sorting the unboxed keys and then look up the values during serialziation is 2x faster
+    // Sorting the unboxed keys and then look up the values during serialization is 2x faster
     // than sorting map entries with a custom comparator directly.
     int[] keys = new int[m.size()];
     int index = 0;
@@ -3142,7 +3142,7 @@ public abstract class GeneratedMessageV3 extends AbstractMessage
       return;
     }
 
-    // Sorting the String keys and then look up the values during serialziation is 25% faster than
+    // Sorting the String keys and then look up the values during serialization is 25% faster than
     // sorting map entries with a custom comparator directly.
     String[] keys = new String[m.size()];
     keys = m.keySet().toArray(keys);

--- a/java/core/src/main/java/com/google/protobuf/LazyFieldLite.java
+++ b/java/core/src/main/java/com/google/protobuf/LazyFieldLite.java
@@ -274,7 +274,7 @@ public class LazyFieldLite {
 
     // At least one is parsed and both contain data. We won't drop any extensions here directly, but
     // in the case that the extension registries are not the same then we might in the future if we
-    // need to serialze and parse a message again.
+    // need to serialize and parse a message again.
     if (this.value == null && other.value != null) {
       setValue(mergeValueAndBytes(other.value, this.delayedBytes, this.extensionRegistry));
       return;

--- a/java/core/src/main/java/com/google/protobuf/SchemaUtil.java
+++ b/java/core/src/main/java/com/google/protobuf/SchemaUtil.java
@@ -767,7 +767,7 @@ final class SchemaUtil {
    * logic in the JDK</a>.
    *
    * @param lo the lowest fieldNumber contained within the message.
-   * @param hi the higest fieldNumber contained within the message.
+   * @param hi the highest fieldNumber contained within the message.
    * @param numFields the total number of fields in the message.
    * @return {@code true} if tableswitch should be used, rather than lookupswitch.
    */

--- a/java/core/src/test/java/com/google/protobuf/FieldPresenceTest.java
+++ b/java/core/src/test/java/com/google/protobuf/FieldPresenceTest.java
@@ -103,7 +103,7 @@ public class FieldPresenceTest extends TestCase {
   public void testOneofEquals() throws Exception {
     TestAllTypes.Builder builder = TestAllTypes.newBuilder();
     TestAllTypes message1 = builder.build();
-    // Set message2's oneof_uint32 field to defalut value. The two
+    // Set message2's oneof_uint32 field to default value. The two
     // messages should be different when check with oneof case.
     builder.setOneofUint32(0);
     TestAllTypes message2 = builder.build();

--- a/java/core/src/test/java/com/google/protobuf/LiteEqualsAndHashTest.java
+++ b/java/core/src/test/java/com/google/protobuf/LiteEqualsAndHashTest.java
@@ -75,7 +75,7 @@ public class LiteEqualsAndHashTest extends TestCase {
     assertEquals(foo1a, foo1b);
     assertEquals(foo1a.hashCode(), foo1b.hashCode());
 
-    // Check that a diffeent object is not equal.
+    // Check that a different object is not equal.
     assertFalse(foo1a.equals(foo2));
 
     // Check that two objects which have different types but the same field values are not

--- a/java/core/src/test/java/com/google/protobuf/LiteralByteStringTest.java
+++ b/java/core/src/test/java/com/google/protobuf/LiteralByteStringTest.java
@@ -94,7 +94,7 @@ public class LiteralByteStringTest extends TestCase {
       stillEqual = (iter.hasNext() && referenceBytes[i] == iter.nextByte());
     }
     assertTrue(classUnderTest + " must capture the right bytes", stillEqual);
-    assertFalse(classUnderTest + " must have exhausted the itertor", iter.hasNext());
+    assertFalse(classUnderTest + " must have exhausted the iterator", iter.hasNext());
 
     try {
       iter.nextByte();
@@ -536,7 +536,7 @@ public class LiteralByteStringTest extends TestCase {
     assertThat(input.read(new byte[1], /* off= */ 0, /*len=*/ 0)).isEqualTo(-1);
 
     input.reset();
-    assertEquals("InputStream.reset() succeded", stringSize - skipped1, input.available());
+    assertEquals("InputStream.reset() succeeded", stringSize - skipped1, input.available());
     assertEquals(
         "InputStream.reset(), read()", stringUnderTest.byteAt(nearEndIndex) & 0xFF, input.read());
   }

--- a/java/core/src/test/java/com/google/protobuf/NioByteStringTest.java
+++ b/java/core/src/test/java/com/google/protobuf/NioByteStringTest.java
@@ -84,7 +84,7 @@ public class NioByteStringTest extends TestCase {
       stillEqual = (iter.hasNext() && BYTES[i] == iter.nextByte());
     }
     assertTrue(CLASSNAME + " must capture the right bytes", stillEqual);
-    assertFalse(CLASSNAME + " must have exhausted the itertor", iter.hasNext());
+    assertFalse(CLASSNAME + " must have exhausted the iterator", iter.hasNext());
 
     try {
       iter.nextByte();
@@ -590,7 +590,7 @@ public class NioByteStringTest extends TestCase {
     assertEquals("InputStream.skip(), no more input", 0, input.available());
     assertEquals("InputStream.skip(), no more input", -1, input.read());
     input.reset();
-    assertEquals("InputStream.reset() succeded", stringSize - skipped1, input.available());
+    assertEquals("InputStream.reset() succeeded", stringSize - skipped1, input.available());
     assertEquals(
         "InputStream.reset(), read()", testString.byteAt(nearEndIndex) & 0xFF, input.read());
   }

--- a/java/core/src/test/proto/com/google/protobuf/map_initialization_order_test.proto
+++ b/java/core/src/test/proto/com/google/protobuf/map_initialization_order_test.proto
@@ -28,7 +28,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Regression test for a map initilaization order bug. The bug only manifests
+// Regression test for a map initialization order bug. The bug only manifests
 // when:
 //   1. A message contains map fields and is also extendable.
 //   2. There is a file-level extension defined in the same file referencing

--- a/java/lite/src/test/java/com/google/protobuf/LiteTest.java
+++ b/java/lite/src/test/java/com/google/protobuf/LiteTest.java
@@ -1997,7 +1997,7 @@ public class LiteTest extends TestCase {
     assertEquals(foo1a, foo1b);
     assertEquals(foo1a.hashCode(), foo1b.hashCode());
 
-    // Check that a diffeent object is not equal.
+    // Check that a different object is not equal.
     assertFalse(foo1a.equals(foo2));
 
     // Check that two objects which have different types but the same field values are not

--- a/js/binary/decoder.js
+++ b/js/binary/decoder.js
@@ -748,7 +748,7 @@ jspb.BinaryDecoder.prototype.readInt32 = function() {
 /**
  * Reads a raw signed 64-bit integer from the binary stream. Note that since
  * Javascript represents all numbers as double-precision floats, there will be
- * precision lost if the absolute vlaue of the integer is larger than 2^53.
+ * precision lost if the absolute value of the integer is larger than 2^53.
  *
  * @return {number} The signed 64-bit integer read from the binary stream.
  *     Precision will be lost if the integer exceeds 2^53.

--- a/js/binary/decoder_test.js
+++ b/js/binary/decoder_test.js
@@ -303,7 +303,7 @@ describe('binaryDecoderTest', function() {
     });
 
     it('does zigzag encoding properly', function() {
-      // Test cases direcly from the protobuf dev guide.
+      // Test cases directly from the protobuf dev guide.
       // https://engdoc.corp.google.com/eng/howto/protocolbuffers/developerguide/encoding.shtml?cl=head#types
       var testCases = [
         {original: '0', zigzag: '0'},

--- a/js/binary/utils.js
+++ b/js/binary/utils.js
@@ -117,7 +117,7 @@ jspb.utils.splitInt64 = function(value) {
 
 
 /**
- * Convers a signed Javascript integer into zigzag format, splits it into two
+ * Converts a signed Javascript integer into zigzag format, splits it into two
  * 32-bit halves, and stores it in the temp values above.
  * @param {number} value The number to split.
  */

--- a/js/binary/utils_test.js
+++ b/js/binary/utils_test.js
@@ -506,7 +506,7 @@ describe('binaryUtilsTest', function() {
     function makeHiLoPair(lo, hi) {
       return {lo: lo >>> 0, hi: hi >>> 0};
     }
-    // Test cases direcly from the protobuf dev guide.
+    // Test cases directly from the protobuf dev guide.
     // https://engdoc.corp.google.com/eng/howto/protocolbuffers/developerguide/encoding.shtml?cl=head#types
     var testCases = [
       {original: stringToHiLoPair('0'), zigzag: stringToHiLoPair('0')},

--- a/js/binary/writer_test.js
+++ b/js/binary/writer_test.js
@@ -210,7 +210,7 @@ describe('binaryWriterTest', function() {
   });
 
   it('writes zigzag 64 fields', function() {
-    // Test cases direcly from the protobuf dev guide.
+    // Test cases directly from the protobuf dev guide.
     // https://engdoc.corp.google.com/eng/howto/protocolbuffers/developerguide/encoding.shtml?cl=head#types
     var testCases = [
       {original: '0', zigzag: '0'},

--- a/js/message.js
+++ b/js/message.js
@@ -317,7 +317,7 @@ jspb.Message.getIndex_ = function(msg, fieldNumber) {
   return fieldNumber + msg.arrayIndexOffset_;
 };
 
-// This is only here to ensure we are not back sliding on ES6 requiements for
+// This is only here to ensure we are not back sliding on ES6 requirements for
 // protos in g3.
 jspb.Message.hiddenES6Property_ = class {};
 
@@ -366,7 +366,7 @@ jspb.Message.initialize = function(
 
   if (!jspb.Message.SERIALIZE_EMPTY_TRAILING_FIELDS) {
     // TODO(jakubvrana): This is same for all instances, move to prototype.
-    // TODO(jakubvrana): There are indexOf calls on this in serializtion,
+    // TODO(jakubvrana): There are indexOf calls on this in serialization,
     // consider switching to a set.
     msg.repeatedFields = repeatedFields;
   }
@@ -1860,7 +1860,7 @@ jspb.Message.clone_ = function(obj) {
  * @param {Function} constructor The message constructor.
  */
 jspb.Message.registerMessageType = function(id, constructor) {
-  // This is needed so we can later access messageId directly on the contructor,
+  // This is needed so we can later access messageId directly on the constructor,
   // otherwise it is not available due to 'property collapsing' by the compiler.
   /**
    * @suppress {strictMissingProperties} messageId is not defined on Function

--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -5,8 +5,8 @@
 ##
 # Select Xcode version
 
-# Remember to udpate the Xcode version when Xcode_11.0.app is not available.
-# If xcode is not available, it will probaly encounter the failure for
+# Remember to update the Xcode version when Xcode_11.0.app is not available.
+# If xcode is not available, it will probably encounter the failure for
 # "autom4te: need GNU m4 1.4 or later: /usr/bin/m4"
 # go/kokoro/userdocs/macos/selecting_xcode.md for more information.
 export DEVELOPER_DIR=/Applications/Xcode_11.0.app/Contents/Developer

--- a/objectivec/DevTools/pddm.py
+++ b/objectivec/DevTools/pddm.py
@@ -288,7 +288,7 @@ class MacroCollection(object):
     name = macro_ref_match.group('name')
     for prev_name, prev_macro_ref in macro_stack:
       if name == prev_name:
-        raise PDDMError('Found macro recusion, invoking "%s":%s' %
+        raise PDDMError('Found macro recursion, invoking "%s":%s' %
                         (macro_ref_str, self._FormatStack(macro_stack)))
     macro = self._macros[name]
     args_str = macro_ref_match.group('args').strip()
@@ -395,7 +395,7 @@ class SourceFile(object):
         wasn't append.  If SUCCESS is True, then CAN_ADD_MORE is True/False to
         indicate if more lines can be added after this one.
       """
-      assert False, "sublcass should have overridden"
+      assert False, "subclass should have overridden"
       return (False, False)
 
     def HitEOF(self):

--- a/objectivec/DevTools/pddm_tests.py
+++ b/objectivec/DevTools/pddm_tests.py
@@ -314,7 +314,7 @@ foo(x, y)
       self.fail('Should throw exception! Test failed to catch recursion.')
     except pddm.PDDMError as e:
       self.assertEqual(e.message,
-                       'Found macro recusion, invoking "foo(1, A)":\n...while expanding "bar(1, A)".\n...while expanding "foo(A,B)".')
+                       'Found macro recursion, invoking "foo(1, A)":\n...while expanding "bar(1, A)".\n...while expanding "foo(A,B)".')
 
 
 class TestParsingSource(unittest.TestCase):

--- a/objectivec/GPBBootstrap.h
+++ b/objectivec/GPBBootstrap.h
@@ -46,7 +46,7 @@
 #endif
 
 // If the headers are imported into Objective-C++, we can run into an issue
-// where the defintion of NS_ENUM (really CF_ENUM) changes based on the C++
+// where the definition of NS_ENUM (really CF_ENUM) changes based on the C++
 // standard that is in effect.  If it isn't C++11 or higher, the definition
 // doesn't allow us to forward declare. We work around this one case by
 // providing a local definition. The default case has to use NS_ENUM for the

--- a/objectivec/GPBDictionary.m
+++ b/objectivec/GPBDictionary.m
@@ -508,7 +508,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 #if defined(__clang_analyzer__)
         case GPBDataTypeGroup:
           // Maps can't really have Groups as the value type, but this case is needed
-          // so the analyzer won't report the posibility of send nil in for the value
+          // so the analyzer won't report the possibility of send nil in for the value
           // in the NSMutableDictionary case below.
 #endif
         case GPBDataTypeMessage: {

--- a/objectivec/GPBMessage.m
+++ b/objectivec/GPBMessage.m
@@ -564,7 +564,7 @@ static id CreateMapForField(GPBFieldDescriptor *field,
 // so use of the array/map after the call returns is flagged as a use after
 // free.
 // But GPBSetRetainedObjectIvarWithFieldInternal() is "consuming" the retain
-// count be holding onto the object (it is transfering it), the object is
+// count be holding onto the object (it is transferring it), the object is
 // still valid after returning from the call.  The other way to avoid this
 // would be to add a -retain/-autorelease, but that would force every
 // repeated/map field parsed into the autorelease pool which is both a memory
@@ -2518,7 +2518,7 @@ static void MergeRepeatedNotPackedFieldFromCodedInputStream(
               GetOrCreateArrayIvarWithField(self, field, syntax);
           [resultArray addRawValuesFromArray:otherArray];
         } else {
-          // The array type doesn't matter, that all implment
+          // The array type doesn't matter, that all implement
           // -addValuesFromArray:.
           GPBInt32Array *resultArray =
               GetOrCreateArrayIvarWithField(self, field, syntax);

--- a/objectivec/GPBUtilities.m
+++ b/objectivec/GPBUtilities.m
@@ -504,7 +504,7 @@ void GPBClearAutocreatedMessageIvarWithField(GPBMessage *self,
   [oldValue release];
 }
 
-// This exists only for briging some aliased types, nothing else should use it.
+// This exists only for bridging some aliased types, nothing else should use it.
 static void GPBSetObjectIvarWithField(GPBMessage *self,
                                       GPBFieldDescriptor *field, id value) {
   if (self == nil || field == nil) return;
@@ -521,7 +521,7 @@ static void GPBSetCopyObjectIvarWithField(GPBMessage *self,
 // is marked as consuming the value. Note: For some reason this doesn't happen
 // with the -retain in GPBSetObjectIvarWithField.
 #if !defined(__clang_analyzer__)
-// This exists only for briging some aliased types, nothing else should use it.
+// This exists only for bridging some aliased types, nothing else should use it.
 static void GPBSetCopyObjectIvarWithField(GPBMessage *self,
                                           GPBFieldDescriptor *field, id value) {
   if (self == nil || field == nil) return;

--- a/objectivec/Tests/GPBDescriptorTests.m
+++ b/objectivec/Tests/GPBDescriptorTests.m
@@ -355,7 +355,7 @@
   XCTAssertNil([oneofBar fieldWithNumber:TestOneof2_FieldNumber_FooString]);
 
   // Check pointers back to the enclosing oneofs.
-  // (pointer comparisions)
+  // (pointer comparisons)
   XCTAssertEqual(fooStringField.containingOneof, oneofFoo);
   XCTAssertEqual(barStringField.containingOneof, oneofBar);
   GPBFieldDescriptor *bazString =

--- a/objectivec/Tests/GPBMessageTests+Merge.m
+++ b/objectivec/Tests/GPBMessageTests+Merge.m
@@ -416,7 +416,7 @@
   XCTAssertEqual(dst.oOneOfCase, Message2_O_OneOfCase_OneofGroup);
   Message2_OneofGroup *mergedGroup = [[dst.oneofGroup retain] autorelease];
   XCTAssertNotNil(mergedGroup);
-  XCTAssertNotEqual(mergedGroup, group);  // Pointer comparision.
+  XCTAssertNotEqual(mergedGroup, group);  // Pointer comparison.
   XCTAssertEqualObjects(mergedGroup, group);
   XCTAssertEqualObjects(dst.oneofBytes, oneofBytesDefault);
 
@@ -427,10 +427,10 @@
   XCTAssertEqual(dst.oOneOfCase, Message2_O_OneOfCase_OneofMessage);
   Message2 *mergedSubMessage = [[dst.oneofMessage retain] autorelease];
   XCTAssertNotNil(mergedSubMessage);
-  XCTAssertNotEqual(mergedSubMessage, subMessage);  // Pointer comparision.
+  XCTAssertNotEqual(mergedSubMessage, subMessage);  // Pointer comparison.
   XCTAssertEqualObjects(mergedSubMessage, subMessage);
   XCTAssertNotNil(dst.oneofGroup);
-  XCTAssertNotEqual(dst.oneofGroup, mergedGroup);  // Pointer comparision.
+  XCTAssertNotEqual(dst.oneofGroup, mergedGroup);  // Pointer comparison.
 
   // Back to something else to make sure message clears out ok.
 
@@ -439,7 +439,7 @@
   XCTAssertEqual(dst.oOneOfCase, Message2_O_OneOfCase_OneofInt32);
   XCTAssertNotNil(dst.oneofMessage);
   XCTAssertNotEqual(dst.oneofMessage,
-                    mergedSubMessage);  // Pointer comparision.
+                    mergedSubMessage);  // Pointer comparison.
 
   //
   // Test merging in to message/group when they already had something.
@@ -452,9 +452,9 @@
   [dst mergeFrom:src];
   XCTAssertEqual(dst.oOneOfCase, Message2_O_OneOfCase_OneofGroup);
   // Shouldn't have been a new object.
-  XCTAssertEqual(dst.oneofGroup, mergedGroup);  // Pointer comparision.
-  XCTAssertEqual(dst.oneofGroup.a, 666);        // Pointer comparision.
-  XCTAssertEqual(dst.oneofGroup.b, 888);        // Pointer comparision.
+  XCTAssertEqual(dst.oneofGroup, mergedGroup);  // Pointer comparison.
+  XCTAssertEqual(dst.oneofGroup.a, 666);        // Pointer comparison.
+  XCTAssertEqual(dst.oneofGroup.b, 888);        // Pointer comparison.
 
   src.oneofMessage = subMessage;
   mergedSubMessage = [Message2 message];
@@ -463,9 +463,9 @@
   [dst mergeFrom:src];
   XCTAssertEqual(dst.oOneOfCase, Message2_O_OneOfCase_OneofMessage);
   // Shouldn't have been a new object.
-  XCTAssertEqual(dst.oneofMessage, mergedSubMessage);   // Pointer comparision.
-  XCTAssertEqual(dst.oneofMessage.optionalInt32, 777);  // Pointer comparision.
-  XCTAssertEqual(dst.oneofMessage.optionalInt64, 999);  // Pointer comparision.
+  XCTAssertEqual(dst.oneofMessage, mergedSubMessage);   // Pointer comparison.
+  XCTAssertEqual(dst.oneofMessage.optionalInt32, 777);  // Pointer comparison.
+  XCTAssertEqual(dst.oneofMessage.optionalInt64, 999);  // Pointer comparison.
 }
 
 - (void)testProto3MergeOneof {
@@ -637,7 +637,7 @@
   XCTAssertEqual(dst.oOneOfCase, Message3_O_OneOfCase_OneofMessage);
   Message3 *mergedSubMessage = [[dst.oneofMessage retain] autorelease];
   XCTAssertNotNil(mergedSubMessage);
-  XCTAssertNotEqual(mergedSubMessage, subMessage);  // Pointer comparision.
+  XCTAssertNotEqual(mergedSubMessage, subMessage);  // Pointer comparison.
   XCTAssertEqualObjects(mergedSubMessage, subMessage);
   XCTAssertEqualObjects(dst.oneofBytes, oneofBytesDefault);
 
@@ -648,7 +648,7 @@
   XCTAssertEqual(dst.oOneOfCase, Message3_O_OneOfCase_OneofInt32);
   XCTAssertNotNil(dst.oneofMessage);
   XCTAssertNotEqual(dst.oneofMessage,
-                    mergedSubMessage);  // Pointer comparision.
+                    mergedSubMessage);  // Pointer comparison.
 
   //
   // Test merging in to message when they already had something.
@@ -661,9 +661,9 @@
   [dst mergeFrom:src];
   XCTAssertEqual(dst.oOneOfCase, Message3_O_OneOfCase_OneofMessage);
   // Shouldn't have been a new object.
-  XCTAssertEqual(dst.oneofMessage, mergedSubMessage);   // Pointer comparision.
-  XCTAssertEqual(dst.oneofMessage.optionalInt32, 777);  // Pointer comparision.
-  XCTAssertEqual(dst.oneofMessage.optionalInt64, 999);  // Pointer comparision.
+  XCTAssertEqual(dst.oneofMessage, mergedSubMessage);   // Pointer comparison.
+  XCTAssertEqual(dst.oneofMessage.optionalInt32, 777);  // Pointer comparison.
+  XCTAssertEqual(dst.oneofMessage.optionalInt64, 999);  // Pointer comparison.
 }
 
 #pragma mark - Subset from from map_tests.cc

--- a/objectivec/Tests/GPBMessageTests+Runtime.m
+++ b/objectivec/Tests/GPBMessageTests+Runtime.m
@@ -212,7 +212,7 @@
   // Proto3 gets:
 
   // Single fields
-  //  - has*/setHas* invalid for primative types.
+  //  - has*/setHas* invalid for primitive types.
   //  - has*/setHas* valid for Message.
 
   for (NSString *name in names) {
@@ -2234,7 +2234,7 @@
 - (void)testProto3OneofSetToZero {
 
   // Normally setting a proto3 field to the zero value should result in it being
-  // reset/cleared.  But in a oneof, it still gets recored so it can go out
+  // reset/cleared.  But in a oneof, it still gets recorded so it can go out
   // over the wire and the other side can see what was set in the oneof.
 
   NSString *oneofStringDefault = @"";
@@ -2367,7 +2367,7 @@
   XCTAssertNotEqual(msg1, msg2);      // Ptr compare, new object.
   XCTAssertEqualObjects(msg1, msg2);  // Equal values.
 
-  // Pointer comparisions, different objects.
+  // Pointer comparisons, different objects.
 
   XCTAssertNotEqual(msg1.optionalGroup, msg2.optionalGroup);
   XCTAssertNotEqual(msg1.optionalNestedMessage, msg2.optionalNestedMessage);
@@ -2423,7 +2423,7 @@
   XCTAssertNotEqual(msg1, msg2);      // Ptr compare, new object.
   XCTAssertEqualObjects(msg1, msg2);  // Equal values.
 
-  // Pointer comparisions, different objects.
+  // Pointer comparisons, different objects.
   XCTAssertNotEqual(msg1.mapInt32Int32, msg2.mapInt32Int32);
   XCTAssertNotEqual(msg1.mapInt64Int64, msg2.mapInt64Int64);
   XCTAssertNotEqual(msg1.mapUint32Uint32, msg2.mapUint32Uint32);
@@ -2492,7 +2492,7 @@
 }
 
 - (void)test_StringFieldsCopy {
-  // ObjC conventions call for NSString properites to be copy, ensure
+  // ObjC conventions call for NSString properties to be copy, ensure
   // that is done correctly and the string isn't simply retained.
 
   Message2 *msg1 = [Message2 message];
@@ -2507,25 +2507,25 @@
 
   XCTAssertEqualObjects(msg1.optionalString, mutableStr);
   XCTAssertEqualObjects(msg1.optionalString, @"foo");
-  XCTAssertTrue(msg1.optionalString != mutableStr);  // Ptr comparision.
+  XCTAssertTrue(msg1.optionalString != mutableStr);  // Ptr comparison.
 
   XCTAssertEqualObjects(msg2.optionalString, mutableStr);
   XCTAssertEqualObjects(msg2.optionalString, @"foo");
-  XCTAssertTrue(msg2.optionalString != mutableStr);  // Ptr comparision.
+  XCTAssertTrue(msg2.optionalString != mutableStr);  // Ptr comparison.
 
   [mutableStr appendString:@"bar"];
 
   XCTAssertNotEqualObjects(msg1.optionalString, mutableStr);
   XCTAssertEqualObjects(msg1.optionalString, @"foo");
-  XCTAssertTrue(msg1.optionalString != mutableStr);  // Ptr comparision.
+  XCTAssertTrue(msg1.optionalString != mutableStr);  // Ptr comparison.
 
   XCTAssertNotEqualObjects(msg2.optionalString, mutableStr);
   XCTAssertEqualObjects(msg2.optionalString, @"foo");
-  XCTAssertTrue(msg2.optionalString != mutableStr);  // Ptr comparision.
+  XCTAssertTrue(msg2.optionalString != mutableStr);  // Ptr comparison.
 }
 
 - (void)test_BytesFieldsCopy {
-  // ObjC conventions call for NSData properites to be copy, ensure
+  // ObjC conventions call for NSData properties to be copy, ensure
   // that is done correctly and the data isn't simply retained.
 
   Message2 *msg1 = [Message2 message];
@@ -2540,21 +2540,21 @@
 
   XCTAssertEqualObjects(msg1.optionalBytes, mutableData);
   XCTAssertEqualObjects(msg1.optionalBytes, DataFromCStr("abc"));
-  XCTAssertTrue(msg1.optionalBytes != mutableData);  // Ptr comparision.
+  XCTAssertTrue(msg1.optionalBytes != mutableData);  // Ptr comparison.
 
   XCTAssertEqualObjects(msg2.optionalBytes, mutableData);
   XCTAssertEqualObjects(msg2.optionalBytes, DataFromCStr("abc"));
-  XCTAssertTrue(msg2.optionalBytes != mutableData);  // Ptr comparision.
+  XCTAssertTrue(msg2.optionalBytes != mutableData);  // Ptr comparison.
 
   [mutableData appendData:DataFromCStr("123")];
 
   XCTAssertNotEqualObjects(msg1.optionalBytes, mutableData);
   XCTAssertEqualObjects(msg1.optionalBytes, DataFromCStr("abc"));
-  XCTAssertTrue(msg1.optionalBytes != mutableData);  // Ptr comparision.
+  XCTAssertTrue(msg1.optionalBytes != mutableData);  // Ptr comparison.
 
   XCTAssertNotEqualObjects(msg2.optionalBytes, mutableData);
   XCTAssertEqualObjects(msg2.optionalBytes, DataFromCStr("abc"));
-  XCTAssertTrue(msg2.optionalBytes != mutableData);  // Ptr comparision.
+  XCTAssertTrue(msg2.optionalBytes != mutableData);  // Ptr comparison.
 }
 
 #pragma mark - Subset from from map_tests.cc

--- a/objectivec/Tests/GPBMessageTests.m
+++ b/objectivec/Tests/GPBMessageTests.m
@@ -1131,10 +1131,10 @@
     XCTAssertNotNil(message.a.iArray);
     XCTAssertFalse([message hasA]);
     GPBInt32Array *iArray = [message.a.iArray retain];
-    XCTAssertEqual(iArray->_autocreator, message.a);  // Pointer comparision
+    XCTAssertEqual(iArray->_autocreator, message.a);  // Pointer comparison
     message.a.iArray = [GPBInt32Array arrayWithValue:1];
     XCTAssertTrue([message hasA]);
-    XCTAssertNotEqual(message.a.iArray, iArray);  // Pointer comparision
+    XCTAssertNotEqual(message.a.iArray, iArray);  // Pointer comparison
     XCTAssertNil(iArray->_autocreator);
     [iArray release];
   }
@@ -1148,10 +1148,10 @@
     GPBAutocreatedArray *strArray =
         (GPBAutocreatedArray *)[message.a.strArray retain];
     XCTAssertTrue([strArray isKindOfClass:[GPBAutocreatedArray class]]);
-    XCTAssertEqual(strArray->_autocreator, message.a);  // Pointer comparision
+    XCTAssertEqual(strArray->_autocreator, message.a);  // Pointer comparison
     message.a.strArray = [NSMutableArray arrayWithObject:@"foo"];
     XCTAssertTrue([message hasA]);
-    XCTAssertNotEqual(message.a.strArray, strArray);  // Pointer comparision
+    XCTAssertNotEqual(message.a.strArray, strArray);  // Pointer comparison
     XCTAssertNil(strArray->_autocreator);
     [strArray release];
   }
@@ -1348,11 +1348,11 @@
     XCTAssertNotNil(message.a.iToI);
     XCTAssertFalse([message hasA]);
     GPBInt32Int32Dictionary *iToI = [message.a.iToI retain];
-    XCTAssertEqual(iToI->_autocreator, message.a);  // Pointer comparision
+    XCTAssertEqual(iToI->_autocreator, message.a);  // Pointer comparison
     message.a.iToI = [[[GPBInt32Int32Dictionary alloc] init] autorelease];
     [message.a.iToI setInt32:6 forKey:7];
     XCTAssertTrue([message hasA]);
-    XCTAssertNotEqual(message.a.iToI, iToI);  // Pointer comparision
+    XCTAssertNotEqual(message.a.iToI, iToI);  // Pointer comparison
     XCTAssertNil(iToI->_autocreator);
     [iToI release];
   }
@@ -1366,11 +1366,11 @@
     GPBAutocreatedDictionary *strToStr =
         (GPBAutocreatedDictionary *)[message.a.strToStr retain];
     XCTAssertTrue([strToStr isKindOfClass:[GPBAutocreatedDictionary class]]);
-    XCTAssertEqual(strToStr->_autocreator, message.a);  // Pointer comparision
+    XCTAssertEqual(strToStr->_autocreator, message.a);  // Pointer comparison
     message.a.strToStr =
         [NSMutableDictionary dictionaryWithObject:@"abc" forKey:@"def"];
     XCTAssertTrue([message hasA]);
-    XCTAssertNotEqual(message.a.strToStr, strToStr);  // Pointer comparision
+    XCTAssertNotEqual(message.a.strToStr, strToStr);  // Pointer comparison
     XCTAssertNil(strToStr->_autocreator);
     [strToStr release];
   }
@@ -1918,7 +1918,7 @@
   aTime = Time_SomethingElse;
   Time_IsValidValue(aTime);
 
-  // This block confirms the names in the decriptors is what we wanted.
+  // This block confirms the names in the descriptors is what we wanted.
 
   GPBEnumDescriptor *descriptor;
   NSString *valueName;

--- a/objectivec/Tests/GPBObjectiveCPlusPlusTest.mm
+++ b/objectivec/Tests/GPBObjectiveCPlusPlusTest.mm
@@ -35,7 +35,7 @@
 //
 // This is just a compile test (here to make sure things never regress).
 //
-// Objective C++ can run into issues with how the NS_ENUM/CF_ENUM declartion
+// Objective C++ can run into issues with how the NS_ENUM/CF_ENUM declaration
 // works because of the C++ spec being used for that compilation unit. So
 // the fact that these imports all work without errors/warning means things
 // are still good.

--- a/objectivec/Tests/GPBSwiftTests.swift
+++ b/objectivec/Tests/GPBSwiftTests.swift
@@ -276,7 +276,7 @@ class GPBBridgeTests: XCTestCase {
     msg5.optionalInt32 = 123
     msg.optional = msg5
     XCTAssertTrue(msg.hasOptionalMessage)
-    // Modifing the autocreated doesn't replaced the explicit set one.
+    // Modifying the autocreated doesn't replaced the explicit set one.
     autoCreated?.optionalInt32 = 456
     XCTAssertTrue(msg.hasOptionalMessage)
     XCTAssertTrue(msg.optional === msg5)

--- a/objectivec/Tests/unittest_extension_chain_f.proto
+++ b/objectivec/Tests/unittest_extension_chain_f.proto
@@ -34,7 +34,7 @@ package protobuf_unittest;
 import "unittest_extension_chain_g.proto";
 
 // The Root for this file should just be merging in the extensions from C's
-// Root (because G doens't define anything itself).
+// Root (because G doesn't define anything itself).
 
 // The generated source will also have to directly import C's .h file so it can
 // compile the reference to C's Root class.

--- a/php/ext/google/protobuf/array.c
+++ b/php/ext/google/protobuf/array.c
@@ -85,7 +85,7 @@ static zend_object *repeated_field_iter_create(zend_class_entry *ce TSRMLS_DC);
 #endif
 
 // -----------------------------------------------------------------------------
-// RepeatedField creation/desctruction
+// RepeatedField creation/destruction
 // -----------------------------------------------------------------------------
 
 zend_class_entry* repeated_field_type;
@@ -484,7 +484,7 @@ PHP_METHOD(RepeatedField, getIterator) {
 }
 
 // -----------------------------------------------------------------------------
-// RepeatedFieldIter creation/desctruction
+// RepeatedFieldIter creation/destruction
 // -----------------------------------------------------------------------------
 
 // Define object free method.

--- a/php/ext/google/protobuf/map.c
+++ b/php/ext/google/protobuf/map.c
@@ -153,7 +153,7 @@ static void map_field_write_dimension(zval *object, zval *key,
                                       zval *value TSRMLS_DC);
 
 // -----------------------------------------------------------------------------
-// MapField creation/desctruction
+// MapField creation/destruction
 // -----------------------------------------------------------------------------
 
 zend_class_entry* map_field_type;
@@ -540,7 +540,7 @@ static zend_function_entry map_field_iter_methods[] = {
 };
 
 // -----------------------------------------------------------------------------
-// MapFieldIter creation/desctruction
+// MapFieldIter creation/destruction
 // -----------------------------------------------------------------------------
 
 // Define object free method.

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -106,8 +106,8 @@ PHP_PROTO_OBJECT_DTOR_END
 // Define object create method.
 PHP_PROTO_OBJECT_CREATE_START(MessageHeader, message)
 // Because php call this create func before calling the sub-message's
-// constructor defined in PHP, it's possible that the decriptor of this class
-// hasn't been added to descritpor pool (when the class is first
+// constructor defined in PHP, it's possible that the descriptor of this class
+// hasn't been added to descriptor pool (when the class is first
 // instantiated). In that case, we will defer the initialization of the custom
 // data to the parent Message's constructor, which will be called by
 // sub-message's constructors after the descriptor has been added.

--- a/php/ext/google/protobuf/upb.c
+++ b/php/ext/google/protobuf/upb.c
@@ -9706,7 +9706,7 @@ static bool start_stringval(upb_json_parser *p) {
   } else if (upb_fielddef_type(p->top->f) != UPB_TYPE_BOOL &&
              upb_fielddef_type(p->top->f) != UPB_TYPE_MESSAGE) {
     /* No need to push a frame -- numeric values in quotes remain in the
-     * current parser frame.  These values must accmulate so we can convert
+     * current parser frame.  These values must accumulate so we can convert
      * them all at once at the end. */
     multipart_startaccum(p);
     return true;

--- a/php/ext/google/protobuf/upb.h
+++ b/php/ext/google/protobuf/upb.h
@@ -6378,7 +6378,7 @@ typedef struct {
 typedef struct {
   /* Space optimization note: we store two pointers here that the JIT
    * doesn't need at all; the upb_handlers* inside the sink and
-   * the dispatch table pointer.  We can optimze so that the JIT uses
+   * the dispatch table pointer.  We can optimize so that the JIT uses
    * smaller stack frames than the interpreter.  The only thing we need
    * to guarantee is that the fallback routines can find end_ofs. */
   upb_sink sink;
@@ -6455,7 +6455,7 @@ struct upb_pbdecoder {
   char residual[UPB_DECODER_MAX_RESIDUAL_BYTES];
   char *residual_end;
 
-  /* Bytes of data that should be discarded from the input beore we start
+  /* Bytes of data that should be discarded from the input before we start
    * parsing again.  We set this when we internally determine that we can
    * safely skip the next N bytes, but this region extends past the current
    * user buffer. */

--- a/php/generate_descriptor_protos.sh
+++ b/php/generate_descriptor_protos.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Run this script to regenerate desriptor protos after the protocol compiler
+# Run this script to regenerate descriptor protos after the protocol compiler
 # changes.
 
 if test ! -e src/google/protobuf/stubs/common.h; then

--- a/php/src/Google/Protobuf/Any.php
+++ b/php/src/Google/Protobuf/Any.php
@@ -252,13 +252,13 @@ class Any extends \Google\Protobuf\Internal\Message
      * the method will create a message of the targeted type and fill it with
      * the decoded value in Any.
      * @return unpacked message
-     * @throws \Exception Type url needs to be type.googleapis.com/fully-qulified.
+     * @throws \Exception Type url needs to be type.googleapis.com/fully-qualified.
      * @throws \Exception Class hasn't been added to descriptor pool.
      * @throws \Exception cannot decode data in value field.
      */
     public function unpack()
     {
-        // Get fully qualifed name from type url.
+        // Get fully qualified name from type url.
         $url_prifix_len = strlen(GPBUtil::TYPE_URL_PREFIX);
         if (substr($this->type_url, 0, $url_prifix_len) !=
                 GPBUtil::TYPE_URL_PREFIX) {
@@ -296,7 +296,7 @@ class Any extends \Google\Protobuf\Internal\Message
             return;
         }
 
-        // Set value using serialzed message.
+        // Set value using serialized message.
         $this->value = $msg->serializeToString();
 
         // Set type url.

--- a/php/src/Google/Protobuf/Internal/CodedInputStream.php
+++ b/php/src/Google/Protobuf/Internal/CodedInputStream.php
@@ -220,7 +220,7 @@ class CodedInputStream
     }
 
     /**
-     * Read 32-bit unsiged integer to $var. If the buffer has less than 4 bytes,
+     * Read 32-bit unsigned integer to $var. If the buffer has less than 4 bytes,
      * return false. Advance buffer with consumed bytes.
      * @param $var.
      */
@@ -236,7 +236,7 @@ class CodedInputStream
     }
 
     /**
-     * Read 64-bit unsiged integer to $var. If the buffer has less than 8 bytes,
+     * Read 64-bit unsigned integer to $var. If the buffer has less than 8 bytes,
      * return false. Advance buffer with consumed bytes.
      * @param $var.
      */
@@ -283,7 +283,7 @@ class CodedInputStream
         }
 
         $result = 0;
-        // The larget tag is 2^29 - 1, which can be represented by int32.
+        // The largest tag is 2^29 - 1, which can be represented by int32.
         $success = $this->readVarint32($result);
         if ($success) {
             return $result;

--- a/php/src/Google/Protobuf/Internal/GPBUtil.php
+++ b/php/src/Google/Protobuf/Internal/GPBUtil.php
@@ -405,7 +405,7 @@ class GPBUtil
 
     public static function parseTimestamp($timestamp)
     {
-        // prevent parsing timestamps containing with the non-existant year "0000"
+        // prevent parsing timestamps containing with the non-existent year "0000"
         // DateTime::createFromFormat parses without failing but as a nonsensical date
         if (substr($timestamp, 0, 4) === "0000") {
             throw new \Exception("Year cannot be zero.");

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -679,8 +679,8 @@ class Message
      * This method merges the contents of the specified message into the
      * current message. Singular fields that are set in the specified message
      * overwrite the corresponding fields in the current message.  Repeated
-     * fields are appended. Map fields key-value pairs are overritten.
-     * Singular/Oneof sub-messages are recursively merged. All overritten
+     * fields are appended. Map fields key-value pairs are overwritten.
+     * Singular/Oneof sub-messages are recursively merged. All overwritten
      * sub-messages are deep-copied.
      *
      * @param object $msg Protobuf message to be merged from.

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -250,7 +250,7 @@ def cc_proto_library(
       include: a string indicating the include path of the .proto files.
       protoc: the label of the protocol compiler to generate the sources.
       internal_bootstrap_hack: a flag indicate the cc_proto_library is used only
-          for bootstraping. When it is set to True, no files will be generated.
+          for bootstrapping. When it is set to True, no files will be generated.
           The rule will simply be a provider for .proto files, so that other
           cc_proto_library can depend on it.
       use_grpc_plugin: a flag to indicate whether to call the grpc C++ plugin

--- a/python/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/descriptor.proto
+++ b/python/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/descriptor.proto
@@ -228,7 +228,7 @@ message MethodDescriptorProto {
 // * For options which will be published and used publicly by multiple
 //   independent entities, e-mail protobuf-global-extension-registry@google.com
 //   to reserve extension numbers. Simply provide your project name (e.g.
-//   Object-C plugin) and your porject website (if available) -- there's no need
+//   Object-C plugin) and your project website (if available) -- there's no need
 //   to explain how you intend to use them. Usually you only need one extension
 //   number. You can declare multiple options with only one extension number by
 //   putting them in a sub-message. See the Custom Options section of the docs

--- a/python/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/unittest_custom_options.proto
+++ b/python/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/unittest_custom_options.proto
@@ -321,7 +321,7 @@ message Aggregate {
 }
 
 // Allow Aggregate to be used as an option at all possible locations
-// in the .proto grammer.
+// in the .proto grammar.
 extend google.protobuf.FileOptions      { optional Aggregate fileopt    = 15478479; }
 extend google.protobuf.MessageOptions   { optional Aggregate msgopt     = 15480088; }
 extend google.protobuf.FieldOptions     { optional Aggregate fieldopt   = 15481374; }

--- a/python/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/unittest_import.proto
+++ b/python/compatibility_tests/v2.5.0/protos/src/proto/google/protobuf/unittest_import.proto
@@ -43,7 +43,7 @@ package protobuf_unittest_import;
 
 option optimize_for = SPEED;
 
-// Excercise the java_package option.
+// Exercise the java_package option.
 option java_package = "com.google.protobuf.test";
 
 // Do not set a java_outer_classname here to verify that Proto2 works without

--- a/python/compatibility_tests/v2.5.0/test.sh
+++ b/python/compatibility_tests/v2.5.0/test.sh
@@ -12,7 +12,7 @@ TEST_VERSION=2.5.0
 # The old version of protobuf that we are testing compatibility against. This
 # is usually the same as TEST_VERSION (i.e., we use the tests extracted from
 # that version to test compatibility of the newest runtime against it), but it
-# is also possible to use this same test set to test the compatibiilty of the
+# is also possible to use this same test set to test the compatibility of the
 # latest version against other versions.
 OLD_VERSION=$1
 OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/$OLD_VERSION/protoc-$OLD_VERSION-linux-x86_64.exe

--- a/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/generator_test.py
+++ b/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/generator_test.py
@@ -148,7 +148,7 @@ class GeneratorTest(unittest.TestCase):
     proto = unittest_custom_options_pb2.TestMessageWithCustomOptions()
     enum_options = proto.DESCRIPTOR.enum_types_by_name['AnEnum'].GetOptions()
     self.assertTrue(enum_options is not None)
-    # TODO(gps): We really should test for the presense of the enum_opt1
+    # TODO(gps): We really should test for the presence of the enum_opt1
     # extension and for its value to be set to -789.
 
   def testNestedTypes(self):

--- a/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/service_reflection_test.py
+++ b/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/service_reflection_test.py
@@ -118,7 +118,7 @@ class FooUnitTest(unittest.TestCase):
     rpc_controller = 'controller'
     request = 'request'
 
-    # GetDescriptor now static, still works as instance method for compatability
+    # GetDescriptor now static, still works as instance method for compatibility
     self.assertEqual(unittest_pb2.TestService_Stub.GetDescriptor(),
                      stub.GetDescriptor())
 

--- a/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/text_format_test.py
+++ b/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/text_format_test.py
@@ -247,7 +247,7 @@ class TextFormatTest(unittest.TestCase):
     text = text.replace('e+0','e+').replace('e+0','e+') \
                .replace('e-0','e-').replace('e-0','e-')
     # Floating point fields are printed with .0 suffix even if they are
-    # actualy integer numbers.
+    # actually integer numbers.
     text = re.compile(r'\.0$', re.MULTILINE).sub('', text)
     return text
 

--- a/python/google/protobuf/descriptor.py
+++ b/python/google/protobuf/descriptor.py
@@ -186,7 +186,7 @@ class _NestedDescriptorBase(DescriptorBase):
         file.serialized_pb that describes this descriptor.
       serialized_end: The end index (exclusive) in block in the
         file.serialized_pb that describes this descriptor.
-      serialized_options: Protocol message serilized options or None.
+      serialized_options: Protocol message serialized options or None.
     """
     super(_NestedDescriptorBase, self).__init__(
         options, serialized_options, options_class_name)
@@ -753,7 +753,7 @@ class ServiceDescriptor(_NestedDescriptorBase):
     name: (str) Name of the service.
     full_name: (str) Full name of the service, including package name.
     index: (int) 0-indexed index giving the order that this services
-      definition appears withing the .proto file.
+      definition appears within the .proto file.
     methods: (list of MethodDescriptor) List of methods provided by this
       service.
     methods_by_name: (dict str -> MethodDescriptor) Same MethodDescriptor

--- a/python/google/protobuf/descriptor_pool.py
+++ b/python/google/protobuf/descriptor_pool.py
@@ -639,7 +639,7 @@ class DescriptorPool(object):
     return list(self._extensions_by_number[message_descriptor].values())
 
   def _TryLoadExtensionFromDB(self, message_descriptor, number):
-    """Try to Load extensions from decriptor db.
+    """Try to Load extensions from descriptor db.
 
     Args:
       message_descriptor: descriptor of the extended message.
@@ -1034,7 +1034,7 @@ class DescriptorPool(object):
 
     Args:
       field_proto: Data about the field in proto format.
-      field_desc: The descriptor to modiy.
+      field_desc: The descriptor to modify.
       package: The package the field's container is in.
       scope: Enclosing scope of available types.
     """

--- a/python/google/protobuf/internal/extension_dict.py
+++ b/python/google/protobuf/internal/extension_dict.py
@@ -139,7 +139,7 @@ class _ExtensionDict(object):
 
   # Note that this is only meaningful for non-repeated, scalar extension
   # fields.  Note also that we may have to call _Modified() when we do
-  # successfully set a field this way, to set any necssary "has" bits in the
+  # successfully set a field this way, to set any necessary "has" bits in the
   # ancestors of the extended message.
   def __setitem__(self, extension_handle, value):
     """If extension_handle specifies a non-repeated, scalar extension

--- a/python/google/protobuf/internal/text_format_test.py
+++ b/python/google/protobuf/internal/text_format_test.py
@@ -97,7 +97,7 @@ class TextFormatBase(unittest.TestCase):
     text = text.replace('e+0','e+').replace('e+0','e+') \
                .replace('e-0','e-').replace('e-0','e-')
     # Floating point fields are printed with .0 suffix even if they are
-    # actualy integer numbers.
+    # actually integer numbers.
     text = re.compile(r'\.0$', re.MULTILINE).sub('', text)
     return text
 

--- a/python/google/protobuf/internal/type_checkers.py
+++ b/python/google/protobuf/internal/type_checkers.py
@@ -38,7 +38,7 @@ TYPE_TO_BYTE_SIZE_FN: A dictionary with field types and a size computing
 TYPE_TO_SERIALIZE_METHOD: A dictionary with field types and serialization
   function.
 FIELD_TYPE_TO_WIRE_TYPE: A dictionary with field typed and their
-  coresponding wire types.
+  corresponding wire types.
 TYPE_TO_DESERIALIZE_METHOD: A dictionary with field types and deserialization
   function.
 """

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -265,7 +265,7 @@ class _Printer(object):
           else:
             name = field.json_name
           if name in js:
-            # Skip the field which has been serailized already.
+            # Skip the field which has been serialized already.
             continue
           if _IsMapEntry(field):
             js[name] = {}

--- a/python/google/protobuf/pyext/descriptor.cc
+++ b/python/google/protobuf/pyext/descriptor.cc
@@ -481,7 +481,7 @@ static PyObject* GetFile(PyBaseDescriptor *self, void *closure) {
 }
 
 static PyObject* GetConcreteClass(PyBaseDescriptor* self, void *closure) {
-  // Retuns the canonical class for the given descriptor.
+  // Returns the canonical class for the given descriptor.
   // This is the class that was registered with the primary descriptor pool
   // which contains this descriptor.
   // This might not be the one you expect! For example the returned object does

--- a/python/google/protobuf/pyext/unknown_fields.cc
+++ b/python/google/protobuf/pyext/unknown_fields.cc
@@ -246,7 +246,7 @@ static PyObject* GetWireType(PyUnknownFieldRef* self, void *closure) {
     return NULL;
   }
 
-  // Assign a default value to suppress may-unintialized warnings (errors
+  // Assign a default value to suppress may-uninitialized warnings (errors
   // when built in some places).
   WireFormatLite::WireType wire_type = WireFormatLite::WIRETYPE_VARINT;
   switch (unknown_field->type()) {

--- a/python/mox.py
+++ b/python/mox.py
@@ -705,7 +705,7 @@ class MockMethod(object):
     """Move this method into group of calls which may be called multiple times.
 
     A group of repeating calls must be defined together, and must be executed in
-    full before the next expected mehtod can be called.
+    full before the next expected method can be called.
 
     Args:
       group_name: the name of the unordered group.

--- a/ruby/compatibility_tests/v3.0.0/README.md
+++ b/ruby/compatibility_tests/v3.0.0/README.md
@@ -1,5 +1,5 @@
 # Protobuf Ruby Compatibility Tests
 
-This drectory contains a snapshot of protobuf ruby 3.0.0 unittest code and
+This directory contains a snapshot of protobuf ruby 3.0.0 unittest code and
 test scripts used to verifies whether the latest version of protobuf is
 still compatible with 3.0.0 generated code.

--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -136,7 +136,7 @@ static void rewrite_enum_default(const upb_symtab* symtab,
  * same number.
  *
  * Here we do a pass over all enum defaults and rewrite numeric defaults by
- * looking up their labels.  This is compilcated by the fact that the enum
+ * looking up their labels.  This is complicated by the fact that the enum
  * definition can live in either the symtab or the file_proto.
  * */
 static void rewrite_enum_defaults(
@@ -572,7 +572,7 @@ VALUE Descriptor_file_descriptor(VALUE _self) {
  * call-seq:
  *     Descriptor.name => name
  *
- * Returns the name of this message type as a fully-qualfied string (e.g.,
+ * Returns the name of this message type as a fully-qualified string (e.g.,
  * My.Package.MessageType).
  */
 VALUE Descriptor_name(VALUE _self) {

--- a/ruby/ext/google/protobuf_c/upb.c
+++ b/ruby/ext/google/protobuf_c/upb.c
@@ -9697,7 +9697,7 @@ static bool start_stringval(upb_json_parser *p) {
   } else if (upb_fielddef_type(p->top->f) != UPB_TYPE_BOOL &&
              upb_fielddef_type(p->top->f) != UPB_TYPE_MESSAGE) {
     /* No need to push a frame -- numeric values in quotes remain in the
-     * current parser frame.  These values must accmulate so we can convert
+     * current parser frame.  These values must accumulate so we can convert
      * them all at once at the end. */
     multipart_startaccum(p);
     return true;

--- a/ruby/ext/google/protobuf_c/upb.h
+++ b/ruby/ext/google/protobuf_c/upb.h
@@ -6368,7 +6368,7 @@ typedef struct {
 typedef struct {
   /* Space optimization note: we store two pointers here that the JIT
    * doesn't need at all; the upb_handlers* inside the sink and
-   * the dispatch table pointer.  We can optimze so that the JIT uses
+   * the dispatch table pointer.  We can optimize so that the JIT uses
    * smaller stack frames than the interpreter.  The only thing we need
    * to guarantee is that the fallback routines can find end_ofs. */
   upb_sink sink;
@@ -6445,7 +6445,7 @@ struct upb_pbdecoder {
   char residual[UPB_DECODER_MAX_RESIDUAL_BYTES];
   char *residual_end;
 
-  /* Bytes of data that should be discarded from the input beore we start
+  /* Bytes of data that should be discarded from the input before we start
    * parsing again.  We set this when we internally determine that we can
    * safely skip the next N bytes, but this region extends past the current
    * user buffer. */

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyDescriptor.java
@@ -85,7 +85,7 @@ public class RubyDescriptor extends RubyObject {
      * call-seq:
      *     Descriptor.name => name
      *
-     * Returns the name of this message type as a fully-qualfied string (e.g.,
+     * Returns the name of this message type as a fully-qualified string (e.g.,
      * My.Package.MessageType).
      */
     @JRubyMethod(name = "name")

--- a/src/google/protobuf/compiler/annotation_test_util.h
+++ b/src/google/protobuf/compiler/annotation_test_util.h
@@ -60,7 +60,7 @@ struct ExpectedOutput {
 // directory.
 void AddFile(const std::string& filename, const std::string& data);
 
-// Runs proto compiler. Captures proto file structrue in FileDescriptorProto.
+// Runs proto compiler. Captures proto file structure in FileDescriptorProto.
 // Files will be generated in TestTempDir() folder. Callers of this
 // function must read generated files themselves.
 //

--- a/src/google/protobuf/compiler/code_generator.cc
+++ b/src/google/protobuf/compiler/code_generator.cc
@@ -50,7 +50,7 @@ bool CodeGenerator::GenerateAll(const std::vector<const FileDescriptor*>& files,
                                 const std::string& parameter,
                                 GeneratorContext* generator_context,
                                 std::string* error) const {
-  // Default implemenation is just to call the per file method, and prefix any
+  // Default implementation is just to call the per file method, and prefix any
   // error string with the file to provide context.
   bool succeeded = true;
   for (int i = 0; i < files.size(); i++) {

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2280,7 +2280,7 @@ namespace {
 // Nested Messages:
 // Note that it only stores the nested message type, iff the nested type is
 // either a direct child of the given descriptor, or the nested type is a
-// decendent of the given descriptor and all the nodes between the
+// descendant of the given descriptor and all the nodes between the
 // nested type and the given descriptor are group types. e.g.
 //
 // message Foo {

--- a/src/google/protobuf/compiler/command_line_interface.h
+++ b/src/google/protobuf/compiler/command_line_interface.h
@@ -97,7 +97,7 @@ class DiskSourceTree;    // importer.h
 //   protoc --cpp_out=outdir --foo_out=outdir --proto_path=src src/foo.proto
 //
 // The .proto file to compile can be specified on the command line using either
-// its physical file path, or a virtual path relative to a diretory specified
+// its physical file path, or a virtual path relative to a directory specified
 // in --proto_path. For example, for src/foo.proto, the following two protoc
 // invocations work the same way:
 //   1. protoc --proto_path=src src/foo.proto (physical file path)
@@ -194,7 +194,7 @@ class PROTOC_EXPORT CommandLineInterface {
   // DEPRECATED. Calling this method has no effect. Protocol compiler now
   // always try to find the .proto file relative to the current directory
   // first and if the file is not found, it will then treat the input path
-  // as a virutal path.
+  // as a virtual path.
   void SetInputsAreProtoPathRelative(bool /* enable */) {}
 
   // Provides some text which will be printed when the --version flag is

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -1074,7 +1074,7 @@ TEST_F(CommandLineInterfaceTest, UnrecognizedExtraParameters) {
 }
 
 TEST_F(CommandLineInterfaceTest, ExtraPluginParametersForOutParameters) {
-  // This doesn't rely on the plugin having been registred and instead that
+  // This doesn't rely on the plugin having been registered and instead that
   // the existence of --[name]_out is enough to make the --[name]_opt valid.
   // However, running out of process plugins found via the search path (i.e. -
   // not pre registered with --plugin) isn't support in this test suite, so we

--- a/src/google/protobuf/compiler/cpp/cpp_file.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_file.cc
@@ -1185,7 +1185,7 @@ void FileGenerator::GenerateForwardDeclarations(io::Printer* printer) {
   FlattenMessagesInFile(file_, &classes);  // All messages need forward decls.
 
   if (options_.proto_h) {  // proto.h needs extra forward declarations.
-    // All classes / enums refered to as field members
+    // All classes / enums referred to as field members
     std::vector<const FieldDescriptor*> fields;
     ListAllFields(file_, &fields);
     for (int i = 0; i < fields.size(); i++) {

--- a/src/google/protobuf/compiler/cpp/cpp_file.h
+++ b/src/google/protobuf/compiler/cpp/cpp_file.h
@@ -148,7 +148,7 @@ class FileGenerator {
   // Generates extension identifiers.
   void GenerateExtensionIdentifiers(io::Printer* printer);
 
-  // Generates inline function defintions.
+  // Generates inline function definitions.
   void GenerateInlineFunctionDefinitions(io::Printer* printer);
 
   void GenerateProto2NamespaceEnumSpecializations(io::Printer* printer);

--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -232,7 +232,7 @@ bool HasPrivateHasMethod(const FieldDescriptor* field) {
 }
 
 // TODO(ckennelly):  Cull these exclusions if/when these protos do not have
-// their methods overriden by subclasses.
+// their methods overridden by subclasses.
 
 bool ShouldMarkClassAsFinal(const Descriptor* descriptor,
                             const Options& options) {

--- a/src/google/protobuf/compiler/importer.h
+++ b/src/google/protobuf/compiler/importer.h
@@ -254,7 +254,7 @@ class PROTOBUF_EXPORT DiskSourceTree : public SourceTree {
   // and then you do:
   //   Open("bar/qux");
   // the DiskSourceTree will first try to open foo/bar/qux, then baz/bar/qux,
-  // returning the first one that opens successfuly.
+  // returning the first one that opens successfully.
   //
   // disk_path may be an absolute path or relative to the current directory,
   // just like a path you'd pass to open().

--- a/src/google/protobuf/compiler/java/java_enum_field.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field.cc
@@ -105,7 +105,7 @@ void SetEnumVariables(const FieldDescriptor* descriptor, int messageBitIndex,
         ".getNumber()";
   }
 
-  // For repated builders, one bit is used for whether the array is immutable.
+  // For repeated builders, one bit is used for whether the array is immutable.
   (*variables)["get_mutable_bit_builder"] = GenerateGetBit(builderBitIndex);
   (*variables)["set_mutable_bit_builder"] = GenerateSetBit(builderBitIndex);
   (*variables)["clear_mutable_bit_builder"] = GenerateClearBit(builderBitIndex);

--- a/src/google/protobuf/compiler/java/java_helpers.h
+++ b/src/google/protobuf/compiler/java/java_helpers.h
@@ -86,7 +86,7 @@ std::string UnderscoresToCamelCase(const MethodDescriptor* method);
 // Same as UnderscoresToCamelCase, but checks for reserved keywords
 std::string UnderscoresToCamelCaseCheckReserved(const FieldDescriptor* field);
 
-// Similar to UnderscoresToCamelCase, but guarentees that the result is a
+// Similar to UnderscoresToCamelCase, but guarantees that the result is a
 // complete Java identifier by adding a _ if needed.
 std::string CamelCaseFieldName(const FieldDescriptor* field);
 

--- a/src/google/protobuf/compiler/java/java_message_field.cc
+++ b/src/google/protobuf/compiler/java/java_message_field.cc
@@ -97,7 +97,7 @@ void SetMessageVariables(const FieldDescriptor* descriptor, int messageBitIndex,
         (*variables)["name"] + "_ != null";
   }
 
-  // For repated builders, one bit is used for whether the array is immutable.
+  // For repeated builders, one bit is used for whether the array is immutable.
   (*variables)["get_mutable_bit_builder"] = GenerateGetBit(builderBitIndex);
   (*variables)["set_mutable_bit_builder"] = GenerateSetBit(builderBitIndex);
   (*variables)["clear_mutable_bit_builder"] = GenerateClearBit(builderBitIndex);

--- a/src/google/protobuf/compiler/java/java_names.h
+++ b/src/google/protobuf/compiler/java/java_names.h
@@ -90,7 +90,7 @@ std::string FileJavaPackage(const FileDescriptor* descriptor);
 // Requires:
 //   descriptor != NULL
 // Returns:
-//   Captialized camel case name field name.
+//   Capitalized camel case name field name.
 std::string CapitalizedFieldName(const FieldDescriptor* descriptor);
 
 // Requires:

--- a/src/google/protobuf/compiler/java/java_primitive_field.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field.cc
@@ -161,7 +161,7 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
     }
   }
 
-  // For repated builders, one bit is used for whether the array is immutable.
+  // For repeated builders, one bit is used for whether the array is immutable.
   (*variables)["get_mutable_bit_builder"] = GenerateGetBit(builderBitIndex);
   (*variables)["set_mutable_bit_builder"] = GenerateSetBit(builderBitIndex);
   (*variables)["clear_mutable_bit_builder"] = GenerateClearBit(builderBitIndex);

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -157,7 +157,7 @@ int ImmutableStringFieldGenerator::GetNumBitsForBuilder() const {
 // A note about how strings are handled. This code used to just store a String
 // in the Message. This had two issues:
 //
-//  1. It wouldn't roundtrip byte arrays that were not vaid UTF-8 encoded
+//  1. It wouldn't roundtrip byte arrays that were not valid UTF-8 encoded
 //     strings, but rather fields that were raw bytes incorrectly marked
 //     as strings in the proto file. This is common because in the proto1
 //     syntax, string was the way to indicate bytes and C++ engineers can

--- a/src/google/protobuf/compiler/java/java_string_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_string_field_lite.cc
@@ -137,7 +137,7 @@ int ImmutableStringFieldLiteGenerator::GetNumBitsForMessage() const {
 // strings are not stored as java.lang.String in the Message because of two
 // issues:
 //
-//  1. It wouldn't roundtrip byte arrays that were not vaid UTF-8 encoded
+//  1. It wouldn't roundtrip byte arrays that were not valid UTF-8 encoded
 //     strings, but rather fields that were raw bytes incorrectly marked
 //     as strings in the proto file. This is common because in the proto1
 //     syntax, string was the way to indicate bytes and C++ engineers can

--- a/src/google/protobuf/compiler/objectivec/objectivec_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_field.cc
@@ -398,7 +398,7 @@ void RepeatedFieldGenerator::GeneratePropertyDeclaration(
 }
 
 bool RepeatedFieldGenerator::WantsHasProperty(void) const {
-  // Consumer check the array size/existance rather than a has bit.
+  // Consumer check the array size/existence rather than a has bit.
   return false;
 }
 

--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -1295,7 +1295,7 @@ bool Parser::ParseDefaultAssignment(
       break;
 
     case FieldDescriptorProto::TYPE_STRING:
-      // Note: When file opton java_string_check_utf8 is true, if a
+      // Note: When file option java_string_check_utf8 is true, if a
       // non-string representation (eg byte[]) is later supported, it must
       // be checked for UTF-8-ness.
       DO(ConsumeString(default_value,

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -1215,7 +1215,7 @@ void GenerateEnumFile(const FileDescriptor* file, const EnumDescriptor* en,
   Outdent(&printer);
   printer.Print("}\n\n");
 
-  // write legacy file for backwards compatiblity with nested messages and enums
+  // write legacy file for backwards compatibility with nested messages and enums
   if (en->containing_type() != NULL) {
     printer.Print(
         "// Adding a class alias for backwards compatibility with the previous class name.\n");
@@ -1314,7 +1314,7 @@ void GenerateMessageFile(const FileDescriptor* file, const Descriptor* message,
   Outdent(&printer);
   printer.Print("}\n\n");
 
-  // write legacy file for backwards compatiblity with nested messages and enums
+  // write legacy file for backwards compatibility with nested messages and enums
   if (message->containing_type() != NULL) {
     printer.Print(
         "// Adding a class alias for backwards compatibility with the previous class name.\n");

--- a/src/google/protobuf/compiler/plugin.h
+++ b/src/google/protobuf/compiler/plugin.h
@@ -79,7 +79,7 @@ PROTOC_EXPORT int PluginMain(int argc, char* argv[],
                              const CodeGenerator* generator);
 
 // Generates code using the given code generator. Returns true if the code
-// generation is successful. If the code geneartion fails, error_msg may be
+// generation is successful. If the code generation fails, error_msg may be
 // populated to describe the failure cause.
 bool GenerateCode(const CodeGeneratorRequest& request,
                   const CodeGenerator& generator,

--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -407,7 +407,7 @@ int GeneratePackageModules(const FileDescriptor* file, io::Printer* printer) {
   if (file->options().has_ruby_package()) {
     package_name = file->options().ruby_package();
 
-    // If :: is in the package use the Ruby formated name as-is
+    // If :: is in the package use the Ruby formatted name as-is
     //    -> A::B::C
     // otherwise, use the dot seperator
     //    -> A.B.C
@@ -421,7 +421,7 @@ int GeneratePackageModules(const FileDescriptor* file, io::Printer* printer) {
     package_name = file->package();
   }
 
-  // Use the appropriate delimter
+  // Use the appropriate delimiter
   string delimiter = need_change_to_module ? "." : "::";
   int delimiter_size = need_change_to_module ? 1 : 2;
 

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -492,7 +492,7 @@ std::set<std::string>* NewAllowedProto3Extendee() {
     allowed_proto3_extendees->insert(std::string("google.protobuf.") +
                                      kOptionNames[i]);
     // Split the word to trick the opensource processing scripts so they
-    // will keep the origial package name.
+    // will keep the original package name.
     allowed_proto3_extendees->insert(std::string("proto") + "2." +
                                      kOptionNames[i]);
   }
@@ -3246,7 +3246,7 @@ class DescriptorBuilder {
   // Like AddSymbol(), but succeeds if the symbol is already defined as long
   // as the existing definition is also a package (because it's OK to define
   // the same package in two different files).  Also adds all parents of the
-  // packgae to the symbol table (e.g. AddPackage("foo.bar", ...) will add
+  // package to the symbol table (e.g. AddPackage("foo.bar", ...) will add
   // "foo.bar" and "foo" to the table).
   void AddPackage(const std::string& name, const Message& proto,
                   const FileDescriptor* file);
@@ -5544,7 +5544,7 @@ void DescriptorBuilder::CrossLinkField(FieldDescriptor* field,
                           proto.has_default_value();
 
     // In case of weak fields we force building the dependency. We need to know
-    // if the type exist or not. If it doesnt exist we substitute Empty which
+    // if the type exist or not. If it doesn't exist we substitute Empty which
     // should only be done if the type can't be found in the generated pool.
     // TODO(gerbens) Ideally we should query the database directly to check
     // if weak fields exist or not so that we don't need to force building

--- a/src/google/protobuf/descriptor.h
+++ b/src/google/protobuf/descriptor.h
@@ -264,7 +264,7 @@ class PROTOBUF_EXPORT Descriptor {
   // isn't, the result may be garbage.
   void CopyTo(DescriptorProto* proto) const;
 
-  // Write the contents of this decriptor in a human-readable form. Output
+  // Write the contents of this descriptor in a human-readable form. Output
   // will be suitable for re-parsing.
   std::string DebugString() const;
 
@@ -1462,7 +1462,7 @@ class PROTOBUF_EXPORT FileDescriptor {
   static void DependenciesOnceInit(const FileDescriptor* to_init);
   void InternalDependenciesOnceInit() const;
 
-  // These are arranged to minimze padding on 64-bit.
+  // These are arranged to minimize padding on 64-bit.
   int dependency_count_;
   int public_dependency_count_;
   int weak_dependency_count_;

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -2532,7 +2532,7 @@ TEST_F(MiscTest, DefaultValues) {
   AddField(message_proto, "empty_string", 11, label, FD::TYPE_STRING)
       ->set_default_value("");
 
-  // Add a second set of fields with implicit defalut values.
+  // Add a second set of fields with implicit default values.
   AddField(message_proto, "implicit_int32", 21, label, FD::TYPE_INT32);
   AddField(message_proto, "implicit_int64", 22, label, FD::TYPE_INT64);
   AddField(message_proto, "implicit_uint32", 23, label, FD::TYPE_UINT32);
@@ -5177,7 +5177,7 @@ TEST_F(ValidationErrorTest, RepeatedMessageOption) {
 }
 
 TEST_F(ValidationErrorTest, ResolveUndefinedOption) {
-  // The following should produce an eror that baz.bar is resolved but not
+  // The following should produce an error that baz.bar is resolved but not
   // defined.
   // foo.proto:
   //   package baz
@@ -7773,7 +7773,7 @@ TEST_F(LazilyBuildDependenciesTest, Message) {
   EXPECT_FALSE(pool_.InternalIsFileLoaded("bar.proto"));
 
   // Finally, verify that if we call message_type() on the field, we will
-  // buid the file where the message is defined, and get a valid descriptor
+  // build the file where the message is defined, and get a valid descriptor
   EXPECT_TRUE(field->message_type() != nullptr);
   EXPECT_TRUE(pool_.InternalIsFileLoaded("bar.proto"));
 }

--- a/src/google/protobuf/dynamic_message_unittest.cc
+++ b/src/google/protobuf/dynamic_message_unittest.cc
@@ -291,7 +291,7 @@ TEST_F(DynamicMessageTest, Proto3) {
   const Reflection* refl = message->GetReflection();
   const Descriptor* desc = message->GetDescriptor();
 
-  // Just test a single primtive and single message field here to make sure we
+  // Just test a single primitive and single message field here to make sure we
   // are getting the no-field-presence semantics elsewhere. DynamicMessage uses
   // GeneratedMessageReflection under the hood, so the rest should be fine as
   // long as GMR recognizes that we're using a proto3 message.

--- a/src/google/protobuf/extension_set.h
+++ b/src/google/protobuf/extension_set.h
@@ -272,7 +272,7 @@ class PROTOBUF_EXPORT ExtensionSet {
   std::string* MutableString(int number, FieldType type, desc);
   MessageLite* MutableMessage(int number, FieldType type,
                               const MessageLite& prototype, desc);
-  MessageLite* MutableMessage(const FieldDescriptor* decsriptor,
+  MessageLite* MutableMessage(const FieldDescriptor* descriptor,
                               MessageFactory* factory);
   // Adds the given message to the ExtensionSet, taking ownership of the
   // message object. Existing message with the same number will be deleted.

--- a/src/google/protobuf/generated_message_reflection.cc
+++ b/src/google/protobuf/generated_message_reflection.cc
@@ -1035,7 +1035,7 @@ void Reflection::ListFields(const Message& message,
 
   // Optimization: Avoid calling GetHasBits() and HasOneofField() many times
   // within the field loop.  We allow this violation of ReflectionSchema
-  // encapsulation because this function takes a noticable about of CPU
+  // encapsulation because this function takes a noticeable about of CPU
   // fleetwide and properly allowing this optimization through public interfaces
   // seems more trouble than it is worth.
   const uint32* const has_bits =

--- a/src/google/protobuf/generated_message_util.h
+++ b/src/google/protobuf/generated_message_util.h
@@ -190,7 +190,7 @@ struct PROTOBUF_EXPORT SCCInfoBase {
     kUninitialized = -1,  // initial state
   };
 #if defined(_MSC_VER) && !defined(__clang__)
-  // MSVC doesnt make std::atomic constant initialized. This union trick
+  // MSVC doesn't make std::atomic constant initialized. This union trick
   // makes it so.
   union {
     int visit_status_to_make_linker_init;

--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -817,7 +817,7 @@ class PROTOBUF_EXPORT EpsCopyOutputStream {
     return is_serialization_deterministic_;
   }
 
-  // The number of bytes writen to the stream at position ptr, relative to the
+  // The number of bytes written to the stream at position ptr, relative to the
   // stream's overall position.
   int64 ByteCount(uint8* ptr) const;
 
@@ -1171,7 +1171,7 @@ class PROTOBUF_EXPORT CodedOutputStream {
   // Returns the number of bytes needed to encode the given value as a varint.
   static size_t VarintSize64(uint64 value);
 
-  // If negative, 10 bytes.  Otheriwse, same as VarintSize32().
+  // If negative, 10 bytes.  Otherwise, same as VarintSize32().
   static size_t VarintSize32SignExtended(int32 value);
 
   // Compile-time equivalent of VarintSize32().

--- a/src/google/protobuf/io/io_win32_unittest.cc
+++ b/src/google/protobuf/io/io_win32_unittest.cc
@@ -372,7 +372,7 @@ TEST_F(IoWin32Test, MkdirTestNonAscii) {
   EXPECT_TRUE(CreateDirectoryW((wtest_tmpdir + L"\\1").c_str(), nullptr));
   EXPECT_TRUE(CreateDirectoryW((wtest_tmpdir + L"\\1\\" + kUtf16Text).c_str(), nullptr));
   // Ensure that we can create a very similarly named directory using mkdir.
-  // We don't attemp to delete and recreate the same directory, because on
+  // We don't attempt to delete and recreate the same directory, because on
   // Windows, deleting files and directories seems to be asynchronous.
   EXPECT_EQ(mkdir((test_tmpdir + "\\2").c_str(), 0644), 0);
   EXPECT_EQ(mkdir((test_tmpdir + "\\2\\" + kUtf8Text).c_str(), 0644), 0);

--- a/src/google/protobuf/io/printer.h
+++ b/src/google/protobuf/io/printer.h
@@ -194,7 +194,7 @@ class PROTOBUF_EXPORT Printer {
 
   ~Printer();
 
-  // Link a subsitution variable emitted by the last call to Print to the object
+  // Link a substitution variable emitted by the last call to Print to the object
   // described by descriptor.
   template <typename SomeDescriptor>
   void Annotate(const char* varname, const SomeDescriptor* descriptor) {
@@ -218,7 +218,7 @@ class PROTOBUF_EXPORT Printer {
     Annotate(begin_varname, end_varname, descriptor->file()->name(), path);
   }
 
-  // Link a subsitution variable emitted by the last call to Print to the file
+  // Link a substitution variable emitted by the last call to Print to the file
   // with path file_name.
   void Annotate(const char* varname, const std::string& file_name) {
     Annotate(varname, varname, file_name);

--- a/src/google/protobuf/io/tokenizer_unittest.cc
+++ b/src/google/protobuf/io/tokenizer_unittest.cc
@@ -56,7 +56,7 @@ namespace {
 // Data-Driven Test Infrastructure
 
 // TODO(kenton):  This is copied from coded_stream_unittest.  This is
-//   temporary until these fetaures are integrated into gTest itself.
+//   temporary until these features are integrated into gTest itself.
 
 // TEST_1D and TEST_2D are macros I'd eventually like to see added to
 // gTest.  These macros can be used to declare tests which should be

--- a/src/google/protobuf/io/zero_copy_stream_impl_lite.h
+++ b/src/google/protobuf/io/zero_copy_stream_impl_lite.h
@@ -231,7 +231,7 @@ class PROTOBUF_EXPORT CopyingInputStreamAdaptor : public ZeroCopyInputStream {
   CopyingInputStream* copying_stream_;
   bool owns_copying_stream_;
 
-  // True if we have seen a permenant error from the underlying stream.
+  // True if we have seen a permanent error from the underlying stream.
   bool failed_;
 
   // The current position of copying_stream_, relative to the point where
@@ -320,7 +320,7 @@ class PROTOBUF_EXPORT CopyingOutputStreamAdaptor : public ZeroCopyOutputStream {
   CopyingOutputStream* copying_stream_;
   bool owns_copying_stream_;
 
-  // True if we have seen a permenant error from the underlying stream.
+  // True if we have seen a permanent error from the underlying stream.
   bool failed_;
 
   // The current position of copying_stream_, relative to the point where

--- a/src/google/protobuf/map_entry_lite.h
+++ b/src/google/protobuf/map_entry_lite.h
@@ -658,7 +658,7 @@ struct MapEntryHelper<MapEntryLite<T, Key, Value, kKeyFieldType,
         key_(FromHelper<kKeyFieldType>::From(map_pair.first)),
         value_(FromHelper<kValueFieldType>::From(map_pair.second)) {}
 
-  // Purposely not folowing the style guide naming. These are the names
+  // Purposely not following the style guide naming. These are the names
   // the proto compiler would generate given the map entry descriptor.
   // The proto compiler generates the offsets in this struct as if this was
   // a regular message. This way the table driven code barely notices it's

--- a/src/google/protobuf/map_test.cc
+++ b/src/google/protobuf/map_test.cc
@@ -3051,7 +3051,7 @@ TEST(WireFormatForMapFieldTest, MapByteSizeDynamicMessage) {
   EXPECT_EQ(expected_size, size);
 
   // Protobuf used to have a bug for serialize when map it marked CLEAN. It used
-  // repeated field to calulate ByteSize but use map to serialize the real data,
+  // repeated field to calculate ByteSize but use map to serialize the real data,
   // thus the ByteSize may bigger than real serialized size. A crash might be
   // happen at SerializeToString(). Or an "unexpect end group" warning was
   // raised at parse back if user use SerializeWithCachedSizes() which avoids
@@ -3320,7 +3320,7 @@ TEST(TextFormatMapTest, NoDisableIterator) {
   TextFormat::Printer printer;
   printer.PrintToString(source, &output);
 
-  // Modify map via the iterator (invalidated in prvious implementation.).
+  // Modify map via the iterator (invalidated in previous implementation.).
   iter->second = 2;
 
   // In previous implementation, the new change won't be reflected in text
@@ -3350,13 +3350,13 @@ TEST(TextFormatMapTest, NoDisableReflectionIterator) {
       reflection->MutableRepeatedPtrField<Message>(&source, field_desc);
   RepeatedPtrField<Message>::iterator iter = map_field->begin();
 
-  // Serialize message to text format, which will invalidate the prvious
+  // Serialize message to text format, which will invalidate the previous
   // iterator previously.
   std::string output;
   TextFormat::Printer printer;
   printer.PrintToString(source, &output);
 
-  // Modify map via the iterator (invalidated in prvious implementation.).
+  // Modify map via the iterator (invalidated in previous implementation.).
   const Reflection* map_entry_reflection = iter->GetReflection();
   const FieldDescriptor* value_field_desc =
       iter->GetDescriptor()->FindFieldByName("value");

--- a/src/google/protobuf/message.cc
+++ b/src/google/protobuf/message.cc
@@ -225,7 +225,7 @@ void SetField(uint64 val, const FieldDescriptor* field, Message* msg,
       break;
     }
     default:
-      GOOGLE_LOG(FATAL) << "Error in descriptors, primitve field with field type "
+      GOOGLE_LOG(FATAL) << "Error in descriptors, primitive field with field type "
                  << field->type();
   }
 #undef STORE_TYPE

--- a/src/google/protobuf/message.h
+++ b/src/google/protobuf/message.h
@@ -936,7 +936,7 @@ class PROTOBUF_EXPORT Reflection final {
 
   // If key is in map field: Saves the value pointer to val and returns
   // false. If key in not in map field: Insert the key into map, saves
-  // value pointer to val and retuns true.
+  // value pointer to val and returns true.
   bool InsertOrLookupMapValue(Message* message, const FieldDescriptor* field,
                               const MapKey& key, MapValueRef* val) const;
 

--- a/src/google/protobuf/message_unittest.inc
+++ b/src/google/protobuf/message_unittest.inc
@@ -309,7 +309,7 @@ class RepeatedInputStream : public io::ZeroCopyInputStream {
 
  private:
   std::string data_;
-  size_t count_;     // The number of strings that haven't been consuemd.
+  size_t count_;     // The number of strings that haven't been consumed.
   size_t position_;  // Position in the std::string for the next read.
   int64 total_byte_count_;
 };
@@ -331,7 +331,7 @@ TEST(MESSAGE_TEST_NAME, TestParseMessagesCloseTo2G) {
   UNITTEST::TestAllTypes result;
   EXPECT_TRUE(result.ParseFromZeroCopyStream(&input));
 
-  // When there are multiple occurences of a singulr field, the last one
+  // When there are multiple occurrences of a singular field, the last one
   // should win.
   EXPECT_EQ(value, result.optional_string());
 }

--- a/src/google/protobuf/metadata_lite.h
+++ b/src/google/protobuf/metadata_lite.h
@@ -192,10 +192,10 @@ class InternalMetadataWithArenaLite
 
   static const std::string& default_instance() {
     // Can't use GetEmptyStringAlreadyInited() here because empty string
-    // may not have been initalized yet. This happens when protocol compiler
+    // may not have been initialized yet. This happens when protocol compiler
     // statically determines the user can't access defaults and omits init code
     // from proto constructors. However unknown fields are always part of a
-    // proto so it needs to be lazily initailzed. See b/112613846.
+    // proto so it needs to be lazily initialized. See b/112613846.
     return GetEmptyString();
   }
 };

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -79,7 +79,7 @@ inline void WriteLengthDelimited(uint32 num, StringPiece val,
 //
 // Where the '-' represent the bytes which are vertically lined up with the
 // bytes of the stream. The proto parser requires its input to be presented
-// similarily with the extra
+// similarly with the extra
 // property that each chunk has kSlopBytes past its end that overlaps with the
 // first kSlopBytes of the next chunk, or if there is no next chunk at least its
 // still valid to read those bytes. Again, pictorially, we now have

--- a/src/google/protobuf/reflection_internal.h
+++ b/src/google/protobuf/reflection_internal.h
@@ -122,7 +122,7 @@ class RepeatedFieldWrapper : public RandomAccessRepeatedFieldAccessor {
     return reinterpret_cast<RepeatedFieldType*>(data);
   }
 
-  // Convert an object recevied by this accessor to an object to be stored in
+  // Convert an object received by this accessor to an object to be stored in
   // the underlying RepeatedField.
   virtual T ConvertToT(const Value* value) const = 0;
 

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -2652,7 +2652,7 @@ UnsafeArenaAllocatedRepeatedPtrFieldBackInserter(
       mutable_field);
 }
 
-// Extern declarations of common instantiations to reduce libray bloat.
+// Extern declarations of common instantiations to reduce library bloat.
 extern template class PROTOBUF_EXPORT_TEMPLATE_DECLARE RepeatedField<bool>;
 extern template class PROTOBUF_EXPORT_TEMPLATE_DECLARE RepeatedField<int32>;
 extern template class PROTOBUF_EXPORT_TEMPLATE_DECLARE RepeatedField<uint32>;

--- a/src/google/protobuf/repeated_field_reflection_unittest.cc
+++ b/src/google/protobuf/repeated_field_reflection_unittest.cc
@@ -344,7 +344,7 @@ TEST(RepeatedFieldReflectionTest, RepeatedFieldRefForRegularFields) {
   }
   EXPECT_EQ(10, index);
 
-  // Test iterator operators that are not ususally used in regular for-loops.
+  // Test iterator operators that are not usually used in regular for-loops.
   // Including: post increment, assign, ==.
   MessageIterator old_it = rf_foreign_message.begin();
   MessageIterator new_it = old_it++;

--- a/src/google/protobuf/service.h
+++ b/src/google/protobuf/service.h
@@ -33,7 +33,7 @@
 //  Sanjay Ghemawat, Jeff Dean, and others.
 //
 // DEPRECATED:  This module declares the abstract interfaces underlying proto2
-// RPC services.  These are intented to be independent of any particular RPC
+// RPC services.  These are intended to be independent of any particular RPC
 // implementation, so that proto2 services can be used on top of a variety
 // of implementations.  Starting with version 2.3.0, RPC implementations should
 // not try to build on these, but should instead provide code generator plugins

--- a/src/google/protobuf/stubs/bytestream.h
+++ b/src/google/protobuf/stubs/bytestream.h
@@ -83,7 +83,7 @@ class PROTOBUF_EXPORT ByteSink {
   // Appends the "n" bytes starting at "bytes".
   virtual void Append(const char* bytes, size_t n) = 0;
 
-  // Flushes internal buffers. The default implemenation does nothing. ByteSink
+  // Flushes internal buffers. The default implementation does nothing. ByteSink
   // subclasses may use internal buffers that require calling Flush() at the end
   // of the stream.
   virtual void Flush();

--- a/src/google/protobuf/stubs/callback.h
+++ b/src/google/protobuf/stubs/callback.h
@@ -68,7 +68,7 @@ namespace protobuf {
 // Also note that the arguments cannot be references:
 //   void Foo(const string& s);
 //   string my_str;
-//   NewCallback(&Foo, my_str);  // WON'T WORK:  Can't use referecnes.
+//   NewCallback(&Foo, my_str);  // WON'T WORK:  Can't use references.
 // However, correctly-typed pointers will work just fine.
 class PROTOBUF_EXPORT Closure {
  public:

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -133,7 +133,7 @@ inline bool IsStructurallyValidUTF8(const std::string& str) {
   return IsStructurallyValidUTF8(str.data(), static_cast<int>(str.length()));
 }
 
-// Returns initial number of bytes of structually valid UTF-8.
+// Returns initial number of bytes of structurally valid UTF-8.
 PROTOBUF_EXPORT int UTF8SpnStructurallyValid(const StringPiece& str);
 
 // Coerce UTF-8 byte string in src_str to be

--- a/src/google/protobuf/stubs/statusor.h
+++ b/src/google/protobuf/stubs/statusor.h
@@ -204,7 +204,7 @@ inline StatusOr<T>::StatusOr(const Status& status) {
 template<typename T>
 inline StatusOr<T>::StatusOr(const T& value) {
   if (internal::StatusOrHelper::Specialize<T>::IsValueNull(value)) {
-    status_ = Status(error::INTERNAL, "nullptr is not a vaild argument.");
+    status_ = Status(error::INTERNAL, "nullptr is not a valid argument.");
   } else {
     status_ = Status::OK;
     value_ = value;

--- a/src/google/protobuf/stubs/structurally_valid.cc
+++ b/src/google/protobuf/stubs/structurally_valid.cc
@@ -457,7 +457,7 @@ int UTF8GenericScan(const UTF8ScanObj* st,
   //----------------------------
 
 
-  // Exit posibilities:
+  // Exit possibilities:
   //  Some exit code, !state0, back up over last char
   //  Some exit code, state0, back up one byte exactly
   //  source consumed, !state0, back up over partial char

--- a/src/google/protobuf/stubs/time.cc
+++ b/src/google/protobuf/stubs/time.cc
@@ -212,7 +212,7 @@ bool SecondsToDateTime(int64 seconds, DateTime* time) {
   if (seconds < kMinTime || seconds > kMaxTime) {
     return false;
   }
-  // It's easier to calcuate the DateTime starting from 0001-01-01T00:00:00
+  // It's easier to calculate the DateTime starting from 0001-01-01T00:00:00
   seconds = seconds + kSecondsFromEraToEpoch;
   int year = 1;
   if (seconds >= kSecondsPer400Years) {

--- a/src/google/protobuf/stubs/time.h
+++ b/src/google/protobuf/stubs/time.h
@@ -58,7 +58,7 @@ bool PROTOBUF_EXPORT DateTimeToSeconds(const DateTime& time, int64* seconds);
 
 void PROTOBUF_EXPORT GetCurrentTime(int64* seconds, int32* nanos);
 
-// Formats a time string in RFC3339 fromat.
+// Formats a time string in RFC3339 format.
 //
 // For example, "2015-05-20T13:29:35.120Z". For nanos, 0, 3, 6 or 9 fractional
 // digits will be used depending on how many are required to represent the exact

--- a/src/google/protobuf/stubs/time_test.cc
+++ b/src/google/protobuf/stubs/time_test.cc
@@ -223,7 +223,7 @@ TEST(DateTimeTest, StringFormat) {
   EXPECT_EQ("0001-01-01T00:00:00Z", FormatTime(start_time, 0));
   EXPECT_EQ("9999-12-31T23:59:59Z", FormatTime(end_time, 0));
 
-  // Make sure the nanoseconds part is formated correctly.
+  // Make sure the nanoseconds part is formatted correctly.
   EXPECT_EQ("1970-01-01T00:00:00.010Z", FormatTime(0, 10000000));
   EXPECT_EQ("1970-01-01T00:00:00.000010Z", FormatTime(0, 10000));
   EXPECT_EQ("1970-01-01T00:00:00.000000010Z", FormatTime(0, 10));

--- a/src/google/protobuf/text_format_unittest.cc
+++ b/src/google/protobuf/text_format_unittest.cc
@@ -776,7 +776,7 @@ TEST_F(TextFormatTest, ParseUnknownEnumFieldProto3) {
 }
 
 TEST_F(TextFormatTest, ParseStringEscape) {
-  // Create a parse string with escpaed characters in it.
+  // Create a parse string with escaped characters in it.
   std::string parse_string =
       "optional_string: " + kEscapeTestStringEscaped + "\n";
 

--- a/src/google/protobuf/unittest.proto
+++ b/src/google/protobuf/unittest.proto
@@ -182,7 +182,7 @@ message TestAllTypes {
   }
 }
 
-// This proto includes a recusively nested message.
+// This proto includes a recursively nested message.
 message NestedTestAllTypes {
   optional NestedTestAllTypes child = 1;
   optional TestAllTypes payload = 2;

--- a/src/google/protobuf/unittest_custom_options.proto
+++ b/src/google/protobuf/unittest_custom_options.proto
@@ -337,7 +337,7 @@ message Aggregate {
 }
 
 // Allow Aggregate to be used as an option at all possible locations
-// in the .proto grammer.
+// in the .proto grammar.
 extend google.protobuf.FileOptions      { optional Aggregate fileopt    = 15478479; }
 extend google.protobuf.MessageOptions   { optional Aggregate msgopt     = 15480088; }
 extend google.protobuf.FieldOptions     { optional Aggregate fieldopt   = 15481374; }

--- a/src/google/protobuf/unittest_proto3.proto
+++ b/src/google/protobuf/unittest_proto3.proto
@@ -183,7 +183,7 @@ message TestUnpackedTypes {
   repeated TestAllTypes.NestedEnum repeated_nested_enum = 14 [packed = false];
 }
 
-// This proto includes a recusively nested message.
+// This proto includes a recursively nested message.
 message NestedTestAllTypes {
   NestedTestAllTypes child = 1;
   TestAllTypes payload = 2;

--- a/src/google/protobuf/unittest_proto3_arena.proto
+++ b/src/google/protobuf/unittest_proto3_arena.proto
@@ -183,7 +183,7 @@ message TestUnpackedTypes {
   repeated TestAllTypes.NestedEnum repeated_nested_enum = 14 [packed = false];
 }
 
-// This proto includes a recusively nested message.
+// This proto includes a recursively nested message.
 message NestedTestAllTypes {
   NestedTestAllTypes child = 1;
   TestAllTypes payload = 2;

--- a/src/google/protobuf/unittest_proto3_arena_lite.proto
+++ b/src/google/protobuf/unittest_proto3_arena_lite.proto
@@ -182,7 +182,7 @@ message TestUnpackedTypes {
   repeated TestAllTypes.NestedEnum repeated_nested_enum = 14 [packed = false];
 }
 
-// This proto includes a recusively nested message.
+// This proto includes a recursively nested message.
 message NestedTestAllTypes {
   NestedTestAllTypes child = 1;
   TestAllTypes payload = 2;

--- a/src/google/protobuf/unittest_proto3_lite.proto
+++ b/src/google/protobuf/unittest_proto3_lite.proto
@@ -181,7 +181,7 @@ message TestUnpackedTypes {
   repeated TestAllTypes.NestedEnum repeated_nested_enum = 14 [packed = false];
 }
 
-// This proto includes a recusively nested message.
+// This proto includes a recursively nested message.
 message NestedTestAllTypes {
   NestedTestAllTypes child = 1;
   TestAllTypes payload = 2;

--- a/src/google/protobuf/util/field_mask_util_test.cc
+++ b/src/google/protobuf/util/field_mask_util_test.cc
@@ -752,7 +752,7 @@ TEST(FieldMaskUtilTest, TrimMessageReturnValue) {
   // Field mask on optional field.
   FieldMaskUtil::FromString("optional_int32", &mask);
 
-  // Verify that if a message is updted by FieldMaskUtil::TrimMessage(), the
+  // Verify that if a message is updated by FieldMaskUtil::TrimMessage(), the
   // function returns true.
   // Test on primary field.
   trimed_msg.set_optional_string("abc");
@@ -793,7 +793,7 @@ TEST(FieldMaskUtilTest, TrimMessageReturnValue) {
   EXPECT_EQ(trimed_msg.optional_int32(), 123);
   trimed_msg.Clear();
 
-  // Field mask on repated field.
+  // Field mask on repeated field.
   FieldMaskUtil::FromString("repeated_string", &mask);
   trimed_msg.add_repeated_string("abc");
   trimed_msg.add_repeated_string("def");

--- a/src/google/protobuf/util/internal/datapiece.h
+++ b/src/google/protobuf/util/internal/datapiece.h
@@ -54,7 +54,7 @@ class ProtoWriter;
 //
 // For string, a StringPiece is stored. For Cord, a pointer to Cord is stored.
 // Just like StringPiece, the DataPiece class does not own the storage for
-// the actual string or Cord, so it is the user's responsiblity to guarantee
+// the actual string or Cord, so it is the user's responsibility to guarantee
 // that the underlying storage is still valid when the DataPiece is accessed.
 class PROTOBUF_EXPORT DataPiece {
  public:

--- a/src/google/protobuf/util/internal/default_value_objectwriter_test.cc
+++ b/src/google/protobuf/util/internal/default_value_objectwriter_test.cc
@@ -166,7 +166,7 @@ INSTANTIATE_TEST_SUITE_P(DifferentTypeInfoSourceTest,
                              testing::USE_TYPE_RESOLVER));
 
 TEST_P(DefaultValueObjectWriterSuppressListTest, Empty) {
-  // Set expectation. Emtpy lists should be suppressed.
+  // Set expectation. Empty lists should be suppressed.
   expects_.StartObject("")
       ->RenderDouble("doubleValue", 0.0)
       ->RenderFloat("floatValue", 0.0)

--- a/src/google/protobuf/util/internal/field_mask_utility.cc
+++ b/src/google/protobuf/util/internal/field_mask_utility.cc
@@ -186,7 +186,7 @@ util::Status DecodeCompactFieldMaskPaths(StringPiece paths,
       // Builds a prefix and save it into the stack.
       prefix.push(AppendPathSegmentToPrefix(current_prefix, segment));
     } else if (!segment.empty()) {
-      // When the current charactor is ')', ',' or the current position has
+      // When the current character is ')', ',' or the current position has
       // passed the end of the input, builds and outputs a new paths by
       // concatenating the last prefix with the current segment.
       RETURN_IF_ERROR(

--- a/src/google/protobuf/util/internal/proto_writer.h
+++ b/src/google/protobuf/util/internal/proto_writer.h
@@ -296,7 +296,7 @@ class PROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
   ProtoWriter* StartListField(const google::protobuf::Field& field,
                               const google::protobuf::Type& type);
 
-  // Renders a primitve field given the field and the enclosing type.
+  // Renders a primitive field given the field and the enclosing type.
   ProtoWriter* RenderPrimitiveField(const google::protobuf::Field& field,
                                     const google::protobuf::Type& type,
                                     const DataPiece& value);

--- a/src/google/protobuf/util/internal/protostream_objectwriter.h
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.h
@@ -382,7 +382,7 @@ class PROTOBUF_EXPORT ProtoStreamObjectWriter : public ProtoWriter {
   // on the underlying ObjectWriter depending on whether is_list is false or
   // not.
   // is_placeholder conveys whether the item is a placeholder item or not.
-  // Placeholder items are pushed when adding auxillary types' StartObject or
+  // Placeholder items are pushed when adding auxiliary types' StartObject or
   // StartList calls.
   void Push(StringPiece name, Item::ItemType item_type,
             bool is_placeholder, bool is_list);

--- a/src/google/protobuf/util/json_util_test.cc
+++ b/src/google/protobuf/util/json_util_test.cc
@@ -241,7 +241,7 @@ TEST_F(JsonUtilTest, TestPrintEnumsAsIntsWithDefaultValue) {
 }
 
 TEST_F(JsonUtilTest, ParseMessage) {
-  // Some random message but good enough to verify that the parsing warpper
+  // Some random message but good enough to verify that the parsing wrapper
   // functions are working properly.
   std::string input =
       "{\n"

--- a/src/google/protobuf/util/message_differencer.cc
+++ b/src/google/protobuf/util/message_differencer.cc
@@ -813,7 +813,7 @@ bool MessageDifferencer::CompareWithFieldsInternal(
       continue;
     }
 
-    // By this point, field1 and field2 are guarenteed to point to the same
+    // By this point, field1 and field2 are guaranteed to point to the same
     // field, so we can now compare the values.
     if (IsIgnored(message1, message2, field1, *parent_fields)) {
       // Ignore this field. Report and move on.
@@ -1549,7 +1549,7 @@ bool MaximumMatcher::Match(int left, int right) {
 bool MaximumMatcher::FindArgumentPathDFS(int v, std::vector<bool>* visited) {
   (*visited)[v] = true;
   // We try to match those un-matched nodes on the right side first. This is
-  // the step that the navie greedy matching algorithm uses. In the best cases
+  // the step that the naive greedy matching algorithm uses. In the best cases
   // where the greedy algorithm can find a maximum matching, we will always
   // find a match in this step and the performance will be identical to the
   // greedy algorithm.
@@ -1561,7 +1561,7 @@ bool MaximumMatcher::FindArgumentPathDFS(int v, std::vector<bool>* visited) {
     }
   }
   // Then we try those already matched nodes and see if we can find an
-  // alternaive match for the node matched to them.
+  // alternative match for the node matched to them.
   // The greedy algorithm will stop before this and fail to produce the
   // correct result.
   for (int i = 0; i < count2_; ++i) {

--- a/src/google/protobuf/util/time_util_test.cc
+++ b/src/google/protobuf/util/time_util_test.cc
@@ -83,7 +83,7 @@ TEST(TimeUtilTest, TimestampStringFormat) {
   EXPECT_TRUE(TimeUtil::FromString("1970-01-01T00:00:00.0000001Z", &time));
   EXPECT_EQ(100, TimeUtil::TimestampToNanoseconds(time));
 
-  // Also accpets offsets.
+  // Also accepts offsets.
   EXPECT_TRUE(TimeUtil::FromString("1970-01-01T00:00:00-08:00", &time));
   EXPECT_EQ(8 * 3600, TimeUtil::TimestampToSeconds(time));
 }

--- a/src/google/protobuf/util/type_resolver.h
+++ b/src/google/protobuf/util/type_resolver.h
@@ -46,7 +46,7 @@ namespace protobuf {
 class DescriptorPool;
 namespace util {
 
-// Abstract interface for a type resovler.
+// Abstract interface for a type resolver.
 //
 // Implementations of this interface must be thread-safe.
 class PROTOBUF_EXPORT TypeResolver {

--- a/src/google/protobuf/wire_format.h
+++ b/src/google/protobuf/wire_format.h
@@ -65,7 +65,7 @@ namespace protobuf {
 namespace internal {
 
 // This class is for internal use by the protocol buffer library and by
-// protocol-complier-generated message classes.  It must not be called
+// protocol-compiler-generated message classes.  It must not be called
 // directly by clients.
 //
 // This class contains code for implementing the binary protocol buffer
@@ -237,7 +237,7 @@ class PROTOBUF_EXPORT WireFormat {
                               const Message& message);
 
   // Parse/serialize a MessageSet::Item group.  Used with messages that use
-  // opion message_set_wire_format = true.
+  // option message_set_wire_format = true.
   static bool ParseAndMergeMessageSetItem(io::CodedInputStream* input,
                                           Message* message);
   static void SerializeMessageSetItemWithCachedSizes(

--- a/src/google/protobuf/wire_format_lite.h
+++ b/src/google/protobuf/wire_format_lite.h
@@ -73,7 +73,7 @@ namespace internal {
 #include <google/protobuf/port_def.inc>
 
 // This class is for internal use by the protocol buffer library and by
-// protocol-complier-generated message classes.  It must not be called
+// protocol-compiler-generated message classes.  It must not be called
 // directly by clients.
 //
 // This class contains helpers for implementing the binary protocol buffer

--- a/tests.sh
+++ b/tests.sh
@@ -195,7 +195,7 @@ use_java() {
   $MVN -version
 }
 
-# --batch-mode supresses download progress output that spams the logs.
+# --batch-mode suppresses download progress output that spams the logs.
 MVN="mvn --batch-mode"
 
 build_java() {
@@ -233,7 +233,7 @@ build_java_oracle7() {
 build_java_compatibility() {
   use_java jdk7
   internal_build_cpp
-  # Use the unit-tests extraced from 2.5.0 to test the compatibilty between
+  # Use the unit-tests extracted from 2.5.0 to test the compatibility between
   # 3.0.0-beta-4 and the current version.
   cd java/compatibility_tests/v2.5.0
   ./test.sh 3.0.0-beta-4
@@ -400,7 +400,7 @@ build_python37_cpp() {
 
 build_python_compatibility() {
   internal_build_cpp
-  # Use the unit-tests extraced from 2.5.0 to test the compatibilty.
+  # Use the unit-tests extracted from 2.5.0 to test the compatibility.
   cd python/compatibility_tests/v2.5.0
   # Test between 2.5.0 and the current version.
   ./test.sh 2.5.0


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.