### PR TITLE
[Java] Remove unnecessary allocation during String field emptiness checks

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -3068,6 +3068,14 @@ public abstract class GeneratedMessageV3 extends AbstractMessage
     return (Extension<MessageType, T>) extension;
   }
 
+  protected static boolean isStringEmpty(final Object value) {
+    if (value instanceof String) {
+      return ((String) value).isEmpty();
+    } else {
+      return ((ByteString) value).isEmpty();
+    }
+  }
+
   protected static int computeStringSize(final int fieldNumber, final Object value) {
     if (value instanceof String) {
       return CodedOutputStream.computeStringSize(fieldNumber, (String) value);

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -78,6 +78,8 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
       "  if (value == null) {\n"
       "    throw new NullPointerException();\n"
       "  }\n";
+  (*variables)["isStringEmpty"] = "com.google.protobuf.GeneratedMessage" +
+                                GeneratedCodeVersionSuffix() + ".isStringEmpty";
   (*variables)["writeString"] = "com.google.protobuf.GeneratedMessage" +
                                 GeneratedCodeVersionSuffix() + ".writeString";
   (*variables)["computeStringSize"] = "com.google.protobuf.GeneratedMessage" +
@@ -110,7 +112,7 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
     (*variables)["clear_has_field_bit_builder"] = "";
 
     (*variables)["is_field_present_message"] =
-        "!get" + (*variables)["capitalized_name"] + "Bytes().isEmpty()";
+       "!" + (*variables)["isStringEmpty"] + "(" + (*variables)["name"] + "_)";
   }
 
   // For repeated builders, one bit is used for whether the array is immutable.


### PR DESCRIPTION
Hi!

I've opened an issue about suspicious String field processing earlier:
#6719 

This patch is trying to fix code generation in case this is actually a bug.