### PR TITLE
[c++] Clean line endings before comparing in test case DynamicMessage. (#5136)

### DIFF
--- a/src/google/protobuf/map_test.cc
+++ b/src/google/protobuf/map_test.cc
@@ -3267,6 +3267,7 @@ TEST(TextFormatMapTest, DynamicMessage) {
       File::GetContents(TestUtil::GetTestDataPath("net/proto2/internal/"
                                                   "testdata/map_test_data.txt"),
                         &expected_text, true));
+  CleanStringLineEndings(&expected_text, false);
 
   EXPECT_EQ(message->DebugString(), expected_text);
 }


### PR DESCRIPTION
Unit test case `TextFormatMapTest.DynamicMessage` is failing due to the line endings when checking out on Windows with `autocrlf = true` settings in Git. Git will automatically convert the `src/google/protobuf/testdata/map_test_data.txt` to CRLF line endings. 

However, in the code the generated data to compare against expected data (read directly from map_test_data.txt) uses LF line endings, leading to the error.

This solution cleans line endings in the read string.

fixes #5136 