### PR TITLE
Implement HasPresence for C#

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Reflection/FieldAccessTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Reflection/FieldAccessTest.cs
@@ -98,7 +98,48 @@ namespace Google.Protobuf.Reflection
         }
 
         [Test]
-        public void HasValue_Proto3()
+        public void HasValue_Proto3_Message()
+        {
+            var message = new TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[TestProtos.TestAllTypes.SingleForeignMessageFieldNumber].Accessor;
+            Assert.False(accessor.HasValue(message));
+            message.SingleForeignMessage = new ForeignMessage();
+            Assert.True(accessor.HasValue(message));
+            message.SingleForeignMessage = null;
+            Assert.False(accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto3_Oneof()
+        {
+            TestAllTypes message = new TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[TestProtos.TestAllTypes.OneofStringFieldNumber].Accessor;
+            Assert.False(accessor.HasValue(message));
+            // Even though it's the default value, we still have a value.
+            message.OneofString = "";
+            Assert.True(accessor.HasValue(message));
+            message.OneofString = "hello";
+            Assert.True(accessor.HasValue(message));
+            message.OneofUint32 = 10;
+            Assert.False(accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto3_Primitive_Optional()
+        {
+            var message = new TestProto3Optional();
+            var accessor = ((IMessage) message).Descriptor.Fields[TestProto3Optional.OptionalInt64FieldNumber].Accessor;
+            Assert.IsFalse(accessor.HasValue(message));
+            message.OptionalInt64 = 5L;
+            Assert.IsTrue(accessor.HasValue(message));
+            message.ClearOptionalInt64();
+            Assert.IsFalse(accessor.HasValue(message));
+            message.OptionalInt64 = 0L;
+            Assert.IsTrue(accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto3_Primitive_NotOptional()
         {
             IMessage message = SampleMessages.CreateFullTestAllTypes();
             var fields = message.Descriptor.Fields;
@@ -106,34 +147,61 @@ namespace Google.Protobuf.Reflection
         }
 
         [Test]
-        public void HasValue_Proto3Optional()
+        public void HasValue_Proto3_Repeated()
         {
-            IMessage message = new TestProto3Optional
-            {
-                OptionalInt32 = 0,
-                LazyNestedMessage = new TestProto3Optional.Types.NestedMessage()
-            };
-            var fields = message.Descriptor.Fields;
-            Assert.IsFalse(fields[TestProto3Optional.OptionalInt64FieldNumber].Accessor.HasValue(message));
-            Assert.IsFalse(fields[TestProto3Optional.OptionalNestedMessageFieldNumber].Accessor.HasValue(message));
-            Assert.IsTrue(fields[TestProto3Optional.LazyNestedMessageFieldNumber].Accessor.HasValue(message));
-            Assert.IsTrue(fields[TestProto3Optional.OptionalInt32FieldNumber].Accessor.HasValue(message));
+            var message = new TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[TestProtos.TestAllTypes.RepeatedBoolFieldNumber].Accessor;
+            Assert.Throws<InvalidOperationException>(() => accessor.HasValue(message));
         }
 
         [Test]
-        public void HasValue()
+        public void HasValue_Proto2_Primitive()
         {
-            IMessage message = new Proto2.TestAllTypes();
-            var fields = message.Descriptor.Fields;
-            var accessor = fields[Proto2.TestAllTypes.OptionalBoolFieldNumber].Accessor;
+            var message = new Proto2.TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[Proto2.TestAllTypes.OptionalInt64FieldNumber].Accessor;
 
+            Assert.IsFalse(accessor.HasValue(message));
+            message.OptionalInt64 = 5L;
+            Assert.IsTrue(accessor.HasValue(message));
+            message.ClearOptionalInt64();
+            Assert.IsFalse(accessor.HasValue(message));
+            message.OptionalInt64 = 0L;
+            Assert.IsTrue(accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto2_Message()
+        {
+            var message = new Proto2.TestAllTypes();
+            var field = ((IMessage) message).Descriptor.Fields[Proto2.TestAllTypes.OptionalForeignMessageFieldNumber];
+            Assert.False(field.Accessor.HasValue(message));
+            message.OptionalForeignMessage = new Proto2.ForeignMessage();
+            Assert.True(field.Accessor.HasValue(message));
+            message.OptionalForeignMessage = null;
+            Assert.False(field.Accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto2_Oneof()
+        {
+            var message = new Proto2.TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[Proto2.TestAllTypes.OneofStringFieldNumber].Accessor;
             Assert.False(accessor.HasValue(message));
-
-            accessor.SetValue(message, true);
+            // Even though it's the default value, we still have a value.
+            message.OneofString = "";
             Assert.True(accessor.HasValue(message));
-
-            accessor.Clear(message);
+            message.OneofString = "hello";
+            Assert.True(accessor.HasValue(message));
+            message.OneofUint32 = 10;
             Assert.False(accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto2_Repeated()
+        {
+            var message = new Proto2.TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[Proto2.TestAllTypes.RepeatedBoolFieldNumber].Accessor;
+            Assert.Throws<InvalidOperationException>(() => accessor.HasValue(message));
         }
 
         [Test]
@@ -263,6 +331,42 @@ namespace Google.Protobuf.Reflection
         }
 
         [Test]
+        public void Clear_Proto3_Oneof()
+        {
+            var message = new TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[TestProtos.TestAllTypes.OneofUint32FieldNumber].Accessor;
+
+            // The field accessor Clear method only affects a oneof if the current case is the one being cleared.
+            message.OneofString = "hello";
+            Assert.AreEqual(TestProtos.TestAllTypes.OneofFieldOneofCase.OneofString, message.OneofFieldCase);
+            accessor.Clear(message);
+            Assert.AreEqual(TestProtos.TestAllTypes.OneofFieldOneofCase.OneofString, message.OneofFieldCase);
+
+            message.OneofUint32 = 100;
+            Assert.AreEqual(TestProtos.TestAllTypes.OneofFieldOneofCase.OneofUint32, message.OneofFieldCase);
+            accessor.Clear(message);
+            Assert.AreEqual(TestProtos.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+        }
+
+        [Test]
+        public void Clear_Proto2_Oneof()
+        {
+            var message = new Proto2.TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[Proto2.TestAllTypes.OneofUint32FieldNumber].Accessor;
+
+            // The field accessor Clear method only affects a oneof if the current case is the one being cleared.
+            message.OneofString = "hello";
+            Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.OneofString, message.OneofFieldCase);
+            accessor.Clear(message);
+            Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.OneofString, message.OneofFieldCase);
+
+            message.OneofUint32 = 100;
+            Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.OneofUint32, message.OneofFieldCase);
+            accessor.Clear(message);
+            Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+        }
+
+        [Test]
         public void FieldDescriptor_ByName()
         {
             var descriptor = TestProtos.TestAllTypes.Descriptor;
@@ -300,6 +404,33 @@ namespace Google.Protobuf.Reflection
 
             message.ClearExtension(RepeatedBoolExtension);
             Assert.IsNull(message.GetExtension(RepeatedBoolExtension));
+        }
+
+        [Test]
+        public void HasPresence()
+        {
+            // Proto3
+            var fields = TestProtos.TestAllTypes.Descriptor.Fields;
+            Assert.IsFalse(fields[TestProtos.TestAllTypes.SingleBoolFieldNumber].HasPresence);
+            Assert.IsTrue(fields[TestProtos.TestAllTypes.OneofBytesFieldNumber].HasPresence);
+            Assert.IsTrue(fields[TestProtos.TestAllTypes.SingleForeignMessageFieldNumber].HasPresence);
+            Assert.IsFalse(fields[TestProtos.TestAllTypes.RepeatedBoolFieldNumber].HasPresence);
+
+            fields = TestMap.Descriptor.Fields;
+            Assert.IsFalse(fields[TestMap.MapBoolBoolFieldNumber].HasPresence);
+
+            fields = TestProto3Optional.Descriptor.Fields;
+            Assert.IsTrue(fields[TestProto3Optional.OptionalBoolFieldNumber].HasPresence);
+
+            // Proto2
+            fields = Proto2.TestAllTypes.Descriptor.Fields;
+            Assert.IsTrue(fields[Proto2.TestAllTypes.OptionalBoolFieldNumber].HasPresence);
+            Assert.IsTrue(fields[Proto2.TestAllTypes.OneofBytesFieldNumber].HasPresence);
+            Assert.IsTrue(fields[Proto2.TestAllTypes.OptionalForeignMessageFieldNumber].HasPresence);
+            Assert.IsFalse(fields[Proto2.TestAllTypes.RepeatedBoolFieldNumber].HasPresence);
+
+            fields = Proto2.TestRequired.Descriptor.Fields;
+            Assert.IsTrue(fields[Proto2.TestRequired.AFieldNumber].HasPresence);
         }
     }
 }

--- a/csharp/src/Google.Protobuf/Reflection/ExtensionAccessor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ExtensionAccessor.cs
@@ -32,7 +32,7 @@
 
 namespace Google.Protobuf.Reflection
 {
-    internal sealed class ExtensionAccessor : IFieldAccessor
+    internal sealed class ExtensionAccessor : IFieldAccessorEx
     {
         private readonly Extension extension;
         private readonly ReflectionUtil.IExtensionReflectionHelper helper;
@@ -65,5 +65,7 @@ namespace Google.Protobuf.Reflection
         {
             helper.SetExtension(message, value);
         }
+
+        public bool HasPresence => helper.HasPresence;
     }
 }

--- a/csharp/src/Google.Protobuf/Reflection/FieldAccessorBase.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldAccessorBase.cs
@@ -39,7 +39,7 @@ namespace Google.Protobuf.Reflection
     /// <summary>
     /// Base class for field accessors.
     /// </summary>
-    internal abstract class FieldAccessorBase : IFieldAccessor
+    internal abstract class FieldAccessorBase : IFieldAccessorEx
     {
         private readonly Func<IMessage, object> getValueDelegate;
         private readonly FieldDescriptor descriptor;
@@ -60,5 +60,6 @@ namespace Google.Protobuf.Reflection
         public abstract bool HasValue(IMessage message);
         public abstract void Clear(IMessage message);
         public abstract void SetValue(IMessage message, object value);
+        public abstract bool HasPresence { get; }
     }
 }

--- a/csharp/src/Google.Protobuf/Reflection/IFieldAccessorEx.cs
+++ b/csharp/src/Google.Protobuf/Reflection/IFieldAccessorEx.cs
@@ -1,6 +1,6 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 // Protocol Buffers - Google's data interchange format
-// Copyright 2015 Google Inc.  All rights reserved.
+// Copyright 2008 Google Inc.  All rights reserved.
 // https://developers.google.com/protocol-buffers/
 //
 // Redistribution and use in source and binary forms, with or without
@@ -30,41 +30,16 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-using System;
-using System.Collections;
-using System.Reflection;
 
 namespace Google.Protobuf.Reflection
 {
     /// <summary>
-    /// Accessor for map fields.
+    /// Internal interface with anything we'd really *like* to add to IFieldAccessor, but
+    /// can't now because it's an interface. Note that this interface should be kept internal
+    /// unless significant thought is put into compatibility.
     /// </summary>
-    internal sealed class MapFieldAccessor : FieldAccessorBase
+    internal interface IFieldAccessorEx : IFieldAccessor
     {
-        internal MapFieldAccessor(PropertyInfo property, FieldDescriptor descriptor) : base(property, descriptor)
-        {
-        }
-
-        public override void Clear(IMessage message)
-        {
-            IDictionary list = (IDictionary) GetValue(message);
-            list.Clear();
-        }
-
-        public override bool HasValue(IMessage message)
-        {
-            throw new InvalidOperationException("HasValue is not implemented for map fields");
-        }
-
-        public override void SetValue(IMessage message, object value)
-        {
-            throw new InvalidOperationException("SetValue is not implemented for map fields");
-        }
-
-        /// <summary>
-        /// Although a map field can be cleared, it doesn't support HasValue,
-        /// so doesn't really support presence.
-        /// </summary>
-        public override bool HasPresence => false;
+        bool HasPresence { get; }
     }
 }

--- a/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs
@@ -151,6 +151,7 @@ namespace Google.Protobuf.Reflection
             void SetExtension(IMessage message, object value);
             bool HasExtension(IMessage message);
             void ClearExtension(IMessage message);
+            bool HasPresence { get; }
         }
 
         private interface IExtensionSetReflector
@@ -306,6 +307,8 @@ namespace Google.Protobuf.Reflection
                     throw new InvalidCastException("The provided extension is not a valid extension identifier type");
                 }
             }
+
+            public bool HasPresence => extension is Extension<T1, T3>;
         }
 
         private class ExtensionSetReflector<T1> : IExtensionSetReflector where T1 : IExtendableMessage<T1>

--- a/csharp/src/Google.Protobuf/Reflection/RepeatedFieldAccessor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/RepeatedFieldAccessor.cs
@@ -61,5 +61,10 @@ namespace Google.Protobuf.Reflection
             throw new InvalidOperationException("SetValue is not implemented for repeated fields");
         }
 
+        /// <summary>
+        /// Although a repeated field can be cleared, it doesn't support HasValue,
+        /// so doesn't really support presence.
+        /// </summary>
+        public override bool HasPresence => false;
     }
 }

--- a/csharp/src/Google.Protobuf/Reflection/SingleFieldAccessor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/SingleFieldAccessor.cs
@@ -57,63 +57,73 @@ namespace Google.Protobuf.Reflection
                 throw new ArgumentException("Not all required properties/methods available");
             }
             setValueDelegate = ReflectionUtil.CreateActionIMessageObject(property.GetSetMethod());
-            if (descriptor.File.Syntax == Syntax.Proto3 && !descriptor.Proto.Proto3Optional)
+
+            // Note: this looks worrying in that we access the containing oneof, which isn't valid until cross-linking
+            // is complete... but field accessors aren't created until after cross-linking.
+            // The oneof itself won't be cross-linked yet, but that's okay: the oneof accessor is created
+            // earlier.
+
+            // Message fields always support presence, via null checks.
+            if (descriptor.FieldType == FieldType.Message)
             {
-                hasDelegate = message =>
+                HasPresence = true;
+                hasDelegate = message => GetValue(message) != null;
+                clearDelegate = message => SetValue(message, null);
+            }
+            // Oneof fields always support presence, via case checks.
+            // Note that clearing the field is a no-op unless that specific field is the current "case".
+            else if (descriptor.RealContainingOneof != null)
+            {
+                HasPresence = true;
+                var oneofAccessor = descriptor.RealContainingOneof.Accessor;
+                hasDelegate = message => oneofAccessor.GetCaseFieldDescriptor(message) == descriptor;
+                clearDelegate = message =>
                 {
-                    throw new InvalidOperationException("HasValue is not implemented for non-optional proto3 fields");
+                    // Clear on a field only affects the oneof itself if the current case is the field we're accessing.
+                    if (oneofAccessor.GetCaseFieldDescriptor(message) == descriptor)
+                    {
+                        oneofAccessor.Clear(message);
+                    }
                 };
+            }
+            // Primitive fields always support presence in proto2, and support presence in proto3 for optional fields.
+            else if (descriptor.File.Syntax == Syntax.Proto2 || descriptor.Proto.Proto3Optional)
+            {
+                HasPresence = true;
+                MethodInfo hasMethod = property.DeclaringType.GetRuntimeProperty("Has" + property.Name).GetMethod;
+                if (hasMethod == null)
+                {
+                    throw new ArgumentException("Not all required properties/methods are available");
+                }
+                hasDelegate = ReflectionUtil.CreateFuncIMessageBool(hasMethod);
+                MethodInfo clearMethod = property.DeclaringType.GetRuntimeMethod("Clear" + property.Name, ReflectionUtil.EmptyTypes);
+                if (clearMethod == null)
+                {
+                    throw new ArgumentException("Not all required properties/methods are available");
+                }
+                clearDelegate = ReflectionUtil.CreateActionIMessage(clearMethod);
+            }
+            // What's left?
+            // Primitive proto3 fields without the optional keyword, which aren't in oneofs.
+            else
+            {
+                HasPresence = false;
+                hasDelegate = message => { throw new InvalidOperationException("Presence is not implemented for this field"); };
+
+                // While presence isn't supported, clearing still is; it's just setting to a default value.
                 var clrType = property.PropertyType;
 
-                // TODO: Validate that this is a reasonable single field? (Should be a value type, a message type, or string/ByteString.)
                 object defaultValue =
-                    descriptor.FieldType == FieldType.Message ? null
-                    : clrType == typeof(string) ? ""
+                    clrType == typeof(string) ? ""
                     : clrType == typeof(ByteString) ? ByteString.Empty
                     : Activator.CreateInstance(clrType);
                 clearDelegate = message => SetValue(message, defaultValue);
             }
-            else
-            {
-                // For message fields, just compare with null and set to null.
-                // For primitive fields, use the Has/Clear methods.
-
-                if (descriptor.FieldType == FieldType.Message)
-                {
-                    hasDelegate = message => GetValue(message) != null;
-                    clearDelegate = message => SetValue(message, null);
-                }
-                else
-                {
-                    MethodInfo hasMethod = property.DeclaringType.GetRuntimeProperty("Has" + property.Name).GetMethod;
-                    if (hasMethod == null)
-                    {
-                        throw new ArgumentException("Not all required properties/methods are available");
-                    }
-                    hasDelegate = ReflectionUtil.CreateFuncIMessageBool(hasMethod);
-                    MethodInfo clearMethod = property.DeclaringType.GetRuntimeMethod("Clear" + property.Name, ReflectionUtil.EmptyTypes);
-                    if (clearMethod == null)
-                    {
-                        throw new ArgumentException("Not all required properties/methods are available");
-                    }
-                    clearDelegate = ReflectionUtil.CreateActionIMessage(clearMethod);
-                }
-            }
         }
 
-        public override void Clear(IMessage message)
-        {
-            clearDelegate(message);
-        }
-
-        public override bool HasValue(IMessage message)
-        {
-            return hasDelegate(message);
-        }
-
-        public override void SetValue(IMessage message, object value)
-        {
-            setValueDelegate(message, value);
-        }
+        public override void Clear(IMessage message) => clearDelegate(message);
+        public override bool HasValue(IMessage message) => hasDelegate(message);
+        public override void SetValue(IMessage message, object value) => setValueDelegate(message, value);
+        public override bool HasPresence { get; }
     }
 }


### PR DESCRIPTION
FieldAccessor.HasPresence returns true if both ClearValue and HasValue can be expected to work. Some fields have a working ClearValue, but no HasValue; HasPresence returns false for those fields.

Generally:
- Repeated fields return false
- Map fields return false
- Message fields return true
- Oneof member fields return true
- Singular primitive proto2 fields return true
- Singular explicitly-optional proto3 fields return true
- Singular not-explicitly-optional proto3 fields return false
- Repeated extension fields return false
- Singular extension fields return true