### PR TITLE
Use lexical-binding in protobuf-mode.el

### DIFF
--- a/editors/protobuf-mode.el
+++ b/editors/protobuf-mode.el
@@ -1,4 +1,4 @@
-;;; protobuf-mode.el --- major mode for editing protocol buffers.
+;;; protobuf-mode.el --- major mode for editing protocol buffers.  -*- lexical-binding: t; -*-
 
 ;; Author: Alexandre Vassalotti <alexandre@peadrop.com>
 ;; Created: 23-Apr-2009


### PR DESCRIPTION
This is a very minor improvement to the Emacs `protobuf-mode.el` file, that just declares the file as using lexical binding. This allows some improvements in how the file is byte-compiled by Emacs, including letting it be optimized in Andrea Corallo's upstream `feature/native-comp` branch, which can only optimize elisp files that use lexical binding (which is how I discovered that the file wasn't using lexical binding in the first place).

The protobuf-mode.el file already requires Emacs >= 24.4, and lexical-binding was added in Emacs 24.1, so there's no chance this will break protobuf-mode for anyone using older Emacs versions.

I have already signed a Google individual CLA.