### PR TITLE
Make defining GOOGLE_PROTOBUF_VERIFY_VERSION optional.

### DIFF
--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -113,11 +113,12 @@ std::string PROTOBUF_EXPORT VersionString(int version);
 // to use the protobuf library) to verify that the version you link against
 // matches the headers you compiled against.  If a version mismatch is
 // detected, the process will abort.
+#ifndef GOOGLE_PROTOBUF_VERIFY_VERSION
 #define GOOGLE_PROTOBUF_VERIFY_VERSION                                    \
   ::google::protobuf::internal::VerifyVersion(                            \
     GOOGLE_PROTOBUF_VERSION, GOOGLE_PROTOBUF_MIN_LIBRARY_VERSION,         \
     __FILE__)
-
+#endif
 
 // ===================================================================
 // from google3/util/utf8/public/unilib.h


### PR DESCRIPTION
This macro will by default use __FILE__ macro, so in C++ compiled
binary filenames are present. This is not always wanted. Also
when classes from proto files are generated and compiled at the
same time as protobuf runtime is compiled, there is no need to
check the compatibility of the versions.

Now you can define GOOGLE_PROTOBUF_VERIFY_VERSION as empty and thus
disable the version checks altogether.

The solution was proposed as part of #5995.