### PR TITLE
Added additional overload in MapField

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Collections/MapFieldTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Collections/MapFieldTest.cs
@@ -179,6 +179,35 @@ namespace Google.Protobuf.Collections
             CollectionAssert.AreEqual(new[] { "before", "x", "a", "after" }, map2.Keys);
         }
 
+        [Test]
+        public void Add_IEnumerable()
+        {
+            var map1 = new MapField<string, string>
+            {
+                { "x", "y" },
+                { "a", "b" }
+            };
+
+            IReadOnlyDictionary<string, string> map2 = new Dictionary<string, string>
+            {
+                {"before", ""},
+                {"after", ""}
+            };
+
+            var expected = new MapField<string, string>
+            {
+                { "before", "" },
+                { "x", "y" },
+                { "a", "b" },
+                { "after", "" }
+            };
+
+            map1.Add(map2);
+
+            Assert.AreEqual(expected, map1);
+            CollectionAssert.AreEqual(new[] { "before", "x", "a", "after" }, map1.Keys);
+        }
+
         // General IDictionary<TKey, TValue> behavior tests
         [Test]
         public void Add_KeyAlreadyExists()

--- a/csharp/src/Google.Protobuf/Collections/MapField.cs
+++ b/csharp/src/Google.Protobuf/Collections/MapField.cs
@@ -248,6 +248,19 @@ namespace Google.Protobuf.Collections
         }
 
         /// <summary>
+        /// Adds the specified entries to the map. The keys and values are not automatically cloned.
+        /// </summary>
+        /// <param name="entries">The entries to add to the map.</param>
+        public void Add(IEnumerable<KeyValuePair<TKey, TValue>> entries)
+        {
+            ProtoPreconditions.CheckNotNull(entries, nameof(entries));
+            foreach (var pair in entries)
+            {
+                Add(pair.Key, pair.Value);
+            }
+        }
+
+        /// <summary>
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>


### PR DESCRIPTION
Hello,

I created an additional Method overload so other IEnumerable<KeyValuePair> collections can be added. This is especially required as e.g. IReadOnlyDictionary is otherwise not possible to Add.