### PR TITLE
[bazel] Move Java runtime/toolchains into //java

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -247,8 +247,10 @@ csharp_EXTRA_DIST=                                                           \
   csharp/src/Google.Protobuf/UnknownFieldSet.cs
 
 java_EXTRA_DIST=                                                                   \
+  java/BUILD                                                                       \
   java/README.md                                                                   \
   java/bom/pom.xml                                                                 \
+  java/core/BUILD                                                                  \
   java/core/generate-sources-build.xml                                             \
   java/core/generate-test-sources-build.xml                                        \
   java/core/pom.xml                                                                \
@@ -504,6 +506,7 @@ java_EXTRA_DIST=                                                                
   java/core/src/test/proto/com/google/protobuf/test_extra_interfaces.proto         \
   java/core/src/test/proto/com/google/protobuf/wrappers_test.proto                 \
   java/lite.md                                                                     \
+  java/lite/BUILD                                                                  \
   java/lite/generate-sources-build.xml                                             \
   java/lite/generate-test-sources-build.xml                                        \
   java/lite/lite.awk                                                               \
@@ -512,6 +515,7 @@ java_EXTRA_DIST=                                                                
   java/lite/src/test/java/com/google/protobuf/LiteTest.java                        \
   java/lite/src/test/java/com/google/protobuf/Proto2MessageLiteInfoFactory.java    \
   java/pom.xml                                                                     \
+  java/util/BUILD                                                                  \
   java/util/pom.xml                                                                \
   java/util/src/main/java/com/google/protobuf/util/Durations.java                  \
   java/util/src/main/java/com/google/protobuf/util/FieldMaskTree.java              \
@@ -1298,7 +1302,7 @@ EXTRA_DIST = $(@DIST_LANG@_EXTRA_DIST)   \
   WORKSPACE                              \
   cmake/CMakeLists.txt                   \
   cmake/README.md                        \
-  cmake/conformance.cmake                   \
+  cmake/conformance.cmake                \
   cmake/examples.cmake                   \
   cmake/extract_includes.bat.in          \
   cmake/install.cmake                    \
@@ -1315,6 +1319,8 @@ EXTRA_DIST = $(@DIST_LANG@_EXTRA_DIST)   \
   cmake/tests.cmake                      \
   cmake/version.rc.in                    \
   compiler_config_setting.bzl            \
+  build_files_updated_unittest.sh        \
+  cc_proto_blacklist_test.bzl            \
   editors/README.txt                     \
   editors/proto.vim                      \
   editors/protobuf-mode.el               \

--- a/compiler_config_setting.bzl
+++ b/compiler_config_setting.bzl
@@ -1,6 +1,6 @@
 """Creates config_setting that allows selecting based on 'compiler' value."""
 
-def create_compiler_config_setting(name, value):
+def create_compiler_config_setting(name, value, visibility = None):
     # The "do_not_use_tools_cpp_compiler_present" attribute exists to
     # distinguish between older versions of Bazel that do not support
     # "@bazel_tools//tools/cpp:compiler" flag_value, and newer ones that do.
@@ -13,9 +13,11 @@ def create_compiler_config_setting(name, value):
             flag_values = {
                 "@bazel_tools//tools/cpp:compiler": value,
             },
+            visibility = visibility,
         )
     else:
         native.config_setting(
             name = name,
             values = {"compiler": value},
+            visibility = visibility,
         )

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the bazel symlinks
+/bazel-*

--- a/java/BUILD
+++ b/java/BUILD
@@ -1,0 +1,9 @@
+config_setting(
+    name = "jdk9",
+    values = {
+        "java_toolchain": "@bazel_tools//tools/jdk:toolchain_jdk9",
+    },
+    visibility = [
+        "//java:__subpackages__",
+    ],
+)

--- a/java/core/BUILD
+++ b/java/core/BUILD
@@ -1,0 +1,137 @@
+load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
+
+LITE_SRCS = [
+    # Keep in sync with `//java/lite:pom.xml`.
+    "src/main/java/com/google/protobuf/AbstractMessageLite.java",
+    "src/main/java/com/google/protobuf/AbstractParser.java",
+    "src/main/java/com/google/protobuf/AbstractProtobufList.java",
+    "src/main/java/com/google/protobuf/AllocatedBuffer.java",
+    "src/main/java/com/google/protobuf/Android.java",
+    "src/main/java/com/google/protobuf/ArrayDecoders.java",
+    "src/main/java/com/google/protobuf/BinaryReader.java",
+    "src/main/java/com/google/protobuf/BinaryWriter.java",
+    "src/main/java/com/google/protobuf/BooleanArrayList.java",
+    "src/main/java/com/google/protobuf/BufferAllocator.java",
+    "src/main/java/com/google/protobuf/ByteBufferWriter.java",
+    "src/main/java/com/google/protobuf/ByteOutput.java",
+    "src/main/java/com/google/protobuf/ByteString.java",
+    "src/main/java/com/google/protobuf/CodedInputStream.java",
+    "src/main/java/com/google/protobuf/CodedInputStreamReader.java",
+    "src/main/java/com/google/protobuf/CodedOutputStream.java",
+    "src/main/java/com/google/protobuf/CodedOutputStreamWriter.java",
+    "src/main/java/com/google/protobuf/DoubleArrayList.java",
+    "src/main/java/com/google/protobuf/ExperimentalApi.java",
+    "src/main/java/com/google/protobuf/ExtensionLite.java",
+    "src/main/java/com/google/protobuf/ExtensionRegistryFactory.java",
+    "src/main/java/com/google/protobuf/ExtensionRegistryLite.java",
+    "src/main/java/com/google/protobuf/ExtensionSchema.java",
+    "src/main/java/com/google/protobuf/ExtensionSchemaLite.java",
+    "src/main/java/com/google/protobuf/ExtensionSchemas.java",
+    "src/main/java/com/google/protobuf/FieldInfo.java",
+    "src/main/java/com/google/protobuf/FieldSet.java",
+    "src/main/java/com/google/protobuf/FieldType.java",
+    "src/main/java/com/google/protobuf/FloatArrayList.java",
+    "src/main/java/com/google/protobuf/GeneratedMessageInfoFactory.java",
+    "src/main/java/com/google/protobuf/GeneratedMessageLite.java",
+    "src/main/java/com/google/protobuf/IntArrayList.java",
+    "src/main/java/com/google/protobuf/Internal.java",
+    "src/main/java/com/google/protobuf/InvalidProtocolBufferException.java",
+    "src/main/java/com/google/protobuf/IterableByteBufferInputStream.java",
+    "src/main/java/com/google/protobuf/JavaType.java",
+    "src/main/java/com/google/protobuf/LazyField.java",
+    "src/main/java/com/google/protobuf/LazyFieldLite.java",
+    "src/main/java/com/google/protobuf/LazyStringArrayList.java",
+    "src/main/java/com/google/protobuf/LazyStringList.java",
+    "src/main/java/com/google/protobuf/ListFieldSchema.java",
+    "src/main/java/com/google/protobuf/LongArrayList.java",
+    "src/main/java/com/google/protobuf/ManifestSchemaFactory.java",
+    "src/main/java/com/google/protobuf/MapEntryLite.java",
+    "src/main/java/com/google/protobuf/MapFieldLite.java",
+    "src/main/java/com/google/protobuf/MapFieldSchema.java",
+    "src/main/java/com/google/protobuf/MapFieldSchemaLite.java",
+    "src/main/java/com/google/protobuf/MapFieldSchemas.java",
+    "src/main/java/com/google/protobuf/MessageInfo.java",
+    "src/main/java/com/google/protobuf/MessageInfoFactory.java",
+    "src/main/java/com/google/protobuf/MessageLite.java",
+    "src/main/java/com/google/protobuf/MessageLiteOrBuilder.java",
+    "src/main/java/com/google/protobuf/MessageLiteToString.java",
+    "src/main/java/com/google/protobuf/MessageSchema.java",
+    "src/main/java/com/google/protobuf/MessageSetSchema.java",
+    "src/main/java/com/google/protobuf/MutabilityOracle.java",
+    "src/main/java/com/google/protobuf/NewInstanceSchema.java",
+    "src/main/java/com/google/protobuf/NewInstanceSchemaLite.java",
+    "src/main/java/com/google/protobuf/NewInstanceSchemas.java",
+    "src/main/java/com/google/protobuf/NioByteString.java",
+    "src/main/java/com/google/protobuf/OneofInfo.java",
+    "src/main/java/com/google/protobuf/Parser.java",
+    "src/main/java/com/google/protobuf/PrimitiveNonBoxingCollection.java",
+    "src/main/java/com/google/protobuf/ProtoSyntax.java",
+    "src/main/java/com/google/protobuf/Protobuf.java",
+    "src/main/java/com/google/protobuf/ProtobufArrayList.java",
+    "src/main/java/com/google/protobuf/ProtobufLists.java",
+    "src/main/java/com/google/protobuf/ProtocolStringList.java",
+    "src/main/java/com/google/protobuf/RawMessageInfo.java",
+    "src/main/java/com/google/protobuf/Reader.java",
+    "src/main/java/com/google/protobuf/RopeByteString.java",
+    "src/main/java/com/google/protobuf/Schema.java",
+    "src/main/java/com/google/protobuf/SchemaFactory.java",
+    "src/main/java/com/google/protobuf/SchemaUtil.java",
+    "src/main/java/com/google/protobuf/SmallSortedMap.java",
+    "src/main/java/com/google/protobuf/StructuralMessageInfo.java",
+    "src/main/java/com/google/protobuf/TextFormatEscaper.java",
+    "src/main/java/com/google/protobuf/UninitializedMessageException.java",
+    "src/main/java/com/google/protobuf/UnknownFieldSchema.java",
+    "src/main/java/com/google/protobuf/UnknownFieldSetLite.java",
+    "src/main/java/com/google/protobuf/UnknownFieldSetLiteSchema.java",
+    "src/main/java/com/google/protobuf/UnmodifiableLazyStringList.java",
+    "src/main/java/com/google/protobuf/UnsafeUtil.java",
+    "src/main/java/com/google/protobuf/Utf8.java",
+    "src/main/java/com/google/protobuf/WireFormat.java",
+    "src/main/java/com/google/protobuf/Writer.java",
+]
+
+javacopts = select({
+    "//java:jdk9": ["--add-modules=jdk.unsupported"],
+    "//conditions:default": [
+        "-source 7",
+        "-target 7",
+    ],
+})
+
+# Should be used as `//java/lite`.
+java_library(
+    name = "lite",
+    srcs = LITE_SRCS,
+    javacopts = javacopts,
+    visibility = [
+        "//java/lite:__pkg__",
+    ],
+)
+
+java_library(
+    name = "core",
+    srcs = glob(
+        [
+            "src/main/java/com/google/protobuf/*.java",
+        ],
+        exclude = LITE_SRCS,
+    ) + [
+        "//:gen_well_known_protos_java",
+    ],
+    javacopts = javacopts,
+    visibility = ["//visibility:public"],
+    exports = [
+        "//java/lite",
+    ],
+    deps = [
+        "//java/lite",
+    ],
+)
+
+proto_lang_toolchain(
+    name = "toolchain",
+    command_line = "--java_out=$(OUT)",
+    runtime = ":core",
+    visibility = ["//visibility:public"],
+)

--- a/java/lite/BUILD
+++ b/java/lite/BUILD
@@ -1,0 +1,14 @@
+load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
+
+alias(
+    name = "lite",
+    actual = "//java/core:lite",
+    visibility = ["//visibility:public"],
+)
+
+proto_lang_toolchain(
+    name = "toolchain",
+    command_line = "--java_out=lite:$(OUT)",
+    runtime = ":lite",
+    visibility = ["//visibility:public"],
+)

--- a/java/lite/pom.xml
+++ b/java/lite/pom.xml
@@ -89,7 +89,7 @@
                 <resource>
                   <directory>${basedir}/../core/src/main/java/com/google/protobuf</directory>
                   <includes>
-                    <!-- Keep in sync with //:BUILD  -->
+                    <!-- Keep in sync with //java/core:BUILD  -->
                     <include>AbstractMessageLite.java</include>
                     <include>AbstractParser.java</include>
                     <include>AbstractProtobufList.java</include>

--- a/java/util/BUILD
+++ b/java/util/BUILD
@@ -1,0 +1,20 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "util",
+    srcs = glob([
+        "src/main/java/com/google/protobuf/util/*.java",
+    ]),
+    javacopts = [
+        "-source 7",
+        "-target 7",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external:error_prone_annotations",
+        "//external:gson",
+        "//external:guava",
+        "//java/core",
+        "//java/lite",
+    ],
+)

--- a/kokoro/linux/bazel/build.sh
+++ b/kokoro/linux/bazel/build.sh
@@ -25,9 +25,10 @@ git submodule update --init --recursive
 trap print_test_logs EXIT
 bazel test --copt=-Werror --host_copt=-Werror \
   //:build_files_updated_unittest \
+  //java/... \
   //:protobuf_test \
   @com_google_protobuf//:cc_proto_blacklist_test
 trap - EXIT
 
 cd examples
-bazel build :all
+bazel build //...

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -318,29 +318,58 @@ def cc_proto_library(
         **kargs
     )
 
-def internal_gen_well_known_protos_java(srcs):
-    """Bazel rule to generate the gen_well_known_protos_java genrule
+def _internal_gen_well_known_protos_java_impl(ctx):
+    args = ctx.actions.args()
 
-    Args:
-      srcs: the well known protos
-    """
-    root = Label("%s//protobuf_java" % (native.repository_name())).workspace_root
-    pkg = native.package_name() + "/" if native.package_name() else ""
-    if root == "":
-        include = " -I%ssrc " % pkg
-    else:
-        include = " -I%s/%ssrc " % (root, pkg)
-    native.genrule(
-        name = "gen_well_known_protos_java",
-        srcs = srcs,
-        outs = [
-            "wellknown.srcjar",
-        ],
-        cmd = "$(location :protoc) --java_out=$(@D)/wellknown.jar" +
-              " %s $(SRCS) " % include +
-              " && mv $(@D)/wellknown.jar $(@D)/wellknown.srcjar",
-        tools = [":protoc"],
+    deps = [d[ProtoInfo] for d in ctx.attr.deps]
+
+    srcjar = ctx.actions.declare_file("{}.srcjar".format(ctx.attr.name))
+    args.add("--java_out", srcjar)
+
+    descriptors = depset(
+        transitive = [dep.transitive_descriptor_sets for dep in deps],
     )
+    args.add_joined(
+        "--descriptor_set_in",
+        descriptors,
+        join_with = ctx.configuration.host_path_separator,
+    )
+
+    for dep in deps:
+        if "." == dep.proto_source_root:
+            args.add_all([src.path for src in dep.direct_sources])
+        else:
+            source_root = dep.proto_source_root
+            offset = len(source_root) + 1  # + '/'.
+            args.add_all([src.path[offset:] for src in dep.direct_sources])
+
+    ctx.actions.run(
+        executable = ctx.executable._protoc,
+        inputs = descriptors,
+        outputs = [srcjar],
+        arguments = [args],
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([srcjar]),
+        ),
+    ]
+
+internal_gen_well_known_protos_java = rule(
+    implementation = _internal_gen_well_known_protos_java_impl,
+    attrs = {
+        "deps": attr.label_list(
+            mandatory = True,
+            providers = [ProtoInfo],
+        ),
+        "_protoc": attr.label(
+            executable = True,
+            cfg = "host",
+            default = "@com_google_protobuf//:protoc",
+        ),
+    },
+)
 
 def internal_copied_filegroup(name, srcs, strip_prefix, dest, **kwargs):
     """Macro to copy files to a different directory and then create a filegroup.

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -886,7 +886,8 @@ int CommandLineInterface::Run(int argc, const char* const argv[]) {
     for (int i = 0; i < output_directives_.size(); i++) {
       std::string output_location = output_directives_[i].output_location;
       if (!HasSuffixString(output_location, ".zip") &&
-          !HasSuffixString(output_location, ".jar")) {
+          !HasSuffixString(output_location, ".jar") &&
+          !HasSuffixString(output_location, ".srcjar")) {
         AddTrailingSlash(&output_location);
       }
 


### PR DESCRIPTION
This change moves `java_library` targets from the top-level BUILD file
into `//java/{core,lite,util}` and declares `alias` targets to point to
their new locations (hence, this is not a breaking change).

This will allow users that don't use Java to stop depending on
`@rules_java` (e.g. as requested in
https://github.com/bazelbuild/rules_scala/pull/989#issuecomment-583405161).

Note that there is no intention to deprecate + remove the top-level
targets in the foreseeable future.