### PR TITLE
Add replace_import_package Python option.

### DIFF
--- a/src/google/protobuf/compiler/python/python_generator.h
+++ b/src/google/protobuf/compiler/python/python_generator.h
@@ -168,6 +168,7 @@ class PROTOC_EXPORT Generator : public CodeGenerator {
   mutable std::string file_descriptor_serialized_;
   mutable io::Printer* printer_;  // Set in Generate().  Under mutex_.
   mutable bool pure_python_workable_;
+  mutable std::map<std::string, std::string> replace_import_package_map_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(Generator);
 };

--- a/src/google/protobuf/compiler/python/python_plugin_unittest.cc
+++ b/src/google/protobuf/compiler/python/python_plugin_unittest.cc
@@ -155,6 +155,342 @@ TEST(PythonPluginTest, ImportTest) {
   EXPECT_TRUE(found_expected_import);
 }
 
+TEST(PythonPluginTest, ReplaceImportPackageBasicTest) {
+/*
+  Both tests recast the protoc generated Python statement:
+
+    import b_bp2 ...
+
+  into the form:
+
+    from PACKAGE import b_pb2 ...
+
+  where PACKAGE is either an absolute or relative package name.
+*/
+  GOOGLE_CHECK_OK(File::SetContents(TestTempDir() + "/a.proto",
+                             "syntax = \"proto3\";\n"
+                             "import \"b.proto\";"
+                             "message A {\n"
+                             "  B b = 1;\n"
+                             "}\n",
+                             true));
+  GOOGLE_CHECK_OK(File::SetContents(TestTempDir() + "/b.proto",
+                             "syntax = \"proto3\";\n"
+                             "message B {}\n",
+                             true));
+
+  compiler::CommandLineInterface cli;
+  python::Generator python_generator;
+  cli.RegisterGenerator("--python_out", "--python_opt", &python_generator, "");
+  std::string proto_path = "--proto_path=" + TestTempDir();
+  std::string python_out = "--python_out=" + TestTempDir();
+
+  // Check that package name supplied with option is inserted into generated
+  // import statement
+  std::string absolute_python_opt = "--python_opt=replace_import_package=|omega";
+  const char* absolute_argv[] = {"protoc", proto_path.c_str(),
+                             python_out.c_str(), absolute_python_opt.c_str(),
+                             "a.proto"};
+  ASSERT_EQ(0, cli.Run(5, absolute_argv));
+  // Loop over the lines of the generated code and verify that we find
+  // a Python import statement with a 'from' clause containing an absolute
+  // package name.
+  std::string absolute_output;
+  GOOGLE_CHECK_OK(File::GetContents(TestTempDir() + "/a_pb2.py",
+                             &absolute_output, true));
+  std::vector<std::string> absolute_lines = Split(absolute_output, "\n");
+  std::string expected_absolute_import = "from omega import b_pb2";
+  bool found_expected_absolute_import = false;
+  for (int i = 0; i < absolute_lines.size(); ++i) {
+    if (absolute_lines[i].find(expected_absolute_import) != std::string::npos) {
+      found_expected_absolute_import = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_expected_absolute_import);
+
+  // Check that default package name "." is inserted into generated
+  // import statement
+  std::string relative_python_opt = "--python_opt=replace_import_package";
+  const char* relative_argv[] = {"protoc", proto_path.c_str(),
+                             python_out.c_str(), relative_python_opt.c_str(),
+                             "a.proto"};
+  ASSERT_EQ(0, cli.Run(5, relative_argv));
+  // Loop over the lines of the generated code and verify that we find
+  // a Python import statement with a 'from' clause containing the default
+  // explicit relative package name ".".
+  std::string relative_output;
+  GOOGLE_CHECK_OK(File::GetContents(TestTempDir() + "/a_pb2.py",
+                             &relative_output, true));
+  std::vector<std::string> relative_lines = Split(relative_output, "\n");
+  std::string expected_relative_import = "from . import b_pb2";
+  bool found_expected_relative_import = false;
+  for (int i = 0; i < relative_lines.size(); ++i) {
+    if (relative_lines[i].find(expected_relative_import) != std::string::npos) {
+      found_expected_relative_import = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_expected_relative_import);
+}
+
+TEST(PythonPluginTest, ReplaceImportPackageExtendedTest) {
+/*
+  Test creates a set of input message files arranged like:
+
+  .
+  ├── a
+  │   └── b
+  │       └── c.proto
+  ├── d
+  │   ├── e.proto
+  │   └── f.proto
+  └── g
+      └── h.proto
+
+  Where file ./d/e.proto imports the other three files.
+
+  The python_opt replace_import_package mapping string "d|.;g|p.g"
+  should convert the protoc generated statements:
+
+    from a.b import c_pb2 ...
+    from d import f_pb2 ...
+    from g import h_pb2 ...
+
+  into the user preferred statements:
+
+    from a.b import c_pb2 ... # unchanged
+    from . import f_pb2 ...
+    from p.g import h_pb2 ...
+*/
+  std::string temp_dir_a = TestTempDir() + "/a";
+  std::string temp_dir_a_b = temp_dir_a + "/b";
+  std::string temp_dir_d = TestTempDir() + "/d";
+  std::string temp_dir_g = TestTempDir() + "/g";
+  std::string temp_dir_p = TestTempDir() + "/p";
+
+  if (File::Exists(temp_dir_a)) {
+    File::DeleteRecursively(temp_dir_a, NULL, NULL);
+  }
+  if (File::Exists(temp_dir_d)) {
+    File::DeleteRecursively(temp_dir_d, NULL, NULL);
+  }
+  if (File::Exists(temp_dir_g)) {
+    File::DeleteRecursively(temp_dir_g, NULL, NULL);
+  }
+  if (File::Exists(temp_dir_p)) {
+    File::DeleteRecursively(temp_dir_p, NULL, NULL);
+  }
+
+  GOOGLE_CHECK_OK(File::CreateDir(temp_dir_a, 0777));
+  GOOGLE_CHECK_OK(File::CreateDir(temp_dir_a_b, 0777));
+  GOOGLE_CHECK_OK(File::CreateDir(temp_dir_d, 0777));
+  GOOGLE_CHECK_OK(File::CreateDir(temp_dir_g, 0777));
+  GOOGLE_CHECK_OK(File::CreateDir(temp_dir_p, 0777));
+
+  GOOGLE_CHECK_OK(File::SetContents(
+    temp_dir_a_b + "/c.proto",
+    "syntax = \"proto3\";\n"
+    "message C {}\n",
+    true
+  ));
+  GOOGLE_CHECK_OK(File::SetContents(
+    temp_dir_d + "/e.proto",
+    "syntax = \"proto3\";\n"
+    "import \"a/b/c.proto\";" // generated: from a.b import c_pb2 ...
+    "import \"d/f.proto\";"   // generated: from d import f_pb2 ...
+    "import \"g/h.proto\";"   // generated: from g import h_pb2 ...
+    "message E {\n"
+    "  C c = 1;\n"
+    "  F f = 2;\n"
+    "  H H = 3;\n"
+    "}\n",
+    true
+  ));
+  GOOGLE_CHECK_OK(File::SetContents(
+    temp_dir_d + "/f.proto",
+    "syntax = \"proto3\";\n"
+    "message F {}\n",
+    true
+  ));
+  GOOGLE_CHECK_OK(File::SetContents(
+    temp_dir_g + "/h.proto",
+    "syntax = \"proto3\";\n"
+    "message H {}\n",
+    true
+  ));
+
+  compiler::CommandLineInterface cli;
+  python::Generator python_generator;
+  cli.RegisterGenerator("--python_out", "--python_opt", &python_generator, "");
+  std::string proto_path = "--proto_path=" + TestTempDir();
+  std::string python_out = "--python_out=" + temp_dir_p;
+  std::string python_opt = "--python_opt=replace_import_package=d|.;g|p.g";
+
+  const char* argv[] = {
+    "protoc",
+    proto_path.c_str(),
+    python_out.c_str(),
+    python_opt.c_str(),
+    "d/e.proto"
+  };
+  ASSERT_EQ(0, cli.Run(5, argv));
+  // Loop over the lines of the generated code and verify that each
+  // generated import package has been mapped to its preferred package
+  // name.
+  std::string output;
+  GOOGLE_CHECK_OK(File::GetContents(temp_dir_p + "/d/e_pb2.py", &output, true));
+  std::vector<std::string> lines = Split(output, "\n");
+  std::string expected_import_a_dot_b = "from a.b import c_pb2";
+  std::string expected_import_dot = "from . import f_pb2";
+  std::string expected_import_p_dot_g = "from p.g import h_pb2";
+  bool found_expected_import_a_dot_b = false;
+  bool found_expected_import_dot = false;
+  bool found_expected_import_p_dot_g = false;
+  for (int i = 0; i < lines.size(); ++i) {
+    if (lines[i].find(expected_import_a_dot_b) != std::string::npos) {
+      found_expected_import_a_dot_b = true;
+    }
+    if (lines[i].find(expected_import_dot) != std::string::npos) {
+      found_expected_import_dot = true;
+    }
+    if (lines[i].find(expected_import_p_dot_g) != std::string::npos) {
+      found_expected_import_p_dot_g = true;
+    }
+  }
+  EXPECT_TRUE(found_expected_import_a_dot_b);
+  EXPECT_TRUE(found_expected_import_dot);
+  EXPECT_TRUE(found_expected_import_p_dot_g);
+}
+
+TEST(PythonPluginTest, ReplaceImportPackageErrorTest) {
+  GOOGLE_CHECK_OK(File::SetContents(TestTempDir() + "/a.proto",
+                             "syntax = \"proto3\";\n"
+                             "import \"b.proto\";"
+                             "message A {\n"
+                             "  B b = 1;\n"
+                             "}\n",
+                             true));
+  GOOGLE_CHECK_OK(File::SetContents(TestTempDir() + "/b.proto",
+                             "syntax = \"proto3\";\n"
+                             "message B {}\n",
+                             true));
+
+  const std::string python_opt_prefix("--python_opt=replace_import_package=");
+
+  struct ErrorMessage {
+    std::string mapping_string;
+    std::string expected_message;
+  };
+
+  const std::vector<ErrorMessage> cases = {
+    {".|a",
+     "invalid relative generated package name found at position 0"},
+    {"a|p;b|q;..|r",
+     "invalid relative generated package name found at position 8"},
+    {";b|q",
+     "invalid empty mapping found near position 0"},
+    {"a|p;b|q;;c|r",
+     "invalid empty mapping found near position 8"},
+    {"?|p",
+     "unexpected character '?' found while reading generated package name at position 0"},
+    {"a|p;b|q;?|r",
+     "unexpected character '?' found while reading generated package name at position 8"},
+    {"a|p;b|q;",
+     "unexpected end of input found while reading generated package name near position 8"},
+    {"a|p;b;",
+     "unexpected delimiter ';' found while reading generated package name at position 5"},
+    {"a|p;b?",
+     "unexpected character '?' found while reading generated package name at position 5"},
+    {"a|p;b",
+     "unexpected end of input found while reading generated package name near position 5"},
+    {"a|;",
+     "invalid empty preferred package name found near position 2"},
+    {"a|",
+     "invalid empty preferred package name found near position 2"},
+    {"a||",
+     "unexpected connector '|' found while reading preferred package name at position 2"},
+    {"a|?",
+     "unexpected character '?' found while reading preferred package name at position 2"},
+    {"a|p|",
+     "unexpected connector '|' found while reading preferred package name at position 3"},
+    {"a|p?",
+     "unexpected character '?' found while reading preferred package name at position 3"}
+  };
+
+  // In each case, pass in the grammatically flawed mapping string and
+  // confirm that the parser output includes the corresponding error
+  // message.
+  for (const ErrorMessage& c : cases) {
+    CaptureTestStderr();
+    compiler::CommandLineInterface cli;
+    python::Generator python_generator;
+    cli.RegisterGenerator("--python_out", "--python_opt", &python_generator, "");
+    std::string proto_path = "--proto_path=" + TestTempDir();
+    std::string python_out = "--python_out=" + TestTempDir();
+    std::string python_opt = python_opt_prefix + c.mapping_string;
+    const char* argv[] = {
+      "protoc",
+      proto_path.c_str(),
+      python_out.c_str(),
+      python_opt.c_str(),
+      "a.proto"
+    };
+    ASSERT_EQ(1, cli.Run(5, argv));
+    std::string captured_message = GetCapturedTestStderr();
+    ASSERT_PRED_FORMAT2(::testing::IsSubstring,
+                        c.expected_message,
+                        captured_message);
+  }
+}
+
+TEST(PythonPluginTest, ReplaceImportPackagePlacementTest) {
+  GOOGLE_CHECK_OK(File::SetContents(TestTempDir() + "/a.proto",
+                             "syntax = \"proto3\";\n"
+                             "import \"b.proto\";"
+                             "message A {\n"
+                             "  B b = 1;\n"
+                             "}\n",
+                             true));
+  GOOGLE_CHECK_OK(File::SetContents(TestTempDir() + "/b.proto",
+                             "syntax = \"proto3\";\n"
+                             "message B {}\n",
+                             true));
+
+  compiler::CommandLineInterface cli;
+  python::Generator python_generator;
+  cli.RegisterGenerator("--python_out", &python_generator, "");
+  std::string proto_path = "--proto_path=" + TestTempDir();
+  // Check that replace_import_packkage flag works correctly when supplied as
+  // prefix to the python_out value
+  std::string python_out =
+      "--python_out=replace_import_package=|alpha.beta;something|anything:" +
+      TestTempDir();
+
+  const char* argv[] = {
+    "protoc",
+    proto_path.c_str(),
+    python_out.c_str(),
+    "a.proto"
+  };
+  ASSERT_EQ(0, cli.Run(4, argv));
+  // Loop over the lines of the generated code and verify that we find
+  // a Python import statement with a 'from' clause containing an absolute
+  // package name.
+  std::string output;
+  GOOGLE_CHECK_OK(File::GetContents(TestTempDir() + "/a_pb2.py", &output, true));
+  std::vector<std::string> lines = Split(output, "\n");
+  std::string expected_import = "from alpha.beta import b_pb2";
+  bool found_expected_import = false;
+  for (int i = 0; i < lines.size(); ++i) {
+    if (lines[i].find(expected_import) != std::string::npos) {
+      found_expected_import = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_expected_import);
+}
+
 }  // namespace
 }  // namespace python
 }  // namespace compiler


### PR DESCRIPTION
##### Overview

This patch proposes a new python_opt option, `replace_import_package`, for the Python code generator that provides a lightweight mechanism for replacing the package name ordinarily generated by protoc in Python import statements (the "generated" package name) with a user supplied package name (the "preferred" package name) in order to allow the imported modules to be found more easily at runtime.

In the simplest case, given a message file (say, "MainMessage.proto") that imports another message file (say, "ImportedMessage.proto") from within the same directory, invoking the new option like:

`protoc --proto_path /protobuf/files --python_out ./my_package --python_opt replace_import_package MainMessage.proto`

will replace the currently generated statement `import ImportedMessage_pb2 as ...` (with no `from` clause), with the preferred statement `from . import ImportedMessage_pb2 as ...` (with a `from` clause referencing an explicit package).

##### Issue Background

When generating Python code from input files that import other protobuf files, protoc will generate Python import statements that either contain no `from` clause (if the input file's import statement contains no relative path prefix) or contain a `from` clause listing a package name derived solely from the relative path used in the protobuf import statement (protoc always ignores the protobuf package statement when generating Python code).  This behavior occasionally results in Python import statements that don't work as expected: for example, import statements with no `from` clause are no longer interpreted as implicit relative imports in Python3.

Current workarounds include:

- extending the PYTHONPATH at runtime to include packages that previously were implicitly searched
- structuring the protobuf input directories to match the desired Python package structure
- post processing the generated code with 2to3 (in simple cases) or sed/awk/etc (in more complex cases) to recast the Python import statements

Each has drawbacks.  Extended discussion of issues and workarounds can be found [here](https://github.com/protocolbuffers/protobuf/issues/1491).

##### A Few Preliminaries

Note that the scope of the new option is limited.  In particular:

1. If you do not supply the new `replace_import_package` option for Python compiles, there is no change in behavior for protoc.

2. If you do not use the protobuf "import" statement in any input files, the new `replace_import_package` option (even if present) is inoperative; it only changes the form of the Python import statements produced by protoc when generating Python code from protobuf files that themselves contain import statements.

3. If your protobuf files happen to be arranged in a directory hierarchy that precisely matches the desired Python package structure, then the new `replace_import_package` option is unnecessary; protoc already creates output files in the desired locations (relative to the directory named in `--python_out`) and produces correct import statements in the generated Python code.

4. The new `replace_import_package` option does not change the protoc dataflow; output files are still generated 1:1 with input files and the location of the generated files is still controlled by the `--python_out` option

##### Proposed Option Operation

- the new option is supplied as a flag to the `--python_opt` command line argument
- the option has the form `replace_import_package=MAPPINGS`
- each mapping in the MAPPINGS string has the form `generated.package|preferred.package`
	- the `generated.package` name:
		- may be empty (with a special meaning, see below)
		- if present, must be absolute (because protoc generates only absolute package names)
	- the `preferred.package` name:
		- must be non-empty
		- may be relative (like . or ..my_package)
- multiple mappings may be specified separated by semicolons
- if the package name in a generated import statement *exactly matches* the `generated.package` in one of the mappings, that generated package name is *fully replaced* by the `preferred.package` name in that mapping

> For example, given the mapping string "a|p;b|q.b;c|c", if protoc generates the import statements:  
>  `from a import m`  
>  `from b import n`  
>  `from c import o`  
> They will be transformed into:  
>  `from p import m`  
>  `from q.b import n`  
>  `from c import o`  

- an import statement with **no** generated package name (that is, a generated import statement with no `from` clause) matches a mapping with an empty `generated.package`, causing the insertion of a `from` clause containing the `preferred.package` name in that mapping
> For example, given the mapping string "|.", if protoc generates the import statement:  
>  `import m`  
> It will be transformed into:  
>  `from . import m`  
- a generated package name that is not matched by any mapping is left unchanged
> For example, given the mapping string "|.;a|p;b|q", if protoc generates the import statement:  
>  `from c import o`  
> It will not be transformed in any way. 
- the MAPPINGS value is optional; if no value is supplied then the implied mapping string is "|."
- some minutiae:
	- if the `replace_import_package` flag appears more than once, the effective set of mappings will be the union of the mappings from all the mapping strings  
	- if the same `generated.package` value appears in more than one mapping, the latest appearing mapping (the rightmost mapping in the rightmost mapping string) is operative 

> For example, the command line option `--python_opt 'replace_import_package=a|p;b|q,replace_import_package=c|r'`, is equivalent to `--python_opt 'replace_import_package=a|p;b|q;c|r'`.  
>  
> And the mapping string "a|p;b|q;a|z" is equivalent to "b|q;a|z".

##### Usage Scenarios

Some example usage scenarios for the new option (with runnable code) can be found [here](https://github.com/tpboudreau/protoc_python_import_examples).