### PR TITLE
Add imenu index support

### DIFF
--- a/editors/protobuf-mode.el
+++ b/editors/protobuf-mode.el
@@ -216,7 +216,11 @@ Key bindings:
   (c-common-init 'protobuf-mode)
   (easy-menu-add protobuf-menu)
   (c-run-mode-hooks 'c-mode-common-hook 'protobuf-mode-hook)
-  (c-update-modeline))
+  (c-update-modeline)
+  (setq imenu-generic-expression
+	    '(("Message" "^[[:space:]]*message[[:space:]]+\\([[:alnum:]]+\\)" 1)
+          ("Enum" "^[[:space:]]*enum[[:space:]]+\\([[:alnum:]]+\\)" 1)
+          ("Service" "^[[:space:]]*service[[:space:]]+\\([[:alnum:]]+\\)" 1))))
 
 (provide 'protobuf-mode)
 


### PR DESCRIPTION
This adds ability for Emacs imenu to index types defined in a protobuf file. For example, [addressbook.proto](https://github.com/yuezhu/protobuf/blob/de6cde0c92f8f7da47d62dcfb39258fe2bf55c27/examples/addressbook.proto) in the example directory would have these imenu items:

![image](https://user-images.githubusercontent.com/1224535/84423823-12d88500-abed-11ea-9d19-0dda66a2f4ee.png)
