### PR TITLE
Test in Ruby 2.7

### DIFF
--- a/kokoro/linux/dockerfile/test/ruby/Dockerfile
+++ b/kokoro/linux/dockerfile/test/ruby/Dockerfile
@@ -32,6 +32,7 @@ RUN /bin/bash -l -c "rvm install 2.3.8"
 RUN /bin/bash -l -c "rvm install 2.4.5"
 RUN /bin/bash -l -c "rvm install 2.5.1"
 RUN /bin/bash -l -c "rvm install 2.6.0"
+RUN /bin/bash -l -c "rvm install 2.7.0"
 
 RUN /bin/bash -l -c "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"

--- a/kokoro/linux/ruby27/build.sh
+++ b/kokoro/linux/ruby27/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# This is the top-level script we give to Kokoro as the entry point for
+# running the "pull request" project:
+#
+# This script selects a specific Dockerfile (for building a Docker image) and
+# a script to run inside that image.  Then we delegate to the general
+# build_and_run_docker.sh script.
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+export DOCKERHUB_ORGANIZATION=protobuftesting
+export DOCKERFILE_DIR=kokoro/linux/dockerfile/test/ruby
+export DOCKER_RUN_SCRIPT=kokoro/linux/pull_request_in_docker.sh
+export OUTPUT_DIR=testoutput
+export TEST_SET="ruby27"
+./kokoro/linux/build_and_run_docker.sh

--- a/kokoro/linux/ruby27/continuous.cfg
+++ b/kokoro/linux/ruby27/continuous.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/ruby27/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/linux/ruby27/presubmit.cfg
+++ b/kokoro/linux/ruby27/presubmit.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/ruby27/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/macos/ruby27/build.sh
+++ b/kokoro/macos/ruby27/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh ruby27

--- a/kokoro/macos/ruby27/continuous.cfg
+++ b/kokoro/macos/ruby27/continuous.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/ruby27/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/ruby27/presubmit.cfg
+++ b/kokoro/macos/ruby27/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/ruby27/build.sh"
+timeout_mins: 1440

--- a/ruby/compatibility_tests/v3.0.0/tests/repeated_field_test.rb
+++ b/ruby/compatibility_tests/v3.0.0/tests/repeated_field_test.rb
@@ -20,6 +20,7 @@ class RepeatedFieldTest < Test::Unit::TestCase
       :iter_for_each_with_index, :dimensions, :copy_data, :copy_data_simple,
       :nitems, :iter_for_reverse_each, :indexes, :append, :prepend]
     arr_methods -= [:union, :difference, :filter!]
+    arr_methods -= [:intersection, :deconstruct] # ruby 2.7 methods we can ignore
     arr_methods.each do |method_name|
       assert m.repeated_string.respond_to?(method_name) == true, "does not respond to #{method_name}"
     end

--- a/ruby/tests/gc_test.rb
+++ b/ruby/tests/gc_test.rb
@@ -4,7 +4,9 @@
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__)))
 
 old_gc = GC.stress
-GC.stress = 0x01 | 0x04
+# Ruby 2.7.0 - 2.7.1 has a GC bug in its parser, so turn off stress for now
+# See https://bugs.ruby-lang.org/issues/16807
+GC.stress = 0x01 | 0x04 unless RUBY_VERSION.match?(/^2\.7\./)
 require 'generated_code_pb'
 require 'generated_code_proto2_pb'
 GC.stress = old_gc

--- a/ruby/travis-test.sh
+++ b/ruby/travis-test.sh
@@ -16,7 +16,7 @@ test_version() {
        git clean -f && \
        gem install bundler && bundle && \
        rake test"
-  elif [ "$version" == "ruby-2.6.0" ] ; then
+  elif [ "$version" == "ruby-2.6.0" -o "$version" == "ruby-2.7.0" ] ; then
     bash --login -c \
       "rvm install $version && rvm use $version && \
        which ruby && \

--- a/tests.sh
+++ b/tests.sh
@@ -919,6 +919,7 @@ Usage: $0 { cpp |
             ruby24 |
             ruby25 |
             ruby26 |
+            ruby27 |
             jruby |
             ruby_all |
             php5.5   |


### PR DESCRIPTION
Split from #7027. This PR focuses on testing on Ruby 2.7, while #7027 focuses on building artifacts for Ruby 2.7.

I guess someone needs to run `kokoro/linux/dockerfile/push_testing_images.sh` before running CI, because I modified a dockerfile in `kokoro/linux/dockerfile/test`?