### PR TITLE
cmake: add 'plugin' argument to protobuf_generate

### DIFF
--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -11,7 +11,7 @@ function(protobuf_generate)
   include(CMakeParseArguments)
 
   set(_options APPEND_PATH)
-  set(_singleargs LANGUAGE OUT_VAR EXPORT_MACRO PROTOC_OUT_DIR)
+  set(_singleargs LANGUAGE OUT_VAR EXPORT_MACRO PROTOC_OUT_DIR PLUGIN)
   if(COMMAND target_sources)
     list(APPEND _singleargs TARGET)
   endif()
@@ -40,6 +40,10 @@ function(protobuf_generate)
 
   if(protobuf_generate_EXPORT_MACRO AND protobuf_generate_LANGUAGE STREQUAL cpp)
     set(_dll_export_decl "dllexport_decl=${protobuf_generate_EXPORT_MACRO}:")
+  endif()
+  
+  if(protobuf_generate_PLUGIN)
+      set(_plugin "--plugin=${protobuf_generate_PLUGIN}")
   endif()
 
   if(NOT protobuf_generate_GENERATE_EXTENSIONS)
@@ -105,7 +109,7 @@ function(protobuf_generate)
     add_custom_command(
       OUTPUT ${_generated_srcs}
       COMMAND  protobuf::protoc
-      ARGS --${protobuf_generate_LANGUAGE}_out ${_dll_export_decl}${protobuf_generate_PROTOC_OUT_DIR} ${_protobuf_include_path} ${_abs_file}
+      ARGS --${protobuf_generate_LANGUAGE}_out ${_dll_export_decl}${protobuf_generate_PROTOC_OUT_DIR} ${_plugin} ${_protobuf_include_path} ${_abs_file}
       DEPENDS ${_abs_file} protobuf::protoc
       COMMENT "Running ${protobuf_generate_LANGUAGE} protocol buffer compiler on ${_proto}"
       VERBATIM )


### PR DESCRIPTION
Added an optional `PLUGIN` argument to `protobuf_generate` which
will be forwarded to the `--plugin=` argument of `protoc`.

This can be used, among other things, to run `protoc` with the grpc extension, as is done here:
https://github.com/faaxm/exmpl-cmake-grpc/blob/master/proto/CMakeLists.txt

Addresses issue #5493.