### PR TITLE
Add flag to mantain proto fieldnames

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -477,7 +477,7 @@ bool IgnoreOneof(const OneofDescriptor* oneof) {
 
 std::string JSIdent(const GeneratorOptions& options,
                     const FieldDescriptor* field, bool is_upper_camel,
-                    bool is_map, bool drop_list, bool preserve_fieldnames = false) {
+                    bool is_map, bool drop_list, bool mantain_proto_fieldnames = false) {
   std::string result;
   if (field->type() == FieldDescriptor::TYPE_GROUP) {
     result = is_upper_camel

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -477,7 +477,7 @@ bool IgnoreOneof(const OneofDescriptor* oneof) {
 
 std::string JSIdent(const GeneratorOptions& options,
                     const FieldDescriptor* field, bool is_upper_camel,
-                    bool is_map, bool drop_list) {
+                    bool is_map, bool drop_list, bool preserve_fieldnames = false) {
   std::string result;
   if (field->type() == FieldDescriptor::TYPE_GROUP) {
     result = is_upper_camel
@@ -487,14 +487,16 @@ std::string JSIdent(const GeneratorOptions& options,
     result = is_upper_camel ? ToUpperCamel(ParseLowerUnderscore(field->name()))
                             : ToLowerCamel(ParseLowerUnderscore(field->name()));
   }
-  if (is_map || field->is_map()) {
-    // JSPB-style or proto3-style map.
-    result += "Map";
-  } else if (!drop_list && field->is_repeated()) {
-    // Repeated field.
-    result += "List";
+  if(!mantain_proto_fieldnames) {
+    if (is_map || field->is_map()) {
+      // JSPB-style or proto3-style map.
+      result += "Map";
+    } else if (!drop_list && field->is_repeated()) {
+      // Repeated field.
+      result += "List";
+    }
+    return result;
   }
-  return result;
 }
 
 std::string JSObjectFieldName(const GeneratorOptions& options,

--- a/src/google/protobuf/compiler/js/js_generator.h
+++ b/src/google/protobuf/compiler/js/js_generator.h
@@ -66,6 +66,8 @@ struct GeneratorOptions {
   std::string namespace_prefix;
   // Enable binary-format support?
   bool binary;
+  // Mantain the names in the repeated values
+  bool mantain_proto_fieldnames;
   // What style of imports should be used.
   enum ImportStyle {
     kImportClosure,         // goog.require()
@@ -74,13 +76,12 @@ struct GeneratorOptions {
     kImportBrowser,         // no import statements
     kImportEs6,             // import { member } from ''
   } import_style;
-  // Mantain the names in the repeated values
-  bool mantain_proto_fieldnames;
 
   GeneratorOptions()
       : output_dir("."),
         namespace_prefix(""),
         binary(false),
+        mantain_proto_fieldnames(false),
         import_style(kImportClosure),
         add_require_for_enums(false),
         testonly(false),
@@ -88,7 +89,6 @@ struct GeneratorOptions {
         error_on_name_conflict(false),
         extension(".js"),
         one_output_file_per_input_file(false),
-        mantain_proto_fieldnames(false),
         annotate_code(false) {}
 
   bool ParseFromOptions(

--- a/src/google/protobuf/compiler/js/js_generator.h
+++ b/src/google/protobuf/compiler/js/js_generator.h
@@ -66,7 +66,7 @@ struct GeneratorOptions {
   std::string namespace_prefix;
   // Enable binary-format support?
   bool binary;
-  // Mantain the names in the repeated values
+  // Mantain the names in the repeated and map filenames
   bool mantain_proto_fieldnames;
   // What style of imports should be used.
   enum ImportStyle {

--- a/src/google/protobuf/compiler/js/js_generator.h
+++ b/src/google/protobuf/compiler/js/js_generator.h
@@ -74,6 +74,8 @@ struct GeneratorOptions {
     kImportBrowser,         // no import statements
     kImportEs6,             // import { member } from ''
   } import_style;
+  // Mantain the names in the repeated values
+  bool mantain_proto_fieldnames;
 
   GeneratorOptions()
       : output_dir("."),
@@ -86,6 +88,7 @@ struct GeneratorOptions {
         error_on_name_conflict(false),
         extension(".js"),
         one_output_file_per_input_file(false),
+        mantain_proto_fieldnames(false),
         annotate_code(false) {}
 
   bool ParseFromOptions(


### PR DESCRIPTION
This feature is for add a flag to protobuf to prevent the append of `List` or `Map` at the end of the proto fieldName for the javascript file.

This feature is [added](https://github.com/protocolbuffers/protobuf/pull/1951/files) in the pass, but is lost with the time. 

