### PR TITLE
Allocated Cloudstate protobuf extensions

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -232,3 +232,7 @@ with info about your project (name and website) so we can add an entry for you.
 1. grpc-graphql-gateway
    * Website: https://github.com/ysugimoto/grpc-graphql-gateway
    * Extensions: 1079
+
+1. Cloudstate
+   * Website: https://cloudstate.io
+   * Extensions: 1080-1084


### PR DESCRIPTION
Note, I've selected 1080 assuming #7308 gets merged first, which registers 1079.

I've requested a block of 5 extension numbers. We already have two concrete extensions that we need ids for. Our project is under active development and we can imagine a number of other extensions that we will want in future, so we thought we'd start by registering a block of 5, instead of raising a new PR here each time we need a new one. See [here](https://github.com/cloudstateio/cloudstate/issues/20) for discussion on that.