### PR TITLE
Ruby: encode repeated field in packed format if desired

### DIFF
--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -521,5 +521,15 @@ module BasicTest
       assert_raise(FrozenErrorType) { m.map_string_int32.delete('a') }
       assert_raise(FrozenErrorType) { m.map_string_int32.clear }
     end
+
+    def test_packed_unpacked
+      m = proto_module::PackedUnpackedMessage.new
+      m.packed_repeated_int32.replace([42, 84, 300])
+      assert_equal proto_module::PackedUnpackedMessage.encode(m), "\x0A\x04\x2A\x54\xAC\x02".b
+
+      m = proto_module::PackedUnpackedMessage.new
+      m.repeated_int32.replace([42, 84, 300])
+      assert_equal proto_module::PackedUnpackedMessage.encode(m), "\x58\x2A\x58\x54\x58\xAC\x02".b
+    end
   end
 end

--- a/ruby/tests/basic_proto2.rb
+++ b/ruby/tests/basic_proto2.rb
@@ -260,5 +260,15 @@ module BasicTestProto2
       assert_equal "tests/basic_test_proto2.proto", file_descriptor.name
       assert_equal :proto2, file_descriptor.syntax
     end
+
+    def test_packed_unpacked
+      m = proto_module::PackedUnpackedMessage.new
+      m.packed_repeated_int32.replace([42, 84, 300])
+      assert_equal proto_module::PackedUnpackedMessage.encode(m), "\x0A\x04\x2A\x54\xAC\x02".b
+
+      m = proto_module::PackedUnpackedMessage.new
+      m.repeated_int32.replace([42, 84, 300])
+      assert_equal proto_module::PackedUnpackedMessage.encode(m), "\x58\x2A\x58\x54\x58\xAC\x02".b
+    end
   end
 end

--- a/ruby/tests/basic_test.proto
+++ b/ruby/tests/basic_test.proto
@@ -192,3 +192,23 @@ message MyStruct {
   string string = 1;
   google.protobuf.Struct struct = 2;
 }
+
+message PackedUnpackedMessage {
+  repeated int32 packed_repeated_int32 = 1;
+  repeated int64 packed_repeated_int64 = 2;
+  repeated uint32 packed_repeated_uint32 = 3;
+  repeated uint64 packed_repeated_uint64 = 4;
+  repeated bool packed_repeated_bool = 5;
+  repeated float packed_repeated_float = 6;
+  repeated double packed_repeated_double = 7;
+  repeated TestEnum packed_repeated_enum = 8;
+
+  repeated int32 repeated_int32 = 11 [packed=false];
+  repeated int64 repeated_int64 = 12 [packed=false];
+  repeated uint32 repeated_uint32 = 13 [packed=false];
+  repeated uint64 repeated_uint64 = 14 [packed=false];
+  repeated bool repeated_bool = 15 [packed=false];
+  repeated float repeated_float = 16 [packed=false];
+  repeated double repeated_double = 17 [packed=false];
+  repeated TestEnum repeated_enum = 18 [packed=false];
+}

--- a/ruby/tests/basic_test_proto2.proto
+++ b/ruby/tests/basic_test_proto2.proto
@@ -187,3 +187,23 @@ message MyStruct {
   optional string string = 1;
   optional google.protobuf.Struct struct = 2;
 }
+
+message PackedUnpackedMessage {
+  repeated int32 packed_repeated_int32 = 1 [packed=true];
+  repeated int64 packed_repeated_int64 = 2 [packed=true];
+  repeated uint32 packed_repeated_uint32 = 3 [packed=true];
+  repeated uint64 packed_repeated_uint64 = 4 [packed=true];
+  repeated bool packed_repeated_bool = 5 [packed=true];
+  repeated float packed_repeated_float = 6 [packed=true];
+  repeated double packed_repeated_double = 7 [packed=true];
+  repeated TestEnum packed_repeated_enum = 8 [packed=true];
+
+  repeated int32 repeated_int32 = 11;
+  repeated int64 repeated_int64 = 12;
+  repeated uint32 repeated_uint32 = 13;
+  repeated uint64 repeated_uint64 = 14;
+  repeated bool repeated_bool = 15;
+  repeated float repeated_float = 16;
+  repeated double repeated_double = 17;
+  repeated TestEnum repeated_enum = 18;
+}

--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -216,6 +216,11 @@ void GenerateField(const FieldDescriptor* field, io::Printer* printer) {
                      DefaultValueForField(field));
     }
 
+    if (field->is_packable()) {
+      printer->Print(", packed: $packed$", "packed",
+                     field->is_packed() ? "true" : "false");
+    }
+
     printer->Print("\n");
   }
 }


### PR DESCRIPTION
This patch adds `packed: true` / `packed: false` options to `repeated` descriptor declaration, and uses that information when encoding packable fields.

```ruby
    add_message "basic_test.TestMessage" do
      optional :optional_int32, :int32, 1
      optional :optional_int64, :int64, 2
      optional :optional_uint32, :uint32, 3
      optional :optional_uint64, :uint64, 4
      optional :optional_bool, :bool, 5
      optional :optional_float, :float, 6
      optional :optional_double, :double, 7
      optional :optional_string, :string, 8
      optional :optional_bytes, :bytes, 9
      optional :optional_msg, :message, 10, "basic_test.TestMessage2"
      optional :optional_enum, :enum, 11, "basic_test.TestEnum"
      repeated :repeated_int32, :int32, 12, packed: true
      repeated :repeated_int64, :int64, 13, packed: true
      repeated :repeated_uint32, :uint32, 14, packed: true
      repeated :repeated_uint64, :uint64, 15, packed: true
      repeated :repeated_bool, :bool, 16, packed: true
      repeated :repeated_float, :float, 17, packed: true
      repeated :repeated_double, :double, 18, packed: true
      repeated :repeated_string, :string, 19
      repeated :repeated_bytes, :bytes, 20
      repeated :repeated_msg, :message, 21, "basic_test.TestMessage2"
      repeated :repeated_enum, :enum, 22, "basic_test.TestEnum", packed: true
    end
```

TODO: implementation for JRuby