### PR TITLE
Fix integration tests for Go examples

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -163,10 +163,13 @@ build_golang() {
 
   export GOPATH="$HOME/gocode"
   mkdir -p "$GOPATH/src/github.com/protocolbuffers"
+  mkdir -p "$GOPATH/src/github.com/golang"
   rm -f "$GOPATH/src/github.com/protocolbuffers/protobuf"
+  rm -f "$GOPATH/src/github.com/golang/protobuf"
   ln -s "`pwd`" "$GOPATH/src/github.com/protocolbuffers/protobuf"
   export PATH="$GOPATH/bin:$PATH"
-  go get github.com/golang/protobuf/protoc-gen-go
+  (cd $GOPATH/src/github.com/golang && git clone https://github.com/golang/protobuf.git && cd protobuf && git checkout v1.3.5)
+  go install github.com/golang/protobuf/protoc-gen-go
 
   cd examples && PROTO_PATH="-I../src -I." make gotest && cd ..
 }


### PR DESCRIPTION
A proper integration test should be hermetic such that its operation
is agnostic to whatever happens outside of its controlled environment.
The script is not so since it uses a fixed (and very old) version of Go,
but continues to build protoc-gen-go from head, leading to an eventual
breakage when protoc-gen-go at head no longer operates on such an old
version of Go.

Fix the script to pin to an older version of protoc-gen-go (i.e., v1.3.5).