### PR TITLE
Remove es6 and browser import styles, update docs

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -9,7 +9,7 @@ This directory contains the JavaScript Protocol Buffers runtime library.
 
 The library is currently compatible with:
 
-1. CommonJS-style imports (eg. `var protos = require('my-protos');`)
+1. CommonJS-style imports (eg. `var protos = require('my-protos');`), which is the default
 2. Closure-style imports (eg. `goog.require('my.package.MyProto');`)
 
 Support for ES6-style imports is not implemented yet.  Browsers can

--- a/js/README.md
+++ b/js/README.md
@@ -24,7 +24,7 @@ To use Protocol Buffers with JavaScript, you need two main components:
    into `.js` files.  The compiler is not currently available via
    npm, but you can download a pre-built binary
    [on GitHub](https://github.com/protocolbuffers/protobuf/releases)
-   (look for the `protoc-*.zip` files under **Downloads**).
+   (look for the `protoc-{version}-{arch}.zip` files under **Downloads**).
 
 
 Setup

--- a/js/README.md
+++ b/js/README.md
@@ -19,9 +19,7 @@ resolve imports at compile time.
 To use Protocol Buffers with JavaScript, you need two main components:
 
 1. The protobuf runtime library.  You can install this with
-   `npm install google-protobuf`, or use the files in this directory.
-    If npm is not being used, as of 3.3.0, the files needed are located in binary subdirectory;
-    arith.js, constants.js, decoder.js, encoder.js, map.js, message.js, reader.js, utils.js, writer.js
+   `npm install google-protobuf`.
 2. The Protocol Compiler `protoc`.  This translates `.proto` files
    into `.js` files.  The compiler is not currently available via
    npm, but you can download a pre-built binary

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -3505,10 +3505,6 @@ bool GeneratorOptions::ParseFromOptions(
         import_style = kImportCommonJs;
       } else if (options[i].second == "commonjs_strict") {
         import_style = kImportCommonJsStrict;
-      } else if (options[i].second == "browser") {
-        import_style = kImportBrowser;
-      } else if (options[i].second == "es6") {
-        import_style = kImportEs6;
       } else {
         *error = "Unknown import style " + options[i].second + ", expected " +
                  "one of: closure, commonjs, browser, es6.";

--- a/src/google/protobuf/compiler/js/js_generator.h
+++ b/src/google/protobuf/compiler/js/js_generator.h
@@ -71,8 +71,6 @@ struct GeneratorOptions {
     kImportClosure,         // goog.require()
     kImportCommonJs,        // require()
     kImportCommonJsStrict,  // require() with no global export
-    kImportBrowser,         // no import statements
-    kImportEs6,             // import { member } from ''
   } import_style;
 
   GeneratorOptions()


### PR DESCRIPTION
See https://github.com/protocolbuffers/protobuf/issues/4165

I think that support for the `browser` import style was broken in 3b3c8abb9635eb3ea078a821a99c9ef29d66dff7 and I notice there are no tests for it (nor for `es6`, which is just a dummy option planned to be implemented from my understanding), thus the breakage slipped through unnoticed.

(To see the breakage, search in that commit for `js_generator.cc`, expand the large diff and search for `IMPORT_BROWSER` which is visible only in removed lines.)

I tried to fix this with a patch:
```diff
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -1877,6 +1877,9 @@ void Generator::GenerateRequiresImpl(const GeneratorOptions& options,
                                      std::set<std::string>* provided,
                                      bool require_jspb, bool require_extension,
                                      bool require_map) const {
+  if (options.import_style == GeneratorOptions::kImportBrowser)
+    return;
+
   if (require_jspb) {
     required->insert("jspb.Message");
     required->insert("jspb.BinaryReader");
```
However this fails also because of an undefined `goog` object, so it was a dead end.

In this PR I propose remove the two unused `kImportBrowser` and `kImportEs6` and I update the documentation to not state that it is possible to use google-protobuf without npm.