### PR TITLE
Update the Xcode version number in Kokoro

### DIFF
--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -5,11 +5,11 @@
 ##
 # Select Xcode version
 
-# Remember to update the Xcode version when Xcode_11.0.app is not available.
+# Remember to update the Xcode version when Xcode_11.3.app is not available.
 # If xcode is not available, it will probably encounter the failure for
 # "autom4te: need GNU m4 1.4 or later: /usr/bin/m4"
 # go/kokoro/userdocs/macos/selecting_xcode.md for more information.
-export DEVELOPER_DIR=/Applications/Xcode_11.0.app/Contents/Developer
+export DEVELOPER_DIR=/Applications/Xcode_11.3.app/Contents/Developer
 
 ##
 # Select C/C++ compilers


### PR DESCRIPTION
Currently all of our MacOS tests are failing with the error: "autom4te: need GNU m4 1.4 or later: /usr/bin/m4". This is likely to be happening because Kokoro has updated their Xcode version to 11.3.