### PR TITLE
Cpp export include

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_file.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_file.cc
@@ -1354,6 +1354,10 @@ void FileGenerator::GenerateLibraryIncludes(io::Printer* printer) {
   if (UseUnknownFieldSet(file_, options_) && !message_generators_.empty()) {
     IncludeFile("net/proto2/public/unknown_field_set.h", printer);
   }
+
+  if (!options_.dllexport_include.empty()) {
+    format("#include \"$1$\"\n", options_.dllexport_include);
+  }  
 }
 
 void FileGenerator::GenerateMetadataPragma(io::Printer* printer,

--- a/src/google/protobuf/compiler/cpp/cpp_generator.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_generator.cc
@@ -83,6 +83,8 @@ bool CppGenerator::Generate(const FileDescriptor* file,
   for (int i = 0; i < options.size(); i++) {
     if (options[i].first == "dllexport_decl") {
       file_options.dllexport_decl = options[i].second;
+    } else if (options[i].first == "dllexport_include") {
+      file_options.dllexport_include = options[i].second;
     } else if (options[i].first == "safe_boundary_check") {
       file_options.safe_boundary_check = true;
     } else if (options[i].first == "annotate_headers") {

--- a/src/google/protobuf/compiler/cpp/cpp_options.h
+++ b/src/google/protobuf/compiler/cpp/cpp_options.h
@@ -52,6 +52,7 @@ enum class EnforceOptimizeMode {
 // Generator options (see generator.cc for a description of each):
 struct Options {
   std::string dllexport_decl;
+  std::string dllexport_include;
   bool safe_boundary_check = false;
   bool proto_h = false;
   bool transitive_pb_h = true;

--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -505,7 +505,11 @@
 #define PROTOBUF_ALIGNAS(byte_alignment) alignas(byte_alignment)
 #endif
 
+#ifndef GOOGLE_PROTOBUF_NO_FINAL
 #define PROTOBUF_FINAL final
+#else
+#define PROTOBUF_FINAL
+#endif
 
 #if defined(_MSC_VER)
 #define PROTOBUF_THREAD_LOCAL __declspec(thread)


### PR DESCRIPTION
Added the capability for the generated cpp code to include the header file that define the export symbol. See this related google group post for reference: https://groups.google.com/forum/#!topic/protobuf/PDR1bqRazts

Also added #GOOGLE_PROTOBUF_NO_FINAL to generate cpp class that are not final. In certain controlled cases it is wanted to derive classes from generated protobuf classes to add system specific logic.