### PR TITLE
Suppress gcc override complaint in generated code

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_file.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_file.cc
@@ -1425,6 +1425,14 @@ void FileGenerator::GenerateGlobalStateFunctionDeclarations(
 
 void FileGenerator::GenerateMessageDefinitions(io::Printer* printer) {
   Formatter format(printer, variables_);
+
+  // gcc -Wsuggest-override demands override even with final
+  format(
+    "#ifdef __GNUC__\n"
+    "  #pragma GCC diagnostic push\n"
+    "  #pragma GCC diagnostic ignored \"-Wsuggest-override\"\n"
+    "#endif  // __GNUC__\n");
+
   // Generate class definitions.
   for (int i = 0; i < message_generators_.size(); i++) {
     if (i > 0) {
@@ -1434,6 +1442,12 @@ void FileGenerator::GenerateMessageDefinitions(io::Printer* printer) {
     }
     message_generators_[i]->GenerateClassDefinition(printer);
   }
+
+  format(
+    "\n"
+    "#ifdef __GNUC__\n"
+    "  #pragma GCC diagnostic pop\n"
+    "#endif  // __GNUC__\n");
 }
 
 void FileGenerator::GenerateEnumDefinitions(io::Printer* printer) {


### PR DESCRIPTION
Unfortunately gcc and clang at high warning levels have incompatible requirements about "override" and "final". Gcc -Wsuggest-override issues warnings on members that have only "final", demanding to also see "override". Clang at high warning levels demands at most one of "virtual", "override", and "final". PROTOBUF_FINAL expands to only "final", so compiling protoc-generated files with gcc at high warning levels results in numerous warnings (or warnings-as-errors): "virtual Something* Something::New() const’ can be marked override [-Werror=suggest-override]".

This change follows the example in FileGenerator::GenerateInlineFunctionDefinitions() for suppressing spurious strict-aliasing warnings by adding a #pragma GCC push/pop within which the suggest-override warning is suppressed.