### PR TITLE
Fix CLI "too long" issues in py_proto_library.

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -75,18 +75,17 @@ def _RelativeOutputPath(path, include, dest = ""):
 def _proto_gen_impl(ctx):
     """General implementation for generating protos"""
     srcs = ctx.files.srcs
-    deps = []
-    deps += ctx.files.srcs
+    deps = depset(direct=ctx.files.srcs)
     source_dir = _SourceDir(ctx)
     gen_dir = _GenDir(ctx).rstrip("/")
     if source_dir:
-        import_flags = ["-I" + source_dir, "-I" + gen_dir]
+        import_flags = depset(direct=["-I" + source_dir, "-I" + gen_dir])
     else:
-        import_flags = ["-I."]
+        import_flags = depset(direct=["-I."])
 
     for dep in ctx.attr.deps:
-        import_flags += dep.proto.import_flags
-        deps += dep.proto.deps
+        import_flags = depset(transitive=[import_flags, dep.proto.import_flags])
+        deps = depset(transitive=[deps, dep.proto.deps])
 
     if not ctx.attr.gen_cc and not ctx.attr.gen_py and not ctx.executable.plugin:
         return struct(
@@ -103,7 +102,7 @@ def _proto_gen_impl(ctx):
         in_gen_dir = src.root.path == gen_dir
         if in_gen_dir:
             import_flags_real = []
-            for f in depset(import_flags).to_list():
+            for f in import_flags.to_list():
                 path = f.replace("-I", "")
                 import_flags_real.append("-I$(realpath -s %s)" % path)
 
@@ -118,7 +117,7 @@ def _proto_gen_impl(ctx):
             outs.extend(_PyOuts([src.basename], use_grpc_plugin = use_grpc_plugin))
 
         outs = [ctx.actions.declare_file(out, sibling = src) for out in outs]
-        inputs = [src] + deps
+        inputs = [src] + deps.to_list()
         tools = [ctx.executable.protoc]
         if ctx.executable.plugin:
             plugin = ctx.executable.plugin
@@ -141,7 +140,7 @@ def _proto_gen_impl(ctx):
                 inputs = inputs,
                 tools = tools,
                 outputs = outs,
-                arguments = args + import_flags + [src.path],
+                arguments = args + import_flags.to_list() + [src.path],
                 executable = ctx.executable.protoc,
                 mnemonic = "ProtoCompile",
                 use_default_shell_env = True,


### PR DESCRIPTION
Envoy was experiencing failed builds due to lots of duplicate -I in the
CLI. The solution is to generally use depset() as per Starlark best
practice for this sort of thing.

Might fix other issues beyond py_proto_library, anything that depends on
proto_gen.

release notes: no

Signed-off-by: Harvey Tuch <htuch@google.com>