### PR TITLE
Downgrade Xcode version to 10.3

### DIFF
--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -5,11 +5,11 @@
 ##
 # Select Xcode version
 
-# Remember to update the Xcode version when Xcode_11.3.app is not available.
+# Remember to update the Xcode version when Xcode_10.3.app is not available.
 # If xcode is not available, it will probably encounter the failure for
 # "autom4te: need GNU m4 1.4 or later: /usr/bin/m4"
 # go/kokoro/userdocs/macos/selecting_xcode.md for more information.
-export DEVELOPER_DIR=/Applications/Xcode_11.3.app/Contents/Developer
+export DEVELOPER_DIR=/Applications/Xcode_10.3.app/Contents/Developer
 
 ##
 # Select C/C++ compilers


### PR DESCRIPTION
Building protoc with Xcode 11.3 gives an error: `ld: library not found for -latomic`

Sponge link: https://sponge.corp.google.com/target?id=c9ac8abf-af0c-453c-a027-18720243aa58&target=protobuf%2Fgithub%2F3.11.x%2Frelease%2Fprotoc%2Fmacos%2Frelease&searchFor=