### PR TITLE
Optionally ignore unknown enum string values in the JSON parser

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
@@ -938,6 +938,38 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void Enum_InvalidString_IgnoreUnknownFields()
+        {
+            // When ignoring unknown fields, invalid enum value strings are ignored too.
+            var parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+            string json = "{ \"singleForeignEnum\": \"NOT_A_VALID_VALUE\" }";
+            var parsed = parser.Parse<TestAllTypes>(json);
+            Assert.AreEqual(ForeignEnum.ForeignUnspecified, parsed.SingleForeignEnum);
+        }
+
+        [Test]
+        public void RepeatedEnum_InvalidString_IgnoreUnknownFields()
+        {
+            // When ignoring unknown fields, invalid enum value strings are ignored too.
+            // For a repeated field, the presence of the value is preserved using the 0 value.
+            var parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+            string json = "{ \"repeatedForeignEnum\": [ \"FOREIGN_FOO\", \"NOT_A_VALID_VALUE\", \"FOREIGN_BAR\" ] }";
+            var parsed = parser.Parse<TestAllTypes>(json);
+            var expected = new[] { ForeignEnum.ForeignFoo, ForeignEnum.ForeignUnspecified, ForeignEnum.ForeignBar };
+            Assert.AreEqual(expected , parsed.RepeatedForeignEnum);
+        }
+
+        [Test]
+        public void Enum_InvalidNumber_IgnoreUnknownFields()
+        {
+            // Even when ignoring unknown fields, fail for non-integer numeric values, because
+            // they could *never* be valid.
+            var parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+            string json = "{ \"singleForeignEnum\": 5.5 }";
+            Assert.Throws<InvalidProtocolBufferException>(() => parser.Parse<TestAllTypes>(json));
+        }
+
+        [Test]
         public void OneofDuplicate_Invalid()
         {
             string json = "{ \"oneofString\": \"x\", \"oneofUint32\": 10 }";

--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -690,7 +690,7 @@ namespace Google.Protobuf
             }
         }
 
-        private static object ParseSingleStringValue(FieldDescriptor field, string text)
+        private object ParseSingleStringValue(FieldDescriptor field, string text)
         {
             switch (field.FieldType)
             {
@@ -731,6 +731,10 @@ namespace Google.Protobuf
                     var enumValue = field.EnumType.FindValueByName(text);
                     if (enumValue == null)
                     {
+                        if (settings.IgnoreUnknownFields)
+                        {
+                            return 0;
+                        }
                         throw new InvalidProtocolBufferException($"Invalid enum value: {text} for enum type: {field.EnumType.FullName}");
                     }
                     // Just return it as an int, and let the CLR convert it.


### PR DESCRIPTION
Note the current (tested) behavior for repeated fields: an unknown string value becomes the unknown enum value, rather than being omitted entirely.
If that's not the behavior we want, it'll be slightly awkward to change, but better to do that now than decide later. (This should be one of the conformance tests, too.)