### PR TITLE
Fix #6174: Add parentheses around min/max methods

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_enum.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_enum.cc
@@ -125,9 +125,9 @@ void EnumGenerator::GenerateDefinition(io::Printer* printer) {
     if (descriptor_->value_count() > 0) format(",\n");
     format(
         "$classname$_$prefix$INT_MIN_SENTINEL_DO_NOT_USE_ = "
-        "std::numeric_limits<$int32$>::min(),\n"
+        "(std::numeric_limits<$int32$>::min)(),\n"
         "$classname$_$prefix$INT_MAX_SENTINEL_DO_NOT_USE_ = "
-        "std::numeric_limits<$int32$>::max()");
+        "(std::numeric_limits<$int32$>::max)()");
   }
 
   format.Outdent();


### PR DESCRIPTION
Compiling protoc generated code on Windows usually leads to errors because of clash between min/max macros defined in Windows SDK headers and the std:: min/max methods.

Generated protobuf code will include parentheses around min and max methods (which are used in enums) to fix this.

Fixes #6174

PS: It's not so easy for consumers of protobuf code to just define `NOMINMAX` to get rid of this issue as this will cause a lot of Windows code to not compile correctly.

C++
Release Notes: No