### PR TITLE
Fix include path to reflection.h in documentation

### DIFF
--- a/src/google/protobuf/message.h
+++ b/src/google/protobuf/message.h
@@ -740,8 +740,7 @@ class PROTOBUF_EXPORT Reflection final {
   // long as the message is not destroyed.
   //
   // Note that to use this method users need to include the header file
-  // "google/protobuf/reflection.h" (which defines the RepeatedFieldRef
-  // class templates).
+  // "reflection.h" (which defines the RepeatedFieldRef class templates).
   template <typename T>
   RepeatedFieldRef<T> GetRepeatedFieldRef(const Message& message,
                                           const FieldDescriptor* field) const;

--- a/src/google/protobuf/message.h
+++ b/src/google/protobuf/message.h
@@ -740,7 +740,7 @@ class PROTOBUF_EXPORT Reflection final {
   // long as the message is not destroyed.
   //
   // Note that to use this method users need to include the header file
-  // "net/proto2/public/reflection.h" (which defines the RepeatedFieldRef
+  // "google/protobuf/reflection.h" (which defines the RepeatedFieldRef
   // class templates).
   template <typename T>
   RepeatedFieldRef<T> GetRepeatedFieldRef(const Message& message,


### PR DESCRIPTION
There is a note in the documentation to `Reflection::GetRepeatedFieldRef()`
about file `net/proto2/public/reflection.h` which contains a definition of
`RepeatedFieldRef`. Since there are few places in code with rewrite of
`net...` path to `google/protobuf/...` it looks like the first one is a
legacy path and should be renamed to `google/protobuf` in documentation
as well.