### PR TITLE
[bazel] Add default shell env to gen_well_known_protos_java

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -352,6 +352,7 @@ def _internal_gen_well_known_protos_java_impl(ctx):
         inputs = descriptors,
         outputs = [srcjar],
         arguments = [args],
+        use_default_shell_env = True,
     )
 
     return [


### PR DESCRIPTION
We may need the shell environment (potentially augmented with
`--action_env`) to invoke protoc on Windows. If protoc was built with
mingw, it probably needs .dll files in non-default locations that must be
in PATH. Previously with `--compiler=mingw-gcc`,
`bazel build //:gen_well_known_protos_java` would fail on Windows. This
CL fixes the issue.

Also we have `default_shell_env` set to True for `ProtoCompile`, this makes
the behavior consistent.

See #2933, and
https://github.com/bazelbuild/rules_go/blob/585a27ad0ab5bdd185aa3bd5b0877a778d4777ad/proto/compiler.bzl#L130