### PR TITLE
Bazel: Discontinue JDK 7 compatibility support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -248,7 +248,6 @@ csharp_EXTRA_DIST=                                                           \
   csharp/src/Google.Protobuf/UnknownFieldSet.cs
 
 java_EXTRA_DIST=                                                                   \
-  java/BUILD                                                                       \
   java/README.md                                                                   \
   java/bom/pom.xml                                                                 \
   java/core/BUILD                                                                  \

--- a/java/BUILD
+++ b/java/BUILD
@@ -1,9 +1,0 @@
-config_setting(
-    name = "jdk9",
-    values = {
-        "java_toolchain": "@bazel_tools//tools/jdk:toolchain_jdk9",
-    },
-    visibility = [
-        "//java:__subpackages__",
-    ],
-)

--- a/java/core/BUILD
+++ b/java/core/BUILD
@@ -91,19 +91,10 @@ LITE_SRCS = [
     "src/main/java/com/google/protobuf/Writer.java",
 ]
 
-javacopts = select({
-    "//java:jdk9": ["--add-modules=jdk.unsupported"],
-    "//conditions:default": [
-        "-source 7",
-        "-target 7",
-    ],
-})
-
 # Should be used as `//java/lite`.
 java_library(
     name = "lite",
     srcs = LITE_SRCS,
-    javacopts = javacopts,
     visibility = [
         "//java/lite:__pkg__",
     ],
@@ -119,7 +110,6 @@ java_library(
     ) + [
         "//:gen_well_known_protos_java",
     ],
-    javacopts = javacopts,
     visibility = ["//visibility:public"],
     exports = [
         "//java/lite",


### PR DESCRIPTION
The primary reason to drop that compatibility is because Bazel is
adding unconditionally -parameters option that is not compatible
with JDK 7. This pollutes the build log with annoying warnings:

  warning: -parameters is not supported for target value 1.7. Use 1.8 or later.

Second reason is that nobody in the wild relies on JDK 7 any more
because it was discontinued years ago.

Test Plan:

Build :protobuf_java and confirm, that there are no warnings any more
and that major byte version 52 is produced, that corresponds to Java 8:

  $ bazel build protobuf_java
  $ javap -v -cp bazel-bin/java/core/libcore.jar com.google.protobuf.Any | grep major
  major version: 52