### PR TITLE
bazel: remove workaround of redundant zlib source

### DIFF
--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -46,10 +46,7 @@ cc_library(
         "trees.c",
         "uncompr.c",
         "zutil.c",
-        # Include the un-prefixed headers in srcs to work
-        # around the fact that zlib isn't consistent in its
-        # choice of <> or "" delimiter when including itself.
-    ] + _ZLIB_HEADERS,
+    ],
     hdrs = _ZLIB_PREFIXED_HEADERS,
     copts = select({
         "@bazel_tools//src/conditions:windows": [],


### PR DESCRIPTION
It is no longer the case so we don't need to add headers into src. With the srcs added it break if zlib is used as rules_foreign_cc dependency.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>