### PR TITLE
examples: update Go example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -16,7 +16,7 @@ clean:
 	rm -f javac_middleman AddPerson*.class ListPeople*.class com/example/tutorial/*.class
 	rm -f protoc_middleman addressbook.pb.cc addressbook.pb.h addressbook_pb2.py com/example/tutorial/AddressBookProtos.java
 	rm -f *.pyc
-	rm -f protoc_middleman_go tutorial/*.pb.go add_person_go list_people_go
+	rm -f go/tutorialpb/*.pb.go add_person_go list_people_go
 	rm -f protoc_middleman_dart dart_tutorial/*.pb*.dart
 	rmdir dart_tutorial 2>/dev/null || true
 	rmdir tutorial 2>/dev/null || true
@@ -28,10 +28,9 @@ protoc_middleman: addressbook.proto
 	protoc $$PROTO_PATH --cpp_out=. --java_out=. --python_out=. addressbook.proto
 	@touch protoc_middleman
 
-protoc_middleman_go: addressbook.proto
-	mkdir -p tutorial # make directory for go package
-	protoc $$PROTO_PATH --go_out=tutorial addressbook.proto
-	@touch protoc_middleman_go
+go/tutorialpb/addressbook.pb.go: addressbook.proto
+	mkdir -p go/tutorialpb # make directory for go package
+	protoc $$PROTO_PATH --go_opt=paths=source_relative --go_out=go/tutorialpb addressbook.proto
 
 protoc_middleman_dart: addressbook.proto
 	mkdir -p dart_tutorial # make directory for the dart package
@@ -51,17 +50,17 @@ add_person_dart: add_person.dart protoc_middleman_dart
 
 list_people_dart: list_people.dart protoc_middleman_dart
 
-add_person_go: add_person.go protoc_middleman_go
-	go build -o add_person_go add_person.go
+add_person_go: go/cmd/add_person/add_person.go go/tutorialpb/addressbook.pb.go
+	cd go && go build -o ../add_person_go ./cmd/add_person
 
-add_person_gotest: add_person_test.go add_person_go
-	go test add_person.go add_person_test.go
+add_person_gotest: go/tutorialpb/addressbook.pb.go
+	cd go && go test ./cmd/add_person
 
-list_people_go: list_people.go protoc_middleman_go
-	go build -o list_people_go list_people.go
+list_people_go: go/cmd/list_people/list_people.go go/tutorialpb/addressbook.pb.go
+	cd go && go build -o ../list_people_go ./cmd/list_people
 
-list_people_gotest: list_people.go list_people_go
-	go test list_people.go list_people_test.go
+list_people_gotest: go/tutorialpb/addressbook.pb.go
+	cd go && go test ./cmd/list_people
 
 javac_middleman: AddPerson.java ListPeople.java protoc_middleman
 	javac -cp $$CLASSPATH AddPerson.java ListPeople.java com/example/tutorial/AddressBookProtos.java

--- a/examples/README.md
+++ b/examples/README.md
@@ -91,22 +91,18 @@ scripts) and can be used to create/display an address book data file.
 
 ### Go
 
-The Go example requires a plugin to the protocol buffer compiler, so it is not
-build with all the other examples.  See:
+Follow instructions in [../README.md](../README.md) to install protoc. Then
+install the Go protoc plugin (protoc-gen-go):
 
-    https://github.com/golang/protobuf
+    $ go install google.golang.org/protobuf/cmd/protoc-gen-go
 
-for more information about Go protocol buffer support.
+The "go install" command will install protoc-gen-go into the GOBIN
+directory.  You can set the $GOBIN environment variable before
+running "go install" to change the install location.  Make sure the
+install directory is in your shell $PATH.
 
-First, install the Protocol Buffers compiler (protoc).
-
-Then, install the Go Protocol Buffers plugin ($GOPATH/bin must be in your $PATH
-for protoc to find it):
-
-    go get github.com/golang/protobuf/protoc-gen-go
-
-Build the Go samples in this directory with "make go".  This creates the
-following executable files in the current directory:
+Build the Go samples with "make go".  This creates the following
+executable files in the current directory:
 
     add_person_go      list_people_go
 

--- a/examples/addressbook.proto
+++ b/examples/addressbook.proto
@@ -18,6 +18,10 @@ option java_package = "com.example.tutorial";
 option java_outer_classname = "AddressBookProtos";
 // [END java_declaration]
 
+// [START go_declaration]
+option go_package = "github.com/protocolbuffers/protobuf/examples/go/tutorialpb";
+// [END go_declaration]
+
 // [START csharp_declaration]
 option csharp_namespace = "Google.Protobuf.Examples.AddressBook";
 // [END csharp_declaration]

--- a/examples/go/cmd/add_person/add_person.go
+++ b/examples/go/cmd/add_person/add_person.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
-	pb "github.com/protocolbuffers/protobuf/examples/tutorial"
+	pb "github.com/protocolbuffers/protobuf/examples/go/tutorialpb"
+	"google.golang.org/protobuf/proto"
 )
 
 func promptForAddress(r io.Reader) (*pb.Person, error) {

--- a/examples/go/cmd/add_person/add_person_test.go
+++ b/examples/go/cmd/add_person/add_person_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
-	pb "github.com/protocolbuffers/protobuf/examples/tutorial"
+	pb "github.com/protocolbuffers/protobuf/examples/go/tutorialpb"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestPromptForAddressReturnsAddress(t *testing.T) {
@@ -51,7 +51,7 @@ unknown
 	}
 	for i := 0; i < phones; i++ {
 		if !proto.Equal(got.Phones[i], want[i]) {
-			t.Errorf("want phone %q, got %q", *want[i], *got.Phones[i])
+			t.Errorf("want phone %q, got %q", want[i], got.Phones[i])
 		}
 
 	}

--- a/examples/go/cmd/list_people/list_people.go
+++ b/examples/go/cmd/list_people/list_people.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/golang/protobuf/proto"
-	pb "github.com/protocolbuffers/protobuf/examples/tutorial"
+	pb "github.com/protocolbuffers/protobuf/examples/go/tutorialpb"
+	"google.golang.org/protobuf/proto"
 )
 
 func writePerson(w io.Writer, p *pb.Person) {

--- a/examples/go/cmd/list_people/list_people_test.go
+++ b/examples/go/cmd/list_people/list_people_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	pb "github.com/protocolbuffers/protobuf/examples/tutorial"
+	pb "github.com/protocolbuffers/protobuf/examples/go/tutorialpb"
 )
 
 func TestWritePersonWritesPerson(t *testing.T) {

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -1,0 +1,8 @@
+module github.com/protocolbuffers/protobuf/examples/go
+
+go 1.14
+
+require (
+	github.com/golang/protobuf v1.4.0-rc.1
+	google.golang.org/protobuf v0.0.0-20200214214710-e8e8875f9406
+)

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -1,0 +1,7 @@
+github.com/golang/protobuf v1.4.0-rc.1 h1:axiiuL94A9bpjZyKcirx5U62av32UORcixjrwLdzvMo=
+github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
+google.golang.org/protobuf v0.0.0-20200214214710-e8e8875f9406 h1:OTjzDp5H5muU0DhxIc14C5cXaZsrzgb6dqPbb8cUzaA=
+google.golang.org/protobuf v0.0.0-20200214214710-e8e8875f9406/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=


### PR DESCRIPTION
Update the Go example to use Go modules: Move the example into a
directory containing a go.mod file, change the installation instructions
to use "go install".

Add a go_package option to addressbook.proto.

Update examples to use the Go APIv2 package
(google.golang.org/protobuf/proto).