### PR TITLE
Support JsType in Java JSON serialization

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -54,6 +54,7 @@ import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor.Type;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
+import com.google.protobuf.DescriptorProtos.FieldOptions;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.Duration;
 import com.google.protobuf.DynamicMessage;
@@ -1153,7 +1154,13 @@ public class JsonFormat {
         case INT64:
         case SINT64:
         case SFIXED64:
-          generator.print("\"" + ((Long) value).toString() + "\"");
+          if (field.getOptions().getJstype() != FieldOptions.JSType.JS_NUMBER) {
+            generator.print("\"");
+          }
+          generator.print(((Long) value).toString());
+          if (field.getOptions().getJstype() != FieldOptions.JSType.JS_NUMBER) {
+            generator.print("\"");
+          }
           break;
 
         case BOOL:
@@ -1225,7 +1232,13 @@ public class JsonFormat {
 
         case UINT64:
         case FIXED64:
-          generator.print("\"" + unsignedToString((Long) value) + "\"");
+          if (field.getOptions().getJstype() != FieldOptions.JSType.JS_NUMBER) {
+            generator.print("\"");
+          }
+          generator.print(unsignedToString((Long) value));
+          if (field.getOptions().getJstype() != FieldOptions.JSType.JS_NUMBER) {
+            generator.print("\"");
+          }
           break;
 
         case STRING:

--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -57,6 +57,7 @@ import com.google.protobuf.util.proto.JsonTestProto.TestAllTypes.NestedEnum;
 import com.google.protobuf.util.proto.JsonTestProto.TestAllTypes.NestedMessage;
 import com.google.protobuf.util.proto.JsonTestProto.TestAny;
 import com.google.protobuf.util.proto.JsonTestProto.TestCustomJsonName;
+import com.google.protobuf.util.proto.JsonTestProto.TestJsonNumberTypes;
 import com.google.protobuf.util.proto.JsonTestProto.TestDuration;
 import com.google.protobuf.util.proto.JsonTestProto.TestFieldMask;
 import com.google.protobuf.util.proto.JsonTestProto.TestMap;
@@ -1314,6 +1315,12 @@ public class JsonFormatTest extends TestCase {
   public void testCustomJsonName() throws Exception {
     TestCustomJsonName message = TestCustomJsonName.newBuilder().setValue(12345).build();
     assertEquals("{\n" + "  \"@value\": 12345\n" + "}", JsonFormat.printer().print(message));
+    assertRoundTripEquals(message);
+  }
+
+  public void testJsonNumberTypes() throws Exception {
+    TestJsonNumberTypes message = TestJsonNumberTypes.newBuilder().setInt64Normal(12345).setInt64String(12345).setInt64Number(12345).build();
+    assertEquals("{\n  \"int64Normal\": \"12345\",\n  \"int64String\": \"12345\",\n  \"int64Number\": 12345\n}", JsonFormat.printer().print(message));
     assertRoundTripEquals(message);
   }
 

--- a/java/util/src/test/proto/com/google/protobuf/util/json_test.proto
+++ b/java/util/src/test/proto/com/google/protobuf/util/json_test.proto
@@ -184,6 +184,12 @@ message TestCustomJsonName {
   int32 value = 1 [json_name = "@value"];
 }
 
+message TestJsonNumberTypes {
+  int64 int64_normal = 1 [jstype = JS_NORMAL];
+  sint64 int64_string = 2 [jstype = JS_STRING];
+  uint64 int64_number = 3 [jstype = JS_NUMBER];
+}
+
 message TestRecursive {
   int32 value = 1;
   TestRecursive nested = 2;


### PR DESCRIPTION
FieldOptions already has a enum for specifying how numbers are serialized
over the wire - this just hooks up the JSON printer to look at this value.

This is both backwards compatible and parsing already supports reading longs
as strings or numbers.