### PR TITLE
Updated minimum required version for C extension to 7.0.

### DIFF
--- a/php/ext/google/protobuf/package.xml
+++ b/php/ext/google/protobuf/package.xml
@@ -51,7 +51,7 @@
  <dependencies>
   <required>
    <php>
-    <min>5.5.9</min>
+    <min>7.0.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0</min>


### PR DESCRIPTION
Fixes https://github.com/protocolbuffers/protobuf/issues/7718