### PR TITLE
Optimize reading strings across segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ cmake/cmake-build-debug/
 # IntelliJ
 .idea
 *.iml
+
+# BenchmarkDotNet
+BenchmarkDotNet.Artifacts/

--- a/csharp/src/Google.Protobuf.Benchmarks/Google.Protobuf.Benchmarks.csproj
+++ b/csharp/src/Google.Protobuf.Benchmarks/Google.Protobuf.Benchmarks.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Google.Protobuf.Test\ReadOnlySequenceFactory.cs" Link="ReadOnlySequenceFactory.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <ProjectReference Include="..\Google.Protobuf\Google.Protobuf.csproj" />
   </ItemGroup>

--- a/csharp/src/Google.Protobuf.Test/ReadOnlySequenceFactory.cs
+++ b/csharp/src/Google.Protobuf.Test/ReadOnlySequenceFactory.cs
@@ -41,11 +41,18 @@ namespace Google.Protobuf
 {
     internal static class ReadOnlySequenceFactory
     {
-        public static ReadOnlySequence<byte> CreateWithContent(byte[] data, int segmentSize = 1)
+        /// <summary>
+        /// Create a sequence from the specified data. The data will be divided up into segments in the sequence.
+        /// </summary>
+        public static ReadOnlySequence<byte> CreateWithContent(byte[] data, int segmentSize = 1, bool addEmptySegmentDelimiters = true)
         {
             var segments = new List<byte[]>();
 
-            segments.Add(new byte[0]);
+            if (addEmptySegmentDelimiters)
+            {
+                segments.Add(new byte[0]);
+            }
+
             var currentIndex = 0;
             while (currentIndex < data.Length)
             {
@@ -55,7 +62,11 @@ namespace Google.Protobuf
                     segment.Add(data[currentIndex++]);
                 }
                 segments.Add(segment.ToArray());
-                segments.Add(new byte[0]);
+
+                if (addEmptySegmentDelimiters)
+                {
+                    segments.Add(new byte[0]);
+                }
             }
 
             return CreateSegments(segments.ToArray());

--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -133,7 +133,7 @@ namespace Google.Protobuf.Collections
                     //
                     // Check that the supplied length doesn't exceed the underlying buffer.
                     // That prevents a malicious length from initializing a very large collection.
-                    if (codec.FixedSize > 0 && length % codec.FixedSize == 0 && IsDataAvailable(ref ctx, length))
+                    if (codec.FixedSize > 0 && length % codec.FixedSize == 0 && ParsingPrimitives.IsDataAvailable(ref ctx.state, length))
                     {
                         EnsureSize(count + (length / codec.FixedSize));
 
@@ -165,24 +165,6 @@ namespace Google.Protobuf.Collections
                     Add(reader(ref ctx));
                 } while (ParsingPrimitives.MaybeConsumeTag(ref ctx.buffer, ref ctx.state, tag));
             }
-        }
-
-        private bool IsDataAvailable(ref ParseContext ctx, int size)
-        {
-            // Data fits in remaining buffer
-            if (size <= ctx.state.bufferSize - ctx.state.bufferPos)
-            {
-                return true;
-            }
-
-            // Data fits in remaining source data.
-            // Note that this will never be true when reading from a stream as the total length is unknown.
-            if (size < ctx.state.segmentedBufferHelper.TotalLength - ctx.state.totalBytesRetired - ctx.state.bufferPos)
-            {
-                return true;
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/ParserInternalState.cs
+++ b/csharp/src/Google.Protobuf/ParserInternalState.cs
@@ -43,7 +43,7 @@ using Google.Protobuf.Collections;
 
 namespace Google.Protobuf
 {
-    
+
     // warning: this is a mutable struct, so it needs to be only passed as a ref!
     internal struct ParserInternalState
     {
@@ -54,12 +54,12 @@ namespace Google.Protobuf
         /// The position within the current buffer (i.e. the next byte to read)
         /// </summary>
         internal int bufferPos;
-        
+
         /// <summary>
         /// Size of the current buffer
         /// </summary>
         internal int bufferSize;
-        
+
         /// <summary>
         /// If we are currently inside a length-delimited block, this is the number of
         /// bytes in the buffer that are still available once we leave the delimited block.
@@ -79,9 +79,9 @@ namespace Google.Protobuf
         internal int totalBytesRetired;
 
         internal int recursionDepth;  // current recursion depth
-        
+
         internal SegmentedBufferHelper segmentedBufferHelper;
-        
+
         /// <summary>
         /// The last tag we read. 0 indicates we've read to the end of the stream
         /// (or haven't read anything yet).
@@ -101,7 +101,7 @@ namespace Google.Protobuf
         // If non-null, the top level parse method was started with given coded input stream as an argument
         // which also means we can potentially fallback to calling MergeFrom(CodedInputStream cis) if needed.
         internal CodedInputStream CodedInputStream => segmentedBufferHelper.CodedInputStream;
-        
+
         /// <summary>
         /// Internal-only property; when set to true, unknown fields will be discarded while parsing.
         /// </summary>

--- a/csharp/src/Google.Protobuf/ParsingPrimitives.cs
+++ b/csharp/src/Google.Protobuf/ParsingPrimitives.cs
@@ -34,6 +34,7 @@ using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -49,6 +50,7 @@ namespace Google.Protobuf
     [SecuritySafeCritical]
     internal static class ParsingPrimitives
     {
+        private const int StackallocThreshold = 256;
 
         /// <summary>
         /// Reads a length for length-delimited data.
@@ -58,7 +60,6 @@ namespace Google.Protobuf
         /// to make the calling code clearer.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-
         public static int ParseLength(ref ReadOnlySpan<byte> buffer, ref ParserInternalState state)
         {
             return (int)ParseRawVarint32(ref buffer, ref state);
@@ -437,13 +438,7 @@ namespace Google.Protobuf
                 throw InvalidProtocolBufferException.NegativeSize();
             }
 
-            if (state.totalBytesRetired + state.bufferPos + size > state.currentLimit)
-            {
-                // Read to the end of the stream (up to the current limit) anyway.
-                SkipRawBytes(ref buffer, ref state, state.currentLimit - state.totalBytesRetired - state.bufferPos);
-                // Then fail.
-                throw InvalidProtocolBufferException.TruncatedMessage();
-            }
+            ValidateCurrentLimit(ref buffer, ref state, size);
 
             if (size <= state.bufferSize - state.bufferPos)
             {
@@ -453,36 +448,13 @@ namespace Google.Protobuf
                 state.bufferPos += size;
                 return bytes;
             }
-            else if (size < buffer.Length || size < state.segmentedBufferHelper.TotalLength)
+            else if (IsDataAvailableInSource(ref state, size))
             {
                 // Reading more bytes than are in the buffer, but not an excessive number
                 // of bytes.  We can safely allocate the resulting array ahead of time.
 
-                // First copy what we have.
                 byte[] bytes = new byte[size];
-                var bytesSpan = new Span<byte>(bytes);
-                int pos = state.bufferSize - state.bufferPos;
-                buffer.Slice(state.bufferPos, pos).CopyTo(bytesSpan.Slice(0, pos));
-                state.bufferPos = state.bufferSize;
-
-                // We want to use RefillBuffer() and then copy from the buffer into our
-                // byte array rather than reading directly into our byte array because
-                // the input may be unbuffered.
-                state.segmentedBufferHelper.RefillBuffer(ref buffer, ref state, true);
-
-                while (size - pos > state.bufferSize)
-                {
-                    buffer.Slice(0, state.bufferSize)
-                        .CopyTo(bytesSpan.Slice(pos, state.bufferSize));
-                    pos += state.bufferSize;
-                    state.bufferPos = state.bufferSize;
-                    state.segmentedBufferHelper.RefillBuffer(ref buffer, ref state, true);
-                }
-
-                buffer.Slice(0, size - pos)
-                        .CopyTo(bytesSpan.Slice(pos, size - pos));
-                state.bufferPos = size - pos;
-
+                ReadRawBytesIntoSpan(ref buffer, ref state, size, bytes);
                 return bytes;
             }
             else
@@ -543,13 +515,7 @@ namespace Google.Protobuf
                 throw InvalidProtocolBufferException.NegativeSize();
             }
 
-            if (state.totalBytesRetired + state.bufferPos + size > state.currentLimit)
-            {
-                // Read to the end of the stream anyway.
-                SkipRawBytes(ref buffer, ref state, state.currentLimit - state.totalBytesRetired - state.bufferPos);
-                // Then fail.
-                throw InvalidProtocolBufferException.TruncatedMessage();
-            }
+            ValidateCurrentLimit(ref buffer, ref state, size);
 
             if (size <= state.bufferSize - state.bufferPos)
             {
@@ -619,7 +585,7 @@ namespace Google.Protobuf
             }
 
 #if GOOGLE_PROTOBUF_SUPPORT_FAST_STRING
-            if (length <= state.bufferSize - state.bufferPos && length > 0)
+            if (length <= state.bufferSize - state.bufferPos)
             {
                 // Fast path: all bytes to decode appear in the same span.
                 ReadOnlySpan<byte> data = buffer.Slice(state.bufferPos, length);
@@ -638,18 +604,74 @@ namespace Google.Protobuf
             }
 #endif
 
-            var decoder = WritingPrimitives.Utf8Encoding.GetDecoder();
+            return ReadStringSlow(ref buffer, ref state, length);
+        }
 
-            // TODO: even if GOOGLE_PROTOBUF_SUPPORT_FAST_STRING is not supported,
-            // we could still create a string efficiently by using Utf8Encoding.GetString(byte[] bytes, int index, int count)
-            // whenever the buffer is backed by a byte array (and avoid creating a new byte array), but the problem is
-            // there is no way to get the underlying byte array from a span.
+        /// <summary>
+        /// Reads a string assuming that it is spread across multiple spans in a <see cref="ReadOnlySequence{T}"/>.
+        /// </summary>
+        private static string ReadStringSlow(ref ReadOnlySpan<byte> buffer, ref ParserInternalState state, int length)
+        {
+            ValidateCurrentLimit(ref buffer, ref state, length);
 
-            // TODO: in case the string spans multiple buffer segments, creating a char[] and decoding into it and then
-            // creating a string from that array might be more efficient than creating a string from the copied bytes.
+#if GOOGLE_PROTOBUF_SUPPORT_FAST_STRING
+            if (IsDataAvailable(ref state, length))
+            {
+                // Read string data into a temporary buffer, either stackalloc'ed or from ArrayPool
+                // Once all data is read then call Encoding.GetString on buffer and return to pool if needed.
+
+                byte[] byteArray = null;
+                Span<byte> byteSpan = length <= StackallocThreshold ?
+                    stackalloc byte[length] :
+                    (byteArray = ArrayPool<byte>.Shared.Rent(length));
+
+                try
+                {
+                    unsafe
+                    {
+                        fixed (byte* pByteSpan = &MemoryMarshal.GetReference(byteSpan))
+                        {
+                            // Compiler doesn't like that a potentially stackalloc'd Span<byte> is being used
+                            // in a method with a "ref Span<byte> buffer" argument. If the stackalloc'd span was assigned
+                            // to the ref argument then bad things would happen. We'll never do that so it is ok.
+                            // Make compiler happy by passing a new span created from pointer.
+                            var tempSpan = new Span<byte>(pByteSpan, byteSpan.Length);
+                            ReadRawBytesIntoSpan(ref buffer, ref state, length, tempSpan);
+
+                            return WritingPrimitives.Utf8Encoding.GetString(pByteSpan, length);
+                        }
+                    }
+                }
+                finally
+                {
+                    if (byteArray != null)
+                    {
+                        ArrayPool<byte>.Shared.Return(byteArray);
+                    }
+                }
+            }
+#endif
 
             // Slow path: Build a byte array first then copy it.
+            // This will be called when reading from a Stream because we don't know the length of the stream,
+            // or there is not enough data in the sequence. If there is not enough data then ReadRawBytes will
+            // throw an exception.
             return WritingPrimitives.Utf8Encoding.GetString(ReadRawBytes(ref buffer, ref state, length), 0, length);
+        }
+
+        /// <summary>
+        /// Validates that the specified size doesn't exceed the current limit. If it does then remaining bytes
+        /// are skipped and an error is thrown.
+        /// </summary>
+        private static void ValidateCurrentLimit(ref ReadOnlySpan<byte> buffer, ref ParserInternalState state, int size)
+        {
+            if (state.totalBytesRetired + state.bufferPos + size > state.currentLimit)
+            {
+                // Read to the end of the stream (up to the current limit) anyway.
+                SkipRawBytes(ref buffer, ref state, state.currentLimit - state.totalBytesRetired - state.bufferPos);
+                // Then fail.
+                throw InvalidProtocolBufferException.TruncatedMessage();
+            }
         }
 
         [SecuritySafeCritical]
@@ -730,6 +752,57 @@ namespace Google.Protobuf
         public static long DecodeZigZag64(ulong n)
         {
             return (long)(n >> 1) ^ -(long)(n & 1);
+        }
+
+        /// <summary>
+        /// Checks whether there is known data available of the specified size remaining to parse.
+        /// When parsing from a Stream this can return false because we have no knowledge of the amount
+        /// of data remaining in the stream until it is read.
+        /// </summary>
+        public static bool IsDataAvailable(ref ParserInternalState state, int size)
+        {
+            // Data fits in remaining buffer
+            if (size <= state.bufferSize - state.bufferPos)
+            {
+                return true;
+            }
+
+            return IsDataAvailableInSource(ref state, size);
+        }
+
+        /// <summary>
+        /// Checks whether there is known data available of the specified size remaining to parse
+        /// in the underlying data source.
+        /// When parsing from a Stream this will return false because we have no knowledge of the amount
+        /// of data remaining in the stream until it is read.
+        /// </summary>
+        private static bool IsDataAvailableInSource(ref ParserInternalState state, int size)
+        {
+            // Data fits in remaining source data.
+            // Note that this will never be true when reading from a stream as the total length is unknown.
+            return size <= state.segmentedBufferHelper.TotalLength - state.totalBytesRetired - state.bufferPos;
+        }
+
+        /// <summary>
+        /// Read raw bytes of the specified length into a span. The amount of data available and the current limit should
+        /// be checked before calling this method.
+        /// </summary>
+        private static void ReadRawBytesIntoSpan(ref ReadOnlySpan<byte> buffer, ref ParserInternalState state, int length, Span<byte> byteSpan)
+        {
+            int remainingByteLength = length;
+            while (remainingByteLength > 0)
+            {
+                if (state.bufferSize - state.bufferPos == 0)
+                {
+                    state.segmentedBufferHelper.RefillBuffer(ref buffer, ref state, true);
+                }
+
+                ReadOnlySpan<byte> unreadSpan = buffer.Slice(state.bufferPos, Math.Min(remainingByteLength, state.bufferSize - state.bufferPos));
+                unreadSpan.CopyTo(byteSpan.Slice(length - remainingByteLength));
+
+                remainingByteLength -= unreadSpan.Length;
+                state.bufferPos += unreadSpan.Length;
+            }
         }
     }
 }


### PR DESCRIPTION
Before
```
|                                    Method | BytesToParse | encodedSize |       Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------------------------ |------------- |------------ |-----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|              ParseString_CodedInputStream |        10080 |           1 |  64.871 us | 0.2090 us | 0.1745 us |      0.1221 |           - |           - |               176 B |
|                  ParseString_ParseContext |        10080 |           1 |  66.493 us | 0.8300 us | 0.6931 us |           - |           - |           - |                   - |
| ParseString_ParseContext_MultipleSegments |        10080 |           1 |  80.660 us | 1.5452 us | 1.7175 us |           - |           - |           - |                   - |
|              ParseString_CodedInputStream |        10080 |           4 |  80.335 us | 1.2552 us | 1.1127 us |    102.6611 |           - |           - |             80816 B |
|                  ParseString_ParseContext |        10080 |           4 | 106.574 us | 0.9521 us | 0.8906 us |    102.4170 |           - |           - |             80640 B |
| ParseString_ParseContext_MultipleSegments |        10080 |           4 | 110.729 us | 2.6566 us | 2.4850 us |    102.4170 |           - |           - |             80640 B |
|              ParseString_CodedInputStream |        10080 |          10 |  42.858 us | 0.6439 us | 0.6023 us |     61.7065 |           - |           - |             48560 B |
|                  ParseString_ParseContext |        10080 |          10 |  54.975 us | 0.1663 us | 0.1474 us |     61.4624 |           - |           - |             48384 B |
| ParseString_ParseContext_MultipleSegments |        10080 |          10 |  70.892 us | 0.3835 us | 0.3399 us |     76.7822 |           - |           - |             60480 B |
|              ParseString_CodedInputStream |        10080 |         105 |  10.244 us | 0.0523 us | 0.0490 us |     29.5105 |           - |           - |             23216 B |
|                  ParseString_ParseContext |        10080 |         105 |  10.740 us | 0.1339 us | 0.1187 us |     29.2816 |           - |           - |             23040 B |
| ParseString_ParseContext_MultipleSegments |        10080 |         105 |  29.147 us | 0.1317 us | 0.1100 us |     51.7273 |           - |           - |             40704 B |
|              ParseString_CodedInputStream |        10080 |       10080 |   6.136 us | 0.1177 us | 0.1309 us |     25.6348 |           - |           - |             20360 B |
|                  ParseString_ParseContext |        10080 |       10080 |   5.732 us | 0.0272 us | 0.0241 us |     25.6348 |           - |           - |             20184 B |
| ParseString_ParseContext_MultipleSegments |        10080 |       10080 |  15.753 us | 0.1460 us | 0.1295 us |     38.4521 |           - |           - |             30344 B |
```

After
```
|                                    Method | BytesToParse | encodedSize |       Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------------------------ |------------- |------------ |-----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|              ParseString_CodedInputStream |        10080 |           1 |  65.621 us | 0.3992 us | 0.3539 us |      0.1221 |           - |           - |               184 B |
|                  ParseString_ParseContext |        10080 |           1 |  65.119 us | 1.1548 us | 1.0237 us |           - |           - |           - |                   - |
| ParseString_ParseContext_MultipleSegments |        10080 |           1 |  76.722 us | 0.6850 us | 0.6073 us |           - |           - |           - |                   - |
|              ParseString_CodedInputStream |        10080 |           4 |  84.192 us | 0.7777 us | 0.7274 us |    102.6611 |           - |           - |             80824 B |
|                  ParseString_ParseContext |        10080 |           4 | 106.247 us | 1.1588 us | 1.0840 us |    102.4170 |           - |           - |             80640 B |
| ParseString_ParseContext_MultipleSegments |        10080 |           4 | 109.838 us | 0.4112 us | 0.3645 us |    102.4170 |           - |           - |             80640 B |
|              ParseString_CodedInputStream |        10080 |          10 |  43.997 us | 0.6887 us | 0.6105 us |     61.7065 |           - |           - |             48568 B |
|                  ParseString_ParseContext |        10080 |          10 |  55.625 us | 0.3236 us | 0.2868 us |     61.4624 |           - |           - |             48384 B |
| ParseString_ParseContext_MultipleSegments |        10080 |          10 |  78.260 us | 1.0150 us | 0.8476 us |     61.5234 |           - |           - |             48440 B |
|              ParseString_CodedInputStream |        10080 |         105 |  10.687 us | 0.2087 us | 0.2786 us |     29.5258 |           - |           - |             23224 B |
|                  ParseString_ParseContext |        10080 |         105 |  10.966 us | 0.2136 us | 0.1894 us |     29.2816 |           - |           - |             23040 B |
| ParseString_ParseContext_MultipleSegments |        10080 |         105 |  35.011 us | 0.4347 us | 0.4066 us |     29.3579 |           - |           - |             23096 B |
|              ParseString_CodedInputStream |        10080 |       10080 |   6.284 us | 0.1229 us | 0.1463 us |     25.6348 |           - |           - |             20368 B |
|                  ParseString_ParseContext |        10080 |       10080 |   5.795 us | 0.0716 us | 0.0670 us |     25.6348 |           - |           - |             20184 B |
| ParseString_ParseContext_MultipleSegments |        10080 |       10080 |  19.453 us | 0.2476 us | 0.2316 us |     25.6348 |           - |           - |             20240 B |
```