### PR TITLE
Install RubyGem bundler version specified in Gemfile.lock to fix release failure

### DIFF
--- a/kokoro/release/ruby/linux/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/linux/ruby/ruby_build_environment.sh
@@ -4,5 +4,6 @@ set +ex
 [[ -s /etc/profile.d/rvm.sh ]] && . /etc/profile.d/rvm.sh
 set -e  # rvm commands are very verbose
 rvm --default use ruby-2.4.1
-gem install bundler --update
+# The version needs to be updated if the version specified in Gemfile.lock is changed
+gem install bundler -v '1.17.3'
 set -ex


### PR DESCRIPTION
Cherry-pick of https://github.com/protocolbuffers/protobuf/pull/7144

Ref: https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html