### PR TITLE
python fix: toDict should obey the integer type

### DIFF
--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -303,7 +303,7 @@ class _Printer(object):
     elif field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_BOOL:
       return bool(value)
     elif field.cpp_type in _INT64_TYPES:
-      return str(value)
+      return int(value)
     elif field.cpp_type in _FLOAT_TYPES:
       if math.isinf(value):
         if value < 0.0:


### PR DESCRIPTION
I'm very confused about this statement, MessageToDict should obey the type of message, but this line seems to convert that integer into string, if this is only for JSON, I can understood that, but for Dict, shouldn't be like this ? 