### PR TITLE
Install RubyGem bundler version specified in Gemfile.lock to fix release failure

### DIFF
--- a/kokoro/release/ruby/linux/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/linux/ruby/ruby_build_environment.sh
@@ -4,5 +4,6 @@ set +ex
 [[ -s /etc/profile.d/rvm.sh ]] && . /etc/profile.d/rvm.sh
 set -e  # rvm commands are very verbose
 rvm --default use ruby-2.4.1
+gem update --system
 gem install bundler --update
 set -ex

--- a/kokoro/release/ruby/linux/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/linux/ruby/ruby_build_environment.sh
@@ -4,8 +4,6 @@ set +ex
 [[ -s /etc/profile.d/rvm.sh ]] && . /etc/profile.d/rvm.sh
 set -e  # rvm commands are very verbose
 rvm --default use ruby-2.4.1
-# Install the bundler version specified in Gemfile.lock.
-# This command can be replaced with "gem install bundler --update" 
-# if we stop specifying the bundler version in Gemfile.lock.
-gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
+# The version needs to be updated if the version specified in Gemfile.lock is changed
+gem install bundler -v '1.17.3'
 set -ex

--- a/kokoro/release/ruby/linux/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/linux/ruby/ruby_build_environment.sh
@@ -4,5 +4,8 @@ set +ex
 [[ -s /etc/profile.d/rvm.sh ]] && . /etc/profile.d/rvm.sh
 set -e  # rvm commands are very verbose
 rvm --default use ruby-2.4.1
-gem install bundler -v '< 2.0'
+# Install the bundler version specified in Gemfile.lock.
+# This command can be replaced with "gem install bundler --update" 
+# if we stop specifying the bundler version in Gemfile.lock.
+gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
 set -ex

--- a/kokoro/release/ruby/linux/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/linux/ruby/ruby_build_environment.sh
@@ -4,6 +4,5 @@ set +ex
 [[ -s /etc/profile.d/rvm.sh ]] && . /etc/profile.d/rvm.sh
 set -e  # rvm commands are very verbose
 rvm --default use ruby-2.4.1
-gem update --system
-gem install bundler --update
+gem install bundler -v '< 2.0'
 set -ex


### PR DESCRIPTION
Ref: https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html