### PR TITLE
Remove unnecessary branch from ReadTag

### DIFF
--- a/csharp/src/Google.Protobuf.Test/IssuesTest.cs
+++ b/csharp/src/Google.Protobuf.Test/IssuesTest.cs
@@ -33,6 +33,7 @@
 using Google.Protobuf.Reflection;
 using UnitTest.Issues.TestProtos;
 using NUnit.Framework;
+using System.IO;
 using static UnitTest.Issues.TestProtos.OneofMerging.Types;
 
 namespace Google.Protobuf
@@ -89,6 +90,26 @@ namespace Google.Protobuf
             var merged = message1.Clone();
             merged.MergeFrom(message2);
             Assert.AreEqual(expected, merged);
+        }
+
+        // See https://github.com/protocolbuffers/protobuf/pull/7289
+        [Test]
+        public void CodedInputStream_LimitReachedRightAfterTag()
+        {
+            MemoryStream ms = new MemoryStream();
+            var cos = new CodedOutputStream(ms);
+            cos.WriteTag(11, WireFormat.WireType.Varint);
+            Assert.AreEqual(1, cos.Position);
+            cos.WriteString("some extra padding");  // ensure is currentLimit distinct from the end of the buffer.
+            cos.Flush();
+
+            var cis = new CodedInputStream(ms.ToArray());
+            cis.PushLimit(1);  // make sure we reach the limit right after reading the tag.
+
+            // we still must read the tag correctly, even though the tag is at the very end of our limited input
+            // (which is a corner case and will most likely result in an error when trying to read value of the field
+            // decribed by this tag, but it would be a logical error not to read the tag that's actually present).
+            cis.AssertNextTag(WireFormat.MakeTag(11, WireFormat.WireType.Varint));
         }
     }
 }

--- a/csharp/src/Google.Protobuf.Test/IssuesTest.cs
+++ b/csharp/src/Google.Protobuf.Test/IssuesTest.cs
@@ -92,7 +92,7 @@ namespace Google.Protobuf
             Assert.AreEqual(expected, merged);
         }
 
-        // See https://github.com/protocolbuffers/protobuf/pull/7289
+        // Check that a tag immediately followed by end of limit can still be read.
         [Test]
         public void CodedInputStream_LimitReachedRightAfterTag()
         {
@@ -109,6 +109,7 @@ namespace Google.Protobuf
             // we still must read the tag correctly, even though the tag is at the very end of our limited input
             // (which is a corner case and will most likely result in an error when trying to read value of the field
             // decribed by this tag, but it would be a logical error not to read the tag that's actually present).
+            // See https://github.com/protocolbuffers/protobuf/pull/7289
             cis.AssertNextTag(WireFormat.MakeTag(11, WireFormat.WireType.Varint));
         }
     }

--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -395,10 +395,6 @@ namespace Google.Protobuf
                 // If we actually read a tag with a field of 0, that's not a valid tag.
                 throw InvalidProtocolBufferException.InvalidTag();
             }
-            if (ReachedLimit)
-            {
-                return 0;
-            }
             return lastTag;
         }
 


### PR DESCRIPTION
I found this when doing some refactorings to how parsing code works.

The purpose of the following snipped at the end of CodedInputStream.ReadTag is unclear.
I don't see a reason why this would be necessary and it actually seems wrong.
- What it does is that if we just read a tag that that is immediately followed by the limit of the stream (but the tag itself is still readable just fine) we will artificially return a tag of 0 and there seems to be no reason we we would want that
- this also potentially affects performance (one extra check after reading a tag).
- if I remove the check, the tests still seem to be passing.
```
if (ReachedLimit)
{
    return 0;
}
```

The snippet was by #5183
https://github.com/protocolbuffers/protobuf/commit/6f73c509365fcb9bca614f31d0d1234ff1323b58#diff-1d948236189c1eb142de5ed1ed631a40R386
