### PR TITLE
Return empty PHP debug info instead of null

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -89,6 +89,7 @@ static zval* message_get_property_ptr_ptr(zval* object, zval* member, int type,
 static HashTable* message_get_gc(zval* object, zval** table, int* n);
 #endif
 static HashTable* message_get_properties(zval* object TSRMLS_DC);
+static HashTable* message_get_debug_info(zval *object, int *is_temp TSRMLS_DC);
 
 // -----------------------------------------------------------------------------
 // PHP Message Handlers
@@ -125,6 +126,7 @@ PHP_PROTO_INIT_CLASS_START("Google\\Protobuf\\Internal\\Message",
   message_handlers->read_property = message_get_property;
   message_handlers->get_property_ptr_ptr = message_get_property_ptr_ptr;
   message_handlers->get_properties = message_get_properties;
+  message_handlers->get_debug_info = message_get_debug_info;
   message_handlers->get_gc = message_get_gc;
 PHP_PROTO_INIT_CLASS_END
 
@@ -254,6 +256,14 @@ static zval* message_get_property_ptr_ptr(zval* object, zval* member, int type,
 
 static HashTable* message_get_properties(zval* object TSRMLS_DC) {
   return NULL;
+}
+
+static HashTable* message_get_debug_info(zval* object, int *is_temp TSRMLS_DC) {
+  *is_temp = 1;
+  HashTable *ht;
+  ALLOC_HASHTABLE(ht);
+  zend_hash_init(ht, 0, NULL, ZVAL_PTR_DTOR, 0);
+  return ht;
 }
 
 static HashTable* message_get_gc(zval* object, CACHED_VALUE** table,


### PR DESCRIPTION
This addresses #6148 which describes an incompatibility between Xdebug and classes derived from the Protobuf extension's internal `\Google\Protobuf\Internal\Message` class. This incompatibility causes a segfault due to a null pointer dereference when using Xdebug's overridden `var_dump()` function or whenever a step debugger inspects one of these instances. The following code segfaults when Xdebug and Protobuf extensions are both installed:

```
<?php

var_dump(new \Google\Protobuf\Timestamp());
```

PHP internal provide two different handlers for accessing an object's properties:
[`get_properties`](https://wiki.php.net/internals/engine/objects#get_properties) and [`get_debug_info`](https://wiki.php.net/internals/engine/objects#get_debug_info).

These handlers offer different guidance: `get_debug_info` "Should not return NULL.", but for `get_properties`, returning `NULL` is explicitly supported in order to support cases such as invocation by the garbage collector.

PHP's helpers for accessing object properties (`zend_get_properties_for()` in PHP 7.4, and the various `Z_OBJDEBUG` macros) fall back to `get_properties` if the `get_debug_info` handler isn't defined, and this is where we get into trouble: Xdebug tries to access debug info for these classes but receives `NULL`, unexpectedly.

As a fix, I added a separate `get_debug_info` handler to the base `Message` class. This handler initializes an empty array and returns it, setting `is_tmp` to indicate that the caller should take ownership. While it's wasteful to allocate a new array every time, `get_debug_info` is accessed infrequently.

This change seemed easier and less invasive than modifying `get_properties()` to return an array. The docs for `get_properties()` indicate that the handler, not the caller, owns the array. This means `get_properties()` cannot allocate a temporary array on the fly. `get_debug_info()`, on the other hand, is designed for this case.

With this change in place, the example code above prints out Xdebug's extended `var_dump` output, as expected:

```
/home/vagrant/proto.php:3:
class Google\Protobuf\Timestamp#1 (0) {
}
```

While it would be nice to get _real_ debug info out of these message classes, that would be a much more involved change. This change only prevents the segfault, without trying to make debug info more useful.