### PR TITLE
Fix conformance_test_runner CMake build

### DIFF
--- a/cmake/conformance.cmake
+++ b/cmake/conformance.cmake
@@ -19,14 +19,17 @@ add_custom_command(
 )
 
 add_executable(conformance_test_runner
-  ${protobuf_source_dir}/conformance/conformance.pb.cc
+  ${protobuf_source_dir}/conformance/conformance_test.h
   ${protobuf_source_dir}/conformance/conformance_test.cc
-  ${protobuf_source_dir}/conformance/binary_json_conformance_main.cc
-  ${protobuf_source_dir}/conformance/binary_json_conformance_suite.cc
+  ${protobuf_source_dir}/conformance/conformance_test_main.cc
   ${protobuf_source_dir}/conformance/binary_json_conformance_suite.h
+  ${protobuf_source_dir}/conformance/binary_json_conformance_suite.cc
+  ${protobuf_source_dir}/conformance/text_format_conformance_suite.h
+  ${protobuf_source_dir}/conformance/text_format_conformance_suite.cc
   ${protobuf_source_dir}/conformance/conformance_test_runner.cc
   ${protobuf_source_dir}/conformance/third_party/jsoncpp/json.h
   ${protobuf_source_dir}/conformance/third_party/jsoncpp/jsoncpp.cpp
+  ${protobuf_source_dir}/conformance/conformance.pb.cc
   ${protobuf_source_dir}/src/google/protobuf/test_messages_proto3.pb.cc
   ${protobuf_source_dir}/src/google/protobuf/test_messages_proto2.pb.cc
 )


### PR DESCRIPTION
Makes the conformance_test_runner declared sources in
cmake/conformance.cmake match the corresponding sources in
conformance/Makefile.am, which allows the test runner to build
successfully with CMake.