### PR TITLE
Do not use ADL when transforming string to lowercase

### DIFF
--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -119,7 +119,7 @@ std::string ReservedNamePrefix(const string& classname,
   bool is_reserved = false;
 
   string lower = classname;
-  transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
 
   for (int i = 0; i < kReservedNamesSize; i++) {
     if (lower == kReservedNames[i]) {
@@ -203,7 +203,7 @@ std::string LegacyGeneratedClassName(const DescriptorType* desc) {
 
 std::string ClassNamePrefix(const string& classname) {
   string lower = classname;
-  transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
 
   for (int i = 0; i < kReservedNamesSize; i++) {
     if (lower == kReservedNames[i]) {
@@ -218,7 +218,7 @@ std::string ConstantNamePrefix(const string& classname) {
   bool is_reserved = false;
 
   string lower = classname;
-  transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
 
   for (int i = 0; i < kReservedNamesSize; i++) {
     if (lower == kReservedNames[i]) {


### PR DESCRIPTION
There is no need to use ADL here and using it breaks the cases when string iterator is a raw pointer.