### PR TITLE
Add compile-time tests for RTTI to port_def.inc

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -308,6 +308,15 @@
 
 #if defined(GOOGLE_PROTOBUF_NO_RTTI) && GOOGLE_PROTOBUF_NO_RTTI
 #define PROTOBUF_RTTI 0
+#elif defined(__has_feature)
+// https://clang.llvm.org/docs/LanguageExtensions.html#has-feature-and-has-extension
+#define PROTOBUF_RTTI __has_feature(cxx_rtti)
+#elif !defined(__cxx_rtti) && __cplusplus >= 199711L
+// https://en.cppreference.com/w/User:D41D8CD98F/feature_testing_macros#C.2B.2B98
+#define PROTOBUF_RTTI 0
+#elif defined(defined(__GNUC__)) && !defined(__GXX_RTTI)
+# https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
+#define PROTOBUF_RTTI 0
 #else
 #define PROTOBUF_RTTI 1
 #endif

--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -311,7 +311,7 @@
 #elif defined(__has_feature)
 // https://clang.llvm.org/docs/LanguageExtensions.html#has-feature-and-has-extension
 #define PROTOBUF_RTTI __has_feature(cxx_rtti)
-#elif !defined(__cxx_rtti) && __cplusplus >= 199711L
+#elif !defined(__cxx_rtti)
 // https://en.cppreference.com/w/User:D41D8CD98F/feature_testing_macros#C.2B.2B98
 #define PROTOBUF_RTTI 0
 #elif defined(__GNUC__) && !defined(__GXX_RTTI)

--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -314,7 +314,7 @@
 #elif !defined(__cxx_rtti) && __cplusplus >= 199711L
 // https://en.cppreference.com/w/User:D41D8CD98F/feature_testing_macros#C.2B.2B98
 #define PROTOBUF_RTTI 0
-#elif defined(defined(__GNUC__)) && !defined(__GXX_RTTI)
+#elif defined(__GNUC__) && !defined(__GXX_RTTI)
 # https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
 #define PROTOBUF_RTTI 0
 #else


### PR DESCRIPTION
This eliminates an ODR violation where users compile and install
Protobuf's C++ runtime without RTTI but do not define
GOOGLE_PROTOBUF_NO_RTTI when compiling their project with
the generated code.