### PR TITLE
Refactor some Protobuf C# microbenchmarks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,15 +85,15 @@ csharp_EXTRA_DIST=                                                           \
   csharp/src/AddressBook/ListPeople.cs                                       \
   csharp/src/AddressBook/Program.cs                                          \
   csharp/src/AddressBook/SampleUsage.cs                                      \
+  csharp/src/Google.Protobuf.Benchmarks/BenchmarkDatasetConfig.cs            \
   csharp/src/Google.Protobuf.Benchmarks/BenchmarkMessage1Proto3.cs           \
   csharp/src/Google.Protobuf.Benchmarks/Benchmarks.cs                        \
   csharp/src/Google.Protobuf.Benchmarks/Google.Protobuf.Benchmarks.csproj    \
+  csharp/src/Google.Protobuf.Benchmarks/GoogleMessageBenchmark.cs            \
   csharp/src/Google.Protobuf.Benchmarks/ParseRawPrimitivesBenchmark.cs       \
+  csharp/src/Google.Protobuf.Benchmarks/ParseMessagesBenchmark.cs            \
   csharp/src/Google.Protobuf.Benchmarks/Program.cs                           \
-  csharp/src/Google.Protobuf.Benchmarks/SerializationBenchmark.cs            \
-  csharp/src/Google.Protobuf.Benchmarks/SerializationConfig.cs               \
   csharp/src/Google.Protobuf.Benchmarks/wrapper_benchmark_messages.proto     \
-  csharp/src/Google.Protobuf.Benchmarks/WrapperBenchmark.cs                  \
   csharp/src/Google.Protobuf.Benchmarks/WrapperBenchmarkMessages.cs          \
   csharp/src/Google.Protobuf.Conformance/Conformance.cs                      \
   csharp/src/Google.Protobuf.Conformance/Google.Protobuf.Conformance.csproj  \


### PR DESCRIPTION
Preparations for https://github.com/protocolbuffers/protobuf/pull/7351.

- make it clearer that the original "SerializationBenchmark" should only be used with standard language-agnostic benchmarking datasets.

- turn WrapperBenchmark into a general-purpose benchmark for benchmarking parsing speed of various messages.