### PR TITLE
Update pddm to work with clang-format

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -530,6 +530,7 @@ java_EXTRA_DIST=                                                                
   java/util/src/test/proto/com/google/protobuf/util/json_test.proto
 
 objectivec_EXTRA_DIST=                                                       \
+  objectivec/.clang-format                                                   \
   objectivec/DevTools/check_version_stamps.sh                                \
   objectivec/DevTools/compile_testing_protos.sh                              \
   objectivec/DevTools/full_mac_build.sh                                      \

--- a/objectivec/.clang-format
+++ b/objectivec/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: Google
+
+# Ignore pddm directives.
+CommentPragmas: '^%'
+
+# Following the rest of the protobuf code.
+ColumnLimit: 80

--- a/objectivec/DevTools/pddm.py
+++ b/objectivec/DevTools/pddm.py
@@ -482,13 +482,14 @@ class SourceFile(object):
         if self._macro_collection:
           # Always add a blank line, seems to read better. (If need be, add an
           # option to the EXPAND to indicate if this should be done.)
-          result.extend([_GENERATED_CODE_LINE, ''])
+          result.extend([_GENERATED_CODE_LINE, '// clang-format off', ''])
           macro = line[directive_len:].strip()
           try:
             expand_result = self._macro_collection.Expand(macro)
             # Since expansions are line oriented, strip trailing whitespace
             # from the lines.
             lines = [x.rstrip() for x in expand_result.split('\n')]
+            lines.append('// clang-format on')
             result.append('\n'.join(lines))
           except PDDMError as e:
             raise PDDMError('%s\n...while expanding "%s" from the section'
@@ -503,7 +504,6 @@ class SourceFile(object):
       else:
         result.append('//%%PDDM-EXPAND-END (%s expansions)' %
                       len(captured_lines))
-
       return result
 
   class DefinitionSection(SectionBase):

--- a/objectivec/DevTools/pddm_tests.py
+++ b/objectivec/DevTools/pddm_tests.py
@@ -394,6 +394,7 @@ class TestParsingSource(unittest.TestCase):
 class TestProcessingSource(unittest.TestCase):
 
   def testBasics(self):
+    self.maxDiff = None
     input_str = u"""
 //%PDDM-IMPORT-DEFINES ImportFile
 foo
@@ -417,18 +418,24 @@ baz
 foo
 //%PDDM-EXPAND mumble(abc)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 abc: doAbc(int abc);
+// clang-format on
 //%PDDM-EXPAND-END mumble(abc)
 bar
 //%PDDM-EXPAND mumble(def)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 def: doDef(int def);
+// clang-format on
 //%PDDM-EXPAND mumble(ghi)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 ghi: doGhi(int ghi);
+// clang-format on
 //%PDDM-EXPAND-END (2 expansions)
 baz
 //%PDDM-DEFINE mumble(a_)

--- a/objectivec/GPBArray.h
+++ b/objectivec/GPBArray.h
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 //%PDDM-EXPAND DECLARE_ARRAYS()
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Int32
 
@@ -1535,6 +1536,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END DECLARE_ARRAYS()
 
 NS_ASSUME_NONNULL_END

--- a/objectivec/GPBArray.m
+++ b/objectivec/GPBArray.m
@@ -295,6 +295,7 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 
 //%PDDM-EXPAND ARRAY_INTERFACE_SIMPLE(Int32, int32_t, %d)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Int32
 
@@ -541,8 +542,10 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_INTERFACE_SIMPLE(UInt32, uint32_t, %u)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - UInt32
 
@@ -789,8 +792,10 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_INTERFACE_SIMPLE(Int64, int64_t, %lld)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Int64
 
@@ -1037,8 +1042,10 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_INTERFACE_SIMPLE(UInt64, uint64_t, %llu)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - UInt64
 
@@ -1285,8 +1292,10 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_INTERFACE_SIMPLE(Float, float, %f)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Float
 
@@ -1533,8 +1542,10 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_INTERFACE_SIMPLE(Double, double, %lf)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Double
 
@@ -1781,8 +1792,10 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_INTERFACE_SIMPLE(Bool, BOOL, %d)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool
 
@@ -2029,6 +2042,7 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END (7 expansions)
 
 #pragma mark - Enum
@@ -2126,6 +2140,7 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 
 //%PDDM-EXPAND ARRAY_IMMUTABLE_CORE(Enum, int32_t, Raw, %d)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)dealloc {
   NSAssert(!_autocreator,
@@ -2185,17 +2200,20 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
     }
   }
 }
+// clang-format on
 //%PDDM-EXPAND-END ARRAY_IMMUTABLE_CORE(Enum, int32_t, Raw, %d)
 
 - (int32_t)valueAtIndex:(NSUInteger)index {
 //%PDDM-EXPAND VALIDATE_RANGE(index, _count)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   if (index >= _count) {
     [NSException raise:NSRangeException
                 format:@"Index (%lu) beyond bounds (%lu)",
                        (unsigned long)index, (unsigned long)_count];
   }
+// clang-format on
 //%PDDM-EXPAND-END VALIDATE_RANGE(index, _count)
   int32_t result = _values[index];
   if (!_validationFunc(result)) {
@@ -2207,12 +2225,14 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 - (int32_t)rawValueAtIndex:(NSUInteger)index {
 //%PDDM-EXPAND VALIDATE_RANGE(index, _count)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   if (index >= _count) {
     [NSException raise:NSRangeException
                 format:@"Index (%lu) beyond bounds (%lu)",
                        (unsigned long)index, (unsigned long)_count];
   }
+// clang-format on
 //%PDDM-EXPAND-END VALIDATE_RANGE(index, _count)
   return _values[index];
 }
@@ -2253,6 +2273,7 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
 
 //%PDDM-EXPAND ARRAY_MUTABLE_CORE(Enum, int32_t, Raw, %d)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)internalResizeToCapacity:(NSUInteger)newCapacity {
   _values = reallocf(_values, newCapacity * sizeof(int32_t));
@@ -2358,8 +2379,10 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
   _values[idx2] = temp;
 }
 
+// clang-format on
 //%PDDM-EXPAND MUTATION_METHODS(Enum, int32_t, , EnumValidationList, EnumValidationOne)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)addValue:(int32_t)value {
   [self addValues:&value count:1];
@@ -2426,6 +2449,7 @@ static BOOL ArrayDefault_IsValidValue(int32_t value) {
   }
   _values[index] = value;
 }
+// clang-format on
 //%PDDM-EXPAND-END (2 expansions)
 
 //%PDDM-DEFINE MUTATION_HOOK_EnumValidationList()

--- a/objectivec/GPBArray_PackagePrivate.h
+++ b/objectivec/GPBArray_PackagePrivate.h
@@ -54,6 +54,7 @@
 
 //%PDDM-EXPAND DECLARE_ARRAY_EXTRAS()
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Int32
 
@@ -119,6 +120,7 @@
 }
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END DECLARE_ARRAY_EXTRAS()
 
 #pragma mark - NSArray Subclass

--- a/objectivec/GPBCodedOutputStream.h
+++ b/objectivec/GPBCodedOutputStream.h
@@ -177,6 +177,7 @@ extern NSString *const GPBCodedOutputStreamException_WriteFailed;
 
 //%PDDM-EXPAND _WRITE_DECLS()
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 /**
  * Write a double for the given field number.
@@ -527,7 +528,8 @@ extern NSString *const GPBCodedOutputStreamException_WriteFailed;
  * @param fieldNumber The field number assigned to the values.
  * @param values      The values to write out.
  **/
-- (void)writeStringArray:(int32_t)fieldNumber values:(NSArray<NSString*> *)values;
+- (void)writeStringArray:(int32_t)fieldNumber
+                  values:(NSArray<NSString*> *)values;
 /**
  * Write a NSString without any tag.
  *
@@ -548,7 +550,8 @@ extern NSString *const GPBCodedOutputStreamException_WriteFailed;
  * @param fieldNumber The field number assigned to the values.
  * @param values      The values to write out.
  **/
-- (void)writeMessageArray:(int32_t)fieldNumber values:(NSArray<GPBMessage*> *)values;
+- (void)writeMessageArray:(int32_t)fieldNumber
+                   values:(NSArray<GPBMessage*> *)values;
 /**
  * Write a GPBMessage without any tag.
  *
@@ -569,7 +572,8 @@ extern NSString *const GPBCodedOutputStreamException_WriteFailed;
  * @param fieldNumber The field number assigned to the values.
  * @param values      The values to write out.
  **/
-- (void)writeBytesArray:(int32_t)fieldNumber values:(NSArray<NSData*> *)values;
+- (void)writeBytesArray:(int32_t)fieldNumber
+                 values:(NSArray<NSData*> *)values;
 /**
  * Write a NSData without any tag.
  *
@@ -591,7 +595,8 @@ extern NSString *const GPBCodedOutputStreamException_WriteFailed;
  * @param fieldNumber The field number assigned to the values.
  * @param values      The values to write out.
  **/
-- (void)writeGroupArray:(int32_t)fieldNumber values:(NSArray<GPBMessage*> *)values;
+- (void)writeGroupArray:(int32_t)fieldNumber
+                 values:(NSArray<GPBMessage*> *)values;
 /**
  * Write a GPBMessage without any tag (but does write the endGroup tag).
  *
@@ -615,7 +620,8 @@ extern NSString *const GPBCodedOutputStreamException_WriteFailed;
  * @param fieldNumber The field number assigned to the values.
  * @param values      The values to write out.
  **/
-- (void)writeUnknownGroupArray:(int32_t)fieldNumber values:(NSArray<GPBUnknownFieldSet*> *)values;
+- (void)writeUnknownGroupArray:(int32_t)fieldNumber
+                        values:(NSArray<GPBUnknownFieldSet*> *)values;
 /**
  * Write a GPBUnknownFieldSet without any tag (but does write the endGroup tag).
  *
@@ -625,6 +631,7 @@ extern NSString *const GPBCodedOutputStreamException_WriteFailed;
 - (void)writeUnknownGroupNoTag:(int32_t)fieldNumber
                          value:(GPBUnknownFieldSet *)value;
 
+// clang-format on
 //%PDDM-EXPAND-END _WRITE_DECLS()
 
 /**
@@ -690,7 +697,8 @@ NS_ASSUME_NONNULL_END
 //% * @param fieldNumber The field number assigned to the values.
 //% * @param values      The values to write out.
 //% **/
-//%- (void)write##NAME##Array:(int32_t)fieldNumber values:(NSArray<##TYPE##*> *)values;
+//%- (void)write##NAME##Array:(int32_t)fieldNumber
+//%           NAME$S values:(NSArray<##TYPE##*> *)values;
 //%/**
 //% * Write a TYPE without any tag.
 //% *
@@ -714,7 +722,8 @@ NS_ASSUME_NONNULL_END
 //% * @param fieldNumber The field number assigned to the values.
 //% * @param values      The values to write out.
 //% **/
-//%- (void)write##NAME##Array:(int32_t)fieldNumber values:(NSArray<##TYPE##*> *)values;
+//%- (void)write##NAME##Array:(int32_t)fieldNumber
+//%           NAME$S values:(NSArray<##TYPE##*> *)values;
 //%/**
 //% * Write a TYPE without any tag (but does write the endGroup tag).
 //% *

--- a/objectivec/GPBCodedOutputStream.m
+++ b/objectivec/GPBCodedOutputStream.m
@@ -452,6 +452,7 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
 //%
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(Double, Double, double, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeDoubleArray:(int32_t)fieldNumber
                   values:(GPBDoubleArray *)values
@@ -477,8 +478,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(Float, Float, float, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeFloatArray:(int32_t)fieldNumber
                  values:(GPBFloatArray *)values
@@ -504,8 +507,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(UInt64, UInt64, uint64_t, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeUInt64Array:(int32_t)fieldNumber
                   values:(GPBUInt64Array *)values
@@ -531,8 +536,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(Int64, Int64, int64_t, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeInt64Array:(int32_t)fieldNumber
                  values:(GPBInt64Array *)values
@@ -558,8 +565,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(Int32, Int32, int32_t, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeInt32Array:(int32_t)fieldNumber
                  values:(GPBInt32Array *)values
@@ -585,8 +594,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(UInt32, UInt32, uint32_t, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeUInt32Array:(int32_t)fieldNumber
                   values:(GPBUInt32Array *)values
@@ -612,8 +623,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(Fixed64, UInt64, uint64_t, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeFixed64Array:(int32_t)fieldNumber
                    values:(GPBUInt64Array *)values
@@ -639,8 +652,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(Fixed32, UInt32, uint32_t, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeFixed32Array:(int32_t)fieldNumber
                    values:(GPBUInt32Array *)values
@@ -666,8 +681,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(SInt32, Int32, int32_t, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeSInt32Array:(int32_t)fieldNumber
                   values:(GPBInt32Array *)values
@@ -693,8 +710,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(SInt64, Int64, int64_t, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeSInt64Array:(int32_t)fieldNumber
                   values:(GPBInt64Array *)values
@@ -720,8 +739,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(SFixed64, Int64, int64_t, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeSFixed64Array:(int32_t)fieldNumber
                     values:(GPBInt64Array *)values
@@ -747,8 +768,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(SFixed32, Int32, int32_t, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeSFixed32Array:(int32_t)fieldNumber
                     values:(GPBInt32Array *)values
@@ -774,8 +797,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(Bool, Bool, BOOL, )
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeBoolArray:(int32_t)fieldNumber
                 values:(GPBBoolArray *)values
@@ -801,8 +826,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_PACKABLE_DEFNS(Enum, Enum, int32_t, Raw)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeEnumArray:(int32_t)fieldNumber
                 values:(GPBEnumArray *)values
@@ -828,8 +855,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_UNPACKABLE_DEFNS(String, NSString)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeStringArray:(int32_t)fieldNumber values:(NSArray *)values {
   for (NSString *value in values) {
@@ -837,8 +866,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_UNPACKABLE_DEFNS(Message, GPBMessage)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeMessageArray:(int32_t)fieldNumber values:(NSArray *)values {
   for (GPBMessage *value in values) {
@@ -846,8 +877,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_UNPACKABLE_DEFNS(Bytes, NSData)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeBytesArray:(int32_t)fieldNumber values:(NSArray *)values {
   for (NSData *value in values) {
@@ -855,8 +888,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_UNPACKABLE_DEFNS(Group, GPBMessage)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeGroupArray:(int32_t)fieldNumber values:(NSArray *)values {
   for (GPBMessage *value in values) {
@@ -864,8 +899,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND WRITE_UNPACKABLE_DEFNS(UnknownGroup, GPBUnknownFieldSet)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)writeUnknownGroupArray:(int32_t)fieldNumber values:(NSArray *)values {
   for (GPBUnknownFieldSet *value in values) {
@@ -873,6 +910,7 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND-END (19 expansions)
 
 - (void)writeMessageSetExtension:(int32_t)fieldNumber

--- a/objectivec/GPBDictionary.h
+++ b/objectivec/GPBDictionary.h
@@ -45,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 //%PDDM-EXPAND DECLARE_DICTIONARIES()
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - UInt32 -> UInt32
 
@@ -5478,6 +5479,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END DECLARE_DICTIONARIES()
 
 NS_ASSUME_NONNULL_END

--- a/objectivec/GPBDictionary.m
+++ b/objectivec/GPBDictionary.m
@@ -147,6 +147,7 @@ static BOOL DictDefault_IsValidValue(int32_t value) {
 //%SERIALIZE_SUPPORT_3_TYPE(Object, id, Message, String, Bytes)
 //%PDDM-EXPAND SERIALIZE_SUPPORT_HELPERS()
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 static size_t ComputeDictInt32FieldSize(int32_t value, uint32_t fieldNum, GPBDataType dataType) {
   if (dataType == GPBDataTypeInt32) {
@@ -325,6 +326,7 @@ static void WriteDictObjectField(GPBCodedOutputStream *stream, id value, uint32_
   }
 }
 
+// clang-format on
 //%PDDM-EXPAND-END SERIALIZE_SUPPORT_HELPERS()
 
 size_t GPBDictionaryComputeSizeInternalHelper(NSDictionary *dict, GPBFieldDescriptor *field) {
@@ -1427,6 +1429,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 //%PDDM-EXPAND DICTIONARY_IMPL_FOR_POD_KEY(UInt32, uint32_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - UInt32 -> UInt32
 
@@ -3173,8 +3176,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_IMPL_FOR_POD_KEY(Int32, int32_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Int32 -> UInt32
 
@@ -4921,8 +4926,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_IMPL_FOR_POD_KEY(UInt64, uint64_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - UInt64 -> UInt32
 
@@ -6669,8 +6676,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_IMPL_FOR_POD_KEY(Int64, int64_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Int64 -> UInt32
 
@@ -8417,8 +8426,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_POD_IMPL_FOR_KEY(String, NSString, *, OBJECT)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - String -> UInt32
 
@@ -10021,11 +10032,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END (5 expansions)
 
 
 //%PDDM-EXPAND DICTIONARY_BOOL_KEY_TO_POD_IMPL(UInt32, uint32_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> UInt32
 
@@ -10233,8 +10246,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_BOOL_KEY_TO_POD_IMPL(Int32, int32_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Int32
 
@@ -10442,8 +10457,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_BOOL_KEY_TO_POD_IMPL(UInt64, uint64_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> UInt64
 
@@ -10651,8 +10668,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_BOOL_KEY_TO_POD_IMPL(Int64, int64_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Int64
 
@@ -10860,8 +10879,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_BOOL_KEY_TO_POD_IMPL(Bool, BOOL)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Bool
 
@@ -11069,8 +11090,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_BOOL_KEY_TO_POD_IMPL(Float, float)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Float
 
@@ -11278,8 +11301,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_BOOL_KEY_TO_POD_IMPL(Double, double)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Double
 
@@ -11487,8 +11512,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_BOOL_KEY_TO_OBJECT_IMPL(Object, id)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Object
 
@@ -11717,6 +11744,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END (8 expansions)
 
 #pragma mark - Bool -> Enum
@@ -11890,6 +11918,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 //%PDDM-EXPAND SERIAL_DATA_FOR_ENTRY_POD_Enum(Bool)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (NSData *)serializedDataForUnknownValue:(int32_t)value
                                    forKey:(GPBGenericValue *)key
@@ -11904,6 +11933,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return data;
 }
 
+// clang-format on
 //%PDDM-EXPAND-END SERIAL_DATA_FOR_ENTRY_POD_Enum(Bool)
 
 - (size_t)computeSerializedSizeAsField:(GPBFieldDescriptor *)field {

--- a/objectivec/GPBDictionary_PackagePrivate.h
+++ b/objectivec/GPBDictionary_PackagePrivate.h
@@ -82,6 +82,7 @@
 
 //%PDDM-EXPAND DICTIONARY_PRIV_INTERFACES_FOR_POD_KEY(UInt32)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 @interface GPBUInt32UInt32Dictionary () <GPBDictionaryInternalsProtocol> {
  @package
@@ -143,8 +144,10 @@
     __attribute__((ns_returns_retained));
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_PRIV_INTERFACES_FOR_POD_KEY(Int32)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 @interface GPBInt32UInt32Dictionary () <GPBDictionaryInternalsProtocol> {
  @package
@@ -206,8 +209,10 @@
     __attribute__((ns_returns_retained));
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_PRIV_INTERFACES_FOR_POD_KEY(UInt64)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 @interface GPBUInt64UInt32Dictionary () <GPBDictionaryInternalsProtocol> {
  @package
@@ -269,8 +274,10 @@
     __attribute__((ns_returns_retained));
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_PRIV_INTERFACES_FOR_POD_KEY(Int64)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 @interface GPBInt64UInt32Dictionary () <GPBDictionaryInternalsProtocol> {
  @package
@@ -332,8 +339,10 @@
     __attribute__((ns_returns_retained));
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_PRIV_INTERFACES_FOR_POD_KEY(Bool)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 @interface GPBBoolUInt32Dictionary () <GPBDictionaryInternalsProtocol> {
  @package
@@ -395,8 +404,10 @@
     __attribute__((ns_returns_retained));
 @end
 
+// clang-format on
 //%PDDM-EXPAND DICTIONARY_POD_PRIV_INTERFACES_FOR_KEY(String)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 @interface GPBStringUInt32Dictionary () <GPBDictionaryInternalsProtocol> {
  @package
@@ -449,6 +460,7 @@
                               keyDataType:(GPBDataType)keyDataType;
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END (6 expansions)
 
 #pragma mark - NSDictionary Subclass

--- a/objectivec/GPBMessage.m
+++ b/objectivec/GPBMessage.m
@@ -1376,6 +1376,7 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
 
 //%PDDM-EXPAND FIELD_CASE(Bool, Bool)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeBool:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1394,8 +1395,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(Fixed32, UInt32)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeFixed32:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1414,8 +1417,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(SFixed32, Int32)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeSFixed32:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1434,8 +1439,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(Float, Float)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeFloat:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1454,8 +1461,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(Fixed64, UInt64)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeFixed64:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1474,8 +1483,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(SFixed64, Int64)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeSFixed64:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1494,8 +1505,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(Double, Double)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeDouble:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1514,8 +1527,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(Int32, Int32)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeInt32:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1534,8 +1549,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(Int64, Int64)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeInt64:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1554,8 +1571,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(SInt32, Int32)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeSInt32:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1574,8 +1593,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(SInt64, Int64)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeSInt64:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1594,8 +1615,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(UInt32, UInt32)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeUInt32:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1614,8 +1637,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE(UInt64, UInt64)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeUInt64:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1634,8 +1659,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE_FULL(Enum, Int32, Enum)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeEnum:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1654,8 +1681,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE2(Bytes)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeBytes:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1678,8 +1707,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE2(String)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeString:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1702,8 +1733,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE2(Message)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeMessage:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1726,8 +1759,10 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND FIELD_CASE2(Group)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
     case GPBDataTypeGroup:
       if (fieldType == GPBFieldTypeRepeated) {
@@ -1750,6 +1785,7 @@ static GPBUnknownFieldSet *GetOrMakeUnknownFields(GPBMessage *self) {
       }
       break;
 
+// clang-format on
 //%PDDM-EXPAND-END (18 expansions)
   }
 }

--- a/objectivec/GPBUtilities.h
+++ b/objectivec/GPBUtilities.h
@@ -94,6 +94,7 @@ void GPBClearMessageField(GPBMessage *self, GPBFieldDescriptor *field);
 
 //%PDDM-EXPAND GPB_ACCESSORS()
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 
 //
@@ -384,6 +385,7 @@ void GPBSetMessageMapField(GPBMessage *self,
                            GPBFieldDescriptor *field,
                            id dictionary);
 
+// clang-format on
 //%PDDM-EXPAND-END GPB_ACCESSORS()
 
 /**

--- a/objectivec/GPBUtilities.m
+++ b/objectivec/GPBUtilities.m
@@ -806,6 +806,7 @@ void GPBSetBoolIvarWithFieldInternal(GPBMessage *self,
 
 //%PDDM-EXPAND IVAR_POD_ACCESSORS_DEFN(Int32, int32_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 int32_t GPBGetMessageInt32Field(GPBMessage *self,
                                 GPBFieldDescriptor *field) {
@@ -872,8 +873,10 @@ void GPBSetInt32IvarWithFieldInternal(GPBMessage *self,
   GPBBecomeVisibleToAutocreator(self);
 }
 
+// clang-format on
 //%PDDM-EXPAND IVAR_POD_ACCESSORS_DEFN(UInt32, uint32_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 uint32_t GPBGetMessageUInt32Field(GPBMessage *self,
                                   GPBFieldDescriptor *field) {
@@ -940,8 +943,10 @@ void GPBSetUInt32IvarWithFieldInternal(GPBMessage *self,
   GPBBecomeVisibleToAutocreator(self);
 }
 
+// clang-format on
 //%PDDM-EXPAND IVAR_POD_ACCESSORS_DEFN(Int64, int64_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 int64_t GPBGetMessageInt64Field(GPBMessage *self,
                                 GPBFieldDescriptor *field) {
@@ -1008,8 +1013,10 @@ void GPBSetInt64IvarWithFieldInternal(GPBMessage *self,
   GPBBecomeVisibleToAutocreator(self);
 }
 
+// clang-format on
 //%PDDM-EXPAND IVAR_POD_ACCESSORS_DEFN(UInt64, uint64_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 uint64_t GPBGetMessageUInt64Field(GPBMessage *self,
                                   GPBFieldDescriptor *field) {
@@ -1076,8 +1083,10 @@ void GPBSetUInt64IvarWithFieldInternal(GPBMessage *self,
   GPBBecomeVisibleToAutocreator(self);
 }
 
+// clang-format on
 //%PDDM-EXPAND IVAR_POD_ACCESSORS_DEFN(Float, float)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 float GPBGetMessageFloatField(GPBMessage *self,
                               GPBFieldDescriptor *field) {
@@ -1144,8 +1153,10 @@ void GPBSetFloatIvarWithFieldInternal(GPBMessage *self,
   GPBBecomeVisibleToAutocreator(self);
 }
 
+// clang-format on
 //%PDDM-EXPAND IVAR_POD_ACCESSORS_DEFN(Double, double)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 double GPBGetMessageDoubleField(GPBMessage *self,
                                 GPBFieldDescriptor *field) {
@@ -1212,12 +1223,14 @@ void GPBSetDoubleIvarWithFieldInternal(GPBMessage *self,
   GPBBecomeVisibleToAutocreator(self);
 }
 
+// clang-format on
 //%PDDM-EXPAND-END (6 expansions)
 
 // Aliases are function calls that are virtually the same.
 
 //%PDDM-EXPAND IVAR_ALIAS_DEFN_COPY_OBJECT(String, NSString)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 // Only exists for public api, no core code should use this.
 NSString *GPBGetMessageStringField(GPBMessage *self,
@@ -1248,8 +1261,10 @@ void GPBSetMessageStringField(GPBMessage *self,
   GPBSetCopyObjectIvarWithField(self, field, (id)value);
 }
 
+// clang-format on
 //%PDDM-EXPAND IVAR_ALIAS_DEFN_COPY_OBJECT(Bytes, NSData)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 // Only exists for public api, no core code should use this.
 NSData *GPBGetMessageBytesField(GPBMessage *self,
@@ -1280,8 +1295,10 @@ void GPBSetMessageBytesField(GPBMessage *self,
   GPBSetCopyObjectIvarWithField(self, field, (id)value);
 }
 
+// clang-format on
 //%PDDM-EXPAND IVAR_ALIAS_DEFN_OBJECT(Message, GPBMessage)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 // Only exists for public api, no core code should use this.
 GPBMessage *GPBGetMessageMessageField(GPBMessage *self,
@@ -1312,8 +1329,10 @@ void GPBSetMessageMessageField(GPBMessage *self,
   GPBSetObjectIvarWithField(self, field, (id)value);
 }
 
+// clang-format on
 //%PDDM-EXPAND IVAR_ALIAS_DEFN_OBJECT(Group, GPBMessage)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 // Only exists for public api, no core code should use this.
 GPBMessage *GPBGetMessageGroupField(GPBMessage *self,
@@ -1344,6 +1363,7 @@ void GPBSetMessageGroupField(GPBMessage *self,
   GPBSetObjectIvarWithField(self, field, (id)value);
 }
 
+// clang-format on
 //%PDDM-EXPAND-END (4 expansions)
 
 // GPBGetMessageRepeatedField is defined in GPBMessage.m

--- a/objectivec/GPBUtilities_PackagePrivate.h
+++ b/objectivec/GPBUtilities_PackagePrivate.h
@@ -215,60 +215,76 @@ void GPBMaybeClearOneof(GPBMessage *self, GPBOneofDescriptor *oneof,
 //%            NAME$S                     GPBFileSyntax syntax);
 //%PDDM-EXPAND GPB_IVAR_SET_DECL(Bool, BOOL)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 void GPBSetBoolIvarWithFieldInternal(GPBMessage *self,
                                      GPBFieldDescriptor *field,
                                      BOOL value,
                                      GPBFileSyntax syntax);
+// clang-format on
 //%PDDM-EXPAND GPB_IVAR_SET_DECL(Int32, int32_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 void GPBSetInt32IvarWithFieldInternal(GPBMessage *self,
                                       GPBFieldDescriptor *field,
                                       int32_t value,
                                       GPBFileSyntax syntax);
+// clang-format on
 //%PDDM-EXPAND GPB_IVAR_SET_DECL(UInt32, uint32_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 void GPBSetUInt32IvarWithFieldInternal(GPBMessage *self,
                                        GPBFieldDescriptor *field,
                                        uint32_t value,
                                        GPBFileSyntax syntax);
+// clang-format on
 //%PDDM-EXPAND GPB_IVAR_SET_DECL(Int64, int64_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 void GPBSetInt64IvarWithFieldInternal(GPBMessage *self,
                                       GPBFieldDescriptor *field,
                                       int64_t value,
                                       GPBFileSyntax syntax);
+// clang-format on
 //%PDDM-EXPAND GPB_IVAR_SET_DECL(UInt64, uint64_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 void GPBSetUInt64IvarWithFieldInternal(GPBMessage *self,
                                        GPBFieldDescriptor *field,
                                        uint64_t value,
                                        GPBFileSyntax syntax);
+// clang-format on
 //%PDDM-EXPAND GPB_IVAR_SET_DECL(Float, float)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 void GPBSetFloatIvarWithFieldInternal(GPBMessage *self,
                                       GPBFieldDescriptor *field,
                                       float value,
                                       GPBFileSyntax syntax);
+// clang-format on
 //%PDDM-EXPAND GPB_IVAR_SET_DECL(Double, double)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 void GPBSetDoubleIvarWithFieldInternal(GPBMessage *self,
                                        GPBFieldDescriptor *field,
                                        double value,
                                        GPBFileSyntax syntax);
+// clang-format on
 //%PDDM-EXPAND GPB_IVAR_SET_DECL(Enum, int32_t)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 void GPBSetEnumIvarWithFieldInternal(GPBMessage *self,
                                      GPBFieldDescriptor *field,
                                      int32_t value,
                                      GPBFileSyntax syntax);
+// clang-format on
 //%PDDM-EXPAND-END (8 expansions)
 
 int32_t GPBGetEnumIvarWithFieldInternal(GPBMessage *self,

--- a/objectivec/Tests/GPBArrayTests.m
+++ b/objectivec/Tests/GPBArrayTests.m
@@ -433,6 +433,7 @@ static BOOL TestingEnum_IsValidValue2(int32_t value) {
 //%
 //%PDDM-EXPAND ARRAY_TESTS(Int32, int32_t, 1, 2, 3, 4)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Int32
 
@@ -775,8 +776,10 @@ static BOOL TestingEnum_IsValidValue2(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_TESTS(UInt32, uint32_t, 11U, 12U, 13U, 14U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - UInt32
 
@@ -1119,8 +1122,10 @@ static BOOL TestingEnum_IsValidValue2(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_TESTS(Int64, int64_t, 31LL, 32LL, 33LL, 34LL)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Int64
 
@@ -1463,8 +1468,10 @@ static BOOL TestingEnum_IsValidValue2(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_TESTS(UInt64, uint64_t, 41ULL, 42ULL, 43ULL, 44ULL)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - UInt64
 
@@ -1807,8 +1814,10 @@ static BOOL TestingEnum_IsValidValue2(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_TESTS(Float, float, 51.f, 52.f, 53.f, 54.f)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Float
 
@@ -2151,8 +2160,10 @@ static BOOL TestingEnum_IsValidValue2(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_TESTS(Double, double, 61., 62., 63., 64.)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Double
 
@@ -2495,8 +2506,10 @@ static BOOL TestingEnum_IsValidValue2(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_TESTS(Bool, BOOL, TRUE, TRUE, FALSE, FALSE)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool
 
@@ -2839,8 +2852,10 @@ static BOOL TestingEnum_IsValidValue2(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND ARRAY_TESTS2(Enum, int32_t, 71, 72, 73, 74, Raw)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Enum
 
@@ -3183,6 +3198,7 @@ static BOOL TestingEnum_IsValidValue2(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END (8 expansions)
 
 #pragma mark - Non macro-based Enum tests

--- a/objectivec/Tests/GPBDictionaryTests+Bool.m
+++ b/objectivec/Tests/GPBDictionaryTests+Bool.m
@@ -42,6 +42,7 @@
 
 //%PDDM-EXPAND BOOL_TESTS_FOR_POD_VALUE(UInt32, uint32_t, 100U, 101U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> UInt32
 
@@ -345,8 +346,10 @@
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND BOOL_TESTS_FOR_POD_VALUE(Int32, int32_t, 200, 201)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Int32
 
@@ -650,8 +653,10 @@
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND BOOL_TESTS_FOR_POD_VALUE(UInt64, uint64_t, 300U, 301U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> UInt64
 
@@ -955,8 +960,10 @@
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND BOOL_TESTS_FOR_POD_VALUE(Int64, int64_t, 400, 401)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Int64
 
@@ -1260,8 +1267,10 @@
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND BOOL_TESTS_FOR_POD_VALUE(Bool, BOOL, NO, YES)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Bool
 
@@ -1565,8 +1574,10 @@
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND BOOL_TESTS_FOR_POD_VALUE(Float, float, 500.f, 501.f)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Float
 
@@ -1870,8 +1881,10 @@
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND BOOL_TESTS_FOR_POD_VALUE(Double, double, 600., 601.)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Double
 
@@ -2175,8 +2188,10 @@
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND TESTS_FOR_BOOL_KEY_OBJECT_VALUE(Object, NSString*, @"abc", @"def")
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 #pragma mark - Bool -> Object
 
@@ -2445,6 +2460,7 @@
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END (8 expansions)
 
 

--- a/objectivec/Tests/GPBDictionaryTests+Int32.m
+++ b/objectivec/Tests/GPBDictionaryTests+Int32.m
@@ -42,6 +42,7 @@
 
 //%PDDM-EXPAND TEST_FOR_POD_KEY(Int32, int32_t, 11, 12, 13, 14)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 // To let the testing macros work, add some extra methods to simplify things.
 @interface GPBInt32EnumDictionary (TestingTweak)
@@ -3672,5 +3673,6 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END TEST_FOR_POD_KEY(Int32, int32_t, 11, 12, 13, 14)
 

--- a/objectivec/Tests/GPBDictionaryTests+Int64.m
+++ b/objectivec/Tests/GPBDictionaryTests+Int64.m
@@ -42,6 +42,7 @@
 
 //%PDDM-EXPAND TEST_FOR_POD_KEY(Int64, int64_t, 21LL, 22LL, 23LL, 24LL)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 // To let the testing macros work, add some extra methods to simplify things.
 @interface GPBInt64EnumDictionary (TestingTweak)
@@ -3672,5 +3673,6 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END TEST_FOR_POD_KEY(Int64, int64_t, 21LL, 22LL, 23LL, 24LL)
 

--- a/objectivec/Tests/GPBDictionaryTests+String.m
+++ b/objectivec/Tests/GPBDictionaryTests+String.m
@@ -42,6 +42,7 @@
 
 //%PDDM-EXPAND TESTS_FOR_POD_VALUES(String, NSString, *, Objects, @"foo", @"bar", @"baz", @"mumble")
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 // To let the testing macros work, add some extra methods to simplify things.
 @interface GPBStringEnumDictionary (TestingTweak)
@@ -3380,5 +3381,6 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END TESTS_FOR_POD_VALUES(String, NSString, *, Objects, @"foo", @"bar", @"baz", @"mumble")
 

--- a/objectivec/Tests/GPBDictionaryTests+UInt32.m
+++ b/objectivec/Tests/GPBDictionaryTests+UInt32.m
@@ -42,6 +42,7 @@
 
 //%PDDM-EXPAND TEST_FOR_POD_KEY(UInt32, uint32_t, 1U, 2U, 3U, 4U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 // To let the testing macros work, add some extra methods to simplify things.
 @interface GPBUInt32EnumDictionary (TestingTweak)
@@ -3672,5 +3673,6 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END TEST_FOR_POD_KEY(UInt32, uint32_t, 1U, 2U, 3U, 4U)
 

--- a/objectivec/Tests/GPBDictionaryTests+UInt64.m
+++ b/objectivec/Tests/GPBDictionaryTests+UInt64.m
@@ -42,6 +42,7 @@
 
 //%PDDM-EXPAND TEST_FOR_POD_KEY(UInt64, uint64_t, 31ULL, 32ULL, 33ULL, 34ULL)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 // To let the testing macros work, add some extra methods to simplify things.
 @interface GPBUInt64EnumDictionary (TestingTweak)
@@ -3672,4 +3673,5 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
 @end
 
+// clang-format on
 //%PDDM-EXPAND-END TEST_FOR_POD_KEY(UInt64, uint64_t, 31ULL, 32ULL, 33ULL, 34ULL)

--- a/objectivec/Tests/GPBMessageTests+Merge.m
+++ b/objectivec/Tests/GPBMessageTests+Merge.m
@@ -267,6 +267,7 @@
 //%
 //%PDDM-EXPAND MERGE2_TEST(Int32, 10, Enum, Message2_Enum_Baz)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofInt32 = 10;
   [dst mergeFrom:src];
@@ -274,8 +275,10 @@
   XCTAssertEqual(dst.oneofInt32, 10);
   XCTAssertEqual(dst.oneofEnum, Message2_Enum_Baz);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Int64, 11, Int32, 100)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofInt64 = 11;
   [dst mergeFrom:src];
@@ -283,8 +286,10 @@
   XCTAssertEqual(dst.oneofInt64, 11);
   XCTAssertEqual(dst.oneofInt32, 100);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Uint32, 12U, Int64, 101)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofUint32 = 12U;
   [dst mergeFrom:src];
@@ -292,8 +297,10 @@
   XCTAssertEqual(dst.oneofUint32, 12U);
   XCTAssertEqual(dst.oneofInt64, 101);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Uint64, 13U, Uint32, 102U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofUint64 = 13U;
   [dst mergeFrom:src];
@@ -301,8 +308,10 @@
   XCTAssertEqual(dst.oneofUint64, 13U);
   XCTAssertEqual(dst.oneofUint32, 102U);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Sint32, 14, Uint64, 103U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofSint32 = 14;
   [dst mergeFrom:src];
@@ -310,8 +319,10 @@
   XCTAssertEqual(dst.oneofSint32, 14);
   XCTAssertEqual(dst.oneofUint64, 103U);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Sint64, 15, Sint32, 104)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofSint64 = 15;
   [dst mergeFrom:src];
@@ -319,8 +330,10 @@
   XCTAssertEqual(dst.oneofSint64, 15);
   XCTAssertEqual(dst.oneofSint32, 104);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Fixed32, 16U, Sint64, 105)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofFixed32 = 16U;
   [dst mergeFrom:src];
@@ -328,8 +341,10 @@
   XCTAssertEqual(dst.oneofFixed32, 16U);
   XCTAssertEqual(dst.oneofSint64, 105);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Fixed64, 17U, Fixed32, 106U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofFixed64 = 17U;
   [dst mergeFrom:src];
@@ -337,8 +352,10 @@
   XCTAssertEqual(dst.oneofFixed64, 17U);
   XCTAssertEqual(dst.oneofFixed32, 106U);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Sfixed32, 18, Fixed64, 107U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofSfixed32 = 18;
   [dst mergeFrom:src];
@@ -346,8 +363,10 @@
   XCTAssertEqual(dst.oneofSfixed32, 18);
   XCTAssertEqual(dst.oneofFixed64, 107U);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Sfixed64, 19, Sfixed32, 108)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofSfixed64 = 19;
   [dst mergeFrom:src];
@@ -355,8 +374,10 @@
   XCTAssertEqual(dst.oneofSfixed64, 19);
   XCTAssertEqual(dst.oneofSfixed32, 108);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Float, 20.0f, Sfixed64, 109)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofFloat = 20.0f;
   [dst mergeFrom:src];
@@ -364,8 +385,10 @@
   XCTAssertEqual(dst.oneofFloat, 20.0f);
   XCTAssertEqual(dst.oneofSfixed64, 109);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Double, 21.0, Float, 110.0f)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofDouble = 21.0;
   [dst mergeFrom:src];
@@ -373,8 +396,10 @@
   XCTAssertEqual(dst.oneofDouble, 21.0);
   XCTAssertEqual(dst.oneofFloat, 110.0f);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Bool, NO, Double, 111.0)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofBool = NO;
   [dst mergeFrom:src];
@@ -382,8 +407,10 @@
   XCTAssertEqual(dst.oneofBool, NO);
   XCTAssertEqual(dst.oneofDouble, 111.0);
 
+// clang-format on
 //%PDDM-EXPAND MERGE2_TEST(Enum, Message2_Enum_Bar, Bool, YES)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofEnum = Message2_Enum_Bar;
   [dst mergeFrom:src];
@@ -391,6 +418,7 @@
   XCTAssertEqual(dst.oneofEnum, Message2_Enum_Bar);
   XCTAssertEqual(dst.oneofBool, YES);
 
+// clang-format on
 //%PDDM-EXPAND-END (14 expansions)
 
   NSString *oneofStringDefault = @"string";
@@ -487,6 +515,7 @@
 //%
 //%PDDM-EXPAND MERGE3_TEST(Int32, 10, Enum, Message3_Enum_Foo)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofInt32 = 10;
   [dst mergeFrom:src];
@@ -494,8 +523,10 @@
   XCTAssertEqual(dst.oneofInt32, 10);
   XCTAssertEqual(dst.oneofEnum, Message3_Enum_Foo);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Int64, 11, Int32, 0)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofInt64 = 11;
   [dst mergeFrom:src];
@@ -503,8 +534,10 @@
   XCTAssertEqual(dst.oneofInt64, 11);
   XCTAssertEqual(dst.oneofInt32, 0);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Uint32, 12U, Int64, 0)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofUint32 = 12U;
   [dst mergeFrom:src];
@@ -512,8 +545,10 @@
   XCTAssertEqual(dst.oneofUint32, 12U);
   XCTAssertEqual(dst.oneofInt64, 0);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Uint64, 13U, Uint32, 0U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofUint64 = 13U;
   [dst mergeFrom:src];
@@ -521,8 +556,10 @@
   XCTAssertEqual(dst.oneofUint64, 13U);
   XCTAssertEqual(dst.oneofUint32, 0U);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Sint32, 14, Uint64, 0U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofSint32 = 14;
   [dst mergeFrom:src];
@@ -530,8 +567,10 @@
   XCTAssertEqual(dst.oneofSint32, 14);
   XCTAssertEqual(dst.oneofUint64, 0U);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Sint64, 15, Sint32, 0)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofSint64 = 15;
   [dst mergeFrom:src];
@@ -539,8 +578,10 @@
   XCTAssertEqual(dst.oneofSint64, 15);
   XCTAssertEqual(dst.oneofSint32, 0);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Fixed32, 16U, Sint64, 0)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofFixed32 = 16U;
   [dst mergeFrom:src];
@@ -548,8 +589,10 @@
   XCTAssertEqual(dst.oneofFixed32, 16U);
   XCTAssertEqual(dst.oneofSint64, 0);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Fixed64, 17U, Fixed32, 0U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofFixed64 = 17U;
   [dst mergeFrom:src];
@@ -557,8 +600,10 @@
   XCTAssertEqual(dst.oneofFixed64, 17U);
   XCTAssertEqual(dst.oneofFixed32, 0U);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Sfixed32, 18, Fixed64, 0U)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofSfixed32 = 18;
   [dst mergeFrom:src];
@@ -566,8 +611,10 @@
   XCTAssertEqual(dst.oneofSfixed32, 18);
   XCTAssertEqual(dst.oneofFixed64, 0U);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Sfixed64, 19, Sfixed32, 0)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofSfixed64 = 19;
   [dst mergeFrom:src];
@@ -575,8 +622,10 @@
   XCTAssertEqual(dst.oneofSfixed64, 19);
   XCTAssertEqual(dst.oneofSfixed32, 0);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Float, 20.0f, Sfixed64, 0)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofFloat = 20.0f;
   [dst mergeFrom:src];
@@ -584,8 +633,10 @@
   XCTAssertEqual(dst.oneofFloat, 20.0f);
   XCTAssertEqual(dst.oneofSfixed64, 0);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Double, 21.0, Float, 0.0f)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofDouble = 21.0;
   [dst mergeFrom:src];
@@ -593,8 +644,10 @@
   XCTAssertEqual(dst.oneofDouble, 21.0);
   XCTAssertEqual(dst.oneofFloat, 0.0f);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Bool, YES, Double, 0.0)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofBool = YES;
   [dst mergeFrom:src];
@@ -602,8 +655,10 @@
   XCTAssertEqual(dst.oneofBool, YES);
   XCTAssertEqual(dst.oneofDouble, 0.0);
 
+// clang-format on
 //%PDDM-EXPAND MERGE3_TEST(Enum, Message3_Enum_Bar, Bool, NO)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   src.oneofEnum = Message3_Enum_Bar;
   [dst mergeFrom:src];
@@ -611,6 +666,7 @@
   XCTAssertEqual(dst.oneofEnum, Message3_Enum_Bar);
   XCTAssertEqual(dst.oneofBool, NO);
 
+// clang-format on
 //%PDDM-EXPAND-END (14 expansions)
 
   NSString *oneofStringDefault = @"";

--- a/objectivec/Tests/GPBMessageTests+Runtime.m
+++ b/objectivec/Tests/GPBMessageTests+Runtime.m
@@ -382,6 +382,7 @@
 //%PROTO2_TEST_CLEAR_FIELD_WITH_NIL(Message, [Message2 message])
 //%PDDM-EXPAND PROTO2_TEST_HAS_FIELDS()
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   {  // optionalInt32 :: 1
     Message2 *msg = [[Message2 alloc] init];
@@ -735,6 +736,7 @@
     [msg release];
   }
 
+// clang-format on
 //%PDDM-EXPAND-END PROTO2_TEST_HAS_FIELDS()
 }
 
@@ -796,6 +798,7 @@
 //%PROTO3_TEST_CLEAR_FIELD_WITH_NIL(Message, [Message3 message])
 //%PDDM-EXPAND PROTO3_TEST_HAS_FIELDS()
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
   {  // optionalInt32
     Message3 *msg = [[Message3 alloc] init];
@@ -995,6 +998,7 @@
     [msg release];
   }
 
+// clang-format on
 //%PDDM-EXPAND-END PROTO3_TEST_HAS_FIELDS()
 }
 

--- a/objectivec/Tests/GPBMessageTests+Serialization.m
+++ b/objectivec/Tests/GPBMessageTests+Serialization.m
@@ -273,6 +273,7 @@
 //%
 //%PDDM-EXPAND TEST_ROUNDTRIP_ONEOFS(2, NO)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)testProto2RoundTripOneof {
 
@@ -503,8 +504,10 @@
   [subMessage release];
 }
 
+// clang-format on
 //%PDDM-EXPAND TEST_ROUNDTRIP_ONEOFS(3, YES)
 // This block of code is generated, do not edit it directly.
+// clang-format off
 
 - (void)testProto3RoundTripOneof {
 
@@ -721,6 +724,7 @@
   [subMessage release];
 }
 
+// clang-format on
 //%PDDM-EXPAND-END (2 expansions)
 
 - (void)testPackedUnpackedMessageParsing {


### PR DESCRIPTION
Add clang-format off/on directives around pddm expansions to simplify formatting other code.