### PR TITLE
bug: #7076 adds ERROR to windows portability files

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -382,6 +382,8 @@
 // Windows declares several inconvenient macro names.  We #undef them and then
 // restore them in port_undef.inc.
 #ifdef _MSC_VER
+#pragma push_macro("ERROR")
+#undef ERROR
 #pragma push_macro("GetMessage")
 #undef GetMessage
 #pragma push_macro("IGNORE")

--- a/src/google/protobuf/port_undef.inc
+++ b/src/google/protobuf/port_undef.inc
@@ -71,6 +71,7 @@
 
 // Restore macro that may have been #undef'd in port_def.inc.
 #ifdef _MSC_VER
+#pragma pop_macro("ERROR")
 #pragma pop_macro("GetMessage")
 #pragma pop_macro("IGNORE")
 #pragma pop_macro("IN")


### PR DESCRIPTION
Same as https://github.com/protocolbuffers/protobuf/pull/7088 but for `ERROR`.
Issue: https://github.com/protocolbuffers/protobuf/issues/7076