### PR TITLE
annotate ByteString.CopyFrom(ReadOnlySpan<byte>) as SecuritySafeCritical

### DIFF
--- a/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
@@ -111,6 +111,18 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void CopyFromReadOnlySpanCopiesContents()
+        {
+            byte[] data = new byte[1];
+            data[0] = 10;
+            ReadOnlySpan<byte> byteSpan = data;
+            var bs = ByteString.CopyFrom(byteSpan);
+            Assert.AreEqual(10, bs[0]);
+            data[0] = 5;
+            Assert.AreEqual(10, bs[0]);
+        }
+
+        [Test]
         public void ToByteArrayCopiesContents()
         {
             ByteString bs = ByteString.CopyFromUtf8("Hello");
@@ -249,5 +261,6 @@ namespace Google.Protobuf
             var copied = byteString.Memory.ToArray();
             CollectionAssert.AreEqual(byteString, copied);
         }
+
     }
 }

--- a/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
@@ -261,6 +261,5 @@ namespace Google.Protobuf
             var copied = byteString.Memory.ToArray();
             CollectionAssert.AreEqual(byteString, copied);
         }
-
     }
 }

--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -245,6 +245,7 @@ namespace Google.Protobuf
         /// are copied, so further modifications to the span will not
         /// be reflected in the returned <see cref="ByteString" />.
         /// </summary>
+        [SecuritySafeCritical]
         public static ByteString CopyFrom(ReadOnlySpan<byte> bytes)
         {
             return new ByteString(bytes.ToArray());


### PR DESCRIPTION
The change to test solution for issue: 
> Can't call ByteString.CopyFrom(ReadOnlySpan<byte> bytes) on net45 #7700

Fixes https://github.com/protocolbuffers/protobuf/issues/7700