### PR TITLE
Fix generated pc.h files name collision with winsock2.h (#6683)

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_enum.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_enum.cc
@@ -125,9 +125,9 @@ void EnumGenerator::GenerateDefinition(io::Printer* printer) {
     if (descriptor_->value_count() > 0) format(",\n");
     format(
         "$classname$_$prefix$INT_MIN_SENTINEL_DO_NOT_USE_ = "
-        "std::numeric_limits<$int32$>::min(),\n"
+        "(std::numeric_limits<$int32$>::min)(),\n"
         "$classname$_$prefix$INT_MAX_SENTINEL_DO_NOT_USE_ = "
-        "std::numeric_limits<$int32$>::max()");
+        "(std::numeric_limits<$int32$>::max)()");
   }
 
   format.Outdent();


### PR DESCRIPTION
 Fixed name collisions between `winsock2.h` (and `windows.h`) min and max macros and `std::numeric_limits<uint32_t>::max/min` generated for protobuf enums.

#6683 