### PR TITLE
[python] ParseDict merge dictionaries

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -1213,6 +1213,15 @@ class JsonFormatTest(JsonFormatBase):
         {'value': UnknownClass()},
         message)
 
+  def testParseDictMergeDicts(self):
+      js_dict_1 = {'string_value': 'aaabbbccc', 'empty_dict': {}, 'dict': {'float_value_1': 1.0}}
+      js_dict_2 = {'dict': {'float_value_1': 1.0, 'float_value_2': 2.0}, 'list_value': ['x']}
+      js_dict_result = {'string_value': 'aaabbbccc', 'empty_dict': {}, 'list_value': ['x'],
+                        'dict': {'float_value_1': 1.0, 'float_value_2': 2.0}}
+      struct = json_format.ParseDict(js_dict_1, struct_pb2.Struct())
+      json_format.ParseDict(js_dict_2, struct)
+      self.assertDictEqual(json_format.MessageToDict(struct), js_dict_result)
+
   def testMessageToDict(self):
     message = json_format_proto3_pb2.TestMessage()
     message.int32_value = 12345

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -665,7 +665,8 @@ class _Parser(object):
           'Struct must be in a dict which is {0}.'.format(value))
     # Clear will mark the struct as modified so it will be created even if
     # there are no values.
-    message.Clear()
+    if not value:
+      message.Clear()
     for key in value:
       self._ConvertValueMessage(value[key], message.fields[key])
     return


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/pull/5211 broke old behavior which was merging the dictionaries given to the ParseDict function as the documentation mentions in [here](https://googleapis.dev/python/protobuf/latest/google/protobuf/json_format.html#google.protobuf.json_format.ParseDict):

> **message** – A protocol buffer message to merge into. 

Here I tried to reach the desired behavior without breaking the old one.