### PR TITLE
Add GetDebugString to Python FileDescriptor interface.

### DIFF
--- a/python/google/protobuf/internal/descriptor_test.py
+++ b/python/google/protobuf/internal/descriptor_test.py
@@ -58,6 +58,28 @@ TEST_EMPTY_MESSAGE_DESCRIPTOR_ASCII = """
 name: 'TestEmptyMessage'
 """
 
+TEST_FILE_DESCRIPTOR_DEBUG = """syntax = "proto2";
+
+package protobuf_unittest;
+
+message NestedMessage {
+  enum ForeignEnum {
+    FOREIGN_FOO = 4;
+    FOREIGN_BAR = 5;
+    FOREIGN_BAZ = 6;
+  }
+  optional int32 bb = 1;
+}
+
+message ResponseMessage {
+}
+
+service Service {
+  rpc CallMethod(.protobuf_unittest.NestedMessage) returns (.protobuf_unittest.ResponseMessage);
+}
+
+"""
+
 
 warnings.simplefilter('error', DeprecationWarning)
 
@@ -127,6 +149,9 @@ class DescriptorTest(unittest.TestCase):
 
   def testContainingServiceFixups(self):
     self.assertEqual(self.my_service, self.my_method.containing_service)
+
+  def testGetDebugString(self):
+    self.assertEqual(self.my_file.GetDebugString(), TEST_FILE_DESCRIPTOR_DEBUG)
 
   def testGetOptions(self):
     self.assertEqual(self.my_enum.GetOptions(),

--- a/python/google/protobuf/pyext/descriptor.cc
+++ b/python/google/protobuf/pyext/descriptor.cc
@@ -1398,6 +1398,10 @@ static int SetHasOptions(PyFileDescriptor *self, PyObject *value,
   return CheckCalledFromGeneratedFile("has_options");
 }
 
+static PyObject* GetDebugString(PyFileDescriptor *self) {
+  return PyString_FromCppString(_GetDescriptor(self)->DebugString());
+}
+
 static PyObject* GetOptions(PyFileDescriptor *self) {
   return GetOrBuildOptions(_GetDescriptor(self));
 }
@@ -1444,6 +1448,7 @@ static PyGetSetDef Getters[] = {
 };
 
 static PyMethodDef Methods[] = {
+  { "GetDebugString", (PyCFunction)GetDebugString, METH_NOARGS, },
   { "GetOptions", (PyCFunction)GetOptions, METH_NOARGS, },
   { "CopyToProto", (PyCFunction)CopyToProto, METH_O, },
   {NULL}


### PR DESCRIPTION
Closes #7484.

This PR exposes the C++ `FileDescriptor` `DebugString` method through to the Python C++ implementation, and adds a test for it.