### PR TITLE
Fixed release.sh and setup.py for Python

### DIFF
--- a/python/release.sh
+++ b/python/release.sh
@@ -11,7 +11,7 @@ function run_install_test() {
   local PYTHON=$2
   local PYPI=$3
 
-  virtualenv --no-site-packages -p `which $PYTHON` test-venv
+  virtualenv -p `which $PYTHON` test-venv
 
   # Intentionally put a broken protoc in the path to make sure installation
   # doesn't require protoc installed.

--- a/python/setup.py
+++ b/python/setup.py
@@ -279,6 +279,7 @@ if __name__ == '__main__':
           'build_py': build_py,
           'test_conformance': test_conformance,
       },
+      setup_requires = ['wheel'],
       install_requires=install_requires,
       ext_modules=ext_module_list,
   )


### PR DESCRIPTION
Newer versions of virtualenv lack the --no-site-packages option, so I
had to remove it to keep the release.sh script working. I read that this
option has already been the default for a long time, so removing it
shouldn't chany any behavior.

For the setup.py script, I was getting some errors about the bdist_wheel
argument to setup.py, but I was able to fix that by adding 'wheel' to
setup_requires.