### PR TITLE
Update third_party.md

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -26,8 +26,8 @@ These are projects we know about implementing Protocol Buffers for other program
 * Clojure: http://github.com/ninjudd/clojure-protobuf
 * Clojure: https://github.com/clojusc/protobuf
 * Clojure: https://protojure.github.io
-* Common Lisp: http://github.com/ndantam/s-protobuf
 * Common Lisp: http://github.com/brown/protobuf
+* Common Lisp: http://github.com/qitab/cl-protobuf
 * D: https://github.com/dcarp/protobuf-d
 * D: https://github.com/msoucy/dproto
 * D: https://github.com/opticron/ProtocolBuffer


### PR DESCRIPTION
 Common Lisp: 
http://github.com/ndantam/s-protobuf  hasn't been updated in 5 years, and hasn't had a real update in 8.
http://github.com/qitab/cl-protobuf is the one used internally and maintained by Googlers (third_party/lisp/cl-protobufs) though I don't know
how to or if I should express that.