### PR TITLE
fix: toDict should obey the integer type

### DIFF
--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -303,7 +303,7 @@ class _Printer(object):
     elif field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_BOOL:
       return bool(value)
     elif field.cpp_type in _INT64_TYPES:
-      return str(value)
+      return int(value)
     elif field.cpp_type in _FLOAT_TYPES:
       if math.isinf(value):
         if value < 0.0:


### PR DESCRIPTION
In python/ json_format.py, I'm confused about this MessagToDict method, if this is going to convert message into dict, it should obey the type claimed in Message other than str() that integer.