### PR TITLE
Cherrypick #6970 and #7065 to 3.11.x release branch

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,6 +3,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test", "objc_library")
 load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
+load("@rules_proto//proto/private:native.bzl", "native_proto_common")
 load("@rules_python//python:defs.bzl", "py_library")
 
 licenses(["notice"])
@@ -986,9 +987,13 @@ cc_library(
     ],
 )
 
+# Note: We use `native_proto_common` here because we depend on an implementation-detail of
+# `proto_lang_toolchain`, which may not be available on `proto_common`.
+reject_blacklisted_files = not hasattr(native_proto_common, "proto_lang_toolchain_rejects_files_do_not_use_or_we_will_break_you_without_mercy")
+cc_toolchain_blacklisted_protos = [proto + "_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()] if reject_blacklisted_files else [":well_known_protos"]
 proto_lang_toolchain(
     name = "cc_toolchain",
-    blacklisted_protos = [proto + "_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()],
+    blacklisted_protos = cc_toolchain_blacklisted_protos,
     command_line = "--cpp_out=$(OUT)",
     runtime = ":protobuf",
     visibility = ["//visibility:public"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,7 @@ load("//:protobuf_deps.bzl", "protobuf_deps")
 
 # Load common dependencies.
 protobuf_deps()
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 
 bind(
     name = "python_headers",
@@ -31,9 +32,14 @@ bind(
     actual = "@submodule_gmock//:gtest_main",
 )
 
-maven_jar(
+jvm_maven_import_external(
     name = "guava_maven",
     artifact = "com.google.guava:guava:18.0",
+    artifact_sha256 = "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
+    server_urls = [
+        "https://jcenter.bintray.com/",
+        "https://repo1.maven.org/maven2",
+    ],
 )
 
 bind(
@@ -41,9 +47,14 @@ bind(
     actual = "@guava_maven//jar",
 )
 
-maven_jar(
+jvm_maven_import_external(
     name = "gson_maven",
     artifact = "com.google.code.gson:gson:2.7",
+    artifact_sha256 = "2d43eb5ea9e133d2ee2405cc14f5ee08951b8361302fdd93494a3a997b508d32",
+    server_urls = [
+        "https://jcenter.bintray.com/",
+        "https://repo1.maven.org/maven2",
+    ],
 )
 
 bind(
@@ -51,9 +62,14 @@ bind(
     actual = "@gson_maven//jar",
 )
 
-maven_jar(
+jvm_maven_import_external(
     name = "error_prone_annotations_maven",
     artifact = "com.google.errorprone:error_prone_annotations:2.3.2",
+    artifact_sha256 = "357cd6cfb067c969226c442451502aee13800a24e950fdfde77bcdb4565a668d",
+    server_urls = [
+        "https://jcenter.bintray.com/",
+        "https://repo1.maven.org/maven2",
+    ],
 )
 
 bind(


### PR DESCRIPTION
* Blacklist .proto source files is Bazel allows us to

This is a partial revert of https://github.com/protocolbuffers/protobuf/commit/7b28278c7d4f4175e70aef2f89d304696eb85ae3 to unblock, e.g., https://github.com/grpc/grpc/pull/21590 or https://github.com/lyft/envoy-mobile/issues/617 until Bazel is fixed.

Note: this is a forward-compatible change that automatically switches to the behavior intended by https://github.com/protocolbuffers/protobuf/commit/7b28278c7d4f4175e70aef2f89d304696eb85ae3 when a compatible Bazel is released without requiring users to upgrade Protobuf. We will revert this change when Bazel is fixed.

* Remove trailing ,

* Update BUILD