### PR TITLE
fix issue #6401 - replace new by Parser.CreateTemplate

### DIFF
--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -60,7 +60,7 @@ namespace Google.Protobuf
         /// Creates a template instance ready for population.
         /// </summary>
         /// <returns>An empty message.</returns>
-        internal IMessage CreateTemplate()
+        public IMessage CreateTemplate()
         {
             return factory();
         }
@@ -247,7 +247,7 @@ namespace Google.Protobuf
         /// Creates a template instance ready for population.
         /// </summary>
         /// <returns>An empty message.</returns>
-        internal new T CreateTemplate()
+        public new T CreateTemplate()
         {
             return factory();
         }

--- a/src/google/protobuf/compiler/csharp/csharp_message_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message_field.cc
@@ -104,7 +104,7 @@ void MessageFieldGenerator::GenerateMergingCode(io::Printer* printer) {
     variables_,
     "if (other.$has_property_check$) {\n"
     "  if ($has_not_property_check$) {\n"
-    "    $property_name$ = new $type_name$();\n"
+    "    $property_name$ = $type_name$.Parser.CreateTemplate();\n"
     "  }\n"
     "  $property_name$.MergeFrom(other.$property_name$);\n"
     "}\n");
@@ -114,7 +114,7 @@ void MessageFieldGenerator::GenerateParsingCode(io::Printer* printer) {
   printer->Print(
     variables_,
     "if ($has_not_property_check$) {\n"
-    "  $property_name$ = new $type_name$();\n"
+    "  $property_name$ = $type_name$.Parser.CreateTemplate();\n"
     "}\n");
   if (descriptor_->type() == FieldDescriptor::Type::TYPE_MESSAGE) {
     printer->Print(variables_, "input.ReadMessage($property_name$);\n");
@@ -255,7 +255,7 @@ void MessageOneofFieldGenerator::GenerateMembers(io::Printer* printer) {
 void MessageOneofFieldGenerator::GenerateMergingCode(io::Printer* printer) {
   printer->Print(variables_,
     "if ($property_name$ == null) {\n"
-    "  $property_name$ = new $type_name$();\n"
+    "  $property_name$ = $type_name$.Parser.CreateTemplate();\n"
     "}\n"
     "$property_name$.MergeFrom(other.$property_name$);\n");
 }
@@ -264,7 +264,7 @@ void MessageOneofFieldGenerator::GenerateParsingCode(io::Printer* printer) {
   // TODO(jonskeet): We may be able to do better than this
   printer->Print(
     variables_,
-    "$type_name$ subBuilder = new $type_name$();\n"
+    "$type_name$ subBuilder = $type_name$.Parser.CreateTemplate();\n"
     "if ($has_property_check$) {\n"
     "  subBuilder.MergeFrom($property_name$);\n"
     "}\n");


### PR DESCRIPTION
Moves all message allocations to CreateTemplate(), making it easier to e.g. use pools to prevent GC load.