### PR TITLE
[bazel] Update gtest and deprecate //external:{gtest,gtest_main}

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+# These are fetched as external repositories.
+third_party/benchmark
+third_party/googletest

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,20 @@
 workspace(name = "com_google_protobuf")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 local_repository(
     name = "com_google_protobuf_examples",
     path = "examples",
 )
 
-local_repository(
-    name = "submodule_gmock",
-    path = "third_party/googletest",
+http_archive(
+    name = "com_google_googletest",
+    sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
+    strip_prefix = "googletest-release-1.10.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/google/googletest/archive/release-1.10.0.tar.gz",
+        "https://github.com/google/googletest/archive/release-1.10.0.tar.gz",
+    ],
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -22,14 +29,16 @@ bind(
     actual = "//util/python:python_headers",
 )
 
+# TODO(yannic): Remove in 3.13.0.
 bind(
     name = "gtest",
-    actual = "@submodule_gmock//:gtest",
+    actual = "@com_google_googletest//:gtest",
 )
 
+# TODO(yannic): Remove in 3.13.0.
 bind(
     name = "gtest_main",
-    actual = "@submodule_gmock//:gtest_main",
+    actual = "@com_google_googletest//:gtest_main",
 )
 
 jvm_maven_import_external(


### PR DESCRIPTION
This change updates the gtest-version used by Bazel.
Also, `//external:{gtest,gtest_main}` is deprecated so we can remove some
of the uses of the discouraged `bind` function.

RELNOTES[bazel]: Starting with Protobuf 3.13.0, building and running
Protobuf tests requires `@com_google_googletest//:{gtest,gtest_main}`
instead of `//external:{gtest,gtest_main}`. Use
`--@com_google_protobuf//:incompatible_use_com_google_googletest=true`
to verify your workspace is not affected by this change.