### PR TITLE
C# project cleanup for dotnet SDK 3.1

### DIFF
--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.2"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="1.0.0-beta2-18618-05"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="1.0.0"/>
     <!-- Needed for the net45 build to work on Unix. See https://github.com/dotnet/designs/pull/33 -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0"/>
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 ﻿{
   "sdk": {
-    "version": "3.0.100"
+    "version": "3.0.100",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
- allow building with newer dotnet SDK than just 3.0.100
- upgrade Microsoft.SourceLink.GitHub dependency (current version causes trouble with dotnet SDK 3.1.x)