### PR TITLE
[objc] Remove unnecessary call to [self descriptor] in resolveClassMethod:

### DIFF
--- a/objectivec/GPBMessage.m
+++ b/objectivec/GPBMessage.m
@@ -3253,7 +3253,7 @@ static void ResolveIvarSet(__unsafe_unretained GPBFieldDescriptor *field,
 
 + (BOOL)resolveClassMethod:(SEL)sel {
   // Extensions scoped to a Message and looked up via class methods.
-  if (GPBResolveExtensionClassMethod([self descriptor].messageClass, sel)) {
+  if (GPBResolveExtensionClassMethod(self, sel)) {
     return YES;
   }
   return [super resolveClassMethod:sel];


### PR DESCRIPTION
This was causing problems in OCMock due to recursion when OCMock was trying
to mock a protobuf.

`_forwardStackInvocation:` was being called as part of the resolution of `descriptor`.