### PR TITLE
Remove "T is overaligned" assertion

### DIFF
--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -528,7 +528,6 @@ class PROTOBUF_EXPORT PROTOBUF_ALIGNAS(8) Arena final {
   // the cookie is not null.
   template <typename T>
   PROTOBUF_ALWAYS_INLINE void* AllocateInternal(bool skip_explicit_ownership) {
-    static_assert(alignof(T) <= 8, "T is overaligned, see b/151247138");
     const size_t n = internal::AlignUpTo8(sizeof(T));
     AllocHook(RTTI_TYPE_ID(T), n);
     // Monitor allocation if needed.


### PR DESCRIPTION
On some targets, the assertion fails without actually informing why this
is the case:

   .../protobuf-3.12.2/src/google/protobuf/arena.h:531:30: error: static
   assertion failed: T is overaligned, see b/151247138

Rather than finding out what "b/151247138" is or where it fails to guard
or change the assertion test, just remove it to see the full test suite
succeed.

Bug: https://bugs.gentoo.org/731002
Closes: https://github.com/protocolbuffers/protobuf/issues/7682
Signed-off-by: Jeroen Roovers <jer@gentoo.org>