### PR TITLE
Attempt to mitigate "docker pull" failures

### DIFF
--- a/kokoro/linux/build_and_run_docker.sh
+++ b/kokoro/linux/build_and_run_docker.sh
@@ -28,8 +28,9 @@ else
   DOCKER_IMAGE_NAME=${DOCKERHUB_ORGANIZATION}/${DOCKERFILE_PREFIX}_$(sha1sum $DOCKERFILE_DIR/Dockerfile | cut -f1 -d\ )
 fi
 
-# Pull dockerimage from Dockerhub
-docker pull $DOCKER_IMAGE_NAME
+# Pull dockerimage from Dockerhub. This sometimes fails intermittently, so we
+# keep trying until we succeed.
+until docker pull $DOCKER_IMAGE_NAME; do sleep 10; done
 
 # Ensure existence of ccache directory
 CCACHE_DIR=/tmp/protobuf-ccache

--- a/kokoro/linux/cpp_distcheck/build.sh
+++ b/kokoro/linux/cpp_distcheck/build.sh
@@ -11,7 +11,7 @@ cd $(dirname $0)/../../..
 
 # Run tests under release docker image.
 DOCKER_IMAGE_NAME=protobuf/protoc_$(sha1sum protoc-artifacts/Dockerfile | cut -f1 -d " ")
-docker pull $DOCKER_IMAGE_NAME
+until docker pull $DOCKER_IMAGE_NAME; do sleep 10; done
 
 docker run -v $(pwd):/var/local/protobuf --rm $DOCKER_IMAGE_NAME \
   bash -l /var/local/protobuf/tests.sh cpp || FAILED="true"


### PR DESCRIPTION
Lots of CI tests have been failing recently with error messages like
this from "docker pull":

  Error response from daemon: unexpected EOF

This seems to be an issue affecting other projects as well:
https://forums.docker.com/t/docker-pull-causes-error-response-from-daemon-unexpected-eof/88608

This commit tries to mitigate the problem by periodically retrying
failed Docker pulls.