### PR TITLE
Use PROTOBUF_RTTI from port_def.inc macro instead of checking for absence of GOOGLE_PROTOBUF_NO_RTTI macro

### DIFF
--- a/src/google/protobuf/message.h
+++ b/src/google/protobuf/message.h
@@ -1193,11 +1193,11 @@ const T* DynamicCastToGenerated(const Message* from) {
   const Message* unused = static_cast<T*>(nullptr);
   (void)unused;
 
-#ifdef GOOGLE_PROTOBUF_NO_RTTI
+#if PROTOBUF_RTTI
+  return dynamic_cast<const T*>(from);
+#else
   bool ok = T::default_instance().GetReflection() == from->GetReflection();
   return ok ? down_cast<const T*>(from) : nullptr;
-#else
-  return dynamic_cast<const T*>(from);
 #endif
 }
 

--- a/src/google/protobuf/stubs/casts.h
+++ b/src/google/protobuf/stubs/casts.h
@@ -35,9 +35,12 @@
 
 #include <google/protobuf/stubs/common.h>
 
+#include <google/protobuf/port_def.inc>
+
 namespace google {
 namespace protobuf {
 namespace internal {
+
 // Use implicit_cast as a safe version of static_cast or const_cast
 // for upcasting in the type hierarchy (i.e. casting a pointer to Foo
 // to a pointer to SuperclassOfFoo or casting a pointer to Foo to
@@ -88,7 +91,7 @@ inline To down_cast(From* f) {                   // so we only accept pointers
     implicit_cast<From*, To>(0);
   }
 
-#if !defined(NDEBUG) && !defined(GOOGLE_PROTOBUF_NO_RTTI)
+#if !defined(NDEBUG) && PROTOBUF_RTTI
   assert(f == nullptr || dynamic_cast<To>(f) != nullptr);  // RTTI: debug mode only!
 #endif
   return static_cast<To>(f);
@@ -105,7 +108,7 @@ inline To down_cast(From& f) {
     implicit_cast<From*, ToAsPointer>(0);
   }
 
-#if !defined(NDEBUG) && !defined(GOOGLE_PROTOBUF_NO_RTTI)
+#if !defined(NDEBUG) && PROTOBUF_RTTI
   // RTTI: debug mode only!
   assert(dynamic_cast<ToAsPointer>(&f) != nullptr);
 #endif
@@ -131,4 +134,7 @@ using internal::bit_cast;
 
 }  // namespace protobuf
 }  // namespace google
+
+#include <google/protobuf/port_undef.inc>
+
 #endif  // GOOGLE_PROTOBUF_CASTS_H__


### PR DESCRIPTION
These were the only 2 remaining occurrences of this pattern.