### PR TITLE
Fix #5858:provide clear message when specifying a directory as an input file

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -1273,13 +1273,16 @@ bool CommandLineInterface::MakeProtoProtoPathRelative(
                    "comes first."
                 << std::endl;
       return false;
-    case DiskSourceTree::CANNOT_OPEN:
+    case DiskSourceTree::CANNOT_OPEN: {
       if (in_fallback_database) {
         return true;
       }
+      std::string error_str = source_tree->GetLastErrorMessage().empty() ?
+        strerror(errno) : source_tree->GetLastErrorMessage();
       std::cerr << "Could not map to virtual file: " << *proto << ": "
-                << strerror(errno) << std::endl;
+                << error_str << std::endl;
       return false;
+    }
     case DiskSourceTree::NO_MAPPING: {
       // Try to interpret the path as a virtual path.
       std::string disk_file;

--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -490,6 +490,15 @@ io::ZeroCopyInputStream* DiskSourceTree::OpenVirtualFile(
 
 io::ZeroCopyInputStream* DiskSourceTree::OpenDiskFile(
     const std::string& filename) {
+  struct stat sb;
+  int ret = 0;
+  do {
+    ret = stat(filename.c_str(), &sb);
+  } while (ret != 0 && errno == EINTR);
+  if (!S_ISREG(sb.st_mode)) {
+    last_error_message_ = "Input file is not a regular file.";
+    return NULL;
+  }
   int file_descriptor;
   do {
     file_descriptor = open(filename.c_str(), O_RDONLY);

--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -495,12 +495,8 @@ io::ZeroCopyInputStream* DiskSourceTree::OpenDiskFile(
   do {
     ret = stat(filename.c_str(), &sb);
   } while (ret != 0 && errno == EINTR);
-#ifdef _WIN32
-  if ((sb.st_mode & _S_IFMT) == _S_IFREG) {
-#else
-  if (!S_ISREG(sb.st_mode)) {
-#endif
-    last_error_message_ = "Input file is not a regular file.";
+  if (sb.st_mode & S_IFDIR) {
+    last_error_message_ = "Input file is a directory.";
     return NULL;
   }
   int file_descriptor;

--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -495,7 +495,11 @@ io::ZeroCopyInputStream* DiskSourceTree::OpenDiskFile(
   do {
     ret = stat(filename.c_str(), &sb);
   } while (ret != 0 && errno == EINTR);
+#ifdef _WIN32
+  if ((sb.st_mode & _S_IFMT) == _S_IFREG) {
+#else
   if (!S_ISREG(sb.st_mode)) {
+#endif
     last_error_message_ = "Input file is not a regular file.";
     return NULL;
   }


### PR DESCRIPTION
Fix: [5858](https://github.com/protocolbuffers/protobuf/issues/5858)
Language: C++