### PR TITLE
Move min Xcode version to 10.3

### DIFF
--- a/objectivec/README.md
+++ b/objectivec/README.md
@@ -13,7 +13,7 @@ Requirements
 The Objective C implementation requires:
 
 - Objective C 2.0 Runtime (32bit & 64bit iOS, 64bit OS X).
-- Xcode 8.0 (or later).
+- Xcode 10.3 (or later).
 - The library code does *not* use ARC (for performance reasons), but it all can
   be called from ARC code.
 


### PR DESCRIPTION
Xcode 10.1 has a compiler bug that breaks on generated code.
Xcode 10.3+ appear to be fine.