### PR TITLE
Support cross-compiling when using the cmake build system.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -37,6 +37,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES Intel)
 endif()
 
 # Options
+if(WITH_PROTOC)
+  set(protobuf_PROTOC_EXE ${WITH_PROTOC} CACHE FILEPATH "Protocol Buffer Compiler executable" FORCE)
+endif()
 option(protobuf_BUILD_TESTS "Build tests" ON)
 option(protobuf_BUILD_CONFORMANCE "Build conformance tests" OFF)
 option(protobuf_BUILD_EXAMPLES "Build examples" OFF)
@@ -58,6 +61,12 @@ mark_as_advanced(protobuf_DEBUG_POSTFIX)
 # User options
 include(protobuf-options.cmake)
 
+# Overrides for option dependencies
+if (protobuf_BUILD_PROTOC_BINARIES OR protobuf_BUILD_TESTS)
+  set(protobuf_BUILD_LIBPROTOC ON)
+else()
+  set(protobuf_BUILD_LIBPROTOC OFF)
+endif ()
 # Path to main configure script
 set(protobuf_CONFIGURE_SCRIPT "../configure.ac")
 
@@ -242,10 +251,28 @@ endif (protobuf_UNICODE)
 
 include(libprotobuf-lite.cmake)
 include(libprotobuf.cmake)
-if (protobuf_BUILD_PROTOC_BINARIES)
+if (protobuf_BUILD_LIBPROTOC)
   include(libprotoc.cmake)
+endif (protobuf_BUILD_LIBPROTOC)
+if (protobuf_BUILD_PROTOC_BINARIES)
   include(protoc.cmake)
+  if (NOT DEFINED protobuf_PROTOC_EXE)
+    set(protobuf_PROTOC_EXE protoc)
+  endif (NOT DEFINED protobuf_PROTOC_EXE)
 endif (protobuf_BUILD_PROTOC_BINARIES)
+
+# Ensure we have a protoc executable if we need one
+if (protobuf_BUILD_TESTS OR protobuf_BUILD_CONFORMANCE OR protobuf_BUILD_EXAMPLES)
+  if (NOT DEFINED protobuf_PROTOC_EXE)
+    find_program(protobuf_PROTOC_EXE protoc)
+    if (NOT protobuf_PROTOC_EXE)
+      message(FATAL "Build requires 'protoc' but binary not found and not building protoc.")
+    endif ()
+  endif ()
+  if(protobuf_VERBOSE)
+    message(STATUS "Using protoc : ${protobuf_PROTOC_EXE}")
+  endif(protobuf_VERBOSE)
+endif ()
 
 if (protobuf_BUILD_TESTS)
   include(tests.cmake)
@@ -262,5 +289,5 @@ if (protobuf_BUILD_EXAMPLES)
 endif (protobuf_BUILD_EXAMPLES)
 
 if(protobuf_VERBOSE)
-    message(STATUS "Protocol Buffers Configuring done")
-endif()
+  message(STATUS "Protocol Buffers Configuring done")
+endif(protobuf_VERBOSE)

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -343,3 +343,23 @@ unique, so there should be no problem with this, but MSVC prints warning
 nevertheless.  So, we disable it.  Unfortunately, this warning will also be
 produced when compiling code which merely uses protocol buffers, meaning you
 may have to disable it in your code too.
+
+Cross-compiling
+===============
+
+When cross-compiling you will need to disable building the tests which are ON
+by default. You can do so by specifying the following flags when configuring
+your build: 
+
+	-Dprotobuf_BUILD_TESTS=OFF
+
+Alternatively you can compile (or download) 'protoc' for your host machine
+prior to configuring your target build. To specify an existing 'protoc' binary
+for your build, specify the following flag:
+
+	-DWITH_PROTOC=<path to your protoc binary>
+
+You can also save compilation time by disabling building 'protoc' for your
+target build:
+
+	-Dprotobuf_BUILD_PROTOC_BINARIES=OFF

--- a/cmake/conformance.cmake
+++ b/cmake/conformance.cmake
@@ -1,8 +1,8 @@
 
 add_custom_command(
   OUTPUT ${protobuf_source_dir}/conformance/conformance.pb.cc
-  DEPENDS protoc ${protobuf_source_dir}/conformance/conformance.proto
-  COMMAND protoc ${protobuf_source_dir}/conformance/conformance.proto
+  DEPENDS ${protobuf_PROTOC_EXE} ${protobuf_source_dir}/conformance/conformance.proto
+  COMMAND ${protobuf_PROTOC_EXE} ${protobuf_source_dir}/conformance/conformance.proto
       --proto_path=${protobuf_source_dir}/conformance
       --cpp_out=${protobuf_source_dir}/conformance
 )
@@ -10,9 +10,9 @@ add_custom_command(
 add_custom_command(
   OUTPUT ${protobuf_source_dir}/src/google/protobuf/test_messages_proto3.pb.cc
          ${protobuf_source_dir}/src/google/protobuf/test_messages_proto2.pb.cc
-  DEPENDS protoc ${protobuf_source_dir}/src/google/protobuf/test_messages_proto3.proto
-          protoc ${protobuf_source_dir}/src/google/protobuf/test_messages_proto2.proto
-  COMMAND protoc ${protobuf_source_dir}/src/google/protobuf/test_messages_proto3.proto
+  DEPENDS ${protobuf_PROTOC_EXE} ${protobuf_source_dir}/src/google/protobuf/test_messages_proto3.proto
+          ${protobuf_PROTOC_EXE} ${protobuf_source_dir}/src/google/protobuf/test_messages_proto2.proto
+  COMMAND ${protobuf_PROTOC_EXE} ${protobuf_source_dir}/src/google/protobuf/test_messages_proto3.proto
                  ${protobuf_source_dir}/src/google/protobuf/test_messages_proto2.proto
       --proto_path=${protobuf_source_dir}/src
       --cpp_out=${protobuf_source_dir}/src

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -90,8 +90,8 @@ macro(compile_proto_file filename)
   get_filename_component(basename ${filename} NAME_WE)
   add_custom_command(
     OUTPUT ${protobuf_source_dir}/src/${dirname}/${basename}.pb.cc
-    DEPENDS protoc ${protobuf_source_dir}/src/${dirname}/${basename}.proto
-    COMMAND protoc ${protobuf_source_dir}/src/${dirname}/${basename}.proto
+    DEPENDS ${protobuf_PROTOC_EXE} ${protobuf_source_dir}/src/${dirname}/${basename}.proto
+    COMMAND ${protobuf_PROTOC_EXE} ${protobuf_source_dir}/src/${dirname}/${basename}.proto
         --proto_path=${protobuf_source_dir}/src
         --cpp_out=${protobuf_source_dir}/src
         --experimental_allow_proto3_optional


### PR DESCRIPTION
Adds the "WITH_PROTOC" definition when configuring a build with cmake, which specifies an existing 'protoc' binary to use.  This is required when building for another target.

"WITH_PROTOC" was chosen to specifically mimick the "--with-protoc" option used when using the standard 'automake' based build system.

Furthermore, 'libprotoc' is now only built if it is actually required, which can save some porting effort.