### PR TITLE
Add Ruby tests for oneof cases.

### DIFF
--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -128,6 +128,7 @@ module BasicTest
       m.a = "foo"
       assert_equal "foo", m.a
       assert m.has_my_oneof?
+      assert_equal :a, m.my_oneof
       m.clear_a
       assert !m.has_my_oneof?
 

--- a/ruby/tests/basic_proto2.rb
+++ b/ruby/tests/basic_proto2.rb
@@ -73,10 +73,11 @@ module BasicTestProto2
       m = OneofMessage.new
       assert !m.has_my_oneof?
       m.a = "foo"
+      assert m.has_my_oneof?
+      assert_equal :a, m.my_oneof
       assert m.has_a?
       assert OneofMessage.descriptor.lookup('a').has?(m)
       assert_equal "foo", m.a
-      assert m.has_my_oneof?
       assert !m.has_b?
       assert !OneofMessage.descriptor.lookup('b').has?(m)
       assert !m.has_c?


### PR DESCRIPTION
In Ruby, the oneof case returns a symbol with the name of the field that is set. These were not previously tested.