### PR TITLE
[Javascript] Disable ESLint and TypeScript on JS protobuf file

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -1654,6 +1654,8 @@ void Generator::GenerateHeader(const GeneratorOptions& options,
       " * @public\n"
       " */\n"
       "// GENERATED CODE -- DO NOT EDIT!\n"
+      "/* eslint-disable */\n"
+      "// @ts-nocheck\n"
       "\n");
 }
 


### PR DESCRIPTION
I was getting TypeScript errors on the generated protobuf file.

These directives to turn off ESLint and TypeScript are just comments. They shouldn't affect anyone who is not using ESLint or TypeScript.

A similar change was made in the grpc/grpc-web project: https://github.com/grpc/grpc-web/pull/752