### PR TITLE
Improve performance of parsing repeated fixed sized types

### DIFF
--- a/csharp/src/Google.Protobuf.Benchmarks/ParseMessagesBenchmark.cs
+++ b/csharp/src/Google.Protobuf.Benchmarks/ParseMessagesBenchmark.cs
@@ -37,6 +37,7 @@ using System.IO;
 using System.Linq;
 using System.Buffers;
 using Google.Protobuf.WellKnownTypes;
+using Benchmarks.Proto3;
 
 namespace Google.Protobuf.Benchmarks
 {
@@ -50,6 +51,7 @@ namespace Google.Protobuf.Benchmarks
 
         SubTest manyWrapperFieldsTest = new SubTest(CreateManyWrapperFieldsMessage(), ManyWrapperFieldsMessage.Parser, () => new ManyWrapperFieldsMessage(), MaxMessages);
         SubTest manyPrimitiveFieldsTest = new SubTest(CreateManyPrimitiveFieldsMessage(), ManyPrimitiveFieldsMessage.Parser, () => new ManyPrimitiveFieldsMessage(), MaxMessages);
+        SubTest repeatedFieldTest = new SubTest(CreateRepeatedFieldMessage(), GoogleMessage1.Parser, () => new GoogleMessage1(), MaxMessages);
         SubTest emptyMessageTest = new SubTest(new Empty(), Empty.Parser, () => new Empty(), MaxMessages);
 
         public IEnumerable<int> MessageCountValues => new[] { 10, 100 };
@@ -81,6 +83,18 @@ namespace Google.Protobuf.Benchmarks
         public IMessage ManyPrimitiveFieldsMessage_ParseFromReadOnlySequence()
         {
             return manyPrimitiveFieldsTest.ParseFromReadOnlySequence();
+        }
+
+        [Benchmark]
+        public IMessage RepeatedFieldMessage_ParseFromByteArray()
+        {
+            return repeatedFieldTest.ParseFromByteArray();
+        }
+
+        [Benchmark]
+        public IMessage RepeatedFieldMessage_ParseFromReadOnlySequence()
+        {
+            return repeatedFieldTest.ParseFromReadOnlySequence();
         }
 
         [Benchmark]
@@ -123,6 +137,20 @@ namespace Google.Protobuf.Benchmarks
             manyPrimitiveFieldsTest.ParseDelimitedMessagesFromReadOnlySequence(messageCount);
         }
 
+        [Benchmark]
+        [ArgumentsSource(nameof(MessageCountValues))]
+        public void RepeatedFieldMessage_ParseDelimitedMessagesFromByteArray(int messageCount)
+        {
+            repeatedFieldTest.ParseDelimitedMessagesFromByteArray(messageCount);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(MessageCountValues))]
+        public void RepeatedFieldMessage_ParseDelimitedMessagesFromReadOnlySequence(int messageCount)
+        {
+            repeatedFieldTest.ParseDelimitedMessagesFromReadOnlySequence(messageCount);
+        }
+
         private static ManyWrapperFieldsMessage CreateManyWrapperFieldsMessage()
         {
             // Example data match data of an internal benchmarks
@@ -155,6 +183,17 @@ namespace Google.Protobuf.Benchmarks
                 DoubleField7 = 234,
                 DoubleField50 = 2.45
             };
+        }
+
+        private static GoogleMessage1 CreateRepeatedFieldMessage()
+        {
+            // Message with a repeated fixed length item collection
+            var message = new GoogleMessage1();
+            for (ulong i = 0; i < 1000; i++)
+            {
+                message.Field5.Add(i);
+            }
+            return message;
         }
 
         private class SubTest

--- a/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
@@ -595,6 +595,95 @@ namespace Google.Protobuf.Collections
             Assert.AreEqual(((SampleEnum)(-5)), values[5]);
         }
 
+        [Test]
+        public void TestPackedRepeatedFieldCollectionNonDivisibleLength()
+        {
+            uint tag = WireFormat.MakeTag(10, WireFormat.WireType.LengthDelimited);
+            var codec = FieldCodec.ForFixed32(tag);
+            var stream = new MemoryStream();
+            var output = new CodedOutputStream(stream);
+            output.WriteTag(tag);
+            output.WriteString("A long string");
+            output.WriteTag(codec.Tag);
+            output.WriteRawVarint32((uint)codec.FixedSize - 1); // Length not divisible by FixedSize
+            output.WriteFixed32(uint.MaxValue);
+            output.Flush();
+            stream.Position = 0;
+
+            var input = new CodedInputStream(stream);
+            input.ReadTag();
+            input.ReadString();
+            input.ReadTag();
+            var field = new RepeatedField<uint>();
+            Assert.Throws<InvalidProtocolBufferException>(() => field.AddEntriesFrom(input, codec));
+
+            // Collection was not pre-initialized
+            Assert.AreEqual(0, field.Count);
+        }
+
+        [Test]
+        public void TestPackedRepeatedFieldCollectionNotAllocatedWhenLengthExceedsBuffer()
+        {
+            uint tag = WireFormat.MakeTag(10, WireFormat.WireType.LengthDelimited);
+            var codec = FieldCodec.ForFixed32(tag);
+            var stream = new MemoryStream();
+            var output = new CodedOutputStream(stream);
+            output.WriteTag(tag);
+            output.WriteString("A long string");
+            output.WriteTag(codec.Tag);
+            output.WriteRawVarint32((uint)codec.FixedSize);
+            // Note that there is no content for the packed field.
+            // The field length exceeds the remaining length of content.
+            output.Flush();
+            stream.Position = 0;
+
+            var input = new CodedInputStream(stream);
+            input.ReadTag();
+            input.ReadString();
+            input.ReadTag();
+            var field = new RepeatedField<uint>();
+            Assert.Throws<InvalidProtocolBufferException>(() => field.AddEntriesFrom(input, codec));
+
+            // Collection was not pre-initialized
+            Assert.AreEqual(0, field.Count);
+        }
+
+        [Test]
+        public void TestPackedRepeatedFieldCollectionNotAllocatedWhenLengthExceedsRemainingData()
+        {
+            uint tag = WireFormat.MakeTag(10, WireFormat.WireType.LengthDelimited);
+            var codec = FieldCodec.ForFixed32(tag);
+            var stream = new MemoryStream();
+            var output = new CodedOutputStream(stream);
+            output.WriteTag(tag);
+            output.WriteString("A long string");
+            output.WriteTag(codec.Tag);
+            output.WriteRawVarint32((uint)codec.FixedSize);
+            // Note that there is no content for the packed field.
+            // The field length exceeds the remaining length of the buffer.
+            output.Flush();
+            stream.Position = 0;
+
+            var sequence = ReadOnlySequenceFactory.CreateWithContent(stream.ToArray());
+            ParseContext.Initialize(sequence, out ParseContext ctx);
+
+            ctx.ReadTag();
+            ctx.ReadString();
+            ctx.ReadTag();
+            var field = new RepeatedField<uint>();
+            try
+            {
+                field.AddEntriesFrom(ref ctx, codec);
+                Assert.Fail();
+            }
+            catch (InvalidProtocolBufferException)
+            {
+            }
+
+            // Collection was not pre-initialized
+            Assert.AreEqual(0, field.Count);
+        }
+
         // Fairly perfunctory tests for the non-generic IList implementation
         [Test]
         public void IList_Indexer()

--- a/csharp/src/Google.Protobuf.Test/ReadOnlySequenceFactory.cs
+++ b/csharp/src/Google.Protobuf.Test/ReadOnlySequenceFactory.cs
@@ -50,9 +50,9 @@ namespace Google.Protobuf
             while (currentIndex < data.Length)
             {
                 var segment = new List<byte>();
-                for (; currentIndex < Math.Min(currentIndex + segmentSize, data.Length); currentIndex++)
+                while (segment.Count < segmentSize && currentIndex < data.Length)
                 {
-                    segment.Add(data[currentIndex]);
+                    segment.Add(data[currentIndex++]);
                 }
                 segments.Add(segment.ToArray());
                 segments.Add(new byte[0]);


### PR DESCRIPTION
Based on https://github.com/protocolbuffers/protobuf/pull/7351. Will rebase on master once it is merged.

Actual changes: https://github.com/JamesNK/protobuf/commit/d0d576e316a0944bc6eb2f38b371ccc2ddce15c8

@jtattermusch 

Before:
```
|                                                          Method | messageCount |        Mean |      Error |     StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|---------------------------------------------------------------- |------------- |------------:|-----------:|-----------:|------------:|------------:|------------:|--------------------:|
|                         RepeatedFieldMessage_ParseFromByteArray |            ? |    13.44 us |  0.1718 us |  0.1523 us |     21.4996 |           - |           - |            16.54 KB |
|                  RepeatedFieldMessage_ParseFromReadOnlySequence |            ? |    13.11 us |  0.0688 us |  0.0610 us |     21.2708 |           - |           - |            16.36 KB |
|        RepeatedFieldMessage_ParseDelimitedMessagesFromByteArray |           10 |   133.31 us |  1.8114 us |  1.6944 us |    212.6465 |           - |           - |           163.77 KB |
| RepeatedFieldMessage_ParseDelimitedMessagesFromReadOnlySequence |           10 |   126.78 us |  0.8992 us |  0.7971 us |    212.6465 |           - |           - |           163.59 KB |
|        RepeatedFieldMessage_ParseDelimitedMessagesFromByteArray |          100 | 1,332.55 us | 28.6365 us | 25.3855 us |   2126.9531 |           - |           - |          1636.12 KB |
| RepeatedFieldMessage_ParseDelimitedMessagesFromReadOnlySequence |          100 | 1,273.07 us | 13.5838 us | 10.6054 us |   2126.9531 |           - |           - |          1635.94 KB |
```
After:
```
|                                                          Method | messageCount |       Mean |      Error |     StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|---------------------------------------------------------------- |------------- |-----------:|-----------:|-----------:|------------:|------------:|------------:|--------------------:|
|                         RepeatedFieldMessage_ParseFromByteArray |            ? |   6.127 us |  0.0373 us |  0.0330 us |     10.6354 |           - |           - |             8.25 KB |
|                  RepeatedFieldMessage_ParseFromReadOnlySequence |            ? |   6.095 us |  0.0695 us |  0.0581 us |     10.4141 |           - |           - |             8.07 KB |
|        RepeatedFieldMessage_ParseDelimitedMessagesFromByteArray |           10 |  60.599 us |  0.5330 us |  0.4725 us |    105.2246 |           - |           - |            80.88 KB |
| RepeatedFieldMessage_ParseDelimitedMessagesFromReadOnlySequence |           10 |  59.789 us |  0.2847 us |  0.2377 us |    104.1260 |           - |           - |             80.7 KB |
|        RepeatedFieldMessage_ParseDelimitedMessagesFromByteArray |          100 | 622.160 us | 12.3938 us | 20.7072 us |   1041.0156 |           - |           - |           807.21 KB |
| RepeatedFieldMessage_ParseDelimitedMessagesFromReadOnlySequence |          100 | 597.545 us |  5.5646 us |  4.9328 us |   1041.0156 |           - |           - |           807.03 KB |
```