### PR TITLE
[PHP] Changed parameter type from long to integer

### DIFF
--- a/php/src/Google/Protobuf/Internal/RepeatedField.php
+++ b/php/src/Google/Protobuf/Internal/RepeatedField.php
@@ -67,7 +67,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Constructs an instance of RepeatedField.
      *
-     * @param long $type Type of the stored element.
+     * @param integer $type Type of the stored element.
      * @param string $klass Message/Enum class name (message/enum fields only).
      * @ignore
      */
@@ -116,7 +116,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * This will also be called for: $ele = $arr[0]
      *
-     * @param long $offset The index of the element to be fetched.
+     * @param integer $offset The index of the element to be fetched.
      * @return object The stored element at given index.
      * @throws \ErrorException Invalid type for index.
      * @throws \ErrorException Non-existing index.
@@ -131,7 +131,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * This will also be called for: $arr []= $ele and $arr[0] = ele
      *
-     * @param long $offset The index of the element to be assigned.
+     * @param integer $offset The index of the element to be assigned.
      * @param object $value The element to be assigned.
      * @return void
      * @throws \ErrorException Invalid type for index.
@@ -204,7 +204,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * This will also be called for: unset($arr)
      *
-     * @param long $offset The index of the element to be removed.
+     * @param integer $offset The index of the element to be removed.
      * @return void
      * @throws \ErrorException Invalid type for index.
      * @throws \ErrorException The element to be removed is not at the end of the
@@ -227,7 +227,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * This will also be called for: isset($arr)
      *
-     * @param long $offset The index of the element to be removed.
+     * @param integer $offset The index of the element to be removed.
      * @return bool True if the element at the given offset exists.
      * @throws \ErrorException Invalid type for index.
      */


### PR DESCRIPTION
PHP does not have a long type, and IDEs don't necessarily understand that long is the same as integer. 
E.g. PhpStorm will give an error like this: `Expected parameter of type '\Google\Protobuf\Internal\long', 'int' provided`