### PR TITLE
[PHP] Test Deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "php": ">=5.5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=4.8.0"
+    "phpunit/phpunit": "^5|^4.8.0",
+    "symfony/phpunit-bridge": "^5.1"
   },
   "suggest": {
     "ext-bcmath": "Need to support JSON deserialization"

--- a/php/composer.json
+++ b/php/composer.json
@@ -9,7 +9,8 @@
     "php": ">=5.5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5|^4.8.0"
+    "phpunit/phpunit": "^5|^4.8.0",
+    "symfony/phpunit-bridge": "^5.1"
   },
   "autoload": {
     "psr-4": {

--- a/php/phpunit.xml
+++ b/php/phpunit.xml
@@ -3,6 +3,7 @@
          colors="true">
   <testsuites>
     <testsuite name="protobuf-tests">
+      <file>tests/php_deprecation_test.php</file>
       <file>tests/php_implementation_test.php</file>
       <file>tests/array_test.php</file>
       <file>tests/encode_decode_test.php</file>
@@ -15,4 +16,7 @@
       <file>tests/wrapper_type_setters_test.php</file>
     </testsuite>
   </testsuites>
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
 </phpunit>

--- a/php/src/Google/Protobuf/Internal/Descriptor.php
+++ b/php/src/Google/Protobuf/Internal/Descriptor.php
@@ -185,8 +185,8 @@ class Descriptor
             $containing,
             $file_proto,
             $message_name_without_package,
-            $legacy_classname,
             $classname,
+            $legacy_classname,
             $fullname);
         $desc->setFullName($fullname);
         $desc->setClass($classname);

--- a/php/tests/php_deprecation_test.php
+++ b/php/tests/php_deprecation_test.php
@@ -1,0 +1,39 @@
+<?php
+
+require_once('test_base.php');
+require_once('test_util.php');
+
+use Foo\TestMessage\Sub;
+use Foo\TestMessage_Sub;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
+/**
+ * Please note, this test is only intended to be run without the protobuf C
+ * extension.
+ */
+class DeprecationTest extends TestBase
+{
+    use ExpectDeprecationTrait;
+
+    public function setUp()
+    {
+        if (extension_loaded('protobuf')) {
+            $this->markTestSkipped();
+        }
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedSubMessage()
+    {
+        $this->expectDeprecation(sprintf(
+            '%s is deprecated and will be removed in the next major release. Use %s instead',
+            TestMessage_Sub::class,
+            Sub::class,
+        ));
+
+        $sub_m = new TestMessage_Sub();
+        $this->assertInstanceOf(Sub::class, $sub_m);
+    }
+}


### PR DESCRIPTION
Following #7629 this PR introduces test coverage for deprecated message classes.

This wasn't included in #7629 as it introduces a new dev dependency on `symfony/phpunit-bridge`, which might not be desirable.

If you'd prefer not to test deprecations like this, I'll close this PR.