### PR TITLE
Removed the unnecessary setuptools package dependency for Python package

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -241,7 +241,7 @@ if __name__ == '__main__':
     os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'cpp'
 
   # Keep this list of dependencies in sync with tox.ini.
-  install_requires = ['six>=1.9', 'setuptools']
+  install_requires = ['six>=1.9']
   if sys.version_info <= (2,7):
     install_requires.append('ordereddict')
     install_requires.append('unittest2')


### PR DESCRIPTION
The setuptools package was added to allow definition of namespaces using
the now outdated (and discouraged from use) pkg_resources-style.

The code here, for a long while now, uses a try/except (`ImportError`)
protection around the setuptools code, and falls back to the more
encoraged pkgutil-style.

Removing this library won't affect any current workflow, and in the case
of setuptools not found, it'll actually use a more modern (and
encouraged) flow.

More info: https://packaging.python.org/guides/packaging-namespace-packages/