### PR TITLE
Bugfix for when message constructor has no argument.

### DIFF
--- a/php/ext/google/protobuf2/message.c
+++ b/php/ext/google/protobuf2/message.c
@@ -366,7 +366,7 @@ PHP_METHOD(Message, __construct) {
   const Descriptor* desc = Descriptor_GetFromClassEntry(Z_OBJCE_P(getThis()));
   const upb_msgdef *msgdef = desc->msgdef;
   upb_arena *arena = Arena_Get(&intern->arena);
-  zval *init_arr;
+  zval *init_arr = NULL;
 
   intern->desc = desc;
   intern->msg = upb_msg_new(msgdef, arena);


### PR DESCRIPTION
This fixes the user issue: https://github.com/protocolbuffers/protobuf/issues/7611#issuecomment-647025031