### PR TITLE
Deterministic `protoc --descriptor_set_out`

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2228,12 +2228,18 @@ bool CommandLineInterface::WriteDescriptorSet(
   }
 
   io::FileOutputStream out(fd);
-  if (!file_set.SerializeToZeroCopyStream(&out)) {
+
+  io::CodedOutputStream coded_out(&out);
+  // Determinism is useful here because build outputs are sometimes checked
+  // into version control.
+  coded_out.SetSerializationDeterministic(true);
+  if (!file_set.SerializeToCodedStream(&coded_out)) {
     std::cerr << descriptor_set_out_name_ << ": " << strerror(out.GetErrno())
               << std::endl;
     out.Close();
     return false;
   }
+  coded_out.Trim();
   if (!out.Close()) {
     std::cerr << descriptor_set_out_name_ << ": " << strerror(out.GetErrno())
               << std::endl;

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2229,17 +2229,19 @@ bool CommandLineInterface::WriteDescriptorSet(
 
   io::FileOutputStream out(fd);
 
-  io::CodedOutputStream coded_out(&out);
-  // Determinism is useful here because build outputs are sometimes checked
-  // into version control.
-  coded_out.SetSerializationDeterministic(true);
-  if (!file_set.SerializeToCodedStream(&coded_out)) {
-    std::cerr << descriptor_set_out_name_ << ": " << strerror(out.GetErrno())
-              << std::endl;
-    out.Close();
-    return false;
+  {
+    io::CodedOutputStream coded_out(&out);
+    // Determinism is useful here because build outputs are sometimes checked
+    // into version control.
+    coded_out.SetSerializationDeterministic(true);
+    if (!file_set.SerializeToCodedStream(&coded_out)) {
+      std::cerr << descriptor_set_out_name_ << ": " << strerror(out.GetErrno())
+                << std::endl;
+      out.Close();
+      return false;
+    }
   }
-  coded_out.Trim();
+
   if (!out.Close()) {
     std::cerr << descriptor_set_out_name_ << ": " << strerror(out.GetErrno())
               << std::endl;


### PR DESCRIPTION
Repeatable protoc output is useful because it's sometimes checked into version control, and rerunning protoc should not generate unnecessary diffs.