### PR TITLE
csharp compiler support deprecated enum options

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_enum.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_enum.cc
@@ -74,6 +74,9 @@ void EnumGenerator::Generate(io::Printer* printer) {
           << ") in " << descriptor_->name() << "; adding underscore to distinguish";
         name += "_";
       }
+      if (descriptor_->value(i)->options().deprecated()) {
+          printer->Print("[global::System.Obsolete]");
+      }
       int number = descriptor_->value(i)->number();
       if (!used_number.insert(number).second) {
           printer->Print("[pbr::OriginalName(\"$original_name$\", PreferredAlias = false)] $name$ = $number$,\n",


### PR DESCRIPTION
The deprecated option was only missing on enums