### PR TITLE
Adding forgotten duration.proto to the lite library

### DIFF
--- a/java/lite/pom.xml
+++ b/java/lite/pom.xml
@@ -52,6 +52,7 @@
         <includes>
           <include>google/protobuf/any.proto</include>
           <include>google/protobuf/api.proto</include>
+          <include>google/protobuf/duration.proto</include>
           <include>google/protobuf/empty.proto</include>
           <include>google/protobuf/field_mask.proto</include>
           <include>google/protobuf/source_context.proto</include>


### PR DESCRIPTION
timestamp.proto is part of the java lite release but duration is not.
I assume this is accidental.