### PR TITLE
upgrade dotnet SDK in the CI to 3.1

### DIFF
--- a/csharp/install_dotnet_sdk.ps1
+++ b/csharp/install_dotnet_sdk.ps1
@@ -1,5 +1,5 @@
 #!/usr/bin/env powershell
-# Install dotnet SDK based on the SDK version from global.json
+# Install dotnet SDK using the official dotnet-install.ps1 script
 
 Set-StrictMode -Version 2
 $ErrorActionPreference = 'Stop'
@@ -9,16 +9,12 @@ $ErrorActionPreference = 'Stop'
 
 $InstallScriptUrl = 'https://dot.net/v1/dotnet-install.ps1'
 $InstallScriptPath = Join-Path  "$env:TEMP" 'dotnet-install.ps1'
-$GlobalJsonPath = Join-Path $PSScriptRoot '..' | Join-Path -ChildPath 'global.json'
-
-# Resolve SDK version from global.json file
-$GlobalJson = Get-Content -Raw $GlobalJsonPath | ConvertFrom-Json
-$SDKVersion = $GlobalJson.sdk.version
 
 # Download install script
 Write-Host "Downloading install script: $InstallScriptUrl => $InstallScriptPath"
 Invoke-WebRequest -Uri $InstallScriptUrl -OutFile $InstallScriptPath
-&$InstallScriptPath -Version $SDKVersion
 
-# Also install dotnet SDK LTS which is required to run some of the tests
+# The SDK versions to install should be kept in sync with versions
+# installed by kokoro/linux/dockerfile/test/csharp/Dockerfile
 &$InstallScriptPath -Version 2.1.802
+&$InstallScriptPath -Version 3.1.301

--- a/kokoro/linux/dockerfile/test/csharp/Dockerfile
+++ b/kokoro/linux/dockerfile/test/csharp/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y libunwind8 libicu57 && apt-get clean
 RUN wget -q https://dot.net/v1/dotnet-install.sh && \
     chmod u+x dotnet-install.sh && \
     ./dotnet-install.sh --version 2.1.802 && \
-    ./dotnet-install.sh --version 3.0.100 && \
+    ./dotnet-install.sh --version 3.1.301 && \
     ln -s /root/.dotnet/dotnet /usr/local/bin
 
 RUN wget -q www.nuget.org/NuGet.exe -O /usr/local/bin/nuget.exe


### PR DESCRIPTION
the 3.0 SDK is no longer supported and dotnet SDK 3.1 is the LTS version.

This is a prerequsite for https://github.com/protocolbuffers/protobuf/pull/7658