### PR TITLE
python: publish sphinx docs to googleapis.dev

### DIFF
--- a/kokoro/docs/common.cfg
+++ b/kokoro/docs/common.cfg
@@ -1,0 +1,44 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "protobuf/kokoro/docs/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/python-multi"
+}
+
+env_vars: {
+    key: "STAGING_BUCKET"
+    value: "docs-staging"
+}
+
+# Fetch the token needed for reporting release status to GitHub
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "yoshi-automation-github-key"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
+}

--- a/kokoro/docs/publish-python.sh
+++ b/kokoro/docs/publish-python.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Adapted from https://github.com/googleapis/google-cloud-python/blob/master/.kokoro/publish-docs.sh
+
+set -eo pipefail
+
+# Disable buffering, so that the logs stream through.
+export PYTHONUNBUFFERED=1
+
+cd github/protobuf/python
+
+# install package
+sudo apt-get update
+sudo apt-get -y install software-properties-common
+sudo add-apt-repository universe
+sudo apt-get update
+sudo apt-get -y install unzip
+wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protoc-3.11.2-linux-x86_64.zip
+unzip protoc-3.11.2-linux-x86_64.zip bin/protoc
+mv bin/protoc ../src/protoc
+python3.6 -m venv venv
+source venv/bin/activate
+python setup.py install
+
+# install docs dependencies
+python -m pip install -r docs/requirements.txt
+
+# build docs
+cd docs
+make html
+cd ..
+deactivate
+
+python3.6 -m pip install protobuf==3.11.1 gcp-docuploader
+
+# install a json parser
+sudo apt-get -y install jq
+
+# create metadata
+python3.6 -m docuploader create-metadata \
+  --name=$(jq --raw-output '.name // empty' .repo-metadata.json) \
+  --version=$(python3 setup.py --version) \
+  --language=$(jq --raw-output '.language // empty' .repo-metadata.json) \
+  --distribution-name=$(python3 setup.py --name) \
+  --product-page=$(jq --raw-output '.product_documentation // empty' .repo-metadata.json) \
+  --github-repository=$(jq --raw-output '.repo // empty' .repo-metadata.json) \
+  --issue-tracker=$(jq --raw-output '.issue_tracker // empty' .repo-metadata.json)
+
+cat docs.metadata
+
+# upload docs
+python3.6 -m docuploader upload docs/_build/html --metadata-file docs.metadata --staging-bucket docs-staging

--- a/kokoro/docs/python.cfg
+++ b/kokoro/docs/python.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/protobuf/kokoro/docs/publish-python.sh"
+}

--- a/kokoro/docs/trampoline.sh
+++ b/kokoro/docs/trampoline.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copied from https://github.com/googleapis/google-cloud-python/blob/master/.kokoro/trampoline.sh
+
+set -eo pipefail
+
+python3 "${KOKORO_GFILE_DIR}/trampoline_v1.py"  || ret_code=$?
+
+chmod +x ${KOKORO_GFILE_DIR}/trampoline_cleanup.sh
+${KOKORO_GFILE_DIR}/trampoline_cleanup.sh || true
+
+exit ${ret_code}

--- a/python/.repo-metadata.json
+++ b/python/.repo-metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "protobuf",
+  "name_pretty": "Protocol Buffers",
+  "product_documentation": "https://developers.google.com/protocol-buffers ",
+  "client_documentation": "https://developers.google.com/protocol-buffers/docs/pythontutorial",
+  "issue_tracker": "https://github.com/protocolbuffers/protobuf/issues",
+  "release_level": "ga",
+  "language": "python",
+  "repo": "protocolbuffers/protobuf ",
+  "distribution_name": "protobuf"
+}


### PR DESCRIPTION
**Background:**

This is a follow-up to https://github.com/protocolbuffers/protobuf/pull/6525, which adds sphinx docs.

Googleapis.dev hosts client library documentation for several languages as
well as documentation for core packages such as google-api-core. It is owned
and maintained by the Cloud DevRel Core team.

**About this change:**

The `kokoro/docs/publish-python.sh` script builds the docs with sphinx, then
uses the [googleapis/docuploader](https://github.com/googleapis/docuploader)
tool to publish to googleapis.dev. The publish script is triggered manually
with a Kokoro RELEASE type job. Googlers, see go link
protobuf-docs-python-design for additional internal references.

Towards #4498