### PR TITLE
C# write benchmark improvements

### DIFF
--- a/csharp/src/Google.Protobuf.Benchmarks/Google.Protobuf.Benchmarks.csproj
+++ b/csharp/src/Google.Protobuf.Benchmarks/Google.Protobuf.Benchmarks.csproj
@@ -2,15 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyOriginatorKeyFile>../../keys/Google.Protobuf.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <IsPackable>False</IsPackable>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <ProjectReference Include="..\Google.Protobuf\Google.Protobuf.csproj" />
   </ItemGroup>
 

--- a/csharp/src/Google.Protobuf.Benchmarks/WriteRawPrimitivesBenchmark.cs
+++ b/csharp/src/Google.Protobuf.Benchmarks/WriteRawPrimitivesBenchmark.cs
@@ -123,9 +123,9 @@ namespace Google.Protobuf.Benchmarks
         {
             var values = varint32Values[encodedSize];
             var cos = new CodedOutputStream(outputBuffer);
-            foreach (var value in values)
+            for (int i = 0; i < values.Length; i++)
             {
-                cos.WriteRawVarint32(value);
+                cos.WriteRawVarint32(values[i]);
             }
             cos.Flush();
             cos.CheckNoSpaceLeft();
@@ -142,9 +142,9 @@ namespace Google.Protobuf.Benchmarks
             var values = varint32Values[encodedSize];
             var span = new Span<byte>(outputBuffer);
             WriteContext.Initialize(ref span, out WriteContext ctx);
-            foreach (var value in values)
+            for (int i = 0; i < values.Length; i++)
             {
-                ctx.WriteUInt32(value);
+                ctx.WriteUInt32(values[i]);
             }
             ctx.Flush();
             ctx.CheckNoSpaceLeft();
@@ -165,9 +165,9 @@ namespace Google.Protobuf.Benchmarks
         {
             var values = varint64Values[encodedSize];
             var cos = new CodedOutputStream(outputBuffer);
-            foreach (var value in values)
+            for (int i = 0; i < values.Length; i++)
             {
-                cos.WriteRawVarint64(value);
+                cos.WriteRawVarint64(values[i]);
             }
             cos.Flush();
             cos.CheckNoSpaceLeft();
@@ -189,9 +189,9 @@ namespace Google.Protobuf.Benchmarks
             var values = varint64Values[encodedSize];
             var span = new Span<byte>(outputBuffer);
             WriteContext.Initialize(ref span, out WriteContext ctx);
-            foreach (var value in values)
+            for (int i = 0; i < values.Length; i++)
             {
-                ctx.WriteUInt64(value);
+                ctx.WriteUInt64(values[i]);
             }
             ctx.Flush();
             ctx.CheckNoSpaceLeft();
@@ -202,7 +202,7 @@ namespace Google.Protobuf.Benchmarks
         {
             const int encodedSize = sizeof(uint);
             var cos = new CodedOutputStream(outputBuffer);
-            for(int i = 0; i < BytesToWrite / encodedSize; i++)
+            for (int i = 0; i < BytesToWrite / encodedSize; i++)
             {
                 cos.WriteFixed32(12345);
             }
@@ -247,6 +247,58 @@ namespace Google.Protobuf.Benchmarks
             {
                 ctx.WriteFixed64(123456789);
             }
+            ctx.Flush();
+            ctx.CheckNoSpaceLeft();
+        }
+
+        [Benchmark]
+        public void WriteRawTag_OneByte_WriteContext()
+        {
+            const int encodedSize = 1;
+            var span = new Span<byte>(outputBuffer);
+            WriteContext.Initialize(ref span, out WriteContext ctx);
+            for (uint i = 0; i < BytesToWrite / encodedSize; i++)
+            {
+                ctx.WriteRawTag(16);
+            }
+            ctx.Flush();
+            ctx.CheckNoSpaceLeft();
+        }
+
+        [Benchmark]
+        public void WriteRawTag_TwoBytes_WriteContext()
+        {
+            const int encodedSize = 2;
+            var span = new Span<byte>(outputBuffer);
+            WriteContext.Initialize(ref span, out WriteContext ctx);
+            for (uint i = 0; i < BytesToWrite / encodedSize; i++)
+            {
+                ctx.WriteRawTag(137, 6);
+            }
+            ctx.Flush();
+            ctx.CheckNoSpaceLeft();
+        }
+
+        [Benchmark]
+        public void WriteRawTag_ThreeBytes_WriteContext()
+        {
+            const int encodedSize = 3;
+            var span = new Span<byte>(outputBuffer);
+            WriteContext.Initialize(ref span, out WriteContext ctx);
+            for (uint i = 0; i < BytesToWrite / encodedSize; i++)
+            {
+                ctx.WriteRawTag(160, 131, 1);
+            }
+            ctx.Flush();
+            ctx.CheckNoSpaceLeft();
+        }
+
+        [Benchmark]
+        public void Baseline_WriteContext()
+        {
+            var span = new Span<byte>(outputBuffer);
+            WriteContext.Initialize(ref span, out WriteContext ctx);
+            ctx.state.position = outputBuffer.Length;
             ctx.Flush();
             ctx.CheckNoSpaceLeft();
         }

--- a/csharp/src/Google.Protobuf/WritingPrimitives.cs
+++ b/csharp/src/Google.Protobuf/WritingPrimitives.cs
@@ -384,18 +384,8 @@ namespace Google.Protobuf
             }
             else
             {
-                // TODO(jtattermusch): According to the benchmarks, writing byte-by-byte is actually faster
-                // than using BinaryPrimitives.WriteUInt64LittleEndian.
-                // This is strange especially because WriteUInt32LittleEndian seems to be much faster
-                // in terms of throughput.
-                buffer[state.position++] = ((byte)value);
-                buffer[state.position++] = ((byte)(value >> 8));
-                buffer[state.position++] = ((byte)(value >> 16));
-                buffer[state.position++] = ((byte)(value >> 24));
-                buffer[state.position++] = ((byte)(value >> 32));
-                buffer[state.position++] = ((byte)(value >> 40));
-                buffer[state.position++] = ((byte)(value >> 48));
-                buffer[state.position++] = ((byte)(value >> 56));
+                BinaryPrimitives.WriteUInt64LittleEndian(buffer.Slice(state.position), value);
+                state.position += length;
             }
         }
 


### PR DESCRIPTION
- target netcoreapp3.1 (the newest LTS of .NET core)
- add a few more useful write benchmarks
- use `BinaryPrimitives.WriteUInt64LittleEndian` for writing fixed64 values as starting from .NET Core 3.x, this is much faster than the current workaround.

Changes are mostly taken from https://github.com/JamesNK/protobuf/commit/337780c0e098185d4df76d498c8f435e105f8a56 (as recommended here https://github.com/protocolbuffers/protobuf/pull/7576#issuecomment-647069227 for more context). Thanks @JamesNK  for the improvements!
