### PR TITLE
Reserve extension for Bazel failure detail metadata

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -224,3 +224,7 @@ with info about your project (name and website) so we can add an entry for you.
 1. Wire since and until
    * Website: https://square.github.io/wire/
    * Extensions: 1076, 1077
+
+1. Bazel, Failure Details
+   * Website: https://github.com/bazelbuild/bazel
+   * Extensions: 1078


### PR DESCRIPTION
The Bazel project (https://github.com/bazelbuild/bazel) intends to
enrich its server app's (protobuf-defined) command service's status
message with a structured representation of what, if anything, went
wrong while processing a command. We wish to use custom options to add
metadata to the protobuf constructs involved.