### PR TITLE
Fix compile error on GHS from using __has_cpp_attribute with clang::reinitializes

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -242,7 +242,7 @@
 #endif
 #endif
 
-#if defined(__has_cpp_attribute)
+#if defined(__clang__) && defined(__has_cpp_attribute)
 #if __has_cpp_attribute(clang::reinitializes)
 #define PROTOBUF_ATTRIBUTE_REINITIALIZES [[clang::reinitializes]]
 #endif


### PR DESCRIPTION
clang:: prefixed attributes are not supported on GHS compiler, even when it supports __has_cpp_attribute.  This change only checks for clang::reinitializes if we're compiling on clang.