### PR TITLE
Updated Rakefile to build for Ruby 2.7.0

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -70,13 +70,13 @@ else
 
   task 'gem:windows' do
     require 'rake_compiler_dock'
-    RakeCompilerDock.sh "bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.0:2.4.0:2.3.0"
+    RakeCompilerDock.sh "bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.0:2.4.0:2.3.0"
   end
 
   if RUBY_PLATFORM =~ /darwin/
     task 'gem:native' do
       system "rake genproto"
-      system "rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.1:2.4.0:2.3.0"
+      system "rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.1:2.4.0:2.3.0"
     end
   else
     task 'gem:native' => [:genproto, 'gem:windows']


### PR DESCRIPTION
Per issue #7070, google-protobuf 3.11.2 won't load on Ruby 2.7 (just released). The Rakefile wasn't building for Ruby 2.7.0 in lines 73 or 79, added that as a build target to fix the problem moving forward. Only file changed is protobuf/ruby/Rakefile.

After making this change, and building/installing the gem locally, programs which relied on google-protobuf now run.