### PR TITLE
[bazel] Remove bootstrap hack from cc_proto_library and add interop with proto_library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -114,6 +114,7 @@ LINK_OPTS = select({
 
 load(
     ":protobuf.bzl",
+    "adapt_proto_library",
     "cc_proto_library",
     "internal_copied_filegroup",
     "internal_gen_well_known_protos_java",
@@ -290,13 +291,15 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-cc_proto_library(
+adapt_proto_library(
+    name = "cc_wkt_protos_genproto",
+    deps = [proto + "_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "cc_wkt_protos",
-    srcs = WELL_KNOWN_PROTOS,
-    include = "src",
-    default_runtime = ":protobuf",
-    internal_bootstrap_hack = 1,
-    protoc = ":protoc",
+    deprecation = "Only for backward compatibility. Do not use.",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Bazel had a native `cc_proto_library` for more than 2 years now.
This is the first step towards removing that rule from the Protobuf
repo.