### PR TITLE
[C#] Make FieldDescriptor propertyName public

### DIFF
--- a/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
@@ -45,7 +45,6 @@ namespace Google.Protobuf.Reflection
         private MessageDescriptor extendeeType;
         private MessageDescriptor messageType;
         private FieldType fieldType;
-        private readonly string propertyName; // Annoyingly, needed in Crosslink.
         private IFieldAccessor accessor;
 
         /// <summary>
@@ -69,6 +68,11 @@ namespace Google.Protobuf.Reflection
         /// but can be overridden using the <c>json_name</c> option in the .proto file.
         /// </summary>
         public string JsonName { get; }
+
+        /// <summary>
+        /// The name of the property in the <c>ContainingType.ClrType</c> class.
+        /// </summary>
+        public string PropertyName { get; }
 
         /// <summary>
         /// Indicates whether this field supports presence, either implicitly (e.g. due to it being a message
@@ -123,7 +127,7 @@ namespace Google.Protobuf.Reflection
             // for later.
             // We could trust the generated code and check whether the type of the property is
             // a MapField, but that feels a tad nasty.
-            this.propertyName = propertyName;
+            PropertyName = propertyName;
             Extension = extension;
             JsonName =  Proto.JsonName == "" ? JsonFormatter.ToJsonName(Proto.Name) : Proto.JsonName;
         }
@@ -436,15 +440,15 @@ namespace Google.Protobuf.Reflection
             // If we're given no property name, that's because we really don't want an accessor.
             // This could be because it's a map message, or it could be that we're loading a FileDescriptor dynamically.
             // TODO: Support dynamic messages.
-            if (propertyName == null)
+            if (PropertyName == null)
             {
                 return null;
             }
 
-            var property = ContainingType.ClrType.GetProperty(propertyName);
+            var property = ContainingType.ClrType.GetProperty(PropertyName);
             if (property == null)
             {
-                throw new DescriptorValidationException(this, $"Property {propertyName} not found in {ContainingType.ClrType}");
+                throw new DescriptorValidationException(this, $"Property {PropertyName} not found in {ContainingType.ClrType}");
             }
             return IsMap ? new MapFieldAccessor(property, this)
                 : IsRepeated ? new RepeatedFieldAccessor(property, this)


### PR DESCRIPTION
Saw in https://github.com/protocolbuffers/protobuf/issues/4120 that this small change was on the cards. It gives a clean way to go from C# property names to ProtoBuf snake_case names.