### PR TITLE
check null pointer dereference for map_entry

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -253,6 +253,10 @@ void CollectMapInfo(const Options& options, const Descriptor* descriptor,
   std::map<std::string, std::string>& vars = *variables;
   const FieldDescriptor* key = descriptor->FindFieldByName("key");
   const FieldDescriptor* val = descriptor->FindFieldByName("value");
+  // Can`t find the 'key'
+  GOOGLE_CHECK_NE(key, nullptr);
+  // Can`t find the 'val'
+  GOOGLE_CHECK_NE(val, nullptr);
   vars["key_cpp"] = PrimitiveTypeName(options, key->cpp_type());
   switch (val->cpp_type()) {
     case FieldDescriptor::CPPTYPE_MESSAGE:


### PR DESCRIPTION
null pointer dereference
```
syntax = "proto3";

package tutorial;

message Person0 {
	option map_entry = true;
}
// ...
```