### PR TITLE
Fix build failed for visual studio in multi-byte windows environments

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -182,6 +182,10 @@ endif (protobuf_BUILD_SHARED_LIBS)
 if (MSVC)
   # Build with multiple processes
   add_definitions(/MP)
+  # Set source file and execution character sets to UTF-8 when Visual Studio 2015 or later
+  if (NOT (MSVC_VERSION LESS 1900))
+    add_definitions(/utf-8)
+  endif (NOT (MSVC_VERSION LESS 1900))
   # MSVC warning suppressions
   add_definitions(
     /wd4018 # 'expression' : signed/unsigned mismatch


### PR DESCRIPTION
Protobuf source files use utf-8 encoding.
But, Visual Studio assumes that the source files is encoded using the current user code page.

This PR sets the source and executable charset to utf-8 when Visual Studio 2015 or later.

refs: #4762

see also:
https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=vs-2015
