### PR TITLE
Override pip and virtualenv installation for macOS.

### DIFF
--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -66,7 +66,7 @@ fi
 # Install Tox
 
 if [[ "${KOKORO_INSTALL_TOX:-}" == "yes" ]] ; then
-  sudo pip install tox==2.4.1
+  sudo python3 -m pip install --upgrade pip tox
 fi
 
 ##

--- a/kokoro/release/python/macos/config.sh
+++ b/kokoro/release/python/macos/config.sh
@@ -1,6 +1,25 @@
 # Define custom utilities
 # Test for OSX with [ -n "$IS_OSX" ]
 
+function remove_travis_ve_pip {
+    # Removing the system virtualenv or pip can be very problematic for
+    # macOS on Kokoro, so just leave them be.
+    :;
+}
+
+function install_pip {
+    check_python
+    PIP_CMD="sudo $PYTHON_EXE -m pip${pip_args:+ $pip_args}"
+    $PIP_CMD install --upgrade pip
+}
+
+function install_virtualenv {
+    check_python
+    check_pip
+    $PIP_CMD install --upgrade virtualenv
+    VIRTUALENV_CMD="$PYTHON_EXE -m virtualenv"
+}
+
 function pre_build {
     # Any stuff that you need to do before you start building the wheels
     # Runs in the root directory of this repository.

--- a/tests.sh
+++ b/tests.sh
@@ -314,7 +314,7 @@ build_python() {
   if [ $(uname -s) == "Linux" ]; then
     envlist=py\{27,33,34,35,36\}-python
   else
-    envlist=py27-python
+    envlist=py\{27,36\}-python
   fi
   tox -e $envlist
   cd ..
@@ -364,7 +364,7 @@ build_python_cpp() {
   if [ $(uname -s) == "Linux" ]; then
     envlist=py\{27,33,34,35,36\}-cpp
   else
-    envlist=py27-cpp
+    envlist=py\{27,36\}-cpp
   fi
   tox -e $envlist
   cd ..


### PR DESCRIPTION
-  Always use `python -m {pip | virtualenv}` form of commands.
-  Only upgrade in-place, and never use `--ignore-installed`.

These changes ensure that multibuilder won't break the system-installed Python
on the Kokoro macOS builder, and won't resolve the ancient system version.