### PR TITLE
Remove protoc release for 32-bit Macs

### DIFF
--- a/kokoro/release/protoc/macos/build.sh
+++ b/kokoro/release/protoc/macos/build.sh
@@ -6,14 +6,6 @@ CXXFLAGS_COMMON="-std=c++14 -DNDEBUG -mmacosx-version-min=10.9"
 cd github/protobuf
 ./autogen.sh
 
-mkdir build32 && cd build32
-export CXXFLAGS="$CXXFLAGS_COMMON -m32"
-../configure --disable-shared
-make -j4
-file src/protoc
-otool -L src/protoc | grep dylib
-cd ..
-
 mkdir build64 && cd build64
 export CXXFLAGS="$CXXFLAGS_COMMON -m64"
 ../configure --disable-shared

--- a/protoc-artifacts/pom.xml
+++ b/protoc-artifacts/pom.xml
@@ -71,11 +71,6 @@
                   <type>exe</type>
                 </artifact>
                 <artifact>
-                  <file>${basedir}/target/osx/x86_32/protoc.exe</file>
-                  <classifier>osx-x86_32</classifier>
-                  <type>exe</type>
-                </artifact>
-                <artifact>
                   <file>${basedir}/target/linux/aarch_64/protoc.exe</file>
                   <classifier>linux-aarch_64</classifier>
                   <type>exe</type>


### PR DESCRIPTION
Apple has been removing the support for 32-bit Mac apps: https://support.apple.com/en-us/HT208436

Our release infrastructure no longer supports building for 32-bit architecture.