### PR TITLE
Suppress dot-delimiter warning if ruby_package consists of a single component

### DIFF
--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -413,7 +413,7 @@ int GeneratePackageModules(const FileDescriptor* file, io::Printer* printer) {
     //    -> A.B.C
     if (package_name.find("::") != std::string::npos) {
       need_change_to_module = false;
-    } else {
+    } else if (package_name.find(".") != std::string::npos) {
       GOOGLE_LOG(WARNING) << "ruby_package option should be in the form of:"
                           << " 'A::B::C' and not 'A.B.C'";
     }


### PR DESCRIPTION
After https://github.com/protocolbuffers/protobuf/pull/5735, something like

```proto
option ruby_package = "SomeTopLevelPb";
```

leads to the following warning with false description:

```
[libprotobuf WARNING ../../../../../src/google/protobuf/compiler/ruby/ruby_generator.cc:417] ruby_package option should be in the form of: 'A::B::C' and not 'A.B.C'
```

This patch suppresses the warning as this warning is not helpful in this case.