### PR TITLE
Fix the Ruby extensions build

### DIFF
--- a/kokoro/linux/dockerfile/test/ruby/Dockerfile
+++ b/kokoro/linux/dockerfile/test/ruby/Dockerfile
@@ -32,6 +32,7 @@ RUN /bin/bash -l -c "rvm install 2.3.8"
 RUN /bin/bash -l -c "rvm install 2.4.5"
 RUN /bin/bash -l -c "rvm install 2.5.1"
 RUN /bin/bash -l -c "rvm install 2.6.0"
+RUN /bin/bash -l -c "rvm install 2.7.0"
 
 RUN /bin/bash -l -c "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"

--- a/kokoro/release/ruby/linux/ruby/ruby_build.sh
+++ b/kokoro/release/ruby/linux/ruby/ruby_build.sh
@@ -11,6 +11,7 @@ fi
 
 umask 0022
 pushd ruby
+gem install bundler -v 2.1.4
 bundle install && bundle exec rake gem:native
 ls pkg
 mv pkg/* $ARTIFACT_DIR

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -5,8 +5,8 @@ set -ex
 set +ex  # rvm script is very verbose and exits with errorcode
 source $HOME/.rvm/scripts/rvm
 set -e  # rvm commands are very verbose
-time rvm install 2.5.0
-rvm use 2.5.0 --default
+time rvm install 2.7.0
+rvm use 2.7.0 --default
 gem install rake-compiler --no-document
 gem install bundler --no-document
 rvm osx-ssl-certs status all
@@ -17,13 +17,13 @@ rm -rf ~/.rake-compiler
 
 CROSS_RUBY=$(mktemp tmpfile.XXXXXXXX)
 
-curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v1.0.3/tasks/bin/cross-ruby.rake > "$CROSS_RUBY"
+curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v1.0.9/tasks/bin/cross-ruby.rake > "$CROSS_RUBY"
 
 # See https://github.com/grpc/grpc/issues/12161 for verconf.h patch details
 patch "$CROSS_RUBY" << EOF
 --- cross-ruby.rake	2018-04-10 11:32:16.000000000 -0700
 +++ patched	2018-04-10 11:40:25.000000000 -0700
-@@ -133,8 +133,10 @@
+@@ -141,8 +141,10 @@
      "--host=#{MINGW_HOST}",
      "--target=#{MINGW_TARGET}",
      "--build=#{RUBY_BUILD}",
@@ -35,9 +35,9 @@ patch "$CROSS_RUBY" << EOF
      '--with-ext='
    ]
 
-@@ -151,6 +153,7 @@
+@@ -159,6 +161,7 @@
  # make
- file "#{USER_HOME}/builds/#{MINGW_HOST}/#{RUBY_CC_VERSION}/ruby.exe" => ["#{USER_HOME}/builds/#{MINGW_HOST}/#{RUBY_CC_VERSION}/Makefile"] do |t|
+ file "#{build_dir}/ruby.exe" => ["#{build_dir}/Makefile"] do |t|
    chdir File.dirname(t.prerequisites.first) do
 +    sh "test -s verconf.h || rm -f verconf.h"  # if verconf.h has size 0, make sure it gets re-built by make
      sh MAKE
@@ -47,7 +47,7 @@ EOF
 
 MAKE="make -j8"
 
-for v in 2.6.0 2.5.1 2.4.0 2.3.0 ; do
+for v in 2.7.0 2.6.0 2.5.1 2.4.0 2.3.0 ; do
   ccache -c
   rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
 done

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -70,13 +70,13 @@ else
 
   task 'gem:windows' do
     require 'rake_compiler_dock'
-    RakeCompilerDock.sh "bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.0:2.4.0:2.3.0"
+    RakeCompilerDock.sh "bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.0:2.4.0:2.3.0"
   end
 
   if RUBY_PLATFORM =~ /darwin/
     task 'gem:native' do
       system "rake genproto"
-      system "rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.1:2.4.0:2.3.0"
+      system "rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.1:2.4.0:2.3.0"
     end
   else
     task 'gem:native' => [:genproto, 'gem:windows']

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -70,7 +70,7 @@ else
 
   task 'gem:windows' do
     require 'rake_compiler_dock'
-    RakeCompilerDock.sh "bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.0:2.4.0:2.3.0"
+    RakeCompilerDock.sh "bundle install bundeler -v 2.1.4 && bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.0:2.4.0:2.3.0"
   end
 
   if RUBY_PLATFORM =~ /darwin/

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   else
     s.files     += Dir.glob('ext/**/*')
     s.extensions= ["ext/google/protobuf_c/extconf.rb"]
-    s.add_development_dependency "rake-compiler-dock", "~> 0.6.0"
+    s.add_development_dependency "rake-compiler-dock", "~> 1.0"
   end
   s.test_files  = ["tests/basic.rb",
                   "tests/stress.rb",


### PR DESCRIPTION
Based on https://github.com/protocolbuffers/protobuf/pull/7027/

I finally managed to reproduce locally with:

```
docker run -v $PWD:/tmpfs/src/github/protobuf/ruby -e UID\=1000 -e GID\=1000 -e USER\=kbuilder -e GROUP\=kbuilder -e GEM_PRIVATE_KEY_PASSPHRASE -e ftp_proxy -e http_proxy -e https_proxy -e RCD_HOST_RUBY_PLATFORM\=x86_64-linux -e RCD_HOST_RUBY_VERSION\=2.4.1 -e RCD_IMAGE\=protobuftesting/ruby_rake_compiler_52bbc96c6d72ba1b25e99e19bdcfeb240438566c -w /tmpfs/src/github/protobuf/ruby --rm -i protobuftesting/ruby_rake_compiler_52bbc96c6d72ba1b25e99e19bdcfeb240438566c runas sigfw bash -c 'bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION\=2.7.0:2.6.0:2.5.0:2.4.0:2.3.0]'
```

Installing `bundler` just before `bundle install` like this is not super elegant, but given that I don't have a proper  feedback loop, it seems like the most straightforward fix.

@qnighy @haberman 

