### PR TITLE
add php_namespace option to descirptor.php

### DIFF
--- a/src/google/protobuf/descriptor.proto
+++ b/src/google/protobuf/descriptor.proto
@@ -47,6 +47,7 @@ option java_outer_classname = "DescriptorProtos";
 option csharp_namespace = "Google.Protobuf.Reflection";
 option objc_class_prefix = "GPB";
 option cc_enable_arenas = true;
+option php_namespace = "Google\\Protobuf\\Internal";
 
 // descriptor.proto must be optimized for speed because reflection-based
 // algorithms don't work during bootstrapping.


### PR DESCRIPTION

### What

This PR adds `php_namespace` option to google/protobuf.descriptor.proto in order to place generated files under `\Google\Protobuf\Internal` namespace for php.

### Problem

When we use messages in google/protobuf/descriptor.proto, the generated php files refer nonexistent class.

For example, in this `test.proto` file

```
syntax = "proto3";

package test;

import "google/protobuf/descriptor.proto";

message TestMessage {
  google.protobuf.FileDescriptorSet fds = 1;
  google.protobuf.FileDescriptorProto fdp = 2;
  google.protobuf.DescriptorProto dp = 3;
}
```

then run `protoc --php_out=. test.proto`. That generates this php file.

```
class TestMessage extends \Google\Protobuf\Internal\Message
{

... 

    /**
     * Generated from protobuf field <code>.google.protobuf.FileDescriptorSet fds = 1;</code>
     * @return \Google\Protobuf\FileDescriptorSet
     */
    public function getFds()
    {
        return $this->fds;
    }

    /**
     * Generated from protobuf field <code>.google.protobuf.FileDescriptorSet fds = 1;</code>
     * @param \Google\Protobuf\FileDescriptorSet $var
     * @return $this
     */
    public function setFds($var)
    {
        GPBUtil::checkMessage($var, \Google\Protobuf\FileDescriptorSet::class);
        $this->fds = $var;

        return $this;
    }

...

}
```

The generated file refer `FileDescriptorSet` message as `\Google\Protobuf\FileDescriptorSet` but it does not exist in [protobuf-php](https://github.com/protocolbuffers/protobuf-php/tree/master/src/Google/Protobuf). It exists under `\Google\Protobuf\Internal` as [here](https://github.com/protocolbuffers/protobuf-php/blob/master/src/Google/Protobuf/Internal/FileDescriptorSet.php). It seems all messages in google/protobuf/descriptor.proto exist under `\Google\Protobuf\Internal` namespace for php.


