### PR TITLE
[PHP] Fix GPBUtil::getFullClassName() argument order

### DIFF
--- a/php/src/Google/Protobuf/Internal/Descriptor.php
+++ b/php/src/Google/Protobuf/Internal/Descriptor.php
@@ -185,8 +185,8 @@ class Descriptor
             $containing,
             $file_proto,
             $message_name_without_package,
-            $legacy_classname,
             $classname,
+            $legacy_classname,
             $fullname);
         $desc->setFullName($fullname);
         $desc->setClass($classname);


### PR DESCRIPTION
### Fixed
- `Google\Protobuf\Internal\Descriptor::buildFromProto()` now passes arguments to `Google\Protobuf\Internal\GPBUtil::getFullClassName()` in the correct order, preventing deprecation notices for legacy classes.

#### Notes:
- Issue was discovered due to unexpected deprecation notices for legacy classes.
- #7447 is a similar issue, but unrelated to this PR.
- [`Google\Protobuf\Internal\EnumDescriptor::buildFromProto()`](https://github.com/protocolbuffers/protobuf/blob/master/php/src/Google/Protobuf/Internal/EnumDescriptor.php#L97) already passes arguments in the correct order.
- Introduced in #4741