### PR TITLE
[Java] add protobuf util to validate dynamic json data

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonValidator.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonValidator.java
@@ -124,6 +124,7 @@ public final class JsonValidator
       for (Entry<String, Value> entry : node.getStructValue().getFieldsMap().entrySet()) {
         helper(++depth, fields.get(1), entry.getValue(), warnings);
       }
+      return;
     }
 
     if (field.isRepeated()) {
@@ -155,6 +156,8 @@ public final class JsonValidator
         break;
       case INT:
       case LONG:
+      case FLOAT:
+      case DOUBLE:
         if (!val.getKindCase().equals(KindCase.NUMBER_VALUE)) {
           warnings.add(field.getName() + " supposed to be numeric but not.");
         }

--- a/java/util/src/main/java/com/google/protobuf/util/JsonValidator.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonValidator.java
@@ -81,13 +81,17 @@ public final class JsonValidator
         // schema defined but not included
         // possibly "optional"
         // generate warning for now
-        warnings.add(field.getName() + " is not included.");
+        // warnings.add(field.getName() + " is not included.");
       }
     }
   }
 
   static void helper(int depth, FieldDescriptor field, Value val, List<String> warnings)
   {
+    if (val.getKindCase().equals(KindCase.NULL_VALUE)) {
+      // allow any field to be null for now
+      return;
+    }
     if (field.getJavaType() == JavaType.MESSAGE) {
       if (!val.hasListValue() && !val.hasStructValue()) {
         warnings.add(field.getName() + " supposed to be object but not.");

--- a/java/util/src/main/java/com/google/protobuf/util/JsonValidator.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonValidator.java
@@ -1,0 +1,171 @@
+package com.google.protobuf.util;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
+import com.google.protobuf.Message;
+import com.google.protobuf.Value;
+import com.google.protobuf.Value.KindCase;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Util class to validate JSON against a predefined protobuf schema.
+ * JSON data is parsed into a tree with root type {@link com.google.protobuf.Value}.
+ *
+ * @author Lawrence He
+ */
+public final class JsonValidator
+{
+  /**
+   * Validate dynamic JSON data against supplied Java Protobuf class
+   */
+  public static List<String> validate(Value root, Class<? extends Message> clazz)
+  {
+    List<String> warnings = new LinkedList<String>();
+
+    if (root == null) {
+      warnings.add("Json data is undefined");
+      return warnings;
+    }
+
+    int depth = 0;
+
+    // traverse two trees at same time
+    start(depth, root, clazz, warnings);
+    return warnings;
+  }
+
+  static Descriptor getMessageDescriptor(Class<? extends Message> protoClass)
+  {
+    try {
+      Method getDescriptor = protoClass.getMethod("getDescriptor");
+      return (Descriptor) getDescriptor.invoke((Object) null);
+    }
+    catch (NoSuchMethodException | IllegalAccessException var2) {
+      throw new IllegalArgumentException(var2);
+    }
+    catch (InvocationTargetException var3) {
+      return null;
+    }
+  }
+
+  static void start(int depth, Value root, Class<? extends Message> clazz, List<String> warnings)
+  {
+    Descriptors.Descriptor descriptor = getMessageDescriptor(clazz);
+    dfs(depth, descriptor.getFields(), root, warnings);
+  }
+
+  static void dfs(int depth, List<FieldDescriptor> fieldDescriptors, Value val, List<String> warnings)
+  {
+    Map<String, Value> m = null;
+    if (val.hasStructValue()) {
+
+      m = new HashMap<>(val.getStructValue().getFieldsMap());
+    }
+
+    for (FieldDescriptor field : fieldDescriptors) {
+      String key = field.getName();
+      if (m != null && m.containsKey(key)) {
+        helper(++depth, field, m.get(key), warnings);
+        depth--;
+      }
+      else {
+        // schema defined but not included
+        // possibly "optional"
+        // generate warning for now
+        warnings.add(field.getName() + " is not included.");
+      }
+    }
+  }
+
+  static void helper(int depth, FieldDescriptor field, Value val, List<String> warnings)
+  {
+    if (field.getJavaType() == JavaType.MESSAGE) {
+      if (!val.hasListValue() && !val.hasStructValue()) {
+        warnings.add(field.getName() + " supposed to be object but not.");
+      }
+      else {
+        handleNode(depth, field, val, warnings);
+      }
+      return;
+    }
+
+    if (field.isRepeated()) {
+      if (!val.hasListValue()) {
+        warnings.add(field.getName() + " supposed to be list but not.");
+      }
+      return;
+    }
+
+    handleConcreteData(field, val, warnings);
+  }
+
+  static void handleNode(int depth, FieldDescriptor field, Value node, List<String> warnings)
+  {
+    if (field.isMapField()) {
+      if (!node.hasStructValue()) {
+        warnings.add(field.getName() + " supposed to be map but not.");
+        return;
+      }
+      List<FieldDescriptor> fields = field.getMessageType().getFields();
+      if (fields.size() != 2) {
+        throw new UnsupportedOperationException("Both map key and value are required.");
+      }
+
+
+      for (Entry<String, Value> entry : node.getStructValue().getFieldsMap().entrySet()) {
+        helper(++depth, fields.get(1), entry.getValue(), warnings);
+      }
+    }
+
+    if (field.isRepeated()) {
+      if (!node.hasListValue()) {
+        warnings.add(field.getName() + " supposed to be list but not.");
+        return;
+      }
+      for (Value v : node.getListValue().getValuesList()) {
+        dfs(depth, field.getMessageType().getFields(), v, warnings);
+      }
+      return;
+    }
+
+    dfs(depth, field.getMessageType().getFields(), node, warnings);
+  }
+
+  /**
+   * Sample schema data handling
+   */
+  static void handleConcreteData(FieldDescriptor field, Value val, List<String> warnings)
+  {
+    JavaType javaType = field.getJavaType();
+
+    switch (field.getJavaType()) {
+      case STRING:
+        if (!val.getKindCase().equals(KindCase.STRING_VALUE)) {
+          warnings.add(field.getName() + " supposed to be string but not.");
+        }
+        break;
+      case INT:
+      case LONG:
+        if (!val.getKindCase().equals(KindCase.NUMBER_VALUE)) {
+          warnings.add(field.getName() + " supposed to be numeric but not.");
+        }
+        break;
+      case BOOLEAN:
+        if (!val.getKindCase().equals(KindCase.BOOL_VALUE)) {
+          warnings.add(field.getName() + " supposed to be boolean but not.");
+        }
+        break;
+      default:
+        throw new UnsupportedOperationException("Cannot convert protobuf type: unsupported type " + javaType);
+    }
+  }
+}

--- a/java/util/src/test/java/com/google/protobuf/util/JsonValidatorTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonValidatorTest.java
@@ -1,0 +1,44 @@
+package com.google.protobuf.util;
+
+import com.google.common.collect.Sets;
+import com.google.protobuf.Message;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.proto.JsonTestProto.TestComplicatedType;
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public final class JsonValidatorTest extends TestCase
+{
+  private void mergeFromJson(String json, Message.Builder builder)
+          throws IOException
+  {
+    JsonFormat.parser().merge(json, builder);
+  }
+
+  public void test()
+          throws IOException
+  {
+    Value.Builder builder = Value.newBuilder();
+    mergeFromJson("{\n" +
+            "  \"type_string\": \"\",\n" +
+            "  \"type_TestStruct\": 1\n" +
+            "}", builder);
+    Set<String> expected = new HashSet<String>()
+    {{
+      add("type_int64 is not included.");
+      add("type_int32 is not included.");
+      add("type_uint32 is not included.");
+      add("type_uint64 is not included.");
+      add("type_float is not included.");
+      add("type_double is not included.");
+      add("type_bool is not included.");
+      add("type_TestStruct supposed to be object but not.");
+    }};
+    Set<String> principal = new HashSet<String>(JsonValidator.validate(builder.build(), TestComplicatedType.class));
+    assertEquals(0, Sets.difference(expected, principal).size());
+  }
+}

--- a/java/util/src/test/java/com/google/protobuf/util/JsonValidatorTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonValidatorTest.java
@@ -4,10 +4,12 @@ import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
 import com.google.protobuf.Value;
 import com.google.protobuf.util.proto.JsonTestProto.TestJsonValidator;
+import com.google.protobuf.util.proto.JsonTestProto.TestStruct;
 import junit.framework.TestCase;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 
@@ -19,30 +21,23 @@ public final class JsonValidatorTest extends TestCase
     JsonFormat.parser().merge(json, builder);
   }
 
-  public void test()
+  public void testBasic()
           throws IOException
   {
     Value.Builder builder = Value.newBuilder();
     mergeFromJson("{\n" +
             "  \"type_string\": \"\",\n" +
-            "  \"type_TestStruct\": 1\n" +
+            "  \"type_map_string_string\": 1\n" +
             "}", builder);
     Set<String> expected = new HashSet<String>()
     {{
-      add("type_int64 is not included.");
-      add("type_int32 is not included.");
-      add("type_uint32 is not included.");
-      add("type_uint64 is not included.");
-      add("type_float is not included.");
-      add("type_double is not included.");
-      add("type_bool is not included.");
-      add("type_TestStruct supposed to be object but not.");
+      add("type_map_string_string supposed to be object but not.");
     }};
     Set<String> principal = new HashSet<String>(JsonValidator.validate(builder.build(), TestJsonValidator.class));
     assertEquals(0, Sets.difference(expected, principal).size());
   }
 
-  public void test2()
+  public void testComplexSchema()
           throws IOException
   {
     Value.Builder builder = Value.newBuilder();
@@ -75,19 +70,8 @@ public final class JsonValidatorTest extends TestCase
             "    \"k2\": \"v2\"\n" +
             "  }\n" +
             "}\n", builder);
-//    Set<String> expected = new HashSet<String>()
-//    {{
-//      add("type_int64 is not included.");
-//      add("type_int32 is not included.");
-//      add("type_uint32 is not included.");
-//      add("type_uint64 is not included.");
-//      add("type_float is not included.");
-//      add("type_double is not included.");
-//      add("type_bool is not included.");
-//      add("type_TestStruct supposed to be object but not.");
-//    }};
-//    Set<String> principal = new HashSet<String>(JsonValidator.validate(builder.build(), TestJsonValidator.class));
-//    assertEquals(0, Sets.difference(expected, principal).size());
-    System.out.println(JsonValidator.validate(builder.build(), TestJsonValidator.class));
+    List<String> result = JsonValidator.validate(builder.build(), TestJsonValidator.class);
+    System.out.println(result);
+    assertEquals(0, result.size());
   }
 }

--- a/java/util/src/test/java/com/google/protobuf/util/JsonValidatorTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonValidatorTest.java
@@ -3,7 +3,7 @@ package com.google.protobuf.util;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
 import com.google.protobuf.Value;
-import com.google.protobuf.util.proto.JsonTestProto.TestComplicatedType;
+import com.google.protobuf.util.proto.JsonTestProto.TestJsonValidator;
 import junit.framework.TestCase;
 
 import java.io.IOException;
@@ -38,7 +38,56 @@ public final class JsonValidatorTest extends TestCase
       add("type_bool is not included.");
       add("type_TestStruct supposed to be object but not.");
     }};
-    Set<String> principal = new HashSet<String>(JsonValidator.validate(builder.build(), TestComplicatedType.class));
+    Set<String> principal = new HashSet<String>(JsonValidator.validate(builder.build(), TestJsonValidator.class));
     assertEquals(0, Sets.difference(expected, principal).size());
+  }
+
+  public void test2()
+          throws IOException
+  {
+    Value.Builder builder = Value.newBuilder();
+    mergeFromJson("{\n" +
+            "  \"type_string\": \"\",\n" +
+            "  \"type_int64\": 9223372036854775806,\n" +
+            "  \"type_int32\": 2147483647,\n" +
+            "  \"type_uint32\": 4294967295,\n" +
+            "  \"type_uint64\": 18446744073709551615,\n" +
+            "  \"type_float\": 123.45,\n" +
+            "  \"type_double\": 123312.123213,\n" +
+            "  \"type_bool\": true,\n" +
+            "  \"repeated_type_TestRecursive\": [\n" +
+            "    {\n" +
+            "      \"value\": 1,\n" +
+            "      \"nested\": {\n" +
+            "        \"value\": 2,\n" +
+            "        \"nested\": {\n" +
+            "          \"value\": 3,\n" +
+            "          \"nested\": {\n" +
+            "            \"value\": 4,\n" +
+            "            \"nested\": null\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"type_map_string_string\": {\n" +
+            "    \"k1\": \"v1\",\n" +
+            "    \"k2\": \"v2\"\n" +
+            "  }\n" +
+            "}\n", builder);
+//    Set<String> expected = new HashSet<String>()
+//    {{
+//      add("type_int64 is not included.");
+//      add("type_int32 is not included.");
+//      add("type_uint32 is not included.");
+//      add("type_uint64 is not included.");
+//      add("type_float is not included.");
+//      add("type_double is not included.");
+//      add("type_bool is not included.");
+//      add("type_TestStruct supposed to be object but not.");
+//    }};
+//    Set<String> principal = new HashSet<String>(JsonValidator.validate(builder.build(), TestJsonValidator.class));
+//    assertEquals(0, Sets.difference(expected, principal).size());
+    System.out.println(JsonValidator.validate(builder.build(), TestJsonValidator.class));
   }
 }

--- a/java/util/src/test/proto/com/google/protobuf/util/json_test.proto
+++ b/java/util/src/test/proto/com/google/protobuf/util/json_test.proto
@@ -189,7 +189,7 @@ message TestRecursive {
   TestRecursive nested = 2;
 }
 
-message TestComplicatedType {
+message TestJsonValidator {
   string type_string = 1;
   int64 type_int64 = 2;
   int32 type_int32 = 3;
@@ -198,5 +198,6 @@ message TestComplicatedType {
   float type_float = 6;
   double type_double = 7;
   bool type_bool = 8;
-  TestStruct type_TestStruct = 9;
+  repeated TestRecursive repeated_type_TestRecursive = 9;
+  map<string, string> type_map_string_string = 10;
 }

--- a/java/util/src/test/proto/com/google/protobuf/util/json_test.proto
+++ b/java/util/src/test/proto/com/google/protobuf/util/json_test.proto
@@ -188,3 +188,15 @@ message TestRecursive {
   int32 value = 1;
   TestRecursive nested = 2;
 }
+
+message TestComplicatedType {
+  string type_string = 1;
+  int64 type_int64 = 2;
+  int32 type_int32 = 3;
+  uint32 type_uint32 = 4;
+  uint64 type_uint64 = 5;
+  float type_float = 6;
+  double type_double = 7;
+  bool type_bool = 8;
+  TestStruct type_TestStruct = 9;
+}


### PR DESCRIPTION
#7216 prototyping

Hi, here's a Java util to validate json data, it basically traverses dynamic json tree to examine every possible mismatch, current supported json type includes: `number/string/bool/null/list/struct`.

**Usage**
Use `JsonValidator.validate(Value, Class)` as static function
```java
Value.Builder builder = Value.newBuilder();
mergeFromJson("JSONSTRING", builder);
List<String> result = JsonValidator.validate(builder.build(), TestJsonValidator.class);
```

**Output**
Generate following mismatch warnings:
```
<field> supposed to be object but not.
<field> supposed to be list but not.
<field> supposed to be map but not.
<field> supposed to be string but not.
<field> supposed to be numeric but not.
<field> supposed to be boolean but not.
```
Throw following exceptions
```
UnsupportedOperationException - Java type is not supported
err message: Cannot convert protobuf type: unsupported type <java type>
UnsupportedOperationException - dynamic map key or value is null
err message: Both map key and value are required.
```

Some tunable behavior/engineering opportunities 
- It collects all mismatches(warnings) into a list.
- It does not differentiate fields with same name (e.g., heterogeneous list, nested struct). 
- For null value in json data, it skips further validation on that field. 
- It skips protobuf "optional" field if json data doesn't have it. (commented out)
- Format of warnings