### PR TITLE
[bazel] Add BUILD files for benchmark protos

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,15 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "com_github_google_benchmark",
+    sha256 = "2a778d821997df7d8646c9c59b8edb9a573a6e04c534c01892a40aa524a7b68c",
+    strip_prefix = "benchmark-bf585a2789e30585b4e3ce6baf11ef2750b54677",
+    urls = [
+        "https://github.com/google/benchmark/archive/bf585a2789e30585b4e3ce6baf11ef2750b54677.zip",
+    ],
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//:protobuf_deps.bzl", "protobuf_deps")
 

--- a/benchmarks/BUILD
+++ b/benchmarks/BUILD
@@ -8,12 +8,16 @@ proto_library(
         "benchmarks.proto",
     ],
     strip_import_prefix = "/benchmarks",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//benchmarks:__subpackages__",
+    ],
 )
 
 cc_proto_library(
     name = "benchmarks_cc_proto",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//benchmarks:__subpackages__",
+    ],
     deps = [
         "benchmarks_proto",
     ],
@@ -21,7 +25,9 @@ cc_proto_library(
 
 java_proto_library(
     name = "benchmarks_java_proto",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//benchmarks:__subpackages__",
+    ],
     deps = [
         "benchmarks_proto",
     ],
@@ -33,12 +39,16 @@ proto_library(
         "google_size.proto",
     ],
     strip_import_prefix = "/benchmarks",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//benchmarks:__subpackages__",
+    ],
 )
 
 cc_proto_library(
     name = "google_size_cc_proto",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//benchmarks:__subpackages__",
+    ],
     deps = [
         "google_size_proto",
     ],
@@ -46,7 +56,9 @@ cc_proto_library(
 
 java_proto_library(
     name = "google_size_java_proto",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//benchmarks:__subpackages__",
+    ],
     deps = [
         "google_size_proto",
     ],

--- a/benchmarks/BUILD
+++ b/benchmarks/BUILD
@@ -1,0 +1,53 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "benchmarks_proto",
+    srcs = [
+        "benchmarks.proto",
+    ],
+    strip_import_prefix = "/benchmarks",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "benchmarks_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "benchmarks_proto",
+    ],
+)
+
+java_proto_library(
+    name = "benchmarks_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "benchmarks_proto",
+    ],
+)
+
+proto_library(
+    name = "google_size_proto",
+    srcs = [
+        "google_size.proto",
+    ],
+    strip_import_prefix = "/benchmarks",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "google_size_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "google_size_proto",
+    ],
+)
+
+java_proto_library(
+    name = "google_size_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "google_size_proto",
+    ],
+)

--- a/benchmarks/cpp/BUILD
+++ b/benchmarks/cpp/BUILD
@@ -1,0 +1,15 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "cpp",
+    srcs = [
+        "cpp_benchmark.cc",
+    ],
+    tags = ["benchmark"],
+    deps = [
+        "//:protobuf",
+        "//benchmarks:benchmarks_cc_proto",
+        "//benchmarks/datasets:cc_protos",
+        "@com_github_google_benchmark//:benchmark_main",
+    ],
+)

--- a/benchmarks/datasets/BUILD
+++ b/benchmarks/datasets/BUILD
@@ -11,12 +11,16 @@ filegroup(
         "//benchmarks/datasets/google_message3:datasets",
         "//benchmarks/datasets/google_message4:datasets",
     ],
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//benchmarks:__subpackages__",
+    ],
 )
 
 proto_library(
     name = "protos",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//benchmarks:__subpackages__",
+    ],
     deps = [
         "//benchmarks/datasets/google_message1/proto2:benchmark_message1_proto2_proto",
         "//benchmarks/datasets/google_message1/proto3:benchmark_message1_proto3_proto",
@@ -28,7 +32,9 @@ proto_library(
 
 cc_library(
     name = "cc_protos",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//benchmarks:__subpackages__",
+    ],
     deps = [
         "//benchmarks/datasets/google_message1/proto2:benchmark_message1_proto2_cc_proto",
         "//benchmarks/datasets/google_message1/proto3:benchmark_message1_proto3_cc_proto",
@@ -40,7 +46,9 @@ cc_library(
 
 java_library(
     name = "java_protos",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//benchmarks:__subpackages__",
+    ],
     exports = [
         "//benchmarks/datasets/google_message1/proto2:benchmark_message1_proto2_java_proto",
         "//benchmarks/datasets/google_message1/proto3:benchmark_message1_proto3_java_proto",

--- a/benchmarks/datasets/BUILD
+++ b/benchmarks/datasets/BUILD
@@ -1,0 +1,51 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+filegroup(
+    name = "datasets",
+    srcs = [
+        "//benchmarks/datasets/google_message1/proto2:datasets",
+        "//benchmarks/datasets/google_message1/proto3:datasets",
+        "//benchmarks/datasets/google_message2:datasets",
+        "//benchmarks/datasets/google_message3:datasets",
+        "//benchmarks/datasets/google_message4:datasets",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//benchmarks/datasets/google_message1/proto2:benchmark_message1_proto2_proto",
+        "//benchmarks/datasets/google_message1/proto3:benchmark_message1_proto3_proto",
+        "//benchmarks/datasets/google_message2:benchmark_message2_proto",
+        "//benchmarks/datasets/google_message3:benchmark_message3_proto",
+        "//benchmarks/datasets/google_message4:benchmark_message4_proto",
+    ],
+)
+
+cc_library(
+    name = "cc_protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//benchmarks/datasets/google_message1/proto2:benchmark_message1_proto2_cc_proto",
+        "//benchmarks/datasets/google_message1/proto3:benchmark_message1_proto3_cc_proto",
+        "//benchmarks/datasets/google_message2:benchmark_message2_cc_proto",
+        "//benchmarks/datasets/google_message3:benchmark_message3_cc_proto",
+        "//benchmarks/datasets/google_message4:benchmark_message4_cc_proto",
+    ],
+)
+
+java_library(
+    name = "java_protos",
+    visibility = ["//visibility:public"],
+    exports = [
+        "//benchmarks/datasets/google_message1/proto2:benchmark_message1_proto2_java_proto",
+        "//benchmarks/datasets/google_message1/proto3:benchmark_message1_proto3_java_proto",
+        "//benchmarks/datasets/google_message2:benchmark_message2_java_proto",
+        "//benchmarks/datasets/google_message3:benchmark_message3_java_proto",
+        "//benchmarks/datasets/google_message4:benchmark_message4_java_proto",
+    ],
+)

--- a/benchmarks/datasets/google_message1/proto2/BUILD
+++ b/benchmarks/datasets/google_message1/proto2/BUILD
@@ -1,0 +1,44 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+filegroup(
+    name = "datasets",
+    srcs = [
+        "dataset.google_message1_proto2.pb",
+    ],
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+)
+
+proto_library(
+    name = "benchmark_message1_proto2_proto",
+    srcs = [
+        "benchmark_message1_proto2.proto",
+    ],
+    strip_import_prefix = "/benchmarks",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+)
+
+cc_proto_library(
+    name = "benchmark_message1_proto2_cc_proto",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+    deps = [
+        "benchmark_message1_proto2_proto",
+    ],
+)
+
+java_proto_library(
+    name = "benchmark_message1_proto2_java_proto",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+    deps = [
+        "benchmark_message1_proto2_proto",
+    ],
+)

--- a/benchmarks/datasets/google_message1/proto3/BUILD
+++ b/benchmarks/datasets/google_message1/proto3/BUILD
@@ -1,0 +1,44 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+filegroup(
+    name = "datasets",
+    srcs = [
+        "dataset.google_message1_proto3.pb",
+    ],
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+)
+
+proto_library(
+    name = "benchmark_message1_proto3_proto",
+    srcs = [
+        "benchmark_message1_proto3.proto",
+    ],
+    strip_import_prefix = "/benchmarks",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+)
+
+cc_proto_library(
+    name = "benchmark_message1_proto3_cc_proto",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+    deps = [
+        "benchmark_message1_proto3_proto",
+    ],
+)
+
+java_proto_library(
+    name = "benchmark_message1_proto3_java_proto",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+    deps = [
+        "benchmark_message1_proto3_proto",
+    ],
+)

--- a/benchmarks/datasets/google_message2/BUILD
+++ b/benchmarks/datasets/google_message2/BUILD
@@ -1,0 +1,44 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+filegroup(
+    name = "datasets",
+    srcs = [
+        "dataset.google_message2.pb",
+    ],
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+)
+
+proto_library(
+    name = "benchmark_message2_proto",
+    srcs = [
+        "benchmark_message2.proto",
+    ],
+    strip_import_prefix = "/benchmarks",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+)
+
+cc_proto_library(
+    name = "benchmark_message2_cc_proto",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+    deps = [
+        "benchmark_message2_proto",
+    ],
+)
+
+java_proto_library(
+    name = "benchmark_message2_java_proto",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+    deps = [
+        "benchmark_message2_proto",
+    ],
+)

--- a/benchmarks/datasets/google_message3/BUILD
+++ b/benchmarks/datasets/google_message3/BUILD
@@ -1,0 +1,50 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+filegroup(
+    name = "datasets",
+    srcs = [],
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+)
+
+proto_library(
+    name = "benchmark_message3_proto",
+    srcs = [
+        "benchmark_message3.proto",
+        "benchmark_message3_1.proto",
+        "benchmark_message3_2.proto",
+        "benchmark_message3_3.proto",
+        "benchmark_message3_4.proto",
+        "benchmark_message3_5.proto",
+        "benchmark_message3_6.proto",
+        "benchmark_message3_7.proto",
+        "benchmark_message3_8.proto",
+    ],
+    strip_import_prefix = "/benchmarks",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+)
+
+cc_proto_library(
+    name = "benchmark_message3_cc_proto",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+    deps = [
+        "benchmark_message3_proto",
+    ],
+)
+
+java_proto_library(
+    name = "benchmark_message3_java_proto",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+    deps = [
+        "benchmark_message3_proto",
+    ],
+)

--- a/benchmarks/datasets/google_message4/BUILD
+++ b/benchmarks/datasets/google_message4/BUILD
@@ -1,0 +1,45 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+filegroup(
+    name = "datasets",
+    srcs = [],
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+)
+
+proto_library(
+    name = "benchmark_message4_proto",
+    srcs = [
+        "benchmark_message4.proto",
+        "benchmark_message4_1.proto",
+        "benchmark_message4_2.proto",
+        "benchmark_message4_3.proto",
+    ],
+    strip_import_prefix = "/benchmarks",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+)
+
+cc_proto_library(
+    name = "benchmark_message4_cc_proto",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+    deps = [
+        "benchmark_message4_proto",
+    ],
+)
+
+java_proto_library(
+    name = "benchmark_message4_java_proto",
+    visibility = [
+        "//benchmarks/datasets:__pkg__",
+    ],
+    deps = [
+        "benchmark_message4_proto",
+    ],
+)


### PR DESCRIPTION
This change adds BUILD files to //benchmarks that allow
users to consume the .proto files in that directory
to run benchmarks (e.g. for custom generators).