### PR TITLE
[PHP] [3.12.x] Fix GPBUtil::getFullClassName() argument order

### DIFF
--- a/php/src/Google/Protobuf/Internal/Descriptor.php
+++ b/php/src/Google/Protobuf/Internal/Descriptor.php
@@ -185,8 +185,8 @@ class Descriptor
             $containing,
             $file_proto,
             $message_name_without_package,
-            $legacy_classname,
             $classname,
+            $legacy_classname,
             $fullname);
         $desc->setFullName($fullname);
         $desc->setClass($classname);


### PR DESCRIPTION
#7629 for `3.12.x`