### PR TITLE
Cherry-pick fixes onto 3.12.x branch for 3.12.0-rc2

### DIFF
--- a/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto2.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto2.cs
@@ -290,13 +290,13 @@ namespace ProtobufTestMessages.Proto2 {
       optionalBool_ = other.optionalBool_;
       optionalString_ = other.optionalString_;
       optionalBytes_ = other.optionalBytes_;
-      optionalNestedMessage_ = other.HasOptionalNestedMessage ? other.optionalNestedMessage_.Clone() : null;
-      optionalForeignMessage_ = other.HasOptionalForeignMessage ? other.optionalForeignMessage_.Clone() : null;
+      optionalNestedMessage_ = other.optionalNestedMessage_ != null ? other.optionalNestedMessage_.Clone() : null;
+      optionalForeignMessage_ = other.optionalForeignMessage_ != null ? other.optionalForeignMessage_.Clone() : null;
       optionalNestedEnum_ = other.optionalNestedEnum_;
       optionalForeignEnum_ = other.optionalForeignEnum_;
       optionalStringPiece_ = other.optionalStringPiece_;
       optionalCord_ = other.optionalCord_;
-      recursiveMessage_ = other.HasRecursiveMessage ? other.recursiveMessage_.Clone() : null;
+      recursiveMessage_ = other.recursiveMessage_ != null ? other.recursiveMessage_.Clone() : null;
       repeatedInt32_ = other.repeatedInt32_.Clone();
       repeatedInt64_ = other.repeatedInt64_.Clone();
       repeatedUint32_ = other.repeatedUint32_.Clone();
@@ -794,16 +794,6 @@ namespace ProtobufTestMessages.Proto2 {
         optionalNestedMessage_ = value;
       }
     }
-    /// <summary>Gets whether the optional_nested_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalNestedMessage {
-      get { return optionalNestedMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_nested_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalNestedMessage() {
-      optionalNestedMessage_ = null;
-    }
 
     /// <summary>Field number for the "optional_foreign_message" field.</summary>
     public const int OptionalForeignMessageFieldNumber = 19;
@@ -814,16 +804,6 @@ namespace ProtobufTestMessages.Proto2 {
       set {
         optionalForeignMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the optional_foreign_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalForeignMessage {
-      get { return optionalForeignMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_foreign_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalForeignMessage() {
-      optionalForeignMessage_ = null;
     }
 
     /// <summary>Field number for the "optional_nested_enum" field.</summary>
@@ -929,16 +909,6 @@ namespace ProtobufTestMessages.Proto2 {
       set {
         recursiveMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the recursive_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasRecursiveMessage {
-      get { return recursiveMessage_ != null; }
-    }
-    /// <summary>Clears the value of the recursive_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearRecursiveMessage() {
-      recursiveMessage_ = null;
     }
 
     /// <summary>Field number for the "repeated_int32" field.</summary>
@@ -1660,22 +1630,10 @@ namespace ProtobufTestMessages.Proto2 {
     public const int OneofNestedMessageFieldNumber = 112;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::ProtobufTestMessages.Proto2.TestAllTypesProto2.Types.NestedMessage OneofNestedMessage {
-      get { return HasOneofNestedMessage ? (global::ProtobufTestMessages.Proto2.TestAllTypesProto2.Types.NestedMessage) oneofField_ : null; }
+      get { return oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage ? (global::ProtobufTestMessages.Proto2.TestAllTypesProto2.Types.NestedMessage) oneofField_ : null; }
       set {
         oneofField_ = value;
         oneofFieldCase_ = value == null ? OneofFieldOneofCase.None : OneofFieldOneofCase.OneofNestedMessage;
-      }
-    }
-    /// <summary>Gets whether the "oneof_nested_message" field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOneofNestedMessage {
-      get { return oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage; }
-    }
-    /// <summary> Clears the value of the oneof if it's currently set to "oneof_nested_message" </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOneofNestedMessage() {
-      if (HasOneofNestedMessage) {
-        ClearOneofField();
       }
     }
 
@@ -2479,13 +2437,13 @@ namespace ProtobufTestMessages.Proto2 {
       if (HasOptionalBool) hash ^= OptionalBool.GetHashCode();
       if (HasOptionalString) hash ^= OptionalString.GetHashCode();
       if (HasOptionalBytes) hash ^= OptionalBytes.GetHashCode();
-      if (HasOptionalNestedMessage) hash ^= OptionalNestedMessage.GetHashCode();
-      if (HasOptionalForeignMessage) hash ^= OptionalForeignMessage.GetHashCode();
+      if (optionalNestedMessage_ != null) hash ^= OptionalNestedMessage.GetHashCode();
+      if (optionalForeignMessage_ != null) hash ^= OptionalForeignMessage.GetHashCode();
       if (HasOptionalNestedEnum) hash ^= OptionalNestedEnum.GetHashCode();
       if (HasOptionalForeignEnum) hash ^= OptionalForeignEnum.GetHashCode();
       if (HasOptionalStringPiece) hash ^= OptionalStringPiece.GetHashCode();
       if (HasOptionalCord) hash ^= OptionalCord.GetHashCode();
-      if (HasRecursiveMessage) hash ^= RecursiveMessage.GetHashCode();
+      if (recursiveMessage_ != null) hash ^= RecursiveMessage.GetHashCode();
       hash ^= repeatedInt32_.GetHashCode();
       hash ^= repeatedInt64_.GetHashCode();
       hash ^= repeatedUint32_.GetHashCode();
@@ -2555,7 +2513,7 @@ namespace ProtobufTestMessages.Proto2 {
       hash ^= MapStringNestedEnum.GetHashCode();
       hash ^= MapStringForeignEnum.GetHashCode();
       if (HasOneofUint32) hash ^= OneofUint32.GetHashCode();
-      if (HasOneofNestedMessage) hash ^= OneofNestedMessage.GetHashCode();
+      if (oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage) hash ^= OneofNestedMessage.GetHashCode();
       if (HasOneofString) hash ^= OneofString.GetHashCode();
       if (HasOneofBytes) hash ^= OneofBytes.GetHashCode();
       if (HasOneofBool) hash ^= OneofBool.GetHashCode();
@@ -2659,11 +2617,11 @@ namespace ProtobufTestMessages.Proto2 {
         output.WriteRawTag(122);
         output.WriteBytes(OptionalBytes);
       }
-      if (HasOptionalNestedMessage) {
+      if (optionalNestedMessage_ != null) {
         output.WriteRawTag(146, 1);
         output.WriteMessage(OptionalNestedMessage);
       }
-      if (HasOptionalForeignMessage) {
+      if (optionalForeignMessage_ != null) {
         output.WriteRawTag(154, 1);
         output.WriteMessage(OptionalForeignMessage);
       }
@@ -2683,7 +2641,7 @@ namespace ProtobufTestMessages.Proto2 {
         output.WriteRawTag(202, 1);
         output.WriteString(OptionalCord);
       }
-      if (HasRecursiveMessage) {
+      if (recursiveMessage_ != null) {
         output.WriteRawTag(218, 1);
         output.WriteMessage(RecursiveMessage);
       }
@@ -2759,7 +2717,7 @@ namespace ProtobufTestMessages.Proto2 {
         output.WriteRawTag(248, 6);
         output.WriteUInt32(OneofUint32);
       }
-      if (HasOneofNestedMessage) {
+      if (oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage) {
         output.WriteRawTag(130, 7);
         output.WriteMessage(OneofNestedMessage);
       }
@@ -2924,10 +2882,10 @@ namespace ProtobufTestMessages.Proto2 {
       if (HasOptionalBytes) {
         size += 1 + pb::CodedOutputStream.ComputeBytesSize(OptionalBytes);
       }
-      if (HasOptionalNestedMessage) {
+      if (optionalNestedMessage_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(OptionalNestedMessage);
       }
-      if (HasOptionalForeignMessage) {
+      if (optionalForeignMessage_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(OptionalForeignMessage);
       }
       if (HasOptionalNestedEnum) {
@@ -2942,7 +2900,7 @@ namespace ProtobufTestMessages.Proto2 {
       if (HasOptionalCord) {
         size += 2 + pb::CodedOutputStream.ComputeStringSize(OptionalCord);
       }
-      if (HasRecursiveMessage) {
+      if (recursiveMessage_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(RecursiveMessage);
       }
       size += repeatedInt32_.CalculateSize(_repeated_repeatedInt32_codec);
@@ -3016,7 +2974,7 @@ namespace ProtobufTestMessages.Proto2 {
       if (HasOneofUint32) {
         size += 2 + pb::CodedOutputStream.ComputeUInt32Size(OneofUint32);
       }
-      if (HasOneofNestedMessage) {
+      if (oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(OneofNestedMessage);
       }
       if (HasOneofString) {
@@ -3156,14 +3114,14 @@ namespace ProtobufTestMessages.Proto2 {
       if (other.HasOptionalBytes) {
         OptionalBytes = other.OptionalBytes;
       }
-      if (other.HasOptionalNestedMessage) {
-        if (!HasOptionalNestedMessage) {
+      if (other.optionalNestedMessage_ != null) {
+        if (optionalNestedMessage_ == null) {
           OptionalNestedMessage = new global::ProtobufTestMessages.Proto2.TestAllTypesProto2.Types.NestedMessage();
         }
         OptionalNestedMessage.MergeFrom(other.OptionalNestedMessage);
       }
-      if (other.HasOptionalForeignMessage) {
-        if (!HasOptionalForeignMessage) {
+      if (other.optionalForeignMessage_ != null) {
+        if (optionalForeignMessage_ == null) {
           OptionalForeignMessage = new global::ProtobufTestMessages.Proto2.ForeignMessageProto2();
         }
         OptionalForeignMessage.MergeFrom(other.OptionalForeignMessage);
@@ -3180,8 +3138,8 @@ namespace ProtobufTestMessages.Proto2 {
       if (other.HasOptionalCord) {
         OptionalCord = other.OptionalCord;
       }
-      if (other.HasRecursiveMessage) {
-        if (!HasRecursiveMessage) {
+      if (other.recursiveMessage_ != null) {
+        if (recursiveMessage_ == null) {
           RecursiveMessage = new global::ProtobufTestMessages.Proto2.TestAllTypesProto2();
         }
         RecursiveMessage.MergeFrom(other.RecursiveMessage);
@@ -3422,14 +3380,14 @@ namespace ProtobufTestMessages.Proto2 {
             break;
           }
           case 146: {
-            if (!HasOptionalNestedMessage) {
+            if (optionalNestedMessage_ == null) {
               OptionalNestedMessage = new global::ProtobufTestMessages.Proto2.TestAllTypesProto2.Types.NestedMessage();
             }
             input.ReadMessage(OptionalNestedMessage);
             break;
           }
           case 154: {
-            if (!HasOptionalForeignMessage) {
+            if (optionalForeignMessage_ == null) {
               OptionalForeignMessage = new global::ProtobufTestMessages.Proto2.ForeignMessageProto2();
             }
             input.ReadMessage(OptionalForeignMessage);
@@ -3452,7 +3410,7 @@ namespace ProtobufTestMessages.Proto2 {
             break;
           }
           case 218: {
-            if (!HasRecursiveMessage) {
+            if (recursiveMessage_ == null) {
               RecursiveMessage = new global::ProtobufTestMessages.Proto2.TestAllTypesProto2();
             }
             input.ReadMessage(RecursiveMessage);
@@ -3779,7 +3737,7 @@ namespace ProtobufTestMessages.Proto2 {
           }
           case 898: {
             global::ProtobufTestMessages.Proto2.TestAllTypesProto2.Types.NestedMessage subBuilder = new global::ProtobufTestMessages.Proto2.TestAllTypesProto2.Types.NestedMessage();
-            if (HasOneofNestedMessage) {
+            if (oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage) {
               subBuilder.MergeFrom(OneofNestedMessage);
             }
             input.ReadMessage(subBuilder);
@@ -3962,7 +3920,7 @@ namespace ProtobufTestMessages.Proto2 {
         public NestedMessage(NestedMessage other) : this() {
           _hasBits0 = other._hasBits0;
           a_ = other.a_;
-          corecursive_ = other.HasCorecursive ? other.corecursive_.Clone() : null;
+          corecursive_ = other.corecursive_ != null ? other.corecursive_.Clone() : null;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -4005,16 +3963,6 @@ namespace ProtobufTestMessages.Proto2 {
             corecursive_ = value;
           }
         }
-        /// <summary>Gets whether the corecursive field is set</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public bool HasCorecursive {
-          get { return corecursive_ != null; }
-        }
-        /// <summary>Clears the value of the corecursive field</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public void ClearCorecursive() {
-          corecursive_ = null;
-        }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
@@ -4038,7 +3986,7 @@ namespace ProtobufTestMessages.Proto2 {
         public override int GetHashCode() {
           int hash = 1;
           if (HasA) hash ^= A.GetHashCode();
-          if (HasCorecursive) hash ^= Corecursive.GetHashCode();
+          if (corecursive_ != null) hash ^= Corecursive.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -4056,7 +4004,7 @@ namespace ProtobufTestMessages.Proto2 {
             output.WriteRawTag(8);
             output.WriteInt32(A);
           }
-          if (HasCorecursive) {
+          if (corecursive_ != null) {
             output.WriteRawTag(18);
             output.WriteMessage(Corecursive);
           }
@@ -4071,7 +4019,7 @@ namespace ProtobufTestMessages.Proto2 {
           if (HasA) {
             size += 1 + pb::CodedOutputStream.ComputeInt32Size(A);
           }
-          if (HasCorecursive) {
+          if (corecursive_ != null) {
             size += 1 + pb::CodedOutputStream.ComputeMessageSize(Corecursive);
           }
           if (_unknownFields != null) {
@@ -4088,8 +4036,8 @@ namespace ProtobufTestMessages.Proto2 {
           if (other.HasA) {
             A = other.A;
           }
-          if (other.HasCorecursive) {
-            if (!HasCorecursive) {
+          if (other.corecursive_ != null) {
+            if (corecursive_ == null) {
               Corecursive = new global::ProtobufTestMessages.Proto2.TestAllTypesProto2();
             }
             Corecursive.MergeFrom(other.Corecursive);
@@ -4110,7 +4058,7 @@ namespace ProtobufTestMessages.Proto2 {
                 break;
               }
               case 18: {
-                if (!HasCorecursive) {
+                if (corecursive_ == null) {
                   Corecursive = new global::ProtobufTestMessages.Proto2.TestAllTypesProto2();
                 }
                 input.ReadMessage(Corecursive);
@@ -4937,7 +4885,7 @@ namespace ProtobufTestMessages.Proto2 {
       _hasBits0 = other._hasBits0;
       optionalInt32_ = other.optionalInt32_;
       optionalString_ = other.optionalString_;
-      nestedMessage_ = other.HasNestedMessage ? other.nestedMessage_.Clone() : null;
+      nestedMessage_ = other.nestedMessage_ != null ? other.nestedMessage_.Clone() : null;
       optionalGroup_ = other.HasOptionalGroup ? other.optionalGroup_.Clone() : null;
       optionalBool_ = other.optionalBool_;
       repeatedInt32_ = other.repeatedInt32_.Clone();
@@ -5005,16 +4953,6 @@ namespace ProtobufTestMessages.Proto2 {
       set {
         nestedMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the nested_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasNestedMessage {
-      get { return nestedMessage_ != null; }
-    }
-    /// <summary>Clears the value of the nested_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearNestedMessage() {
-      nestedMessage_ = null;
     }
 
     /// <summary>Field number for the "optionalgroup" field.</summary>
@@ -5099,7 +5037,7 @@ namespace ProtobufTestMessages.Proto2 {
       int hash = 1;
       if (HasOptionalInt32) hash ^= OptionalInt32.GetHashCode();
       if (HasOptionalString) hash ^= OptionalString.GetHashCode();
-      if (HasNestedMessage) hash ^= NestedMessage.GetHashCode();
+      if (nestedMessage_ != null) hash ^= NestedMessage.GetHashCode();
       if (HasOptionalGroup) hash ^= OptionalGroup.GetHashCode();
       if (HasOptionalBool) hash ^= OptionalBool.GetHashCode();
       hash ^= repeatedInt32_.GetHashCode();
@@ -5124,7 +5062,7 @@ namespace ProtobufTestMessages.Proto2 {
         output.WriteRawTag(210, 62);
         output.WriteString(OptionalString);
       }
-      if (HasNestedMessage) {
+      if (nestedMessage_ != null) {
         output.WriteRawTag(218, 62);
         output.WriteMessage(NestedMessage);
       }
@@ -5152,7 +5090,7 @@ namespace ProtobufTestMessages.Proto2 {
       if (HasOptionalString) {
         size += 2 + pb::CodedOutputStream.ComputeStringSize(OptionalString);
       }
-      if (HasNestedMessage) {
+      if (nestedMessage_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(NestedMessage);
       }
       if (HasOptionalGroup) {
@@ -5179,8 +5117,8 @@ namespace ProtobufTestMessages.Proto2 {
       if (other.HasOptionalString) {
         OptionalString = other.OptionalString;
       }
-      if (other.HasNestedMessage) {
-        if (!HasNestedMessage) {
+      if (other.nestedMessage_ != null) {
+        if (nestedMessage_ == null) {
           NestedMessage = new global::ProtobufTestMessages.Proto2.ForeignMessageProto2();
         }
         NestedMessage.MergeFrom(other.NestedMessage);
@@ -5215,7 +5153,7 @@ namespace ProtobufTestMessages.Proto2 {
             break;
           }
           case 8026: {
-            if (!HasNestedMessage) {
+            if (nestedMessage_ == null) {
               NestedMessage = new global::ProtobufTestMessages.Proto2.ForeignMessageProto2();
             }
             input.ReadMessage(NestedMessage);

--- a/csharp/src/Google.Protobuf.Test.TestProtos/Unittest.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/Unittest.cs
@@ -1165,16 +1165,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       optionalString_ = other.optionalString_;
       optionalBytes_ = other.optionalBytes_;
       optionalGroup_ = other.HasOptionalGroup ? other.optionalGroup_.Clone() : null;
-      optionalNestedMessage_ = other.HasOptionalNestedMessage ? other.optionalNestedMessage_.Clone() : null;
-      optionalForeignMessage_ = other.HasOptionalForeignMessage ? other.optionalForeignMessage_.Clone() : null;
-      optionalImportMessage_ = other.HasOptionalImportMessage ? other.optionalImportMessage_.Clone() : null;
+      optionalNestedMessage_ = other.optionalNestedMessage_ != null ? other.optionalNestedMessage_.Clone() : null;
+      optionalForeignMessage_ = other.optionalForeignMessage_ != null ? other.optionalForeignMessage_.Clone() : null;
+      optionalImportMessage_ = other.optionalImportMessage_ != null ? other.optionalImportMessage_.Clone() : null;
       optionalNestedEnum_ = other.optionalNestedEnum_;
       optionalForeignEnum_ = other.optionalForeignEnum_;
       optionalImportEnum_ = other.optionalImportEnum_;
       optionalStringPiece_ = other.optionalStringPiece_;
       optionalCord_ = other.optionalCord_;
-      optionalPublicImportMessage_ = other.HasOptionalPublicImportMessage ? other.optionalPublicImportMessage_.Clone() : null;
-      optionalLazyMessage_ = other.HasOptionalLazyMessage ? other.optionalLazyMessage_.Clone() : null;
+      optionalPublicImportMessage_ = other.optionalPublicImportMessage_ != null ? other.optionalPublicImportMessage_.Clone() : null;
+      optionalLazyMessage_ = other.optionalLazyMessage_ != null ? other.optionalLazyMessage_.Clone() : null;
       repeatedInt32_ = other.repeatedInt32_.Clone();
       repeatedInt64_ = other.repeatedInt64_.Clone();
       repeatedUint32_ = other.repeatedUint32_.Clone();
@@ -1635,16 +1635,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         optionalNestedMessage_ = value;
       }
     }
-    /// <summary>Gets whether the optional_nested_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalNestedMessage {
-      get { return optionalNestedMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_nested_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalNestedMessage() {
-      optionalNestedMessage_ = null;
-    }
 
     /// <summary>Field number for the "optional_foreign_message" field.</summary>
     public const int OptionalForeignMessageFieldNumber = 19;
@@ -1656,16 +1646,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         optionalForeignMessage_ = value;
       }
     }
-    /// <summary>Gets whether the optional_foreign_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalForeignMessage {
-      get { return optionalForeignMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_foreign_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalForeignMessage() {
-      optionalForeignMessage_ = null;
-    }
 
     /// <summary>Field number for the "optional_import_message" field.</summary>
     public const int OptionalImportMessageFieldNumber = 20;
@@ -1676,16 +1656,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         optionalImportMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the optional_import_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalImportMessage {
-      get { return optionalImportMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_import_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalImportMessage() {
-      optionalImportMessage_ = null;
     }
 
     /// <summary>Field number for the "optional_nested_enum" field.</summary>
@@ -1819,16 +1789,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         optionalPublicImportMessage_ = value;
       }
     }
-    /// <summary>Gets whether the optional_public_import_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalPublicImportMessage {
-      get { return optionalPublicImportMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_public_import_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalPublicImportMessage() {
-      optionalPublicImportMessage_ = null;
-    }
 
     /// <summary>Field number for the "optional_lazy_message" field.</summary>
     public const int OptionalLazyMessageFieldNumber = 27;
@@ -1839,16 +1799,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         optionalLazyMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the optional_lazy_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalLazyMessage {
-      get { return optionalLazyMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_lazy_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalLazyMessage() {
-      optionalLazyMessage_ = null;
     }
 
     /// <summary>Field number for the "repeated_int32" field.</summary>
@@ -2610,22 +2560,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     public const int OneofNestedMessageFieldNumber = 112;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage OneofNestedMessage {
-      get { return HasOneofNestedMessage ? (global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage) oneofField_ : null; }
+      get { return oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage ? (global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage) oneofField_ : null; }
       set {
         oneofField_ = value;
         oneofFieldCase_ = value == null ? OneofFieldOneofCase.None : OneofFieldOneofCase.OneofNestedMessage;
-      }
-    }
-    /// <summary>Gets whether the "oneof_nested_message" field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOneofNestedMessage {
-      get { return oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage; }
-    }
-    /// <summary> Clears the value of the oneof if it's currently set to "oneof_nested_message" </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOneofNestedMessage() {
-      if (HasOneofNestedMessage) {
-        ClearOneofField();
       }
     }
 
@@ -2807,16 +2745,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasOptionalString) hash ^= OptionalString.GetHashCode();
       if (HasOptionalBytes) hash ^= OptionalBytes.GetHashCode();
       if (HasOptionalGroup) hash ^= OptionalGroup.GetHashCode();
-      if (HasOptionalNestedMessage) hash ^= OptionalNestedMessage.GetHashCode();
-      if (HasOptionalForeignMessage) hash ^= OptionalForeignMessage.GetHashCode();
-      if (HasOptionalImportMessage) hash ^= OptionalImportMessage.GetHashCode();
+      if (optionalNestedMessage_ != null) hash ^= OptionalNestedMessage.GetHashCode();
+      if (optionalForeignMessage_ != null) hash ^= OptionalForeignMessage.GetHashCode();
+      if (optionalImportMessage_ != null) hash ^= OptionalImportMessage.GetHashCode();
       if (HasOptionalNestedEnum) hash ^= OptionalNestedEnum.GetHashCode();
       if (HasOptionalForeignEnum) hash ^= OptionalForeignEnum.GetHashCode();
       if (HasOptionalImportEnum) hash ^= OptionalImportEnum.GetHashCode();
       if (HasOptionalStringPiece) hash ^= OptionalStringPiece.GetHashCode();
       if (HasOptionalCord) hash ^= OptionalCord.GetHashCode();
-      if (HasOptionalPublicImportMessage) hash ^= OptionalPublicImportMessage.GetHashCode();
-      if (HasOptionalLazyMessage) hash ^= OptionalLazyMessage.GetHashCode();
+      if (optionalPublicImportMessage_ != null) hash ^= OptionalPublicImportMessage.GetHashCode();
+      if (optionalLazyMessage_ != null) hash ^= OptionalLazyMessage.GetHashCode();
       hash ^= repeatedInt32_.GetHashCode();
       hash ^= repeatedInt64_.GetHashCode();
       hash ^= repeatedUint32_.GetHashCode();
@@ -2863,7 +2801,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasDefaultStringPiece) hash ^= DefaultStringPiece.GetHashCode();
       if (HasDefaultCord) hash ^= DefaultCord.GetHashCode();
       if (HasOneofUint32) hash ^= OneofUint32.GetHashCode();
-      if (HasOneofNestedMessage) hash ^= OneofNestedMessage.GetHashCode();
+      if (oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage) hash ^= OneofNestedMessage.GetHashCode();
       if (HasOneofString) hash ^= OneofString.GetHashCode();
       if (HasOneofBytes) hash ^= OneofBytes.GetHashCode();
       hash ^= (int) oneofFieldCase_;
@@ -2945,15 +2883,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteGroup(OptionalGroup);
         output.WriteRawTag(132, 1);
       }
-      if (HasOptionalNestedMessage) {
+      if (optionalNestedMessage_ != null) {
         output.WriteRawTag(146, 1);
         output.WriteMessage(OptionalNestedMessage);
       }
-      if (HasOptionalForeignMessage) {
+      if (optionalForeignMessage_ != null) {
         output.WriteRawTag(154, 1);
         output.WriteMessage(OptionalForeignMessage);
       }
-      if (HasOptionalImportMessage) {
+      if (optionalImportMessage_ != null) {
         output.WriteRawTag(162, 1);
         output.WriteMessage(OptionalImportMessage);
       }
@@ -2977,11 +2915,11 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(202, 1);
         output.WriteString(OptionalCord);
       }
-      if (HasOptionalPublicImportMessage) {
+      if (optionalPublicImportMessage_ != null) {
         output.WriteRawTag(210, 1);
         output.WriteMessage(OptionalPublicImportMessage);
       }
-      if (HasOptionalLazyMessage) {
+      if (optionalLazyMessage_ != null) {
         output.WriteRawTag(218, 1);
         output.WriteMessage(OptionalLazyMessage);
       }
@@ -3094,7 +3032,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(248, 6);
         output.WriteUInt32(OneofUint32);
       }
-      if (HasOneofNestedMessage) {
+      if (oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage) {
         output.WriteRawTag(130, 7);
         output.WriteMessage(OneofNestedMessage);
       }
@@ -3162,13 +3100,13 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasOptionalGroup) {
         size += 4 + pb::CodedOutputStream.ComputeGroupSize(OptionalGroup);
       }
-      if (HasOptionalNestedMessage) {
+      if (optionalNestedMessage_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(OptionalNestedMessage);
       }
-      if (HasOptionalForeignMessage) {
+      if (optionalForeignMessage_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(OptionalForeignMessage);
       }
-      if (HasOptionalImportMessage) {
+      if (optionalImportMessage_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(OptionalImportMessage);
       }
       if (HasOptionalNestedEnum) {
@@ -3186,10 +3124,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasOptionalCord) {
         size += 2 + pb::CodedOutputStream.ComputeStringSize(OptionalCord);
       }
-      if (HasOptionalPublicImportMessage) {
+      if (optionalPublicImportMessage_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(OptionalPublicImportMessage);
       }
-      if (HasOptionalLazyMessage) {
+      if (optionalLazyMessage_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(OptionalLazyMessage);
       }
       size += repeatedInt32_.CalculateSize(_repeated_repeatedInt32_codec);
@@ -3280,7 +3218,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasOneofUint32) {
         size += 2 + pb::CodedOutputStream.ComputeUInt32Size(OneofUint32);
       }
-      if (HasOneofNestedMessage) {
+      if (oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(OneofNestedMessage);
       }
       if (HasOneofString) {
@@ -3351,20 +3289,20 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         }
         OptionalGroup.MergeFrom(other.OptionalGroup);
       }
-      if (other.HasOptionalNestedMessage) {
-        if (!HasOptionalNestedMessage) {
+      if (other.optionalNestedMessage_ != null) {
+        if (optionalNestedMessage_ == null) {
           OptionalNestedMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage();
         }
         OptionalNestedMessage.MergeFrom(other.OptionalNestedMessage);
       }
-      if (other.HasOptionalForeignMessage) {
-        if (!HasOptionalForeignMessage) {
+      if (other.optionalForeignMessage_ != null) {
+        if (optionalForeignMessage_ == null) {
           OptionalForeignMessage = new global::Google.Protobuf.TestProtos.Proto2.ForeignMessage();
         }
         OptionalForeignMessage.MergeFrom(other.OptionalForeignMessage);
       }
-      if (other.HasOptionalImportMessage) {
-        if (!HasOptionalImportMessage) {
+      if (other.optionalImportMessage_ != null) {
+        if (optionalImportMessage_ == null) {
           OptionalImportMessage = new global::Google.Protobuf.TestProtos.Proto2.ImportMessage();
         }
         OptionalImportMessage.MergeFrom(other.OptionalImportMessage);
@@ -3384,14 +3322,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other.HasOptionalCord) {
         OptionalCord = other.OptionalCord;
       }
-      if (other.HasOptionalPublicImportMessage) {
-        if (!HasOptionalPublicImportMessage) {
+      if (other.optionalPublicImportMessage_ != null) {
+        if (optionalPublicImportMessage_ == null) {
           OptionalPublicImportMessage = new global::Google.Protobuf.TestProtos.Proto2.PublicImportMessage();
         }
         OptionalPublicImportMessage.MergeFrom(other.OptionalPublicImportMessage);
       }
-      if (other.HasOptionalLazyMessage) {
-        if (!HasOptionalLazyMessage) {
+      if (other.optionalLazyMessage_ != null) {
+        if (optionalLazyMessage_ == null) {
           OptionalLazyMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage();
         }
         OptionalLazyMessage.MergeFrom(other.OptionalLazyMessage);
@@ -3578,21 +3516,21 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             break;
           }
           case 146: {
-            if (!HasOptionalNestedMessage) {
+            if (optionalNestedMessage_ == null) {
               OptionalNestedMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage();
             }
             input.ReadMessage(OptionalNestedMessage);
             break;
           }
           case 154: {
-            if (!HasOptionalForeignMessage) {
+            if (optionalForeignMessage_ == null) {
               OptionalForeignMessage = new global::Google.Protobuf.TestProtos.Proto2.ForeignMessage();
             }
             input.ReadMessage(OptionalForeignMessage);
             break;
           }
           case 162: {
-            if (!HasOptionalImportMessage) {
+            if (optionalImportMessage_ == null) {
               OptionalImportMessage = new global::Google.Protobuf.TestProtos.Proto2.ImportMessage();
             }
             input.ReadMessage(OptionalImportMessage);
@@ -3619,14 +3557,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             break;
           }
           case 210: {
-            if (!HasOptionalPublicImportMessage) {
+            if (optionalPublicImportMessage_ == null) {
               OptionalPublicImportMessage = new global::Google.Protobuf.TestProtos.Proto2.PublicImportMessage();
             }
             input.ReadMessage(OptionalPublicImportMessage);
             break;
           }
           case 218: {
-            if (!HasOptionalLazyMessage) {
+            if (optionalLazyMessage_ == null) {
               OptionalLazyMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage();
             }
             input.ReadMessage(OptionalLazyMessage);
@@ -3834,7 +3772,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           }
           case 898: {
             global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage subBuilder = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage();
-            if (HasOneofNestedMessage) {
+            if (oneofFieldCase_ == OneofFieldOneofCase.OneofNestedMessage) {
               subBuilder.MergeFrom(OneofNestedMessage);
             }
             input.ReadMessage(subBuilder);
@@ -4341,8 +4279,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public NestedTestAllTypes(NestedTestAllTypes other) : this() {
-      child_ = other.HasChild ? other.child_.Clone() : null;
-      payload_ = other.HasPayload ? other.payload_.Clone() : null;
+      child_ = other.child_ != null ? other.child_.Clone() : null;
+      payload_ = other.payload_ != null ? other.payload_.Clone() : null;
       repeatedChild_ = other.repeatedChild_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
@@ -4362,16 +4300,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         child_ = value;
       }
     }
-    /// <summary>Gets whether the child field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasChild {
-      get { return child_ != null; }
-    }
-    /// <summary>Clears the value of the child field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearChild() {
-      child_ = null;
-    }
 
     /// <summary>Field number for the "payload" field.</summary>
     public const int PayloadFieldNumber = 2;
@@ -4382,16 +4310,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         payload_ = value;
       }
-    }
-    /// <summary>Gets whether the payload field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasPayload {
-      get { return payload_ != null; }
-    }
-    /// <summary>Clears the value of the payload field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearPayload() {
-      payload_ = null;
     }
 
     /// <summary>Field number for the "repeated_child" field.</summary>
@@ -4426,8 +4344,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasChild) hash ^= Child.GetHashCode();
-      if (HasPayload) hash ^= Payload.GetHashCode();
+      if (child_ != null) hash ^= Child.GetHashCode();
+      if (payload_ != null) hash ^= Payload.GetHashCode();
       hash ^= repeatedChild_.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -4442,11 +4360,11 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasChild) {
+      if (child_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(Child);
       }
-      if (HasPayload) {
+      if (payload_ != null) {
         output.WriteRawTag(18);
         output.WriteMessage(Payload);
       }
@@ -4459,10 +4377,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasChild) {
+      if (child_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Child);
       }
-      if (HasPayload) {
+      if (payload_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Payload);
       }
       size += repeatedChild_.CalculateSize(_repeated_repeatedChild_codec);
@@ -4477,14 +4395,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasChild) {
-        if (!HasChild) {
+      if (other.child_ != null) {
+        if (child_ == null) {
           Child = new global::Google.Protobuf.TestProtos.Proto2.NestedTestAllTypes();
         }
         Child.MergeFrom(other.Child);
       }
-      if (other.HasPayload) {
-        if (!HasPayload) {
+      if (other.payload_ != null) {
+        if (payload_ == null) {
           Payload = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
         }
         Payload.MergeFrom(other.Payload);
@@ -4502,14 +4420,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasChild) {
+            if (child_ == null) {
               Child = new global::Google.Protobuf.TestProtos.Proto2.NestedTestAllTypes();
             }
             input.ReadMessage(Child);
             break;
           }
           case 18: {
-            if (!HasPayload) {
+            if (payload_ == null) {
               Payload = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
             }
             input.ReadMessage(Payload);
@@ -7835,7 +7753,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestRequiredForeign(TestRequiredForeign other) : this() {
       _hasBits0 = other._hasBits0;
-      optionalMessage_ = other.HasOptionalMessage ? other.optionalMessage_.Clone() : null;
+      optionalMessage_ = other.optionalMessage_ != null ? other.optionalMessage_.Clone() : null;
       repeatedMessage_ = other.repeatedMessage_.Clone();
       dummy_ = other.dummy_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -7855,16 +7773,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         optionalMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the optional_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalMessage {
-      get { return optionalMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalMessage() {
-      optionalMessage_ = null;
     }
 
     /// <summary>Field number for the "repeated_message" field.</summary>
@@ -7923,7 +7831,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasOptionalMessage) hash ^= OptionalMessage.GetHashCode();
+      if (optionalMessage_ != null) hash ^= OptionalMessage.GetHashCode();
       hash ^= repeatedMessage_.GetHashCode();
       if (HasDummy) hash ^= Dummy.GetHashCode();
       if (_unknownFields != null) {
@@ -7939,7 +7847,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasOptionalMessage) {
+      if (optionalMessage_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(OptionalMessage);
       }
@@ -7956,7 +7864,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasOptionalMessage) {
+      if (optionalMessage_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(OptionalMessage);
       }
       size += repeatedMessage_.CalculateSize(_repeated_repeatedMessage_codec);
@@ -7974,8 +7882,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasOptionalMessage) {
-        if (!HasOptionalMessage) {
+      if (other.optionalMessage_ != null) {
+        if (optionalMessage_ == null) {
           OptionalMessage = new global::Google.Protobuf.TestProtos.Proto2.TestRequired();
         }
         OptionalMessage.MergeFrom(other.OptionalMessage);
@@ -7996,7 +7904,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasOptionalMessage) {
+            if (optionalMessage_ == null) {
               OptionalMessage = new global::Google.Protobuf.TestProtos.Proto2.TestRequired();
             }
             input.ReadMessage(OptionalMessage);
@@ -8041,9 +7949,9 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestRequiredMessage(TestRequiredMessage other) : this() {
-      optionalMessage_ = other.HasOptionalMessage ? other.optionalMessage_.Clone() : null;
+      optionalMessage_ = other.optionalMessage_ != null ? other.optionalMessage_.Clone() : null;
       repeatedMessage_ = other.repeatedMessage_.Clone();
-      requiredMessage_ = other.HasRequiredMessage ? other.requiredMessage_.Clone() : null;
+      requiredMessage_ = other.requiredMessage_ != null ? other.requiredMessage_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -8061,16 +7969,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         optionalMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the optional_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalMessage {
-      get { return optionalMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalMessage() {
-      optionalMessage_ = null;
     }
 
     /// <summary>Field number for the "repeated_message" field.</summary>
@@ -8092,16 +7990,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         requiredMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the required_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasRequiredMessage {
-      get { return requiredMessage_ != null; }
-    }
-    /// <summary>Clears the value of the required_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearRequiredMessage() {
-      requiredMessage_ = null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8126,9 +8014,9 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasOptionalMessage) hash ^= OptionalMessage.GetHashCode();
+      if (optionalMessage_ != null) hash ^= OptionalMessage.GetHashCode();
       hash ^= repeatedMessage_.GetHashCode();
-      if (HasRequiredMessage) hash ^= RequiredMessage.GetHashCode();
+      if (requiredMessage_ != null) hash ^= RequiredMessage.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -8142,12 +8030,12 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasOptionalMessage) {
+      if (optionalMessage_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(OptionalMessage);
       }
       repeatedMessage_.WriteTo(output, _repeated_repeatedMessage_codec);
-      if (HasRequiredMessage) {
+      if (requiredMessage_ != null) {
         output.WriteRawTag(26);
         output.WriteMessage(RequiredMessage);
       }
@@ -8159,11 +8047,11 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasOptionalMessage) {
+      if (optionalMessage_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(OptionalMessage);
       }
       size += repeatedMessage_.CalculateSize(_repeated_repeatedMessage_codec);
-      if (HasRequiredMessage) {
+      if (requiredMessage_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(RequiredMessage);
       }
       if (_unknownFields != null) {
@@ -8177,15 +8065,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasOptionalMessage) {
-        if (!HasOptionalMessage) {
+      if (other.optionalMessage_ != null) {
+        if (optionalMessage_ == null) {
           OptionalMessage = new global::Google.Protobuf.TestProtos.Proto2.TestRequired();
         }
         OptionalMessage.MergeFrom(other.OptionalMessage);
       }
       repeatedMessage_.Add(other.repeatedMessage_);
-      if (other.HasRequiredMessage) {
-        if (!HasRequiredMessage) {
+      if (other.requiredMessage_ != null) {
+        if (requiredMessage_ == null) {
           RequiredMessage = new global::Google.Protobuf.TestProtos.Proto2.TestRequired();
         }
         RequiredMessage.MergeFrom(other.RequiredMessage);
@@ -8202,7 +8090,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasOptionalMessage) {
+            if (optionalMessage_ == null) {
               OptionalMessage = new global::Google.Protobuf.TestProtos.Proto2.TestRequired();
             }
             input.ReadMessage(OptionalMessage);
@@ -8213,7 +8101,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             break;
           }
           case 26: {
-            if (!HasRequiredMessage) {
+            if (requiredMessage_ == null) {
               RequiredMessage = new global::Google.Protobuf.TestProtos.Proto2.TestRequired();
             }
             input.ReadMessage(RequiredMessage);
@@ -8253,7 +8141,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestForeignNested(TestForeignNested other) : this() {
-      foreignNested_ = other.HasForeignNested ? other.foreignNested_.Clone() : null;
+      foreignNested_ = other.foreignNested_ != null ? other.foreignNested_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -8271,16 +8159,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         foreignNested_ = value;
       }
-    }
-    /// <summary>Gets whether the foreign_nested field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasForeignNested {
-      get { return foreignNested_ != null; }
-    }
-    /// <summary>Clears the value of the foreign_nested field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearForeignNested() {
-      foreignNested_ = null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8303,7 +8181,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasForeignNested) hash ^= ForeignNested.GetHashCode();
+      if (foreignNested_ != null) hash ^= ForeignNested.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -8317,7 +8195,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasForeignNested) {
+      if (foreignNested_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(ForeignNested);
       }
@@ -8329,7 +8207,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasForeignNested) {
+      if (foreignNested_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(ForeignNested);
       }
       if (_unknownFields != null) {
@@ -8343,8 +8221,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasForeignNested) {
-        if (!HasForeignNested) {
+      if (other.foreignNested_ != null) {
+        if (foreignNested_ == null) {
           ForeignNested = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage();
         }
         ForeignNested.MergeFrom(other.ForeignNested);
@@ -8361,7 +8239,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasForeignNested) {
+            if (foreignNested_ == null) {
               ForeignNested = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage();
             }
             input.ReadMessage(ForeignNested);
@@ -8982,7 +8860,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestRecursiveMessage(TestRecursiveMessage other) : this() {
       _hasBits0 = other._hasBits0;
-      a_ = other.HasA ? other.a_.Clone() : null;
+      a_ = other.a_ != null ? other.a_.Clone() : null;
       i_ = other.i_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
@@ -9001,16 +8879,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         a_ = value;
       }
-    }
-    /// <summary>Gets whether the a field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasA {
-      get { return a_ != null; }
-    }
-    /// <summary>Clears the value of the a field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearA() {
-      a_ = null;
     }
 
     /// <summary>Field number for the "i" field.</summary>
@@ -9058,7 +8926,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasA) hash ^= A.GetHashCode();
+      if (a_ != null) hash ^= A.GetHashCode();
       if (HasI) hash ^= I.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -9073,7 +8941,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasA) {
+      if (a_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(A);
       }
@@ -9089,7 +8957,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasA) {
+      if (a_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(A);
       }
       if (HasI) {
@@ -9106,8 +8974,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasA) {
-        if (!HasA) {
+      if (other.a_ != null) {
+        if (a_ == null) {
           A = new global::Google.Protobuf.TestProtos.Proto2.TestRecursiveMessage();
         }
         A.MergeFrom(other.A);
@@ -9127,7 +8995,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasA) {
+            if (a_ == null) {
               A = new global::Google.Protobuf.TestProtos.Proto2.TestRecursiveMessage();
             }
             input.ReadMessage(A);
@@ -9171,7 +9039,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestMutualRecursionA(TestMutualRecursionA other) : this() {
-      bb_ = other.HasBb ? other.bb_.Clone() : null;
+      bb_ = other.bb_ != null ? other.bb_.Clone() : null;
       subGroup_ = other.HasSubGroup ? other.subGroup_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
@@ -9190,16 +9058,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         bb_ = value;
       }
-    }
-    /// <summary>Gets whether the bb field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasBb {
-      get { return bb_ != null; }
-    }
-    /// <summary>Clears the value of the bb field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearBb() {
-      bb_ = null;
     }
 
     /// <summary>Field number for the "subgroup" field.</summary>
@@ -9244,7 +9102,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasBb) hash ^= Bb.GetHashCode();
+      if (bb_ != null) hash ^= Bb.GetHashCode();
       if (HasSubGroup) hash ^= SubGroup.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -9259,7 +9117,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasBb) {
+      if (bb_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(Bb);
       }
@@ -9276,7 +9134,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasBb) {
+      if (bb_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Bb);
       }
       if (HasSubGroup) {
@@ -9293,8 +9151,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasBb) {
-        if (!HasBb) {
+      if (other.bb_ != null) {
+        if (bb_ == null) {
           Bb = new global::Google.Protobuf.TestProtos.Proto2.TestMutualRecursionB();
         }
         Bb.MergeFrom(other.Bb);
@@ -9317,7 +9175,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasBb) {
+            if (bb_ == null) {
               Bb = new global::Google.Protobuf.TestProtos.Proto2.TestMutualRecursionB();
             }
             input.ReadMessage(Bb);
@@ -9363,7 +9221,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public SubMessage(SubMessage other) : this() {
-          b_ = other.HasB ? other.b_.Clone() : null;
+          b_ = other.b_ != null ? other.b_.Clone() : null;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -9381,16 +9239,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           set {
             b_ = value;
           }
-        }
-        /// <summary>Gets whether the b field is set</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public bool HasB {
-          get { return b_ != null; }
-        }
-        /// <summary>Clears the value of the b field</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public void ClearB() {
-          b_ = null;
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9413,7 +9261,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override int GetHashCode() {
           int hash = 1;
-          if (HasB) hash ^= B.GetHashCode();
+          if (b_ != null) hash ^= B.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -9427,7 +9275,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
-          if (HasB) {
+          if (b_ != null) {
             output.WriteRawTag(10);
             output.WriteMessage(B);
           }
@@ -9439,7 +9287,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public int CalculateSize() {
           int size = 0;
-          if (HasB) {
+          if (b_ != null) {
             size += 1 + pb::CodedOutputStream.ComputeMessageSize(B);
           }
           if (_unknownFields != null) {
@@ -9453,8 +9301,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           if (other == null) {
             return;
           }
-          if (other.HasB) {
-            if (!HasB) {
+          if (other.b_ != null) {
+            if (b_ == null) {
               B = new global::Google.Protobuf.TestProtos.Proto2.TestMutualRecursionB();
             }
             B.MergeFrom(other.B);
@@ -9471,7 +9319,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
               case 10: {
-                if (!HasB) {
+                if (b_ == null) {
                   B = new global::Google.Protobuf.TestProtos.Proto2.TestMutualRecursionB();
                 }
                 input.ReadMessage(B);
@@ -9508,8 +9356,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public SubGroup(SubGroup other) : this() {
-          subMessage_ = other.HasSubMessage ? other.subMessage_.Clone() : null;
-          notInThisScc_ = other.HasNotInThisScc ? other.notInThisScc_.Clone() : null;
+          subMessage_ = other.subMessage_ != null ? other.subMessage_.Clone() : null;
+          notInThisScc_ = other.notInThisScc_ != null ? other.notInThisScc_.Clone() : null;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -9531,16 +9379,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             subMessage_ = value;
           }
         }
-        /// <summary>Gets whether the sub_message field is set</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public bool HasSubMessage {
-          get { return subMessage_ != null; }
-        }
-        /// <summary>Clears the value of the sub_message field</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public void ClearSubMessage() {
-          subMessage_ = null;
-        }
 
         /// <summary>Field number for the "not_in_this_scc" field.</summary>
         public const int NotInThisSccFieldNumber = 4;
@@ -9551,16 +9389,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           set {
             notInThisScc_ = value;
           }
-        }
-        /// <summary>Gets whether the not_in_this_scc field is set</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public bool HasNotInThisScc {
-          get { return notInThisScc_ != null; }
-        }
-        /// <summary>Clears the value of the not_in_this_scc field</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public void ClearNotInThisScc() {
-          notInThisScc_ = null;
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9584,8 +9412,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override int GetHashCode() {
           int hash = 1;
-          if (HasSubMessage) hash ^= SubMessage.GetHashCode();
-          if (HasNotInThisScc) hash ^= NotInThisScc.GetHashCode();
+          if (subMessage_ != null) hash ^= SubMessage.GetHashCode();
+          if (notInThisScc_ != null) hash ^= NotInThisScc.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -9599,11 +9427,11 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
-          if (HasSubMessage) {
+          if (subMessage_ != null) {
             output.WriteRawTag(26);
             output.WriteMessage(SubMessage);
           }
-          if (HasNotInThisScc) {
+          if (notInThisScc_ != null) {
             output.WriteRawTag(34);
             output.WriteMessage(NotInThisScc);
           }
@@ -9615,10 +9443,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public int CalculateSize() {
           int size = 0;
-          if (HasSubMessage) {
+          if (subMessage_ != null) {
             size += 1 + pb::CodedOutputStream.ComputeMessageSize(SubMessage);
           }
-          if (HasNotInThisScc) {
+          if (notInThisScc_ != null) {
             size += 1 + pb::CodedOutputStream.ComputeMessageSize(NotInThisScc);
           }
           if (_unknownFields != null) {
@@ -9632,14 +9460,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           if (other == null) {
             return;
           }
-          if (other.HasSubMessage) {
-            if (!HasSubMessage) {
+          if (other.subMessage_ != null) {
+            if (subMessage_ == null) {
               SubMessage = new global::Google.Protobuf.TestProtos.Proto2.TestMutualRecursionA.Types.SubMessage();
             }
             SubMessage.MergeFrom(other.SubMessage);
           }
-          if (other.HasNotInThisScc) {
-            if (!HasNotInThisScc) {
+          if (other.notInThisScc_ != null) {
+            if (notInThisScc_ == null) {
               NotInThisScc = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
             }
             NotInThisScc.MergeFrom(other.NotInThisScc);
@@ -9658,14 +9486,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
               case 26: {
-                if (!HasSubMessage) {
+                if (subMessage_ == null) {
                   SubMessage = new global::Google.Protobuf.TestProtos.Proto2.TestMutualRecursionA.Types.SubMessage();
                 }
                 input.ReadMessage(SubMessage);
                 break;
               }
               case 34: {
-                if (!HasNotInThisScc) {
+                if (notInThisScc_ == null) {
                   NotInThisScc = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
                 }
                 input.ReadMessage(NotInThisScc);
@@ -9709,7 +9537,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestMutualRecursionB(TestMutualRecursionB other) : this() {
       _hasBits0 = other._hasBits0;
-      a_ = other.HasA ? other.a_.Clone() : null;
+      a_ = other.a_ != null ? other.a_.Clone() : null;
       optionalInt32_ = other.optionalInt32_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
@@ -9728,16 +9556,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         a_ = value;
       }
-    }
-    /// <summary>Gets whether the a field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasA {
-      get { return a_ != null; }
-    }
-    /// <summary>Clears the value of the a field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearA() {
-      a_ = null;
     }
 
     /// <summary>Field number for the "optional_int32" field.</summary>
@@ -9785,7 +9603,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasA) hash ^= A.GetHashCode();
+      if (a_ != null) hash ^= A.GetHashCode();
       if (HasOptionalInt32) hash ^= OptionalInt32.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -9800,7 +9618,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasA) {
+      if (a_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(A);
       }
@@ -9816,7 +9634,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasA) {
+      if (a_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(A);
       }
       if (HasOptionalInt32) {
@@ -9833,8 +9651,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasA) {
-        if (!HasA) {
+      if (other.a_ != null) {
+        if (a_ == null) {
           A = new global::Google.Protobuf.TestProtos.Proto2.TestMutualRecursionA();
         }
         A.MergeFrom(other.A);
@@ -9854,7 +9672,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasA) {
+            if (a_ == null) {
               A = new global::Google.Protobuf.TestProtos.Proto2.TestMutualRecursionA();
             }
             input.ReadMessage(A);
@@ -9895,7 +9713,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestIsInitialized(TestIsInitialized other) : this() {
-      subMessage_ = other.HasSubMessage ? other.subMessage_.Clone() : null;
+      subMessage_ = other.subMessage_ != null ? other.subMessage_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -9913,16 +9731,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         subMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the sub_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasSubMessage {
-      get { return subMessage_ != null; }
-    }
-    /// <summary>Clears the value of the sub_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearSubMessage() {
-      subMessage_ = null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9945,7 +9753,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasSubMessage) hash ^= SubMessage.GetHashCode();
+      if (subMessage_ != null) hash ^= SubMessage.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -9959,7 +9767,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasSubMessage) {
+      if (subMessage_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(SubMessage);
       }
@@ -9971,7 +9779,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasSubMessage) {
+      if (subMessage_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(SubMessage);
       }
       if (_unknownFields != null) {
@@ -9985,8 +9793,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasSubMessage) {
-        if (!HasSubMessage) {
+      if (other.subMessage_ != null) {
+        if (subMessage_ == null) {
           SubMessage = new global::Google.Protobuf.TestProtos.Proto2.TestIsInitialized.Types.SubMessage();
         }
         SubMessage.MergeFrom(other.SubMessage);
@@ -10003,7 +9811,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasSubMessage) {
+            if (subMessage_ == null) {
               SubMessage = new global::Google.Protobuf.TestProtos.Proto2.TestIsInitialized.Types.SubMessage();
             }
             input.ReadMessage(SubMessage);
@@ -10891,7 +10699,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestEagerMessage(TestEagerMessage other) : this() {
-      subMessage_ = other.HasSubMessage ? other.subMessage_.Clone() : null;
+      subMessage_ = other.subMessage_ != null ? other.subMessage_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -10909,16 +10717,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         subMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the sub_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasSubMessage {
-      get { return subMessage_ != null; }
-    }
-    /// <summary>Clears the value of the sub_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearSubMessage() {
-      subMessage_ = null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10941,7 +10739,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasSubMessage) hash ^= SubMessage.GetHashCode();
+      if (subMessage_ != null) hash ^= SubMessage.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -10955,7 +10753,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasSubMessage) {
+      if (subMessage_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(SubMessage);
       }
@@ -10967,7 +10765,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasSubMessage) {
+      if (subMessage_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(SubMessage);
       }
       if (_unknownFields != null) {
@@ -10981,8 +10779,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasSubMessage) {
-        if (!HasSubMessage) {
+      if (other.subMessage_ != null) {
+        if (subMessage_ == null) {
           SubMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
         }
         SubMessage.MergeFrom(other.SubMessage);
@@ -10999,7 +10797,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasSubMessage) {
+            if (subMessage_ == null) {
               SubMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
             }
             input.ReadMessage(SubMessage);
@@ -11036,7 +10834,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestLazyMessage(TestLazyMessage other) : this() {
-      subMessage_ = other.HasSubMessage ? other.subMessage_.Clone() : null;
+      subMessage_ = other.subMessage_ != null ? other.subMessage_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -11054,16 +10852,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         subMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the sub_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasSubMessage {
-      get { return subMessage_ != null; }
-    }
-    /// <summary>Clears the value of the sub_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearSubMessage() {
-      subMessage_ = null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11086,7 +10874,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasSubMessage) hash ^= SubMessage.GetHashCode();
+      if (subMessage_ != null) hash ^= SubMessage.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -11100,7 +10888,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasSubMessage) {
+      if (subMessage_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(SubMessage);
       }
@@ -11112,7 +10900,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasSubMessage) {
+      if (subMessage_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(SubMessage);
       }
       if (_unknownFields != null) {
@@ -11126,8 +10914,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasSubMessage) {
-        if (!HasSubMessage) {
+      if (other.subMessage_ != null) {
+        if (subMessage_ == null) {
           SubMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
         }
         SubMessage.MergeFrom(other.SubMessage);
@@ -11144,7 +10932,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasSubMessage) {
+            if (subMessage_ == null) {
               SubMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
             }
             input.ReadMessage(SubMessage);
@@ -11184,7 +10972,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestNestedMessageHasBits(TestNestedMessageHasBits other) : this() {
-      optionalNestedMessage_ = other.HasOptionalNestedMessage ? other.optionalNestedMessage_.Clone() : null;
+      optionalNestedMessage_ = other.optionalNestedMessage_ != null ? other.optionalNestedMessage_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -11202,16 +10990,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         optionalNestedMessage_ = value;
       }
-    }
-    /// <summary>Gets whether the optional_nested_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalNestedMessage {
-      get { return optionalNestedMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_nested_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalNestedMessage() {
-      optionalNestedMessage_ = null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11234,7 +11012,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasOptionalNestedMessage) hash ^= OptionalNestedMessage.GetHashCode();
+      if (optionalNestedMessage_ != null) hash ^= OptionalNestedMessage.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -11248,7 +11026,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasOptionalNestedMessage) {
+      if (optionalNestedMessage_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(OptionalNestedMessage);
       }
@@ -11260,7 +11038,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasOptionalNestedMessage) {
+      if (optionalNestedMessage_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(OptionalNestedMessage);
       }
       if (_unknownFields != null) {
@@ -11274,8 +11052,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasOptionalNestedMessage) {
-        if (!HasOptionalNestedMessage) {
+      if (other.optionalNestedMessage_ != null) {
+        if (optionalNestedMessage_ == null) {
           OptionalNestedMessage = new global::Google.Protobuf.TestProtos.Proto2.TestNestedMessageHasBits.Types.NestedMessage();
         }
         OptionalNestedMessage.MergeFrom(other.OptionalNestedMessage);
@@ -11292,7 +11070,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            if (!HasOptionalNestedMessage) {
+            if (optionalNestedMessage_ == null) {
               OptionalNestedMessage = new global::Google.Protobuf.TestProtos.Proto2.TestNestedMessageHasBits.Types.NestedMessage();
             }
             input.ReadMessage(OptionalNestedMessage);
@@ -11487,7 +11265,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       primitiveField_ = other.primitiveField_;
       stringField_ = other.stringField_;
       enumField_ = other.enumField_;
-      messageField_ = other.HasMessageField ? other.messageField_.Clone() : null;
+      messageField_ = other.messageField_ != null ? other.messageField_.Clone() : null;
       stringPieceField_ = other.stringPieceField_;
       cordField_ = other.cordField_;
       repeatedPrimitiveField_ = other.repeatedPrimitiveField_.Clone();
@@ -11584,16 +11362,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         messageField_ = value;
       }
-    }
-    /// <summary>Gets whether the MessageField field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasMessageField {
-      get { return messageField_ != null; }
-    }
-    /// <summary>Clears the value of the MessageField field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearMessageField() {
-      messageField_ = null;
     }
 
     /// <summary>Field number for the "StringPieceField" field.</summary>
@@ -11736,7 +11504,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasPrimitiveField) hash ^= PrimitiveField.GetHashCode();
       if (HasStringField) hash ^= StringField.GetHashCode();
       if (HasEnumField) hash ^= EnumField.GetHashCode();
-      if (HasMessageField) hash ^= MessageField.GetHashCode();
+      if (messageField_ != null) hash ^= MessageField.GetHashCode();
       if (HasStringPieceField) hash ^= StringPieceField.GetHashCode();
       if (HasCordField) hash ^= CordField.GetHashCode();
       hash ^= repeatedPrimitiveField_.GetHashCode();
@@ -11770,7 +11538,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(24);
         output.WriteEnum((int) EnumField);
       }
-      if (HasMessageField) {
+      if (messageField_ != null) {
         output.WriteRawTag(34);
         output.WriteMessage(MessageField);
       }
@@ -11805,7 +11573,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasEnumField) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) EnumField);
       }
-      if (HasMessageField) {
+      if (messageField_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(MessageField);
       }
       if (HasStringPieceField) {
@@ -11840,8 +11608,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other.HasEnumField) {
         EnumField = other.EnumField;
       }
-      if (other.HasMessageField) {
-        if (!HasMessageField) {
+      if (other.messageField_ != null) {
+        if (messageField_ == null) {
           MessageField = new global::Google.Protobuf.TestProtos.Proto2.ForeignMessage();
         }
         MessageField.MergeFrom(other.MessageField);
@@ -11882,7 +11650,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             break;
           }
           case 34: {
-            if (!HasMessageField) {
+            if (messageField_ == null) {
               MessageField = new global::Google.Protobuf.TestProtos.Proto2.ForeignMessage();
             }
             input.ReadMessage(MessageField);
@@ -11964,7 +11732,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       myString_ = other.myString_;
       myInt_ = other.myInt_;
       myFloat_ = other.myFloat_;
-      optionalNestedMessage_ = other.HasOptionalNestedMessage ? other.optionalNestedMessage_.Clone() : null;
+      optionalNestedMessage_ = other.optionalNestedMessage_ != null ? other.optionalNestedMessage_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
       _extensions = pb::ExtensionSet.Clone(other._extensions);
     }
@@ -12055,16 +11823,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         optionalNestedMessage_ = value;
       }
     }
-    /// <summary>Gets whether the optional_nested_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalNestedMessage {
-      get { return optionalNestedMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_nested_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalNestedMessage() {
-      optionalNestedMessage_ = null;
-    }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
@@ -12095,7 +11853,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasMyString) hash ^= MyString.GetHashCode();
       if (HasMyInt) hash ^= MyInt.GetHashCode();
       if (HasMyFloat) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(MyFloat);
-      if (HasOptionalNestedMessage) hash ^= OptionalNestedMessage.GetHashCode();
+      if (optionalNestedMessage_ != null) hash ^= OptionalNestedMessage.GetHashCode();
       if (_extensions != null) {
         hash ^= _extensions.GetHashCode();
       }
@@ -12124,7 +11882,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(173, 6);
         output.WriteFloat(MyFloat);
       }
-      if (HasOptionalNestedMessage) {
+      if (optionalNestedMessage_ != null) {
         output.WriteRawTag(194, 12);
         output.WriteMessage(OptionalNestedMessage);
       }
@@ -12148,7 +11906,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasMyFloat) {
         size += 2 + 4;
       }
-      if (HasOptionalNestedMessage) {
+      if (optionalNestedMessage_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(OptionalNestedMessage);
       }
       if (_extensions != null) {
@@ -12174,8 +11932,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other.HasMyFloat) {
         MyFloat = other.MyFloat;
       }
-      if (other.HasOptionalNestedMessage) {
-        if (!HasOptionalNestedMessage) {
+      if (other.optionalNestedMessage_ != null) {
+        if (optionalNestedMessage_ == null) {
           OptionalNestedMessage = new global::Google.Protobuf.TestProtos.Proto2.TestFieldOrderings.Types.NestedMessage();
         }
         OptionalNestedMessage.MergeFrom(other.OptionalNestedMessage);
@@ -12207,7 +11965,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             break;
           }
           case 1602: {
-            if (!HasOptionalNestedMessage) {
+            if (optionalNestedMessage_ == null) {
               OptionalNestedMessage = new global::Google.Protobuf.TestProtos.Proto2.TestFieldOrderings.Types.NestedMessage();
             }
             input.ReadMessage(OptionalNestedMessage);
@@ -15616,22 +15374,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     public const int FooMessageFieldNumber = 3;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Google.Protobuf.TestProtos.Proto2.TestAllTypes FooMessage {
-      get { return HasFooMessage ? (global::Google.Protobuf.TestProtos.Proto2.TestAllTypes) foo_ : null; }
+      get { return fooCase_ == FooOneofCase.FooMessage ? (global::Google.Protobuf.TestProtos.Proto2.TestAllTypes) foo_ : null; }
       set {
         foo_ = value;
         fooCase_ = value == null ? FooOneofCase.None : FooOneofCase.FooMessage;
-      }
-    }
-    /// <summary>Gets whether the "foo_message" field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasFooMessage {
-      get { return fooCase_ == FooOneofCase.FooMessage; }
-    }
-    /// <summary> Clears the value of the oneof if it's currently set to "foo_message" </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearFooMessage() {
-      if (HasFooMessage) {
-        ClearFoo();
       }
     }
 
@@ -15705,7 +15451,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       int hash = 1;
       if (HasFooInt) hash ^= FooInt.GetHashCode();
       if (HasFooString) hash ^= FooString.GetHashCode();
-      if (HasFooMessage) hash ^= FooMessage.GetHashCode();
+      if (fooCase_ == FooOneofCase.FooMessage) hash ^= FooMessage.GetHashCode();
       if (HasFooGroup) hash ^= FooGroup.GetHashCode();
       hash ^= (int) fooCase_;
       if (_unknownFields != null) {
@@ -15729,7 +15475,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(18);
         output.WriteString(FooString);
       }
-      if (HasFooMessage) {
+      if (fooCase_ == FooOneofCase.FooMessage) {
         output.WriteRawTag(26);
         output.WriteMessage(FooMessage);
       }
@@ -15752,7 +15498,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasFooString) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(FooString);
       }
-      if (HasFooMessage) {
+      if (fooCase_ == FooOneofCase.FooMessage) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(FooMessage);
       }
       if (HasFooGroup) {
@@ -15811,7 +15557,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           }
           case 26: {
             global::Google.Protobuf.TestProtos.Proto2.TestAllTypes subBuilder = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
-            if (HasFooMessage) {
+            if (fooCase_ == FooOneofCase.FooMessage) {
               subBuilder.MergeFrom(FooMessage);
             }
             input.ReadMessage(subBuilder);
@@ -16055,7 +15801,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       _hasBits0 = other._hasBits0;
       fooInt_ = other.fooInt_;
       fooString_ = other.fooString_;
-      fooMessage_ = other.HasFooMessage ? other.fooMessage_.Clone() : null;
+      fooMessage_ = other.fooMessage_ != null ? other.fooMessage_.Clone() : null;
       fooGroup_ = other.HasFooGroup ? other.fooGroup_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
@@ -16122,16 +15868,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         fooMessage_ = value;
       }
     }
-    /// <summary>Gets whether the foo_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasFooMessage {
-      get { return fooMessage_ != null; }
-    }
-    /// <summary>Clears the value of the foo_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearFooMessage() {
-      fooMessage_ = null;
-    }
 
     /// <summary>Field number for the "foogroup" field.</summary>
     public const int FooGroupFieldNumber = 4;
@@ -16179,7 +15915,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       int hash = 1;
       if (HasFooInt) hash ^= FooInt.GetHashCode();
       if (HasFooString) hash ^= FooString.GetHashCode();
-      if (HasFooMessage) hash ^= FooMessage.GetHashCode();
+      if (fooMessage_ != null) hash ^= FooMessage.GetHashCode();
       if (HasFooGroup) hash ^= FooGroup.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -16202,7 +15938,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(18);
         output.WriteString(FooString);
       }
-      if (HasFooMessage) {
+      if (fooMessage_ != null) {
         output.WriteRawTag(26);
         output.WriteMessage(FooMessage);
       }
@@ -16225,7 +15961,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasFooString) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(FooString);
       }
-      if (HasFooMessage) {
+      if (fooMessage_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(FooMessage);
       }
       if (HasFooGroup) {
@@ -16248,8 +15984,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other.HasFooString) {
         FooString = other.FooString;
       }
-      if (other.HasFooMessage) {
-        if (!HasFooMessage) {
+      if (other.fooMessage_ != null) {
+        if (fooMessage_ == null) {
           FooMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
         }
         FooMessage.MergeFrom(other.FooMessage);
@@ -16280,7 +16016,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             break;
           }
           case 26: {
-            if (!HasFooMessage) {
+            if (fooMessage_ == null) {
               FooMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
             }
             input.ReadMessage(FooMessage);
@@ -16722,22 +16458,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     public const int FooMessageFieldNumber = 7;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Google.Protobuf.TestProtos.Proto2.TestOneof2.Types.NestedMessage FooMessage {
-      get { return HasFooMessage ? (global::Google.Protobuf.TestProtos.Proto2.TestOneof2.Types.NestedMessage) foo_ : null; }
+      get { return fooCase_ == FooOneofCase.FooMessage ? (global::Google.Protobuf.TestProtos.Proto2.TestOneof2.Types.NestedMessage) foo_ : null; }
       set {
         foo_ = value;
         fooCase_ = value == null ? FooOneofCase.None : FooOneofCase.FooMessage;
-      }
-    }
-    /// <summary>Gets whether the "foo_message" field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasFooMessage {
-      get { return fooCase_ == FooOneofCase.FooMessage; }
-    }
-    /// <summary> Clears the value of the oneof if it's currently set to "foo_message" </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearFooMessage() {
-      if (HasFooMessage) {
-        ClearFoo();
       }
     }
 
@@ -16768,22 +16492,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     public const int FooLazyMessageFieldNumber = 11;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Google.Protobuf.TestProtos.Proto2.TestOneof2.Types.NestedMessage FooLazyMessage {
-      get { return HasFooLazyMessage ? (global::Google.Protobuf.TestProtos.Proto2.TestOneof2.Types.NestedMessage) foo_ : null; }
+      get { return fooCase_ == FooOneofCase.FooLazyMessage ? (global::Google.Protobuf.TestProtos.Proto2.TestOneof2.Types.NestedMessage) foo_ : null; }
       set {
         foo_ = value;
         fooCase_ = value == null ? FooOneofCase.None : FooOneofCase.FooLazyMessage;
-      }
-    }
-    /// <summary>Gets whether the "foo_lazy_message" field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasFooLazyMessage {
-      get { return fooCase_ == FooOneofCase.FooLazyMessage; }
-    }
-    /// <summary> Clears the value of the oneof if it's currently set to "foo_lazy_message" </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearFooLazyMessage() {
-      if (HasFooLazyMessage) {
-        ClearFoo();
       }
     }
 
@@ -17065,9 +16777,9 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasFooStringPiece) hash ^= FooStringPiece.GetHashCode();
       if (HasFooBytes) hash ^= FooBytes.GetHashCode();
       if (HasFooEnum) hash ^= FooEnum.GetHashCode();
-      if (HasFooMessage) hash ^= FooMessage.GetHashCode();
+      if (fooCase_ == FooOneofCase.FooMessage) hash ^= FooMessage.GetHashCode();
       if (HasFooGroup) hash ^= FooGroup.GetHashCode();
-      if (HasFooLazyMessage) hash ^= FooLazyMessage.GetHashCode();
+      if (fooCase_ == FooOneofCase.FooLazyMessage) hash ^= FooLazyMessage.GetHashCode();
       if (HasBarInt) hash ^= BarInt.GetHashCode();
       if (HasBarString) hash ^= BarString.GetHashCode();
       if (HasBarCord) hash ^= BarCord.GetHashCode();
@@ -17115,7 +16827,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(48);
         output.WriteEnum((int) FooEnum);
       }
-      if (HasFooMessage) {
+      if (fooCase_ == FooOneofCase.FooMessage) {
         output.WriteRawTag(58);
         output.WriteMessage(FooMessage);
       }
@@ -17124,7 +16836,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteGroup(FooGroup);
         output.WriteRawTag(68);
       }
-      if (HasFooLazyMessage) {
+      if (fooCase_ == FooOneofCase.FooLazyMessage) {
         output.WriteRawTag(90);
         output.WriteMessage(FooLazyMessage);
       }
@@ -17186,13 +16898,13 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasFooEnum) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) FooEnum);
       }
-      if (HasFooMessage) {
+      if (fooCase_ == FooOneofCase.FooMessage) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(FooMessage);
       }
       if (HasFooGroup) {
         size += 2 + pb::CodedOutputStream.ComputeGroupSize(FooGroup);
       }
-      if (HasFooLazyMessage) {
+      if (fooCase_ == FooOneofCase.FooLazyMessage) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(FooLazyMessage);
       }
       if (HasBarInt) {
@@ -17334,7 +17046,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           }
           case 58: {
             global::Google.Protobuf.TestProtos.Proto2.TestOneof2.Types.NestedMessage subBuilder = new global::Google.Protobuf.TestProtos.Proto2.TestOneof2.Types.NestedMessage();
-            if (HasFooMessage) {
+            if (fooCase_ == FooOneofCase.FooMessage) {
               subBuilder.MergeFrom(FooMessage);
             }
             input.ReadMessage(subBuilder);
@@ -17352,7 +17064,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           }
           case 90: {
             global::Google.Protobuf.TestProtos.Proto2.TestOneof2.Types.NestedMessage subBuilder = new global::Google.Protobuf.TestProtos.Proto2.TestOneof2.Types.NestedMessage();
-            if (HasFooLazyMessage) {
+            if (fooCase_ == FooOneofCase.FooLazyMessage) {
               subBuilder.MergeFrom(FooLazyMessage);
             }
             input.ReadMessage(subBuilder);
@@ -17857,22 +17569,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     public const int FooMessageFieldNumber = 3;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Google.Protobuf.TestProtos.Proto2.TestRequiredOneof.Types.NestedMessage FooMessage {
-      get { return HasFooMessage ? (global::Google.Protobuf.TestProtos.Proto2.TestRequiredOneof.Types.NestedMessage) foo_ : null; }
+      get { return fooCase_ == FooOneofCase.FooMessage ? (global::Google.Protobuf.TestProtos.Proto2.TestRequiredOneof.Types.NestedMessage) foo_ : null; }
       set {
         foo_ = value;
         fooCase_ = value == null ? FooOneofCase.None : FooOneofCase.FooMessage;
-      }
-    }
-    /// <summary>Gets whether the "foo_message" field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasFooMessage {
-      get { return fooCase_ == FooOneofCase.FooMessage; }
-    }
-    /// <summary> Clears the value of the oneof if it's currently set to "foo_message" </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearFooMessage() {
-      if (HasFooMessage) {
-        ClearFoo();
       }
     }
 
@@ -17921,7 +17621,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       int hash = 1;
       if (HasFooInt) hash ^= FooInt.GetHashCode();
       if (HasFooString) hash ^= FooString.GetHashCode();
-      if (HasFooMessage) hash ^= FooMessage.GetHashCode();
+      if (fooCase_ == FooOneofCase.FooMessage) hash ^= FooMessage.GetHashCode();
       hash ^= (int) fooCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -17944,7 +17644,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(18);
         output.WriteString(FooString);
       }
-      if (HasFooMessage) {
+      if (fooCase_ == FooOneofCase.FooMessage) {
         output.WriteRawTag(26);
         output.WriteMessage(FooMessage);
       }
@@ -17962,7 +17662,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasFooString) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(FooString);
       }
-      if (HasFooMessage) {
+      if (fooCase_ == FooOneofCase.FooMessage) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(FooMessage);
       }
       if (_unknownFields != null) {
@@ -18012,7 +17712,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           }
           case 26: {
             global::Google.Protobuf.TestProtos.Proto2.TestRequiredOneof.Types.NestedMessage subBuilder = new global::Google.Protobuf.TestProtos.Proto2.TestRequiredOneof.Types.NestedMessage();
-            if (HasFooMessage) {
+            if (fooCase_ == FooOneofCase.FooMessage) {
               subBuilder.MergeFrom(FooMessage);
             }
             input.ReadMessage(subBuilder);
@@ -19559,8 +19259,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       scalarExtension_ = other.scalarExtension_;
       enumExtension_ = other.enumExtension_;
       dynamicEnumExtension_ = other.dynamicEnumExtension_;
-      messageExtension_ = other.HasMessageExtension ? other.messageExtension_.Clone() : null;
-      dynamicMessageExtension_ = other.HasDynamicMessageExtension ? other.dynamicMessageExtension_.Clone() : null;
+      messageExtension_ = other.messageExtension_ != null ? other.messageExtension_.Clone() : null;
+      dynamicMessageExtension_ = other.dynamicMessageExtension_ != null ? other.dynamicMessageExtension_.Clone() : null;
       repeatedExtension_ = other.repeatedExtension_.Clone();
       packedExtension_ = other.packedExtension_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -19653,16 +19353,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         messageExtension_ = value;
       }
     }
-    /// <summary>Gets whether the message_extension field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasMessageExtension {
-      get { return messageExtension_ != null; }
-    }
-    /// <summary>Clears the value of the message_extension field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearMessageExtension() {
-      messageExtension_ = null;
-    }
 
     /// <summary>Field number for the "dynamic_message_extension" field.</summary>
     public const int DynamicMessageExtensionFieldNumber = 2004;
@@ -19673,16 +19363,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         dynamicMessageExtension_ = value;
       }
-    }
-    /// <summary>Gets whether the dynamic_message_extension field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasDynamicMessageExtension {
-      get { return dynamicMessageExtension_ != null; }
-    }
-    /// <summary>Clears the value of the dynamic_message_extension field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearDynamicMessageExtension() {
-      dynamicMessageExtension_ = null;
     }
 
     /// <summary>Field number for the "repeated_extension" field.</summary>
@@ -19734,8 +19414,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasScalarExtension) hash ^= ScalarExtension.GetHashCode();
       if (HasEnumExtension) hash ^= EnumExtension.GetHashCode();
       if (HasDynamicEnumExtension) hash ^= DynamicEnumExtension.GetHashCode();
-      if (HasMessageExtension) hash ^= MessageExtension.GetHashCode();
-      if (HasDynamicMessageExtension) hash ^= DynamicMessageExtension.GetHashCode();
+      if (messageExtension_ != null) hash ^= MessageExtension.GetHashCode();
+      if (dynamicMessageExtension_ != null) hash ^= DynamicMessageExtension.GetHashCode();
       hash ^= repeatedExtension_.GetHashCode();
       hash ^= packedExtension_.GetHashCode();
       if (_unknownFields != null) {
@@ -19763,11 +19443,11 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(144, 125);
         output.WriteEnum((int) DynamicEnumExtension);
       }
-      if (HasMessageExtension) {
+      if (messageExtension_ != null) {
         output.WriteRawTag(154, 125);
         output.WriteMessage(MessageExtension);
       }
-      if (HasDynamicMessageExtension) {
+      if (dynamicMessageExtension_ != null) {
         output.WriteRawTag(162, 125);
         output.WriteMessage(DynamicMessageExtension);
       }
@@ -19790,10 +19470,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasDynamicEnumExtension) {
         size += 2 + pb::CodedOutputStream.ComputeEnumSize((int) DynamicEnumExtension);
       }
-      if (HasMessageExtension) {
+      if (messageExtension_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(MessageExtension);
       }
-      if (HasDynamicMessageExtension) {
+      if (dynamicMessageExtension_ != null) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(DynamicMessageExtension);
       }
       size += repeatedExtension_.CalculateSize(_repeated_repeatedExtension_codec);
@@ -19818,14 +19498,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other.HasDynamicEnumExtension) {
         DynamicEnumExtension = other.DynamicEnumExtension;
       }
-      if (other.HasMessageExtension) {
-        if (!HasMessageExtension) {
+      if (other.messageExtension_ != null) {
+        if (messageExtension_ == null) {
           MessageExtension = new global::Google.Protobuf.TestProtos.Proto2.ForeignMessage();
         }
         MessageExtension.MergeFrom(other.MessageExtension);
       }
-      if (other.HasDynamicMessageExtension) {
-        if (!HasDynamicMessageExtension) {
+      if (other.dynamicMessageExtension_ != null) {
+        if (dynamicMessageExtension_ == null) {
           DynamicMessageExtension = new global::Google.Protobuf.TestProtos.Proto2.TestDynamicExtensions.Types.DynamicMessageType();
         }
         DynamicMessageExtension.MergeFrom(other.DynamicMessageExtension);
@@ -19856,14 +19536,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             break;
           }
           case 16026: {
-            if (!HasMessageExtension) {
+            if (messageExtension_ == null) {
               MessageExtension = new global::Google.Protobuf.TestProtos.Proto2.ForeignMessage();
             }
             input.ReadMessage(MessageExtension);
             break;
           }
           case 16034: {
-            if (!HasDynamicMessageExtension) {
+            if (dynamicMessageExtension_ == null) {
               DynamicMessageExtension = new global::Google.Protobuf.TestProtos.Proto2.TestDynamicExtensions.Types.DynamicMessageType();
             }
             input.ReadMessage(DynamicMessageExtension);
@@ -20313,8 +19993,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public TestParsingMerge(TestParsingMerge other) : this() {
-      requiredAllTypes_ = other.HasRequiredAllTypes ? other.requiredAllTypes_.Clone() : null;
-      optionalAllTypes_ = other.HasOptionalAllTypes ? other.optionalAllTypes_.Clone() : null;
+      requiredAllTypes_ = other.requiredAllTypes_ != null ? other.requiredAllTypes_.Clone() : null;
+      optionalAllTypes_ = other.optionalAllTypes_ != null ? other.optionalAllTypes_.Clone() : null;
       repeatedAllTypes_ = other.repeatedAllTypes_.Clone();
       optionalGroup_ = other.HasOptionalGroup ? other.optionalGroup_.Clone() : null;
       repeatedGroup_ = other.repeatedGroup_.Clone();
@@ -20337,16 +20017,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         requiredAllTypes_ = value;
       }
     }
-    /// <summary>Gets whether the required_all_types field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasRequiredAllTypes {
-      get { return requiredAllTypes_ != null; }
-    }
-    /// <summary>Clears the value of the required_all_types field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearRequiredAllTypes() {
-      requiredAllTypes_ = null;
-    }
 
     /// <summary>Field number for the "optional_all_types" field.</summary>
     public const int OptionalAllTypesFieldNumber = 2;
@@ -20357,16 +20027,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       set {
         optionalAllTypes_ = value;
       }
-    }
-    /// <summary>Gets whether the optional_all_types field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalAllTypes {
-      get { return optionalAllTypes_ != null; }
-    }
-    /// <summary>Clears the value of the optional_all_types field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalAllTypes() {
-      optionalAllTypes_ = null;
     }
 
     /// <summary>Field number for the "repeated_all_types" field.</summary>
@@ -20437,8 +20097,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override int GetHashCode() {
       int hash = 1;
-      if (HasRequiredAllTypes) hash ^= RequiredAllTypes.GetHashCode();
-      if (HasOptionalAllTypes) hash ^= OptionalAllTypes.GetHashCode();
+      if (requiredAllTypes_ != null) hash ^= RequiredAllTypes.GetHashCode();
+      if (optionalAllTypes_ != null) hash ^= OptionalAllTypes.GetHashCode();
       hash ^= repeatedAllTypes_.GetHashCode();
       if (HasOptionalGroup) hash ^= OptionalGroup.GetHashCode();
       hash ^= repeatedGroup_.GetHashCode();
@@ -20458,11 +20118,11 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
-      if (HasRequiredAllTypes) {
+      if (requiredAllTypes_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(RequiredAllTypes);
       }
-      if (HasOptionalAllTypes) {
+      if (optionalAllTypes_ != null) {
         output.WriteRawTag(18);
         output.WriteMessage(OptionalAllTypes);
       }
@@ -20484,10 +20144,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
-      if (HasRequiredAllTypes) {
+      if (requiredAllTypes_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(RequiredAllTypes);
       }
-      if (HasOptionalAllTypes) {
+      if (optionalAllTypes_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(OptionalAllTypes);
       }
       size += repeatedAllTypes_.CalculateSize(_repeated_repeatedAllTypes_codec);
@@ -20509,14 +20169,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other == null) {
         return;
       }
-      if (other.HasRequiredAllTypes) {
-        if (!HasRequiredAllTypes) {
+      if (other.requiredAllTypes_ != null) {
+        if (requiredAllTypes_ == null) {
           RequiredAllTypes = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
         }
         RequiredAllTypes.MergeFrom(other.RequiredAllTypes);
       }
-      if (other.HasOptionalAllTypes) {
-        if (!HasOptionalAllTypes) {
+      if (other.optionalAllTypes_ != null) {
+        if (optionalAllTypes_ == null) {
           OptionalAllTypes = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
         }
         OptionalAllTypes.MergeFrom(other.OptionalAllTypes);
@@ -20544,14 +20204,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             }
             break;
           case 10: {
-            if (!HasRequiredAllTypes) {
+            if (requiredAllTypes_ == null) {
               RequiredAllTypes = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
             }
             input.ReadMessage(RequiredAllTypes);
             break;
           }
           case 18: {
-            if (!HasOptionalAllTypes) {
+            if (optionalAllTypes_ == null) {
               OptionalAllTypes = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
             }
             input.ReadMessage(OptionalAllTypes);
@@ -20877,7 +20537,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public Group1(Group1 other) : this() {
-              field1_ = other.HasField1 ? other.field1_.Clone() : null;
+              field1_ = other.field1_ != null ? other.field1_.Clone() : null;
               _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
             }
 
@@ -20895,16 +20555,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
               set {
                 field1_ = value;
               }
-            }
-            /// <summary>Gets whether the field1 field is set</summary>
-            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            public bool HasField1 {
-              get { return field1_ != null; }
-            }
-            /// <summary>Clears the value of the field1 field</summary>
-            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            public void ClearField1() {
-              field1_ = null;
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -20927,7 +20577,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public override int GetHashCode() {
               int hash = 1;
-              if (HasField1) hash ^= Field1.GetHashCode();
+              if (field1_ != null) hash ^= Field1.GetHashCode();
               if (_unknownFields != null) {
                 hash ^= _unknownFields.GetHashCode();
               }
@@ -20941,7 +20591,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public void WriteTo(pb::CodedOutputStream output) {
-              if (HasField1) {
+              if (field1_ != null) {
                 output.WriteRawTag(90);
                 output.WriteMessage(Field1);
               }
@@ -20953,7 +20603,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public int CalculateSize() {
               int size = 0;
-              if (HasField1) {
+              if (field1_ != null) {
                 size += 1 + pb::CodedOutputStream.ComputeMessageSize(Field1);
               }
               if (_unknownFields != null) {
@@ -20967,8 +20617,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
               if (other == null) {
                 return;
               }
-              if (other.HasField1) {
-                if (!HasField1) {
+              if (other.field1_ != null) {
+                if (field1_ == null) {
                   Field1 = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
                 }
                 Field1.MergeFrom(other.Field1);
@@ -20987,7 +20637,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
                     _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                     break;
                   case 90: {
-                    if (!HasField1) {
+                    if (field1_ == null) {
                       Field1 = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
                     }
                     input.ReadMessage(Field1);
@@ -21024,7 +20674,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public Group2(Group2 other) : this() {
-              field1_ = other.HasField1 ? other.field1_.Clone() : null;
+              field1_ = other.field1_ != null ? other.field1_.Clone() : null;
               _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
             }
 
@@ -21042,16 +20692,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
               set {
                 field1_ = value;
               }
-            }
-            /// <summary>Gets whether the field1 field is set</summary>
-            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            public bool HasField1 {
-              get { return field1_ != null; }
-            }
-            /// <summary>Clears the value of the field1 field</summary>
-            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            public void ClearField1() {
-              field1_ = null;
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -21074,7 +20714,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public override int GetHashCode() {
               int hash = 1;
-              if (HasField1) hash ^= Field1.GetHashCode();
+              if (field1_ != null) hash ^= Field1.GetHashCode();
               if (_unknownFields != null) {
                 hash ^= _unknownFields.GetHashCode();
               }
@@ -21088,7 +20728,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public void WriteTo(pb::CodedOutputStream output) {
-              if (HasField1) {
+              if (field1_ != null) {
                 output.WriteRawTag(170, 1);
                 output.WriteMessage(Field1);
               }
@@ -21100,7 +20740,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public int CalculateSize() {
               int size = 0;
-              if (HasField1) {
+              if (field1_ != null) {
                 size += 2 + pb::CodedOutputStream.ComputeMessageSize(Field1);
               }
               if (_unknownFields != null) {
@@ -21114,8 +20754,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
               if (other == null) {
                 return;
               }
-              if (other.HasField1) {
-                if (!HasField1) {
+              if (other.field1_ != null) {
+                if (field1_ == null) {
                   Field1 = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
                 }
                 Field1.MergeFrom(other.Field1);
@@ -21134,7 +20774,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
                     _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                     break;
                   case 170: {
-                    if (!HasField1) {
+                    if (field1_ == null) {
                       Field1 = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
                     }
                     input.ReadMessage(Field1);
@@ -21176,7 +20816,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public OptionalGroup(OptionalGroup other) : this() {
-          optionalGroupAllTypes_ = other.HasOptionalGroupAllTypes ? other.optionalGroupAllTypes_.Clone() : null;
+          optionalGroupAllTypes_ = other.optionalGroupAllTypes_ != null ? other.optionalGroupAllTypes_.Clone() : null;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -21194,16 +20834,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           set {
             optionalGroupAllTypes_ = value;
           }
-        }
-        /// <summary>Gets whether the optional_group_all_types field is set</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public bool HasOptionalGroupAllTypes {
-          get { return optionalGroupAllTypes_ != null; }
-        }
-        /// <summary>Clears the value of the optional_group_all_types field</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public void ClearOptionalGroupAllTypes() {
-          optionalGroupAllTypes_ = null;
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -21226,7 +20856,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override int GetHashCode() {
           int hash = 1;
-          if (HasOptionalGroupAllTypes) hash ^= OptionalGroupAllTypes.GetHashCode();
+          if (optionalGroupAllTypes_ != null) hash ^= OptionalGroupAllTypes.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -21240,7 +20870,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
-          if (HasOptionalGroupAllTypes) {
+          if (optionalGroupAllTypes_ != null) {
             output.WriteRawTag(90);
             output.WriteMessage(OptionalGroupAllTypes);
           }
@@ -21252,7 +20882,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public int CalculateSize() {
           int size = 0;
-          if (HasOptionalGroupAllTypes) {
+          if (optionalGroupAllTypes_ != null) {
             size += 1 + pb::CodedOutputStream.ComputeMessageSize(OptionalGroupAllTypes);
           }
           if (_unknownFields != null) {
@@ -21266,8 +20896,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           if (other == null) {
             return;
           }
-          if (other.HasOptionalGroupAllTypes) {
-            if (!HasOptionalGroupAllTypes) {
+          if (other.optionalGroupAllTypes_ != null) {
+            if (optionalGroupAllTypes_ == null) {
               OptionalGroupAllTypes = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
             }
             OptionalGroupAllTypes.MergeFrom(other.OptionalGroupAllTypes);
@@ -21286,7 +20916,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
               case 90: {
-                if (!HasOptionalGroupAllTypes) {
+                if (optionalGroupAllTypes_ == null) {
                   OptionalGroupAllTypes = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
                 }
                 input.ReadMessage(OptionalGroupAllTypes);
@@ -21323,7 +20953,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public RepeatedGroup(RepeatedGroup other) : this() {
-          repeatedGroupAllTypes_ = other.HasRepeatedGroupAllTypes ? other.repeatedGroupAllTypes_.Clone() : null;
+          repeatedGroupAllTypes_ = other.repeatedGroupAllTypes_ != null ? other.repeatedGroupAllTypes_.Clone() : null;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -21341,16 +20971,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           set {
             repeatedGroupAllTypes_ = value;
           }
-        }
-        /// <summary>Gets whether the repeated_group_all_types field is set</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public bool HasRepeatedGroupAllTypes {
-          get { return repeatedGroupAllTypes_ != null; }
-        }
-        /// <summary>Clears the value of the repeated_group_all_types field</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public void ClearRepeatedGroupAllTypes() {
-          repeatedGroupAllTypes_ = null;
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -21373,7 +20993,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override int GetHashCode() {
           int hash = 1;
-          if (HasRepeatedGroupAllTypes) hash ^= RepeatedGroupAllTypes.GetHashCode();
+          if (repeatedGroupAllTypes_ != null) hash ^= RepeatedGroupAllTypes.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -21387,7 +21007,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
-          if (HasRepeatedGroupAllTypes) {
+          if (repeatedGroupAllTypes_ != null) {
             output.WriteRawTag(170, 1);
             output.WriteMessage(RepeatedGroupAllTypes);
           }
@@ -21399,7 +21019,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public int CalculateSize() {
           int size = 0;
-          if (HasRepeatedGroupAllTypes) {
+          if (repeatedGroupAllTypes_ != null) {
             size += 2 + pb::CodedOutputStream.ComputeMessageSize(RepeatedGroupAllTypes);
           }
           if (_unknownFields != null) {
@@ -21413,8 +21033,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           if (other == null) {
             return;
           }
-          if (other.HasRepeatedGroupAllTypes) {
-            if (!HasRepeatedGroupAllTypes) {
+          if (other.repeatedGroupAllTypes_ != null) {
+            if (repeatedGroupAllTypes_ == null) {
               RepeatedGroupAllTypes = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
             }
             RepeatedGroupAllTypes.MergeFrom(other.RepeatedGroupAllTypes);
@@ -21433,7 +21053,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
               case 170: {
-                if (!HasRepeatedGroupAllTypes) {
+                if (repeatedGroupAllTypes_ == null) {
                   RepeatedGroupAllTypes = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
                 }
                 input.ReadMessage(RepeatedGroupAllTypes);
@@ -22599,7 +22219,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       optionalEnum_ = other.optionalEnum_;
       optionalString_ = other.optionalString_;
       optionalBytes_ = other.optionalBytes_;
-      optionalMessage_ = other.HasOptionalMessage ? other.optionalMessage_.Clone() : null;
+      optionalMessage_ = other.optionalMessage_ != null ? other.optionalMessage_.Clone() : null;
       optionalGroup_ = other.HasOptionalGroup ? other.optionalGroup_.Clone() : null;
       stringStringMap_ = other.stringStringMap_.Clone();
       switch (other.OneofFieldCase) {
@@ -22774,16 +22394,6 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         optionalMessage_ = value;
       }
     }
-    /// <summary>Gets whether the optional_message field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptionalMessage {
-      get { return optionalMessage_ != null; }
-    }
-    /// <summary>Clears the value of the optional_message field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptionalMessage() {
-      optionalMessage_ = null;
-    }
 
     /// <summary>Field number for the "optionalgroup" field.</summary>
     public const int OptionalGroupFieldNumber = 536870008;
@@ -22843,22 +22453,10 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     public const int OneofTestAllTypesFieldNumber = 536870012;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Google.Protobuf.TestProtos.Proto2.TestAllTypes OneofTestAllTypes {
-      get { return HasOneofTestAllTypes ? (global::Google.Protobuf.TestProtos.Proto2.TestAllTypes) oneofField_ : null; }
+      get { return oneofFieldCase_ == OneofFieldOneofCase.OneofTestAllTypes ? (global::Google.Protobuf.TestProtos.Proto2.TestAllTypes) oneofField_ : null; }
       set {
         oneofField_ = value;
         oneofFieldCase_ = value == null ? OneofFieldOneofCase.None : OneofFieldOneofCase.OneofTestAllTypes;
-      }
-    }
-    /// <summary>Gets whether the "oneof_test_all_types" field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOneofTestAllTypes {
-      get { return oneofFieldCase_ == OneofFieldOneofCase.OneofTestAllTypes; }
-    }
-    /// <summary> Clears the value of the oneof if it's currently set to "oneof_test_all_types" </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOneofTestAllTypes() {
-      if (HasOneofTestAllTypes) {
-        ClearOneofField();
       }
     }
 
@@ -22973,11 +22571,11 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasOptionalEnum) hash ^= OptionalEnum.GetHashCode();
       if (HasOptionalString) hash ^= OptionalString.GetHashCode();
       if (HasOptionalBytes) hash ^= OptionalBytes.GetHashCode();
-      if (HasOptionalMessage) hash ^= OptionalMessage.GetHashCode();
+      if (optionalMessage_ != null) hash ^= OptionalMessage.GetHashCode();
       if (HasOptionalGroup) hash ^= OptionalGroup.GetHashCode();
       hash ^= StringStringMap.GetHashCode();
       if (HasOneofUint32) hash ^= OneofUint32.GetHashCode();
-      if (HasOneofTestAllTypes) hash ^= OneofTestAllTypes.GetHashCode();
+      if (oneofFieldCase_ == OneofFieldOneofCase.OneofTestAllTypes) hash ^= OneofTestAllTypes.GetHashCode();
       if (HasOneofString) hash ^= OneofString.GetHashCode();
       if (HasOneofBytes) hash ^= OneofBytes.GetHashCode();
       hash ^= (int) oneofFieldCase_;
@@ -23019,7 +22617,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(178, 199, 255, 255, 15);
         output.WriteBytes(OptionalBytes);
       }
-      if (HasOptionalMessage) {
+      if (optionalMessage_ != null) {
         output.WriteRawTag(186, 199, 255, 255, 15);
         output.WriteMessage(OptionalMessage);
       }
@@ -23033,7 +22631,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         output.WriteRawTag(216, 199, 255, 255, 15);
         output.WriteUInt32(OneofUint32);
       }
-      if (HasOneofTestAllTypes) {
+      if (oneofFieldCase_ == OneofFieldOneofCase.OneofTestAllTypes) {
         output.WriteRawTag(226, 199, 255, 255, 15);
         output.WriteMessage(OneofTestAllTypes);
       }
@@ -23073,7 +22671,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasOptionalBytes) {
         size += 5 + pb::CodedOutputStream.ComputeBytesSize(OptionalBytes);
       }
-      if (HasOptionalMessage) {
+      if (optionalMessage_ != null) {
         size += 5 + pb::CodedOutputStream.ComputeMessageSize(OptionalMessage);
       }
       if (HasOptionalGroup) {
@@ -23083,7 +22681,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (HasOneofUint32) {
         size += 5 + pb::CodedOutputStream.ComputeUInt32Size(OneofUint32);
       }
-      if (HasOneofTestAllTypes) {
+      if (oneofFieldCase_ == OneofFieldOneofCase.OneofTestAllTypes) {
         size += 5 + pb::CodedOutputStream.ComputeMessageSize(OneofTestAllTypes);
       }
       if (HasOneofString) {
@@ -23123,8 +22721,8 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       if (other.HasOptionalBytes) {
         OptionalBytes = other.OptionalBytes;
       }
-      if (other.HasOptionalMessage) {
-        if (!HasOptionalMessage) {
+      if (other.optionalMessage_ != null) {
+        if (optionalMessage_ == null) {
           OptionalMessage = new global::Google.Protobuf.TestProtos.Proto2.ForeignMessage();
         }
         OptionalMessage.MergeFrom(other.OptionalMessage);
@@ -23199,7 +22797,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             break;
           }
           case 4294960058: {
-            if (!HasOptionalMessage) {
+            if (optionalMessage_ == null) {
               OptionalMessage = new global::Google.Protobuf.TestProtos.Proto2.ForeignMessage();
             }
             input.ReadMessage(OptionalMessage);
@@ -23222,7 +22820,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           }
           case 4294960098: {
             global::Google.Protobuf.TestProtos.Proto2.TestAllTypes subBuilder = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes();
-            if (HasOneofTestAllTypes) {
+            if (oneofFieldCase_ == OneofFieldOneofCase.OneofTestAllTypes) {
               subBuilder.MergeFrom(OneofTestAllTypes);
             }
             input.ReadMessage(subBuilder);

--- a/csharp/src/Google.Protobuf.Test/Reflection/CustomOptionsTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Reflection/CustomOptionsTest.cs
@@ -72,24 +72,48 @@ namespace Google.Protobuf.Test.Reflection
         }
 
         [Test]
+        public void BuiltinOptionsCanBeRetrieved()
+        {
+            // non-custom options (that are not extensions but regular fields) can only be accessed via descriptor.Options
+            var fileOptions = UnittestProto3Reflection.Descriptor.GetOptions();
+            Assert.AreEqual("Google.Protobuf.TestProtos", fileOptions.CsharpNamespace);
+        }
+
+        [Test]
+        public void OptionPresenceCanBeDetected()
+        {
+            // case 1: the descriptor has no options at all so the options message is not present
+            Assert.IsNull(TestAllTypes.Descriptor.GetOptions());
+
+            // case 2: the descriptor has some options, but not the one we're looking for
+            // HasExtension will be false and GetExtension returns extension's default value
+            Assert.IsFalse(UnittestProto3Reflection.Descriptor.GetOptions().HasExtension(FileOpt1));
+            Assert.AreEqual(0, UnittestProto3Reflection.Descriptor.GetOptions().GetExtension(FileOpt1));
+
+            // case 3: option is present
+            Assert.IsTrue(UnittestCustomOptionsProto3Reflection.Descriptor.GetOptions().HasExtension(FileOpt1));
+            Assert.AreEqual(9876543210UL, UnittestCustomOptionsProto3Reflection.Descriptor.GetOptions().GetExtension(FileOpt1));
+        }
+
+        [Test]
         public void ScalarOptions()
         {
             var d = CustomOptionOtherValues.Descriptor;
-            var options = d.CustomOptions;
-            AssertOption(-100, options.TryGetInt32, Int32Opt, d.GetOption);
-            AssertOption(12.3456789f, options.TryGetFloat, FloatOpt, d.GetOption);
-            AssertOption(1.234567890123456789d, options.TryGetDouble, DoubleOpt, d.GetOption);
-            AssertOption("Hello, \"World\"", options.TryGetString, StringOpt, d.GetOption);
-            AssertOption(ByteString.CopyFromUtf8("Hello\0World"), options.TryGetBytes, BytesOpt, d.GetOption);
-            AssertOption(TestEnumType.TestOptionEnumType2, EnumFetcher<TestEnumType>(options), EnumOpt, d.GetOption);
+            var customOptions = d.CustomOptions;
+            AssertOption(-100, customOptions.TryGetInt32, Int32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(12.3456789f, customOptions.TryGetFloat, FloatOpt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(1.234567890123456789d, customOptions.TryGetDouble, DoubleOpt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption("Hello, \"World\"", customOptions.TryGetString, StringOpt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(ByteString.CopyFromUtf8("Hello\0World"), customOptions.TryGetBytes, BytesOpt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(TestEnumType.TestOptionEnumType2, EnumFetcher<TestEnumType>(customOptions), EnumOpt, d.GetOption, d.GetOptions().GetExtension);
         }
 
         [Test]
         public void MessageOptions()
         {
             var d = VariousComplexOptions.Descriptor;
-            var options = d.CustomOptions;
-            AssertOption(new ComplexOptionType1 { Foo = 42, Foo4 = { 99, 88 } }, options.TryGetMessage, ComplexOpt1, d.GetOption);
+            var customOptions = d.CustomOptions;
+            AssertOption(new ComplexOptionType1 { Foo = 42, Foo4 = { 99, 88 } }, customOptions.TryGetMessage, ComplexOpt1, d.GetOption, d.GetOptions().GetExtension);
             AssertOption(new ComplexOptionType2
             {
                 Baz = 987,
@@ -97,85 +121,84 @@ namespace Google.Protobuf.Test.Reflection
                 Fred = new ComplexOptionType4 { Waldo = 321 },
                 Barney = { new ComplexOptionType4 { Waldo = 101 }, new ComplexOptionType4 { Waldo = 212 } }
             },
-                options.TryGetMessage, ComplexOpt2, d.GetOption);
-            AssertOption(new ComplexOptionType3 { Qux = 9 }, options.TryGetMessage, ComplexOpt3, d.GetOption);
+                customOptions.TryGetMessage, ComplexOpt2, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(new ComplexOptionType3 { Qux = 9 }, customOptions.TryGetMessage, ComplexOpt3, d.GetOption, d.GetOptions().GetExtension);
         }
 
         [Test]
         public void OptionLocations()
         {
-            var fileOptions = UnittestCustomOptionsProto3Reflection.Descriptor.CustomOptions;
-            AssertOption(9876543210UL, fileOptions.TryGetUInt64, FileOpt1, UnittestCustomOptionsProto3Reflection.Descriptor.GetOption);
+            var fileDescriptor = UnittestCustomOptionsProto3Reflection.Descriptor;
+            AssertOption(9876543210UL, fileDescriptor.CustomOptions.TryGetUInt64, FileOpt1, fileDescriptor.GetOption, fileDescriptor.GetOptions().GetExtension);
 
-            var messageOptions = TestMessageWithCustomOptions.Descriptor.CustomOptions;
-            AssertOption(-56, messageOptions.TryGetInt32, MessageOpt1, TestMessageWithCustomOptions.Descriptor.GetOption);
+            var messageDescriptor = TestMessageWithCustomOptions.Descriptor;
+            AssertOption(-56, messageDescriptor.CustomOptions.TryGetInt32, MessageOpt1, messageDescriptor.GetOption, messageDescriptor.GetOptions().GetExtension);
 
-            var fieldOptions = TestMessageWithCustomOptions.Descriptor.Fields["field1"].CustomOptions;
-            AssertOption(8765432109UL, fieldOptions.TryGetFixed64, FieldOpt1, TestMessageWithCustomOptions.Descriptor.Fields["field1"].GetOption);
+            var fieldDescriptor = TestMessageWithCustomOptions.Descriptor.Fields["field1"];
+            AssertOption(8765432109UL, fieldDescriptor.CustomOptions.TryGetFixed64, FieldOpt1, fieldDescriptor.GetOption, fieldDescriptor.GetOptions().GetExtension);
 
-            var oneofOptions = TestMessageWithCustomOptions.Descriptor.Oneofs[0].CustomOptions;
-            AssertOption(-99, oneofOptions.TryGetInt32, OneofOpt1, TestMessageWithCustomOptions.Descriptor.Oneofs[0].GetOption);
+            var oneofDescriptor = TestMessageWithCustomOptions.Descriptor.Oneofs[0];
+            AssertOption(-99, oneofDescriptor.CustomOptions.TryGetInt32, OneofOpt1, oneofDescriptor.GetOption, oneofDescriptor.GetOptions().GetExtension);
 
-            var enumOptions = TestMessageWithCustomOptions.Descriptor.EnumTypes[0].CustomOptions;
-            AssertOption(-789, enumOptions.TryGetSFixed32, EnumOpt1, TestMessageWithCustomOptions.Descriptor.EnumTypes[0].GetOption);
+            var enumDescriptor = TestMessageWithCustomOptions.Descriptor.EnumTypes[0];
+            AssertOption(-789, enumDescriptor.CustomOptions.TryGetSFixed32, EnumOpt1, enumDescriptor.GetOption, enumDescriptor.GetOptions().GetExtension);
 
-            var enumValueOptions = TestMessageWithCustomOptions.Descriptor.EnumTypes[0].FindValueByNumber(2).CustomOptions;
-            AssertOption(123, enumValueOptions.TryGetInt32, EnumValueOpt1, TestMessageWithCustomOptions.Descriptor.EnumTypes[0].FindValueByNumber(2).GetOption);
+            var enumValueDescriptor = TestMessageWithCustomOptions.Descriptor.EnumTypes[0].FindValueByNumber(2);
+            AssertOption(123, enumValueDescriptor.CustomOptions.TryGetInt32, EnumValueOpt1, enumValueDescriptor.GetOption, enumValueDescriptor.GetOptions().GetExtension);
 
-            var service = UnittestCustomOptionsProto3Reflection.Descriptor.Services
+            var serviceDescriptor = UnittestCustomOptionsProto3Reflection.Descriptor.Services
                 .Single(s => s.Name == "TestServiceWithCustomOptions");
-            var serviceOptions = service.CustomOptions;
-            AssertOption(-9876543210, serviceOptions.TryGetSInt64, ServiceOpt1, service.GetOption);
+            AssertOption(-9876543210, serviceDescriptor.CustomOptions.TryGetSInt64, ServiceOpt1, serviceDescriptor.GetOption, serviceDescriptor.GetOptions().GetExtension);
 
-            var methodOptions = service.Methods[0].CustomOptions;
-            AssertOption(UnitTest.Issues.TestProtos.MethodOpt1.Val2, EnumFetcher<UnitTest.Issues.TestProtos.MethodOpt1>(methodOptions), UnittestCustomOptionsProto3Extensions.MethodOpt1, service.Methods[0].GetOption);
+            var methodDescriptor = serviceDescriptor.Methods[0];
+            AssertOption(UnitTest.Issues.TestProtos.MethodOpt1.Val2, EnumFetcher<UnitTest.Issues.TestProtos.MethodOpt1>(methodDescriptor.CustomOptions), UnittestCustomOptionsProto3Extensions.MethodOpt1, methodDescriptor.GetOption, methodDescriptor.GetOptions().GetExtension);
         }
 
         [Test]
         public void MinValues()
         {
             var d = CustomOptionMinIntegerValues.Descriptor;
-            var options = d.CustomOptions;
-            AssertOption(false, options.TryGetBool, BoolOpt, d.GetOption);
-            AssertOption(int.MinValue, options.TryGetInt32, Int32Opt, d.GetOption);
-            AssertOption(long.MinValue, options.TryGetInt64, Int64Opt, d.GetOption);
-            AssertOption(uint.MinValue, options.TryGetUInt32, Uint32Opt, d.GetOption);
-            AssertOption(ulong.MinValue, options.TryGetUInt64, Uint64Opt, d.GetOption);
-            AssertOption(int.MinValue, options.TryGetSInt32, Sint32Opt, d.GetOption);
-            AssertOption(long.MinValue, options.TryGetSInt64, Sint64Opt, d.GetOption);
-            AssertOption(uint.MinValue, options.TryGetUInt32, Fixed32Opt, d.GetOption);
-            AssertOption(ulong.MinValue, options.TryGetUInt64, Fixed64Opt, d.GetOption);
-            AssertOption(int.MinValue, options.TryGetInt32, Sfixed32Opt, d.GetOption);
-            AssertOption(long.MinValue, options.TryGetInt64, Sfixed64Opt, d.GetOption);
+            var customOptions = d.CustomOptions;
+            AssertOption(false, customOptions.TryGetBool, BoolOpt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(int.MinValue, customOptions.TryGetInt32, Int32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(long.MinValue, customOptions.TryGetInt64, Int64Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(uint.MinValue, customOptions.TryGetUInt32, Uint32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(ulong.MinValue, customOptions.TryGetUInt64, Uint64Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(int.MinValue, customOptions.TryGetSInt32, Sint32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(long.MinValue, customOptions.TryGetSInt64, Sint64Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(uint.MinValue, customOptions.TryGetUInt32, Fixed32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(ulong.MinValue, customOptions.TryGetUInt64, Fixed64Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(int.MinValue, customOptions.TryGetInt32, Sfixed32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(long.MinValue, customOptions.TryGetInt64, Sfixed64Opt, d.GetOption, d.GetOptions().GetExtension);
         }
 
         [Test]
         public void MaxValues()
         {
             var d = CustomOptionMaxIntegerValues.Descriptor;
-            var options = d.CustomOptions;
-            AssertOption(true, options.TryGetBool, BoolOpt, d.GetOption);
-            AssertOption(int.MaxValue, options.TryGetInt32, Int32Opt, d.GetOption);
-            AssertOption(long.MaxValue, options.TryGetInt64, Int64Opt, d.GetOption);
-            AssertOption(uint.MaxValue, options.TryGetUInt32, Uint32Opt, d.GetOption);
-            AssertOption(ulong.MaxValue, options.TryGetUInt64, Uint64Opt, d.GetOption);
-            AssertOption(int.MaxValue, options.TryGetSInt32, Sint32Opt, d.GetOption);
-            AssertOption(long.MaxValue, options.TryGetSInt64, Sint64Opt, d.GetOption);
-            AssertOption(uint.MaxValue, options.TryGetFixed32, Fixed32Opt, d.GetOption);
-            AssertOption(ulong.MaxValue, options.TryGetFixed64, Fixed64Opt, d.GetOption);
-            AssertOption(int.MaxValue, options.TryGetSFixed32, Sfixed32Opt, d.GetOption);
-            AssertOption(long.MaxValue, options.TryGetSFixed64, Sfixed64Opt, d.GetOption);
+            var customOptions = d.CustomOptions;
+            AssertOption(true, customOptions.TryGetBool, BoolOpt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(int.MaxValue, customOptions.TryGetInt32, Int32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(long.MaxValue, customOptions.TryGetInt64, Int64Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(uint.MaxValue, customOptions.TryGetUInt32, Uint32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(ulong.MaxValue, customOptions.TryGetUInt64, Uint64Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(int.MaxValue, customOptions.TryGetSInt32, Sint32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(long.MaxValue, customOptions.TryGetSInt64, Sint64Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(uint.MaxValue, customOptions.TryGetFixed32, Fixed32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(ulong.MaxValue, customOptions.TryGetFixed64, Fixed64Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(int.MaxValue, customOptions.TryGetSFixed32, Sfixed32Opt, d.GetOption, d.GetOptions().GetExtension);
+            AssertOption(long.MaxValue, customOptions.TryGetSFixed64, Sfixed64Opt, d.GetOption, d.GetOptions().GetExtension);
         }
 
         [Test]
         public void AggregateOptions()
         {
             // Just two examples
-            var messageOptions = AggregateMessage.Descriptor.CustomOptions;
-            AssertOption(new Aggregate { I = 101, S = "MessageAnnotation" }, messageOptions.TryGetMessage, Msgopt, AggregateMessage.Descriptor.GetOption);
+            var messageDescriptor = AggregateMessage.Descriptor;
+            AssertOption(new Aggregate { I = 101, S = "MessageAnnotation" }, messageDescriptor.CustomOptions.TryGetMessage, Msgopt, messageDescriptor.GetOption, messageDescriptor.GetOptions().GetExtension);
 
-            var fieldOptions = AggregateMessage.Descriptor.Fields["fieldname"].CustomOptions;
-            AssertOption(new Aggregate { S = "FieldAnnotation" }, fieldOptions.TryGetMessage, Fieldopt, AggregateMessage.Descriptor.Fields["fieldname"].GetOption);
+            var fieldDescriptor = messageDescriptor.Fields["fieldname"];
+            AssertOption(new Aggregate { S = "FieldAnnotation" }, fieldDescriptor.CustomOptions.TryGetMessage, Fieldopt, fieldDescriptor.GetOption, fieldDescriptor.GetOptions().GetExtension);
         }
 
         [Test]
@@ -199,16 +222,19 @@ namespace Google.Protobuf.Test.Reflection
             var descriptor = UnittestIssue6936CReflection.Descriptor;
             var foo = Foo.Descriptor;
             var bar = Bar.Descriptor;
-            AssertOption("foo", foo.CustomOptions.TryGetString, UnittestIssue6936AExtensions.Opt, foo.GetOption);
-            AssertOption("bar", bar.CustomOptions.TryGetString, UnittestIssue6936AExtensions.Opt, bar.GetOption);
+            AssertOption("foo", foo.CustomOptions.TryGetString, UnittestIssue6936AExtensions.Opt, foo.GetOption, foo.GetOptions().GetExtension);
+            AssertOption("bar", bar.CustomOptions.TryGetString, UnittestIssue6936AExtensions.Opt, bar.GetOption, bar.GetOptions().GetExtension);
         }
 
-        private void AssertOption<T, D>(T expected, OptionFetcher<T> fetcher, Extension<D, T> extension, Func<Extension<D, T>, T> descriptorOptionFetcher) where D : IExtendableMessage<D>
+        private void AssertOption<T, D>(T expected, OptionFetcher<T> customOptionFetcher, Extension<D, T> extension, Func<Extension<D, T>, T> getOptionFetcher, Func<Extension<D, T>, T> extensionFetcher) where D : IExtendableMessage<D>
         {
-            T customOptionsValue;
-            T extensionValue = descriptorOptionFetcher(extension);
-            Assert.IsTrue(fetcher(extension.FieldNumber, out customOptionsValue));
+            Assert.IsTrue(customOptionFetcher(extension.FieldNumber, out T customOptionsValue));
             Assert.AreEqual(expected, customOptionsValue);
+
+            T getOptionValue = getOptionFetcher(extension);
+            Assert.AreEqual(expected, getOptionValue);
+
+            T extensionValue = extensionFetcher(extension);
             Assert.AreEqual(expected, extensionValue);
         }
     }

--- a/csharp/src/Google.Protobuf.Test/Reflection/FieldAccessTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Reflection/FieldAccessTest.cs
@@ -98,7 +98,48 @@ namespace Google.Protobuf.Reflection
         }
 
         [Test]
-        public void HasValue_Proto3()
+        public void HasValue_Proto3_Message()
+        {
+            var message = new TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[TestProtos.TestAllTypes.SingleForeignMessageFieldNumber].Accessor;
+            Assert.False(accessor.HasValue(message));
+            message.SingleForeignMessage = new ForeignMessage();
+            Assert.True(accessor.HasValue(message));
+            message.SingleForeignMessage = null;
+            Assert.False(accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto3_Oneof()
+        {
+            TestAllTypes message = new TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[TestProtos.TestAllTypes.OneofStringFieldNumber].Accessor;
+            Assert.False(accessor.HasValue(message));
+            // Even though it's the default value, we still have a value.
+            message.OneofString = "";
+            Assert.True(accessor.HasValue(message));
+            message.OneofString = "hello";
+            Assert.True(accessor.HasValue(message));
+            message.OneofUint32 = 10;
+            Assert.False(accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto3_Primitive_Optional()
+        {
+            var message = new TestProto3Optional();
+            var accessor = ((IMessage) message).Descriptor.Fields[TestProto3Optional.OptionalInt64FieldNumber].Accessor;
+            Assert.IsFalse(accessor.HasValue(message));
+            message.OptionalInt64 = 5L;
+            Assert.IsTrue(accessor.HasValue(message));
+            message.ClearOptionalInt64();
+            Assert.IsFalse(accessor.HasValue(message));
+            message.OptionalInt64 = 0L;
+            Assert.IsTrue(accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto3_Primitive_NotOptional()
         {
             IMessage message = SampleMessages.CreateFullTestAllTypes();
             var fields = message.Descriptor.Fields;
@@ -106,34 +147,61 @@ namespace Google.Protobuf.Reflection
         }
 
         [Test]
-        public void HasValue_Proto3Optional()
+        public void HasValue_Proto3_Repeated()
         {
-            IMessage message = new TestProto3Optional
-            {
-                OptionalInt32 = 0,
-                LazyNestedMessage = new TestProto3Optional.Types.NestedMessage()
-            };
-            var fields = message.Descriptor.Fields;
-            Assert.IsFalse(fields[TestProto3Optional.OptionalInt64FieldNumber].Accessor.HasValue(message));
-            Assert.IsFalse(fields[TestProto3Optional.OptionalNestedMessageFieldNumber].Accessor.HasValue(message));
-            Assert.IsTrue(fields[TestProto3Optional.LazyNestedMessageFieldNumber].Accessor.HasValue(message));
-            Assert.IsTrue(fields[TestProto3Optional.OptionalInt32FieldNumber].Accessor.HasValue(message));
+            var message = new TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[TestProtos.TestAllTypes.RepeatedBoolFieldNumber].Accessor;
+            Assert.Throws<InvalidOperationException>(() => accessor.HasValue(message));
         }
 
         [Test]
-        public void HasValue()
+        public void HasValue_Proto2_Primitive()
         {
-            IMessage message = new Proto2.TestAllTypes();
-            var fields = message.Descriptor.Fields;
-            var accessor = fields[Proto2.TestAllTypes.OptionalBoolFieldNumber].Accessor;
+            var message = new Proto2.TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[Proto2.TestAllTypes.OptionalInt64FieldNumber].Accessor;
 
+            Assert.IsFalse(accessor.HasValue(message));
+            message.OptionalInt64 = 5L;
+            Assert.IsTrue(accessor.HasValue(message));
+            message.ClearOptionalInt64();
+            Assert.IsFalse(accessor.HasValue(message));
+            message.OptionalInt64 = 0L;
+            Assert.IsTrue(accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto2_Message()
+        {
+            var message = new Proto2.TestAllTypes();
+            var field = ((IMessage) message).Descriptor.Fields[Proto2.TestAllTypes.OptionalForeignMessageFieldNumber];
+            Assert.False(field.Accessor.HasValue(message));
+            message.OptionalForeignMessage = new Proto2.ForeignMessage();
+            Assert.True(field.Accessor.HasValue(message));
+            message.OptionalForeignMessage = null;
+            Assert.False(field.Accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto2_Oneof()
+        {
+            var message = new Proto2.TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[Proto2.TestAllTypes.OneofStringFieldNumber].Accessor;
             Assert.False(accessor.HasValue(message));
-
-            accessor.SetValue(message, true);
+            // Even though it's the default value, we still have a value.
+            message.OneofString = "";
             Assert.True(accessor.HasValue(message));
-
-            accessor.Clear(message);
+            message.OneofString = "hello";
+            Assert.True(accessor.HasValue(message));
+            message.OneofUint32 = 10;
             Assert.False(accessor.HasValue(message));
+        }
+
+        [Test]
+        public void HasValue_Proto2_Repeated()
+        {
+            var message = new Proto2.TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[Proto2.TestAllTypes.RepeatedBoolFieldNumber].Accessor;
+            Assert.Throws<InvalidOperationException>(() => accessor.HasValue(message));
         }
 
         [Test]
@@ -263,6 +331,42 @@ namespace Google.Protobuf.Reflection
         }
 
         [Test]
+        public void Clear_Proto3_Oneof()
+        {
+            var message = new TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[TestProtos.TestAllTypes.OneofUint32FieldNumber].Accessor;
+
+            // The field accessor Clear method only affects a oneof if the current case is the one being cleared.
+            message.OneofString = "hello";
+            Assert.AreEqual(TestProtos.TestAllTypes.OneofFieldOneofCase.OneofString, message.OneofFieldCase);
+            accessor.Clear(message);
+            Assert.AreEqual(TestProtos.TestAllTypes.OneofFieldOneofCase.OneofString, message.OneofFieldCase);
+
+            message.OneofUint32 = 100;
+            Assert.AreEqual(TestProtos.TestAllTypes.OneofFieldOneofCase.OneofUint32, message.OneofFieldCase);
+            accessor.Clear(message);
+            Assert.AreEqual(TestProtos.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+        }
+
+        [Test]
+        public void Clear_Proto2_Oneof()
+        {
+            var message = new Proto2.TestAllTypes();
+            var accessor = ((IMessage) message).Descriptor.Fields[Proto2.TestAllTypes.OneofUint32FieldNumber].Accessor;
+
+            // The field accessor Clear method only affects a oneof if the current case is the one being cleared.
+            message.OneofString = "hello";
+            Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.OneofString, message.OneofFieldCase);
+            accessor.Clear(message);
+            Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.OneofString, message.OneofFieldCase);
+
+            message.OneofUint32 = 100;
+            Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.OneofUint32, message.OneofFieldCase);
+            accessor.Clear(message);
+            Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+        }
+
+        [Test]
         public void FieldDescriptor_ByName()
         {
             var descriptor = TestProtos.TestAllTypes.Descriptor;
@@ -300,6 +404,33 @@ namespace Google.Protobuf.Reflection
 
             message.ClearExtension(RepeatedBoolExtension);
             Assert.IsNull(message.GetExtension(RepeatedBoolExtension));
+        }
+
+        [Test]
+        public void HasPresence()
+        {
+            // Proto3
+            var fields = TestProtos.TestAllTypes.Descriptor.Fields;
+            Assert.IsFalse(fields[TestProtos.TestAllTypes.SingleBoolFieldNumber].HasPresence);
+            Assert.IsTrue(fields[TestProtos.TestAllTypes.OneofBytesFieldNumber].HasPresence);
+            Assert.IsTrue(fields[TestProtos.TestAllTypes.SingleForeignMessageFieldNumber].HasPresence);
+            Assert.IsFalse(fields[TestProtos.TestAllTypes.RepeatedBoolFieldNumber].HasPresence);
+
+            fields = TestMap.Descriptor.Fields;
+            Assert.IsFalse(fields[TestMap.MapBoolBoolFieldNumber].HasPresence);
+
+            fields = TestProto3Optional.Descriptor.Fields;
+            Assert.IsTrue(fields[TestProto3Optional.OptionalBoolFieldNumber].HasPresence);
+
+            // Proto2
+            fields = Proto2.TestAllTypes.Descriptor.Fields;
+            Assert.IsTrue(fields[Proto2.TestAllTypes.OptionalBoolFieldNumber].HasPresence);
+            Assert.IsTrue(fields[Proto2.TestAllTypes.OneofBytesFieldNumber].HasPresence);
+            Assert.IsTrue(fields[Proto2.TestAllTypes.OptionalForeignMessageFieldNumber].HasPresence);
+            Assert.IsFalse(fields[Proto2.TestAllTypes.RepeatedBoolFieldNumber].HasPresence);
+
+            fields = Proto2.TestRequired.Descriptor.Fields;
+            Assert.IsTrue(fields[Proto2.TestRequired.AFieldNumber].HasPresence);
         }
     }
 }

--- a/csharp/src/Google.Protobuf/Extension.cs
+++ b/csharp/src/Google.Protobuf/Extension.cs
@@ -55,6 +55,8 @@ namespace Google.Protobuf
         /// Gets the field number of this extension
         /// </summary>
         public int FieldNumber { get; }
+
+        internal abstract bool IsRepeated { get; }
     }
 
     /// <summary>
@@ -78,6 +80,8 @@ namespace Google.Protobuf
         internal TValue DefaultValue => codec.DefaultValue;
 
         internal override Type TargetType => typeof(TTarget);
+
+        internal override bool IsRepeated => false;
 
         internal override IExtensionValue CreateValue()
         {
@@ -104,6 +108,8 @@ namespace Google.Protobuf
         }
 
         internal override Type TargetType => typeof(TTarget);
+
+        internal override bool IsRepeated => true;
 
         internal override IExtensionValue CreateValue()
         {

--- a/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
@@ -352,8 +352,8 @@ namespace Google.Protobuf.Reflection {
       enumType_ = other.enumType_.Clone();
       service_ = other.service_.Clone();
       extension_ = other.extension_.Clone();
-      options_ = other.HasOptions ? other.options_.Clone() : null;
-      sourceCodeInfo_ = other.HasSourceCodeInfo ? other.sourceCodeInfo_.Clone() : null;
+      options_ = other.options_ != null ? other.options_.Clone() : null;
+      sourceCodeInfo_ = other.sourceCodeInfo_ != null ? other.sourceCodeInfo_.Clone() : null;
       syntax_ = other.syntax_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
@@ -508,16 +508,6 @@ namespace Google.Protobuf.Reflection {
         options_ = value;
       }
     }
-    /// <summary>Gets whether the options field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptions {
-      get { return options_ != null; }
-    }
-    /// <summary>Clears the value of the options field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptions() {
-      options_ = null;
-    }
 
     /// <summary>Field number for the "source_code_info" field.</summary>
     public const int SourceCodeInfoFieldNumber = 9;
@@ -534,16 +524,6 @@ namespace Google.Protobuf.Reflection {
       set {
         sourceCodeInfo_ = value;
       }
-    }
-    /// <summary>Gets whether the source_code_info field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasSourceCodeInfo {
-      get { return sourceCodeInfo_ != null; }
-    }
-    /// <summary>Clears the value of the source_code_info field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearSourceCodeInfo() {
-      sourceCodeInfo_ = null;
     }
 
     /// <summary>Field number for the "syntax" field.</summary>
@@ -613,8 +593,8 @@ namespace Google.Protobuf.Reflection {
       hash ^= enumType_.GetHashCode();
       hash ^= service_.GetHashCode();
       hash ^= extension_.GetHashCode();
-      if (HasOptions) hash ^= Options.GetHashCode();
-      if (HasSourceCodeInfo) hash ^= SourceCodeInfo.GetHashCode();
+      if (options_ != null) hash ^= Options.GetHashCode();
+      if (sourceCodeInfo_ != null) hash ^= SourceCodeInfo.GetHashCode();
       if (HasSyntax) hash ^= Syntax.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -642,11 +622,11 @@ namespace Google.Protobuf.Reflection {
       enumType_.WriteTo(output, _repeated_enumType_codec);
       service_.WriteTo(output, _repeated_service_codec);
       extension_.WriteTo(output, _repeated_extension_codec);
-      if (HasOptions) {
+      if (options_ != null) {
         output.WriteRawTag(66);
         output.WriteMessage(Options);
       }
-      if (HasSourceCodeInfo) {
+      if (sourceCodeInfo_ != null) {
         output.WriteRawTag(74);
         output.WriteMessage(SourceCodeInfo);
       }
@@ -677,10 +657,10 @@ namespace Google.Protobuf.Reflection {
       size += enumType_.CalculateSize(_repeated_enumType_codec);
       size += service_.CalculateSize(_repeated_service_codec);
       size += extension_.CalculateSize(_repeated_extension_codec);
-      if (HasOptions) {
+      if (options_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Options);
       }
-      if (HasSourceCodeInfo) {
+      if (sourceCodeInfo_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(SourceCodeInfo);
       }
       if (HasSyntax) {
@@ -710,14 +690,14 @@ namespace Google.Protobuf.Reflection {
       enumType_.Add(other.enumType_);
       service_.Add(other.service_);
       extension_.Add(other.extension_);
-      if (other.HasOptions) {
-        if (!HasOptions) {
+      if (other.options_ != null) {
+        if (options_ == null) {
           Options = new global::Google.Protobuf.Reflection.FileOptions();
         }
         Options.MergeFrom(other.Options);
       }
-      if (other.HasSourceCodeInfo) {
-        if (!HasSourceCodeInfo) {
+      if (other.sourceCodeInfo_ != null) {
+        if (sourceCodeInfo_ == null) {
           SourceCodeInfo = new global::Google.Protobuf.Reflection.SourceCodeInfo();
         }
         SourceCodeInfo.MergeFrom(other.SourceCodeInfo);
@@ -765,14 +745,14 @@ namespace Google.Protobuf.Reflection {
             break;
           }
           case 66: {
-            if (!HasOptions) {
+            if (options_ == null) {
               Options = new global::Google.Protobuf.Reflection.FileOptions();
             }
             input.ReadMessage(Options);
             break;
           }
           case 74: {
-            if (!HasSourceCodeInfo) {
+            if (sourceCodeInfo_ == null) {
               SourceCodeInfo = new global::Google.Protobuf.Reflection.SourceCodeInfo();
             }
             input.ReadMessage(SourceCodeInfo);
@@ -833,7 +813,7 @@ namespace Google.Protobuf.Reflection {
       enumType_ = other.enumType_.Clone();
       extensionRange_ = other.extensionRange_.Clone();
       oneofDecl_ = other.oneofDecl_.Clone();
-      options_ = other.HasOptions ? other.options_.Clone() : null;
+      options_ = other.options_ != null ? other.options_.Clone() : null;
       reservedRange_ = other.reservedRange_.Clone();
       reservedName_ = other.reservedName_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -937,16 +917,6 @@ namespace Google.Protobuf.Reflection {
         options_ = value;
       }
     }
-    /// <summary>Gets whether the options field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptions {
-      get { return options_ != null; }
-    }
-    /// <summary>Clears the value of the options field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptions() {
-      options_ = null;
-    }
 
     /// <summary>Field number for the "reserved_range" field.</summary>
     public const int ReservedRangeFieldNumber = 9;
@@ -1008,7 +978,7 @@ namespace Google.Protobuf.Reflection {
       hash ^= enumType_.GetHashCode();
       hash ^= extensionRange_.GetHashCode();
       hash ^= oneofDecl_.GetHashCode();
-      if (HasOptions) hash ^= Options.GetHashCode();
+      if (options_ != null) hash ^= Options.GetHashCode();
       hash ^= reservedRange_.GetHashCode();
       hash ^= reservedName_.GetHashCode();
       if (_unknownFields != null) {
@@ -1033,7 +1003,7 @@ namespace Google.Protobuf.Reflection {
       enumType_.WriteTo(output, _repeated_enumType_codec);
       extensionRange_.WriteTo(output, _repeated_extensionRange_codec);
       extension_.WriteTo(output, _repeated_extension_codec);
-      if (HasOptions) {
+      if (options_ != null) {
         output.WriteRawTag(58);
         output.WriteMessage(Options);
       }
@@ -1057,7 +1027,7 @@ namespace Google.Protobuf.Reflection {
       size += enumType_.CalculateSize(_repeated_enumType_codec);
       size += extensionRange_.CalculateSize(_repeated_extensionRange_codec);
       size += oneofDecl_.CalculateSize(_repeated_oneofDecl_codec);
-      if (HasOptions) {
+      if (options_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Options);
       }
       size += reservedRange_.CalculateSize(_repeated_reservedRange_codec);
@@ -1082,8 +1052,8 @@ namespace Google.Protobuf.Reflection {
       enumType_.Add(other.enumType_);
       extensionRange_.Add(other.extensionRange_);
       oneofDecl_.Add(other.oneofDecl_);
-      if (other.HasOptions) {
-        if (!HasOptions) {
+      if (other.options_ != null) {
+        if (options_ == null) {
           Options = new global::Google.Protobuf.Reflection.MessageOptions();
         }
         Options.MergeFrom(other.Options);
@@ -1126,7 +1096,7 @@ namespace Google.Protobuf.Reflection {
             break;
           }
           case 58: {
-            if (!HasOptions) {
+            if (options_ == null) {
               Options = new global::Google.Protobuf.Reflection.MessageOptions();
             }
             input.ReadMessage(Options);
@@ -1181,7 +1151,7 @@ namespace Google.Protobuf.Reflection {
           _hasBits0 = other._hasBits0;
           start_ = other.start_;
           end_ = other.end_;
-          options_ = other.HasOptions ? other.options_.Clone() : null;
+          options_ = other.options_ != null ? other.options_.Clone() : null;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -1254,16 +1224,6 @@ namespace Google.Protobuf.Reflection {
             options_ = value;
           }
         }
-        /// <summary>Gets whether the options field is set</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public bool HasOptions {
-          get { return options_ != null; }
-        }
-        /// <summary>Clears the value of the options field</summary>
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public void ClearOptions() {
-          options_ = null;
-        }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
@@ -1289,7 +1249,7 @@ namespace Google.Protobuf.Reflection {
           int hash = 1;
           if (HasStart) hash ^= Start.GetHashCode();
           if (HasEnd) hash ^= End.GetHashCode();
-          if (HasOptions) hash ^= Options.GetHashCode();
+          if (options_ != null) hash ^= Options.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -1311,7 +1271,7 @@ namespace Google.Protobuf.Reflection {
             output.WriteRawTag(16);
             output.WriteInt32(End);
           }
-          if (HasOptions) {
+          if (options_ != null) {
             output.WriteRawTag(26);
             output.WriteMessage(Options);
           }
@@ -1329,7 +1289,7 @@ namespace Google.Protobuf.Reflection {
           if (HasEnd) {
             size += 1 + pb::CodedOutputStream.ComputeInt32Size(End);
           }
-          if (HasOptions) {
+          if (options_ != null) {
             size += 1 + pb::CodedOutputStream.ComputeMessageSize(Options);
           }
           if (_unknownFields != null) {
@@ -1349,8 +1309,8 @@ namespace Google.Protobuf.Reflection {
           if (other.HasEnd) {
             End = other.End;
           }
-          if (other.HasOptions) {
-            if (!HasOptions) {
+          if (other.options_ != null) {
+            if (options_ == null) {
               Options = new global::Google.Protobuf.Reflection.ExtensionRangeOptions();
             }
             Options.MergeFrom(other.Options);
@@ -1375,7 +1335,7 @@ namespace Google.Protobuf.Reflection {
                 break;
               }
               case 26: {
-                if (!HasOptions) {
+                if (options_ == null) {
                   Options = new global::Google.Protobuf.Reflection.ExtensionRangeOptions();
                 }
                 input.ReadMessage(Options);
@@ -1791,7 +1751,7 @@ namespace Google.Protobuf.Reflection {
       defaultValue_ = other.defaultValue_;
       oneofIndex_ = other.oneofIndex_;
       jsonName_ = other.jsonName_;
-      options_ = other.HasOptions ? other.options_.Clone() : null;
+      options_ = other.options_ != null ? other.options_.Clone() : null;
       proto3Optional_ = other.proto3Optional_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
@@ -2054,16 +2014,6 @@ namespace Google.Protobuf.Reflection {
         options_ = value;
       }
     }
-    /// <summary>Gets whether the options field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptions {
-      get { return options_ != null; }
-    }
-    /// <summary>Clears the value of the options field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptions() {
-      options_ = null;
-    }
 
     /// <summary>Field number for the "proto3_optional" field.</summary>
     public const int Proto3OptionalFieldNumber = 17;
@@ -2151,7 +2101,7 @@ namespace Google.Protobuf.Reflection {
       if (HasDefaultValue) hash ^= DefaultValue.GetHashCode();
       if (HasOneofIndex) hash ^= OneofIndex.GetHashCode();
       if (HasJsonName) hash ^= JsonName.GetHashCode();
-      if (HasOptions) hash ^= Options.GetHashCode();
+      if (options_ != null) hash ^= Options.GetHashCode();
       if (HasProto3Optional) hash ^= Proto3Optional.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -2194,7 +2144,7 @@ namespace Google.Protobuf.Reflection {
         output.WriteRawTag(58);
         output.WriteString(DefaultValue);
       }
-      if (HasOptions) {
+      if (options_ != null) {
         output.WriteRawTag(66);
         output.WriteMessage(Options);
       }
@@ -2245,7 +2195,7 @@ namespace Google.Protobuf.Reflection {
       if (HasJsonName) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(JsonName);
       }
-      if (HasOptions) {
+      if (options_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Options);
       }
       if (HasProto3Optional) {
@@ -2289,8 +2239,8 @@ namespace Google.Protobuf.Reflection {
       if (other.HasJsonName) {
         JsonName = other.JsonName;
       }
-      if (other.HasOptions) {
-        if (!HasOptions) {
+      if (other.options_ != null) {
+        if (options_ == null) {
           Options = new global::Google.Protobuf.Reflection.FieldOptions();
         }
         Options.MergeFrom(other.Options);
@@ -2338,7 +2288,7 @@ namespace Google.Protobuf.Reflection {
             break;
           }
           case 66: {
-            if (!HasOptions) {
+            if (options_ == null) {
               Options = new global::Google.Protobuf.Reflection.FieldOptions();
             }
             input.ReadMessage(Options);
@@ -2458,7 +2408,7 @@ namespace Google.Protobuf.Reflection {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public OneofDescriptorProto(OneofDescriptorProto other) : this() {
       name_ = other.name_;
-      options_ = other.HasOptions ? other.options_.Clone() : null;
+      options_ = other.options_ != null ? other.options_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -2500,16 +2450,6 @@ namespace Google.Protobuf.Reflection {
         options_ = value;
       }
     }
-    /// <summary>Gets whether the options field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptions {
-      get { return options_ != null; }
-    }
-    /// <summary>Clears the value of the options field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptions() {
-      options_ = null;
-    }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
@@ -2533,7 +2473,7 @@ namespace Google.Protobuf.Reflection {
     public override int GetHashCode() {
       int hash = 1;
       if (HasName) hash ^= Name.GetHashCode();
-      if (HasOptions) hash ^= Options.GetHashCode();
+      if (options_ != null) hash ^= Options.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -2551,7 +2491,7 @@ namespace Google.Protobuf.Reflection {
         output.WriteRawTag(10);
         output.WriteString(Name);
       }
-      if (HasOptions) {
+      if (options_ != null) {
         output.WriteRawTag(18);
         output.WriteMessage(Options);
       }
@@ -2566,7 +2506,7 @@ namespace Google.Protobuf.Reflection {
       if (HasName) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
       }
-      if (HasOptions) {
+      if (options_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Options);
       }
       if (_unknownFields != null) {
@@ -2583,8 +2523,8 @@ namespace Google.Protobuf.Reflection {
       if (other.HasName) {
         Name = other.Name;
       }
-      if (other.HasOptions) {
-        if (!HasOptions) {
+      if (other.options_ != null) {
+        if (options_ == null) {
           Options = new global::Google.Protobuf.Reflection.OneofOptions();
         }
         Options.MergeFrom(other.Options);
@@ -2605,7 +2545,7 @@ namespace Google.Protobuf.Reflection {
             break;
           }
           case 18: {
-            if (!HasOptions) {
+            if (options_ == null) {
               Options = new global::Google.Protobuf.Reflection.OneofOptions();
             }
             input.ReadMessage(Options);
@@ -2647,7 +2587,7 @@ namespace Google.Protobuf.Reflection {
     public EnumDescriptorProto(EnumDescriptorProto other) : this() {
       name_ = other.name_;
       value_ = other.value_.Clone();
-      options_ = other.HasOptions ? other.options_.Clone() : null;
+      options_ = other.options_ != null ? other.options_.Clone() : null;
       reservedRange_ = other.reservedRange_.Clone();
       reservedName_ = other.reservedName_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -2700,16 +2640,6 @@ namespace Google.Protobuf.Reflection {
       set {
         options_ = value;
       }
-    }
-    /// <summary>Gets whether the options field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptions {
-      get { return options_ != null; }
-    }
-    /// <summary>Clears the value of the options field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptions() {
-      options_ = null;
     }
 
     /// <summary>Field number for the "reserved_range" field.</summary>
@@ -2767,7 +2697,7 @@ namespace Google.Protobuf.Reflection {
       int hash = 1;
       if (HasName) hash ^= Name.GetHashCode();
       hash ^= value_.GetHashCode();
-      if (HasOptions) hash ^= Options.GetHashCode();
+      if (options_ != null) hash ^= Options.GetHashCode();
       hash ^= reservedRange_.GetHashCode();
       hash ^= reservedName_.GetHashCode();
       if (_unknownFields != null) {
@@ -2788,7 +2718,7 @@ namespace Google.Protobuf.Reflection {
         output.WriteString(Name);
       }
       value_.WriteTo(output, _repeated_value_codec);
-      if (HasOptions) {
+      if (options_ != null) {
         output.WriteRawTag(26);
         output.WriteMessage(Options);
       }
@@ -2806,7 +2736,7 @@ namespace Google.Protobuf.Reflection {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
       }
       size += value_.CalculateSize(_repeated_value_codec);
-      if (HasOptions) {
+      if (options_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Options);
       }
       size += reservedRange_.CalculateSize(_repeated_reservedRange_codec);
@@ -2826,8 +2756,8 @@ namespace Google.Protobuf.Reflection {
         Name = other.Name;
       }
       value_.Add(other.value_);
-      if (other.HasOptions) {
-        if (!HasOptions) {
+      if (other.options_ != null) {
+        if (options_ == null) {
           Options = new global::Google.Protobuf.Reflection.EnumOptions();
         }
         Options.MergeFrom(other.Options);
@@ -2854,7 +2784,7 @@ namespace Google.Protobuf.Reflection {
             break;
           }
           case 26: {
-            if (!HasOptions) {
+            if (options_ == null) {
               Options = new global::Google.Protobuf.Reflection.EnumOptions();
             }
             input.ReadMessage(Options);
@@ -3112,7 +3042,7 @@ namespace Google.Protobuf.Reflection {
       _hasBits0 = other._hasBits0;
       name_ = other.name_;
       number_ = other.number_;
-      options_ = other.HasOptions ? other.options_.Clone() : null;
+      options_ = other.options_ != null ? other.options_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -3178,16 +3108,6 @@ namespace Google.Protobuf.Reflection {
         options_ = value;
       }
     }
-    /// <summary>Gets whether the options field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptions {
-      get { return options_ != null; }
-    }
-    /// <summary>Clears the value of the options field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptions() {
-      options_ = null;
-    }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
@@ -3213,7 +3133,7 @@ namespace Google.Protobuf.Reflection {
       int hash = 1;
       if (HasName) hash ^= Name.GetHashCode();
       if (HasNumber) hash ^= Number.GetHashCode();
-      if (HasOptions) hash ^= Options.GetHashCode();
+      if (options_ != null) hash ^= Options.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -3235,7 +3155,7 @@ namespace Google.Protobuf.Reflection {
         output.WriteRawTag(16);
         output.WriteInt32(Number);
       }
-      if (HasOptions) {
+      if (options_ != null) {
         output.WriteRawTag(26);
         output.WriteMessage(Options);
       }
@@ -3253,7 +3173,7 @@ namespace Google.Protobuf.Reflection {
       if (HasNumber) {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(Number);
       }
-      if (HasOptions) {
+      if (options_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Options);
       }
       if (_unknownFields != null) {
@@ -3273,8 +3193,8 @@ namespace Google.Protobuf.Reflection {
       if (other.HasNumber) {
         Number = other.Number;
       }
-      if (other.HasOptions) {
-        if (!HasOptions) {
+      if (other.options_ != null) {
+        if (options_ == null) {
           Options = new global::Google.Protobuf.Reflection.EnumValueOptions();
         }
         Options.MergeFrom(other.Options);
@@ -3299,7 +3219,7 @@ namespace Google.Protobuf.Reflection {
             break;
           }
           case 26: {
-            if (!HasOptions) {
+            if (options_ == null) {
               Options = new global::Google.Protobuf.Reflection.EnumValueOptions();
             }
             input.ReadMessage(Options);
@@ -3341,7 +3261,7 @@ namespace Google.Protobuf.Reflection {
     public ServiceDescriptorProto(ServiceDescriptorProto other) : this() {
       name_ = other.name_;
       method_ = other.method_.Clone();
-      options_ = other.HasOptions ? other.options_.Clone() : null;
+      options_ = other.options_ != null ? other.options_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -3393,16 +3313,6 @@ namespace Google.Protobuf.Reflection {
         options_ = value;
       }
     }
-    /// <summary>Gets whether the options field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptions {
-      get { return options_ != null; }
-    }
-    /// <summary>Clears the value of the options field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptions() {
-      options_ = null;
-    }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
@@ -3428,7 +3338,7 @@ namespace Google.Protobuf.Reflection {
       int hash = 1;
       if (HasName) hash ^= Name.GetHashCode();
       hash ^= method_.GetHashCode();
-      if (HasOptions) hash ^= Options.GetHashCode();
+      if (options_ != null) hash ^= Options.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -3447,7 +3357,7 @@ namespace Google.Protobuf.Reflection {
         output.WriteString(Name);
       }
       method_.WriteTo(output, _repeated_method_codec);
-      if (HasOptions) {
+      if (options_ != null) {
         output.WriteRawTag(26);
         output.WriteMessage(Options);
       }
@@ -3463,7 +3373,7 @@ namespace Google.Protobuf.Reflection {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
       }
       size += method_.CalculateSize(_repeated_method_codec);
-      if (HasOptions) {
+      if (options_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Options);
       }
       if (_unknownFields != null) {
@@ -3481,8 +3391,8 @@ namespace Google.Protobuf.Reflection {
         Name = other.Name;
       }
       method_.Add(other.method_);
-      if (other.HasOptions) {
-        if (!HasOptions) {
+      if (other.options_ != null) {
+        if (options_ == null) {
           Options = new global::Google.Protobuf.Reflection.ServiceOptions();
         }
         Options.MergeFrom(other.Options);
@@ -3507,7 +3417,7 @@ namespace Google.Protobuf.Reflection {
             break;
           }
           case 26: {
-            if (!HasOptions) {
+            if (options_ == null) {
               Options = new global::Google.Protobuf.Reflection.ServiceOptions();
             }
             input.ReadMessage(Options);
@@ -3552,7 +3462,7 @@ namespace Google.Protobuf.Reflection {
       name_ = other.name_;
       inputType_ = other.inputType_;
       outputType_ = other.outputType_;
-      options_ = other.HasOptions ? other.options_.Clone() : null;
+      options_ = other.options_ != null ? other.options_.Clone() : null;
       clientStreaming_ = other.clientStreaming_;
       serverStreaming_ = other.serverStreaming_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -3646,16 +3556,6 @@ namespace Google.Protobuf.Reflection {
         options_ = value;
       }
     }
-    /// <summary>Gets whether the options field is set</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOptions {
-      get { return options_ != null; }
-    }
-    /// <summary>Clears the value of the options field</summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void ClearOptions() {
-      options_ = null;
-    }
 
     /// <summary>Field number for the "client_streaming" field.</summary>
     public const int ClientStreamingFieldNumber = 5;
@@ -3739,7 +3639,7 @@ namespace Google.Protobuf.Reflection {
       if (HasName) hash ^= Name.GetHashCode();
       if (HasInputType) hash ^= InputType.GetHashCode();
       if (HasOutputType) hash ^= OutputType.GetHashCode();
-      if (HasOptions) hash ^= Options.GetHashCode();
+      if (options_ != null) hash ^= Options.GetHashCode();
       if (HasClientStreaming) hash ^= ClientStreaming.GetHashCode();
       if (HasServerStreaming) hash ^= ServerStreaming.GetHashCode();
       if (_unknownFields != null) {
@@ -3767,7 +3667,7 @@ namespace Google.Protobuf.Reflection {
         output.WriteRawTag(26);
         output.WriteString(OutputType);
       }
-      if (HasOptions) {
+      if (options_ != null) {
         output.WriteRawTag(34);
         output.WriteMessage(Options);
       }
@@ -3796,7 +3696,7 @@ namespace Google.Protobuf.Reflection {
       if (HasOutputType) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(OutputType);
       }
-      if (HasOptions) {
+      if (options_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Options);
       }
       if (HasClientStreaming) {
@@ -3825,8 +3725,8 @@ namespace Google.Protobuf.Reflection {
       if (other.HasOutputType) {
         OutputType = other.OutputType;
       }
-      if (other.HasOptions) {
-        if (!HasOptions) {
+      if (other.options_ != null) {
+        if (options_ == null) {
           Options = new global::Google.Protobuf.Reflection.MethodOptions();
         }
         Options.MergeFrom(other.Options);
@@ -3861,7 +3761,7 @@ namespace Google.Protobuf.Reflection {
             break;
           }
           case 34: {
-            if (!HasOptions) {
+            if (options_ == null) {
               Options = new global::Google.Protobuf.Reflection.MethodOptions();
             }
             input.ReadMessage(Options);

--- a/csharp/src/Google.Protobuf/Reflection/EnumDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/EnumDescriptor.cs
@@ -128,12 +128,21 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// The (possibly empty) set of custom options for this enum.
         /// </summary>
-        [Obsolete("CustomOptions are obsolete. Use GetOption")]
+        [Obsolete("CustomOptions are obsolete. Use the GetOptions() method.")]
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options?._extensions?.ValuesByNumber);
+
+        /// <summary>
+        /// The <c>EnumOptions</c>, defined in <c>descriptor.proto</c>.
+        /// If the options message is not present (i.e. there are no options), <c>null</c> is returned.
+        /// Custom options can be retrieved as extensions of the returned message.
+        /// NOTE: A defensive copy is created each time this property is retrieved.
+        /// </summary>
+        public EnumOptions GetOptions() => Proto.Options?.Clone();
 
         /// <summary>
         /// Gets a single value enum option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public T GetOption<T>(Extension<EnumOptions, T> extension)
         {
             var value = Proto.Options.GetExtension(extension);
@@ -143,6 +152,7 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// Gets a repeated value enum option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public RepeatedField<T> GetOption<T>(RepeatedExtension<EnumOptions, T> extension)
         {
             return Proto.Options.GetExtension(extension).Clone();

--- a/csharp/src/Google.Protobuf/Reflection/EnumValueDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/EnumValueDescriptor.cs
@@ -73,12 +73,21 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// The (possibly empty) set of custom options for this enum value.
         /// </summary>
-        [Obsolete("CustomOptions are obsolete. Use GetOption")]
+        [Obsolete("CustomOptions are obsolete. Use the GetOptions() method.")]
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options?._extensions?.ValuesByNumber);
+
+        /// <summary>
+        /// The <c>EnumValueOptions</c>, defined in <c>descriptor.proto</c>.
+        /// If the options message is not present (i.e. there are no options), <c>null</c> is returned.
+        /// Custom options can be retrieved as extensions of the returned message.
+        /// NOTE: A defensive copy is created each time this property is retrieved.
+        /// </summary>
+        public EnumValueOptions GetOptions() => Proto.Options?.Clone();
 
         /// <summary>
         /// Gets a single value enum value option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public T GetOption<T>(Extension<EnumValueOptions, T> extension)
         {
             var value = Proto.Options.GetExtension(extension);
@@ -88,6 +97,7 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// Gets a repeated value enum value option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public RepeatedField<T> GetOption<T>(RepeatedExtension<EnumValueOptions, T> extension)
         {
             return Proto.Options.GetExtension(extension).Clone();

--- a/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
@@ -394,7 +394,7 @@ namespace Google.Protobuf.Reflection
 
             File.DescriptorPool.AddFieldByNumber(this);
 
-            if (ContainingType != null && ContainingType.Proto.HasOptions && ContainingType.Proto.Options.MessageSetWireFormat)
+            if (ContainingType != null && ContainingType.Proto.Options != null && ContainingType.Proto.Options.MessageSetWireFormat)
             {
                 throw new DescriptorValidationException(this, "MessageSet format is not supported.");
             }

--- a/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
@@ -70,6 +70,21 @@ namespace Google.Protobuf.Reflection
         /// </summary>
         public string JsonName { get; }
 
+        /// <summary>
+        /// Indicates whether this field supports presence, either implicitly (e.g. due to it being a message
+        /// type field) or explicitly via Has/Clear members. If this returns true, it is safe to call
+        /// <see cref="IFieldAccessor.Clear(IMessage)"/> and <see cref="IFieldAccessor.HasValue(IMessage)"/>
+        /// on this field's accessor with a suitable message.
+        /// </summary>
+        public bool HasPresence =>
+            Extension != null ? !Extension.IsRepeated
+            : IsRepeated ? false
+            : IsMap ? false
+            : FieldType == FieldType.Message ? true
+            // This covers "real oneof members" and "proto3 optional fields"
+            : ContainingOneof != null ? true
+            : File.Syntax == Syntax.Proto2;
+
         internal FieldDescriptorProto Proto { get; }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
@@ -304,12 +304,21 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// The (possibly empty) set of custom options for this field.
         /// </summary>
-        [Obsolete("CustomOptions are obsolete. Use GetOption")]
+        [Obsolete("CustomOptions are obsolete. Use the GetOptions() method.")]
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options?._extensions?.ValuesByNumber);
+
+        /// <summary>
+        /// The <c>FieldOptions</c>, defined in <c>descriptor.proto</c>.
+        /// If the options message is not present (i.e. there are no options), <c>null</c> is returned.
+        /// Custom options can be retrieved as extensions of the returned message.
+        /// NOTE: A defensive copy is created each time this property is retrieved.
+        /// </summary>
+        public FieldOptions GetOptions() => Proto.Options?.Clone();
 
         /// <summary>
         /// Gets a single value field option for this descriptor
         /// </summary>
+         [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public T GetOption<T>(Extension<FieldOptions, T> extension)
         {
             var value = Proto.Options.GetExtension(extension);
@@ -319,6 +328,7 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// Gets a repeated value field option for this descriptor
         /// </summary>
+         [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public RepeatedField<T> GetOption<T>(RepeatedExtension<FieldOptions, T> extension)
         {
             return Proto.Options.GetExtension(extension).Clone();

--- a/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
@@ -547,12 +547,21 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// The (possibly empty) set of custom options for this file.
         /// </summary>
-        [Obsolete("CustomOptions are obsolete. Use GetOption")]
+        [Obsolete("CustomOptions are obsolete. Use the GetOptions() method.")]
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options?._extensions?.ValuesByNumber);
+
+        /// <summary>
+        /// The <c>FileOptions</c>, defined in <c>descriptor.proto</c>.
+        /// If the options message is not present (i.e. there are no options), <c>null</c> is returned.
+        /// Custom options can be retrieved as extensions of the returned message.
+        /// NOTE: A defensive copy is created each time this property is retrieved.
+        /// </summary>
+        public FileOptions GetOptions() => Proto.Options?.Clone();
 
         /// <summary>
         /// Gets a single value file option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public T GetOption<T>(Extension<FileOptions, T> extension)
         {
             var value = Proto.Options.GetExtension(extension);
@@ -562,6 +571,7 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// Gets a repeated value file option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public RepeatedField<T> GetOption<T>(RepeatedExtension<FileOptions, T> extension)
         {
             return Proto.Options.GetExtension(extension).Clone();

--- a/csharp/src/Google.Protobuf/Reflection/MessageDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/MessageDescriptor.cs
@@ -287,12 +287,21 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// The (possibly empty) set of custom options for this message.
         /// </summary>
-        [Obsolete("CustomOptions are obsolete. Use GetOption")]
+        [Obsolete("CustomOptions are obsolete. Use the GetOptions() method.")]
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options?._extensions?.ValuesByNumber);
+
+        /// <summary>
+        /// The <c>MessageOptions</c>, defined in <c>descriptor.proto</c>.
+        /// If the options message is not present (i.e. there are no options), <c>null</c> is returned.
+        /// Custom options can be retrieved as extensions of the returned message.
+        /// NOTE: A defensive copy is created each time this property is retrieved.
+        /// </summary>
+        public MessageOptions GetOptions() => Proto.Options?.Clone();
 
         /// <summary>
         /// Gets a single value message option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public T GetOption<T>(Extension<MessageOptions, T> extension)
         {
             var value = Proto.Options.GetExtension(extension);
@@ -302,6 +311,7 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// Gets a repeated value message option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public Collections.RepeatedField<T> GetOption<T>(RepeatedExtension<MessageOptions, T> extension)
         {
             return Proto.Options.GetExtension(extension).Clone();

--- a/csharp/src/Google.Protobuf/Reflection/MethodDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/MethodDescriptor.cs
@@ -73,12 +73,21 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// The (possibly empty) set of custom options for this method.
         /// </summary>
-        [Obsolete("CustomOptions are obsolete. Use GetOption")]
+        [Obsolete("CustomOptions are obsolete. Use the GetOptions() method.")]
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options?._extensions?.ValuesByNumber);
+
+        /// <summary>
+        /// The <c>MethodOptions</c>, defined in <c>descriptor.proto</c>.
+        /// If the options message is not present (i.e. there are no options), <c>null</c> is returned.
+        /// Custom options can be retrieved as extensions of the returned message.
+        /// NOTE: A defensive copy is created each time this property is retrieved.
+        /// </summary>
+        public MethodOptions GetOptions() => Proto.Options?.Clone();
 
         /// <summary>
         /// Gets a single value method option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public T GetOption<T>(Extension<MethodOptions, T> extension)
         {
             var value = Proto.Options.GetExtension(extension);
@@ -88,6 +97,7 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// Gets a repeated value method option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public RepeatedField<T> GetOption<T>(RepeatedExtension<MethodOptions, T> extension)
         {
             return Proto.Options.GetExtension(extension).Clone();

--- a/csharp/src/Google.Protobuf/Reflection/OneofDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/OneofDescriptor.cs
@@ -117,12 +117,21 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// The (possibly empty) set of custom options for this oneof.
         /// </summary>
-        [Obsolete("CustomOptions are obsolete. Use GetOption")]
+        [Obsolete("CustomOptions are obsolete. Use the GetOptions method.")]
         public CustomOptions CustomOptions => new CustomOptions(proto.Options?._extensions?.ValuesByNumber);
+
+        /// <summary>
+        /// The <c>OneofOptions</c>, defined in <c>descriptor.proto</c>.
+        /// If the options message is not present (i.e. there are no options), <c>null</c> is returned.
+        /// Custom options can be retrieved as extensions of the returned message.
+        /// NOTE: A defensive copy is created each time this property is retrieved.
+        /// </summary>
+        public OneofOptions GetOptions() => proto.Options?.Clone();
 
         /// <summary>
         /// Gets a single value oneof option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public T GetOption<T>(Extension<OneofOptions, T> extension)
         {
             var value = proto.Options.GetExtension(extension);
@@ -132,6 +141,7 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// Gets a repeated value oneof option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public RepeatedField<T> GetOption<T>(RepeatedExtension<OneofOptions, T> extension)
         {
             return proto.Options.GetExtension(extension).Clone();

--- a/csharp/src/Google.Protobuf/Reflection/ServiceDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ServiceDescriptor.cs
@@ -94,12 +94,21 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// The (possibly empty) set of custom options for this service.
         /// </summary>
-        [Obsolete("CustomOptions are obsolete. Use GetOption")]
+        [Obsolete("CustomOptions are obsolete. Use the GetOptions() method.")]
         public CustomOptions CustomOptions => new CustomOptions(Proto.Options?._extensions?.ValuesByNumber);
+
+        /// <summary>
+        /// The <c>ServiceOptions</c>, defined in <c>descriptor.proto</c>.
+        /// If the options message is not present (i.e. there are no options), <c>null</c> is returned.
+        /// Custom options can be retrieved as extensions of the returned message.
+        /// NOTE: A defensive copy is created each time this property is retrieved.
+        /// </summary>
+        public ServiceOptions GetOptions() => Proto.Options?.Clone();
 
         /// <summary>
         /// Gets a single value service option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public T GetOption<T>(Extension<ServiceOptions, T> extension)
         {
             var value = Proto.Options.GetExtension(extension);
@@ -109,6 +118,7 @@ namespace Google.Protobuf.Reflection
         /// <summary>
         /// Gets a repeated value service option for this descriptor
         /// </summary>
+        [Obsolete("GetOption is obsolete. Use the GetOptions() method.")]
         public RepeatedField<T> GetOption<T>(RepeatedExtension<ServiceOptions, T> extension)
         {
             return Proto.Options.GetExtension(extension).Clone();

--- a/csharp/src/Google.Protobuf/Reflection/SingleFieldAccessor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/SingleFieldAccessor.cs
@@ -57,63 +57,68 @@ namespace Google.Protobuf.Reflection
                 throw new ArgumentException("Not all required properties/methods available");
             }
             setValueDelegate = ReflectionUtil.CreateActionIMessageObject(property.GetSetMethod());
-            if (descriptor.File.Syntax == Syntax.Proto3 && !descriptor.Proto.Proto3Optional)
+
+            // Note: this looks worrying in that we access the containing oneof, which isn't valid until cross-linking
+            // is complete... but field accessors aren't created until after cross-linking.
+            // The oneof itself won't be cross-linked yet, but that's okay: the oneof accessor is created
+            // earlier.
+
+            // Message fields always support presence, via null checks.
+            if (descriptor.FieldType == FieldType.Message)
             {
-                hasDelegate = message =>
+                hasDelegate = message => GetValue(message) != null;
+                clearDelegate = message => SetValue(message, null);
+            }
+            // Oneof fields always support presence, via case checks.
+            // Note that clearing the field is a no-op unless that specific field is the current "case".
+            else if (descriptor.RealContainingOneof != null)
+            {
+                var oneofAccessor = descriptor.RealContainingOneof.Accessor;
+                hasDelegate = message => oneofAccessor.GetCaseFieldDescriptor(message) == descriptor;
+                clearDelegate = message =>
                 {
-                    throw new InvalidOperationException("HasValue is not implemented for non-optional proto3 fields");
+                    // Clear on a field only affects the oneof itself if the current case is the field we're accessing.
+                    if (oneofAccessor.GetCaseFieldDescriptor(message) == descriptor)
+                    {
+                        oneofAccessor.Clear(message);
+                    }
                 };
+            }
+            // Primitive fields always support presence in proto2, and support presence in proto3 for optional fields.
+            else if (descriptor.File.Syntax == Syntax.Proto2 || descriptor.Proto.Proto3Optional)
+            {
+                MethodInfo hasMethod = property.DeclaringType.GetRuntimeProperty("Has" + property.Name).GetMethod;
+                if (hasMethod == null)
+                {
+                    throw new ArgumentException("Not all required properties/methods are available");
+                }
+                hasDelegate = ReflectionUtil.CreateFuncIMessageBool(hasMethod);
+                MethodInfo clearMethod = property.DeclaringType.GetRuntimeMethod("Clear" + property.Name, ReflectionUtil.EmptyTypes);
+                if (clearMethod == null)
+                {
+                    throw new ArgumentException("Not all required properties/methods are available");
+                }
+                clearDelegate = ReflectionUtil.CreateActionIMessage(clearMethod);
+            }
+            // What's left?
+            // Primitive proto3 fields without the optional keyword, which aren't in oneofs.
+            else
+            {
+                hasDelegate = message => { throw new InvalidOperationException("Presence is not implemented for this field"); };
+
+                // While presence isn't supported, clearing still is; it's just setting to a default value.
                 var clrType = property.PropertyType;
 
-                // TODO: Validate that this is a reasonable single field? (Should be a value type, a message type, or string/ByteString.)
                 object defaultValue =
-                    descriptor.FieldType == FieldType.Message ? null
-                    : clrType == typeof(string) ? ""
+                    clrType == typeof(string) ? ""
                     : clrType == typeof(ByteString) ? ByteString.Empty
                     : Activator.CreateInstance(clrType);
                 clearDelegate = message => SetValue(message, defaultValue);
             }
-            else
-            {
-                // For message fields, just compare with null and set to null.
-                // For primitive fields, use the Has/Clear methods.
-
-                if (descriptor.FieldType == FieldType.Message)
-                {
-                    hasDelegate = message => GetValue(message) != null;
-                    clearDelegate = message => SetValue(message, null);
-                }
-                else
-                {
-                    MethodInfo hasMethod = property.DeclaringType.GetRuntimeProperty("Has" + property.Name).GetMethod;
-                    if (hasMethod == null)
-                    {
-                        throw new ArgumentException("Not all required properties/methods are available");
-                    }
-                    hasDelegate = ReflectionUtil.CreateFuncIMessageBool(hasMethod);
-                    MethodInfo clearMethod = property.DeclaringType.GetRuntimeMethod("Clear" + property.Name, ReflectionUtil.EmptyTypes);
-                    if (clearMethod == null)
-                    {
-                        throw new ArgumentException("Not all required properties/methods are available");
-                    }
-                    clearDelegate = ReflectionUtil.CreateActionIMessage(clearMethod);
-                }
-            }
         }
 
-        public override void Clear(IMessage message)
-        {
-            clearDelegate(message);
-        }
-
-        public override bool HasValue(IMessage message)
-        {
-            return hasDelegate(message);
-        }
-
-        public override void SetValue(IMessage message, object value)
-        {
-            setValueDelegate(message, value);
-        }
+        public override void Clear(IMessage message) => clearDelegate(message);
+        public override bool HasValue(IMessage message) => hasDelegate(message);
+        public override void SetValue(IMessage message, object value) => setValueDelegate(message, value);
     }
 }

--- a/java/core/generate-test-sources-build.xml
+++ b/java/core/generate-test-sources-build.xml
@@ -17,6 +17,7 @@
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_no_generic_services.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_optimize_for.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_proto3.proto"/>
+        <arg value="${protobuf.source.dir}/google/protobuf/unittest_proto3_optional.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_well_known_types.proto"/>
         <arg value="${test.proto.dir}/com/google/protobuf/any_test.proto"/>
         <arg value="${test.proto.dir}/com/google/protobuf/cached_field_size_test.proto"/>

--- a/java/core/src/test/java/com/google/protobuf/FieldPresenceTest.java
+++ b/java/core/src/test/java/com/google/protobuf/FieldPresenceTest.java
@@ -38,6 +38,7 @@ import com.google.protobuf.Descriptors.OneofDescriptor;
 import com.google.protobuf.FieldPresenceTestProto.TestAllTypes;
 import com.google.protobuf.FieldPresenceTestProto.TestOptionalFieldsOnly;
 import com.google.protobuf.FieldPresenceTestProto.TestRepeatedFieldsOnly;
+import com.google.protobuf.testing.proto.TestProto3Optional;
 import protobuf_unittest.UnittestProto;
 import junit.framework.TestCase;
 
@@ -101,6 +102,113 @@ public class FieldPresenceTest extends TestCase {
         UnittestProto.TestAllTypes.Builder.class, TestAllTypes.Builder.class, "OneofBytes");
   }
 
+  public void testHasMethodForProto3Optional() throws Exception {
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalInt32());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalInt64());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalUint32());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalUint64());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalSint32());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalSint64());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalFixed32());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalFixed64());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalFloat());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalDouble());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalBool());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalString());
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOptionalBytes());
+
+    TestProto3Optional.Builder builder = TestProto3Optional.newBuilder().setOptionalInt32(0);
+    assertTrue(builder.hasOptionalInt32());
+    assertTrue(builder.build().hasOptionalInt32());
+
+    TestProto3Optional.Builder otherBuilder = TestProto3Optional.newBuilder().setOptionalInt32(1);
+    otherBuilder.mergeFrom(builder.build());
+    assertTrue(otherBuilder.hasOptionalInt32());
+    assertEquals(0, otherBuilder.getOptionalInt32());
+
+    TestProto3Optional.Builder builder3 =
+        TestProto3Optional.newBuilder().setOptionalNestedEnumValue(5);
+    assertTrue(builder3.hasOptionalNestedEnum());
+
+    TestProto3Optional.Builder builder4 =
+        TestProto3Optional.newBuilder().setOptionalNestedEnum(TestProto3Optional.NestedEnum.FOO);
+    assertTrue(builder4.hasOptionalNestedEnum());
+
+    TestProto3Optional proto = TestProto3Optional.parseFrom(builder.build().toByteArray());
+    assertTrue(proto.hasOptionalInt32());
+    assertTrue(proto.toBuilder().hasOptionalInt32());
+  }
+
+  private static void assertProto3OptionalReflection(String name) throws Exception {
+    FieldDescriptor fieldDescriptor = TestProto3Optional.getDescriptor().findFieldByName(name);
+    OneofDescriptor oneofDescriptor = fieldDescriptor.getContainingOneof();
+    assertNotNull(fieldDescriptor.getContainingOneof());
+    assertTrue(fieldDescriptor.hasOptionalKeyword());
+    assertTrue(fieldDescriptor.hasPresence());
+
+    assertFalse(TestProto3Optional.getDefaultInstance().hasOneof(oneofDescriptor));
+    assertNull(TestProto3Optional.getDefaultInstance().getOneofFieldDescriptor(oneofDescriptor));
+
+    TestProto3Optional.Builder builder = TestProto3Optional.newBuilder();
+    builder.setField(fieldDescriptor, fieldDescriptor.getDefaultValue());
+    assertTrue(builder.hasField(fieldDescriptor));
+    assertEquals(fieldDescriptor.getDefaultValue(), builder.getField(fieldDescriptor));
+    assertTrue(builder.build().hasField(fieldDescriptor));
+    assertEquals(fieldDescriptor.getDefaultValue(), builder.build().getField(fieldDescriptor));
+    assertTrue(builder.hasOneof(oneofDescriptor));
+    assertEquals(fieldDescriptor, builder.getOneofFieldDescriptor(oneofDescriptor));
+    assertTrue(builder.build().hasOneof(oneofDescriptor));
+    assertEquals(fieldDescriptor, builder.build().getOneofFieldDescriptor(oneofDescriptor));
+
+    TestProto3Optional.Builder otherBuilder = TestProto3Optional.newBuilder();
+    otherBuilder.mergeFrom(builder.build());
+    assertTrue(otherBuilder.hasField(fieldDescriptor));
+    assertEquals(fieldDescriptor.getDefaultValue(), otherBuilder.getField(fieldDescriptor));
+
+    TestProto3Optional proto = TestProto3Optional.parseFrom(builder.build().toByteArray());
+    assertTrue(proto.hasField(fieldDescriptor));
+    assertTrue(proto.toBuilder().hasField(fieldDescriptor));
+
+    DynamicMessage.Builder dynamicBuilder =
+        DynamicMessage.newBuilder(TestProto3Optional.getDescriptor());
+    dynamicBuilder.setField(fieldDescriptor, fieldDescriptor.getDefaultValue());
+    assertTrue(dynamicBuilder.hasField(fieldDescriptor));
+    assertEquals(fieldDescriptor.getDefaultValue(), dynamicBuilder.getField(fieldDescriptor));
+    assertTrue(dynamicBuilder.build().hasField(fieldDescriptor));
+    assertEquals(
+        fieldDescriptor.getDefaultValue(), dynamicBuilder.build().getField(fieldDescriptor));
+    assertTrue(dynamicBuilder.hasOneof(oneofDescriptor));
+    assertEquals(fieldDescriptor, dynamicBuilder.getOneofFieldDescriptor(oneofDescriptor));
+    assertTrue(dynamicBuilder.build().hasOneof(oneofDescriptor));
+    assertEquals(fieldDescriptor, dynamicBuilder.build().getOneofFieldDescriptor(oneofDescriptor));
+
+    DynamicMessage.Builder otherDynamicBuilder =
+        DynamicMessage.newBuilder(TestProto3Optional.getDescriptor());
+    otherDynamicBuilder.mergeFrom(dynamicBuilder.build());
+    assertTrue(otherDynamicBuilder.hasField(fieldDescriptor));
+    assertEquals(fieldDescriptor.getDefaultValue(), otherDynamicBuilder.getField(fieldDescriptor));
+
+    DynamicMessage dynamicProto =
+        DynamicMessage.parseFrom(TestProto3Optional.getDescriptor(), builder.build().toByteArray());
+    assertTrue(dynamicProto.hasField(fieldDescriptor));
+    assertTrue(dynamicProto.toBuilder().hasField(fieldDescriptor));
+  }
+
+  public void testProto3Optional_reflection() throws Exception {
+    assertProto3OptionalReflection("optional_int32");
+    assertProto3OptionalReflection("optional_int64");
+    assertProto3OptionalReflection("optional_uint32");
+    assertProto3OptionalReflection("optional_uint64");
+    assertProto3OptionalReflection("optional_sint32");
+    assertProto3OptionalReflection("optional_sint64");
+    assertProto3OptionalReflection("optional_fixed32");
+    assertProto3OptionalReflection("optional_fixed64");
+    assertProto3OptionalReflection("optional_float");
+    assertProto3OptionalReflection("optional_double");
+    assertProto3OptionalReflection("optional_bool");
+    assertProto3OptionalReflection("optional_string");
+    assertProto3OptionalReflection("optional_bytes");
+  }
 
   public void testOneofEquals() throws Exception {
     TestAllTypes.Builder builder = TestAllTypes.newBuilder();

--- a/java/core/src/test/java/com/google/protobuf/TextFormatTest.java
+++ b/java/core/src/test/java/com/google/protobuf/TextFormatTest.java
@@ -40,6 +40,8 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.TextFormat.Parser.SingularOverwritePolicy;
+import com.google.protobuf.testing.proto.TestProto3Optional;
+import com.google.protobuf.testing.proto.TestProto3Optional.NestedEnum;
 import any_test.AnyTestProto.TestAny;
 import map_test.MapTestProto.TestMap;
 import protobuf_unittest.UnittestMset.TestMessageSetExtension1;
@@ -317,6 +319,24 @@ public class TextFormatTest extends TestCase {
             .build();
 
     assertEquals(canonicalExoticText, message.toString());
+  }
+
+  public void testRoundtripProto3Optional() throws Exception {
+    Message message =
+        TestProto3Optional.newBuilder()
+            .setOptionalInt32(1)
+            .setOptionalInt64(2)
+            .setOptionalNestedEnum(NestedEnum.BAZ)
+            .build();
+    TestProto3Optional.Builder message2 = TestProto3Optional.newBuilder();
+    TextFormat.merge(message.toString(), message2);
+
+    assertTrue(message2.hasOptionalInt32());
+    assertTrue(message2.hasOptionalInt64());
+    assertTrue(message2.hasOptionalNestedEnum());
+    assertEquals(1, message2.getOptionalInt32());
+    assertEquals(2, message2.getOptionalInt64());
+    assertEquals(NestedEnum.BAZ, message2.getOptionalNestedEnum());
   }
 
   public void testPrintMessageSet() throws Exception {

--- a/java/lite/generate-test-sources-build.xml
+++ b/java/lite/generate-test-sources-build.xml
@@ -15,6 +15,7 @@
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_no_generic_services.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_optimize_for.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_proto3.proto"/>
+        <arg value="${protobuf.source.dir}/google/protobuf/unittest_proto3_optional.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_well_known_types.proto"/>
         <arg value="${protobuf.basedir}/java/core/${test.proto.dir}/com/google/protobuf/any_test.proto"/>
         <arg value="${protobuf.basedir}/java/core/${test.proto.dir}/com/google/protobuf/cached_field_size_test.proto"/>

--- a/python/google/protobuf/internal/test_proto3_optional.proto
+++ b/python/google/protobuf/internal/test_proto3_optional.proto
@@ -30,10 +30,7 @@
 
 syntax = "proto3";
 
-package protobuf_unittest;
-
-option java_multiple_files = true;
-option java_package = "com.google.protobuf.testing.proto";
+package google.protobuf.python.internal;
 
 message TestProto3Optional {
   message NestedMessage {

--- a/src/google/protobuf/compiler/java/java_enum_field.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field.cc
@@ -225,6 +225,7 @@ void ImmutableEnumFieldGenerator::GenerateBuilderMembers(
     printer->Print(variables_,
                    "$deprecation$public Builder "
                    "${$set$capitalized_name$Value$}$(int value) {\n"
+                   "  $set_has_field_bit_builder$\n"
                    "  $name$_ = value;\n"
                    "  $on_changed$\n"
                    "  return this;\n"

--- a/src/google/protobuf/generated_message_reflection.cc
+++ b/src/google/protobuf/generated_message_reflection.cc
@@ -1061,7 +1061,7 @@ void Reflection::ListFields(const Message& message,
         if (oneof_case_array[containing_oneof->index()] == field->number()) {
           output->push_back(field);
         }
-      } else if (has_bits) {
+      } else if (has_bits && has_bits_indices[i] != -1) {
         // Equivalent to: HasBit(message, field)
         if (IsIndexInHasBitSet(has_bits, has_bits_indices[i])) {
           output->push_back(field);

--- a/src/google/protobuf/proto3_arena_unittest.cc
+++ b/src/google/protobuf/proto3_arena_unittest.cc
@@ -217,9 +217,15 @@ TEST(Proto3OptionalTest, OptionalFieldDescriptor) {
 
   for (int i = 0; i < d->field_count(); i++) {
     const FieldDescriptor* f = d->field(i);
-    EXPECT_TRUE(f->has_optional_keyword()) << f->full_name();
-    EXPECT_TRUE(f->has_presence()) << f->full_name();
-    EXPECT_TRUE(f->containing_oneof()) << f->full_name();
+    if (HasPrefixString(f->name(), "singular")) {
+      EXPECT_FALSE(f->has_optional_keyword()) << f->full_name();
+      EXPECT_FALSE(f->has_presence()) << f->full_name();
+      EXPECT_FALSE(f->containing_oneof()) << f->full_name();
+    } else {
+      EXPECT_TRUE(f->has_optional_keyword()) << f->full_name();
+      EXPECT_TRUE(f->has_presence()) << f->full_name();
+      EXPECT_TRUE(f->containing_oneof()) << f->full_name();
+    }
   }
 }
 

--- a/src/google/protobuf/unittest_proto3_optional.proto
+++ b/src/google/protobuf/unittest_proto3_optional.proto
@@ -72,4 +72,8 @@ message TestProto3Optional {
   optional NestedMessage optional_nested_message = 18;
   optional NestedMessage lazy_nested_message = 19 [lazy = true];
   optional NestedEnum optional_nested_enum = 21;
+
+  // Add some non-optional fields to verify we can mix them.
+  int32 singular_int32 = 22;
+  int64 singular_int64 = 23;
 }


### PR DESCRIPTION
Cherry-picks:

# C++ (and Python/C++):
- fix for https://github.com/protocolbuffers/protobuf/issues/7463

# Java
- fix for #7480

# C#
- [Remove Has/Clear members for C# message fields in proto2](https://github.com/protocolbuffers/protobuf/pull/7429)
- [Implement HasPresence for C#](https://github.com/protocolbuffers/protobuf/pull/7466)
- [C#: Mark GetOption API as obsolete and expose the "GetOptions()" method on descriptors instead]()