### PR TITLE
Extend coded output stream

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>truth</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <version>4.1.51.Final</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
@@ -223,8 +223,7 @@ public abstract class CodedOutputStream extends ByteOutput {
     return new ByteOutputEncoder(byteOutput, bufferSize);
   }
 
-  // Disallow construction outside of this class.
-  private CodedOutputStream() {}
+  public CodedOutputStream() {}
 
   // -----------------------------------------------------------------
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -107,6 +107,11 @@
         <version>1.0.1</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>4.1.51.Final</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/src/google/protobuf/compiler/java/java_enum_field.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field.cc
@@ -285,6 +285,11 @@ void ImmutableEnumFieldGenerator::GenerateBuilderClearCode(
                  "$clear_has_field_bit_builder$\n");
 }
 
+void ImmutableEnumFieldGenerator::GenerateMessageClearCode(
+        io::Printer* printer) const {
+    GenerateBuilderClearCode(printer);
+}
+
 void ImmutableEnumFieldGenerator::GenerateMergingCode(
     io::Printer* printer) const {
   if (SupportFieldPresence(descriptor_)) {
@@ -879,6 +884,11 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderClearCode(
   printer->Print(variables_,
                  "$name$_ = java.util.Collections.emptyList();\n"
                  "$clear_mutable_bit_builder$;\n");
+}
+
+void RepeatedImmutableEnumFieldGenerator::GenerateMessageClearCode(
+        io::Printer* printer) const {
+    GenerateBuilderClearCode(printer);
 }
 
 void RepeatedImmutableEnumFieldGenerator::GenerateMergingCode(

--- a/src/google/protobuf/compiler/java/java_enum_field.h
+++ b/src/google/protobuf/compiler/java/java_enum_field.h
@@ -71,6 +71,7 @@ class ImmutableEnumFieldGenerator : public ImmutableFieldGenerator {
   void GenerateBuilderMembers(io::Printer* printer) const;
   void GenerateInitializationCode(io::Printer* printer) const;
   void GenerateBuilderClearCode(io::Printer* printer) const;
+  void GenerateMessageClearCode(io::Printer* printer) const;
   void GenerateMergingCode(io::Printer* printer) const;
   void GenerateBuildingCode(io::Printer* printer) const;
   void GenerateParsingCode(io::Printer* printer) const;
@@ -128,6 +129,7 @@ class RepeatedImmutableEnumFieldGenerator : public ImmutableFieldGenerator {
   void GenerateBuilderMembers(io::Printer* printer) const;
   void GenerateInitializationCode(io::Printer* printer) const;
   void GenerateBuilderClearCode(io::Printer* printer) const;
+  void GenerateMessageClearCode(io::Printer* printer) const;
   void GenerateMergingCode(io::Printer* printer) const;
   void GenerateBuildingCode(io::Printer* printer) const;
   void GenerateParsingCode(io::Printer* printer) const;

--- a/src/google/protobuf/compiler/java/java_field.h
+++ b/src/google/protobuf/compiler/java/java_field.h
@@ -74,6 +74,7 @@ class ImmutableFieldGenerator {
   virtual void GenerateBuilderMembers(io::Printer* printer) const = 0;
   virtual void GenerateInitializationCode(io::Printer* printer) const = 0;
   virtual void GenerateBuilderClearCode(io::Printer* printer) const = 0;
+  virtual void GenerateMessageClearCode(io::Printer* printer) const = 0;
   virtual void GenerateMergingCode(io::Printer* printer) const = 0;
   virtual void GenerateBuildingCode(io::Printer* printer) const = 0;
   virtual void GenerateParsingCode(io::Printer* printer) const = 0;

--- a/src/google/protobuf/compiler/java/java_map_field.cc
+++ b/src/google/protobuf/compiler/java/java_map_field.cc
@@ -667,6 +667,11 @@ void ImmutableMapFieldGenerator::GenerateBuilderClearCode(
                  "internalGetMutable$capitalized_name$().clear();\n");
 }
 
+void ImmutableMapFieldGenerator::GenerateMessageClearCode(
+        io::Printer* printer) const {
+    GenerateBuilderClearCode(printer);
+}
+
 void ImmutableMapFieldGenerator::GenerateMergingCode(
     io::Printer* printer) const {
   printer->Print(variables_,

--- a/src/google/protobuf/compiler/java/java_map_field.h
+++ b/src/google/protobuf/compiler/java/java_map_field.h
@@ -53,6 +53,7 @@ class ImmutableMapFieldGenerator : public ImmutableFieldGenerator {
   void GenerateBuilderMembers(io::Printer* printer) const;
   void GenerateInitializationCode(io::Printer* printer) const;
   void GenerateBuilderClearCode(io::Printer* printer) const;
+  void GenerateMessageClearCode(io::Printer* printer) const;
   void GenerateMergingCode(io::Printer* printer) const;
   void GenerateBuildingCode(io::Printer* printer) const;
   void GenerateParsingCode(io::Printer* printer) const;

--- a/src/google/protobuf/compiler/java/java_message.cc
+++ b/src/google/protobuf/compiler/java/java_message.cc
@@ -408,7 +408,7 @@ void ImmutableMessageGenerator::Generate(io::Printer* printer) {
               "oneof_name", context_->GetOneofGeneratorInfo(oneof)->name);
   }
 
-  printer->Print("if (handle != null) { RECYCLER.recycle(this, handle); }\n");
+  printer->Print("if (handle != null) { handle.recycle(this); }\n");
 
   printer->Outdent();
   printer->Print(

--- a/src/google/protobuf/compiler/java/java_message.cc
+++ b/src/google/protobuf/compiler/java/java_message.cc
@@ -392,10 +392,12 @@ void ImmutableMessageGenerator::Generate(io::Printer* printer) {
 
   printer->Print("// Reset class fields\n");
 
+  //TODO(Maithem): reset/clear repeated/collections/repeated enum
+
   for (int i = 0; i < descriptor_->field_count(); i++) {
       if (!IsRealOneof(descriptor_->field(i))) {
           field_generators_.get(descriptor_->field(i))
-          .GenerateBuilderClearCode(printer);
+          .GenerateMessageClearCode(printer);
       }
   }
 

--- a/src/google/protobuf/compiler/java/java_message.cc
+++ b/src/google/protobuf/compiler/java/java_message.cc
@@ -358,6 +358,65 @@ void ImmutableMessageGenerator::Generate(io::Printer* printer) {
       "}\n"
       "\n");
 
+  printer->Print("private io.netty.util.Recycler.Handle<$classname$> handle;\n", "classname", descriptor_->name());
+  printer->Print("private $classname$(io.netty.util.Recycler.Handle<$classname$> handle) {\n", "classname",
+                 descriptor_->name());
+  printer->Indent();
+  printer->Print("this.handle = handle;\n");
+  printer->Outdent();
+  printer->Print(
+      "}\n"
+      "\n");
+  printer->Print("private static final io.netty.util.Recycler<$classname$> RECYCLER = new io.netty.util.Recycler<$classname$>() {\n",
+                 "classname", descriptor_->name());
+  printer->Indent();
+  printer->Indent();
+  printer->Print("protected $classname$ newObject(Handle handle) {\n",  "classname", descriptor_->name());
+  printer->Indent();
+  printer->Print("return new $classname$(handle);\n", "classname", descriptor_->name());
+  printer->Outdent();
+  printer->Print(
+      "}\n");
+  printer->Outdent();
+  printer->Outdent();
+  printer->Print(
+      "};\n"
+      "\n");
+
+  printer->Print("public void recycle() {\n");
+  printer->Indent();
+  printer->Print("memoizedIsInitialized = -1;\n");
+  printer->Print("memoizedSize = -1;\n");
+  printer->Print("memoizedHashCode = 0;\n");
+  printer->Print("this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();\n");
+
+  printer->Print("// Reset class fields\n");
+
+  for (int i = 0; i < descriptor_->field_count(); i++) {
+      if (!IsRealOneof(descriptor_->field(i))) {
+          field_generators_.get(descriptor_->field(i))
+          .GenerateBuilderClearCode(printer);
+      }
+  }
+
+  for (auto oneof : oneofs_) {
+      printer->Print(
+              "$oneof_name$Case_ = 0;\n"
+              "$oneof_name$_ = null;\n",
+              "oneof_name", context_->GetOneofGeneratorInfo(oneof)->name);
+  }
+
+  printer->Print("if (handle != null) { RECYCLER.recycle(this, handle); }\n");
+
+  printer->Outdent();
+  printer->Print(
+      "}\n"
+      "\n");
+
+  // TODO(Maithem): generate default instance
+
+
+  /**
   printer->Print(variables,
                  "@java.lang.Override\n"
                  "@SuppressWarnings({\"unused\"})\n"
@@ -366,6 +425,7 @@ void ImmutableMessageGenerator::Generate(io::Printer* printer) {
                  "  return new $classname$();\n"
                  "}\n"
                  "\n");
+  **/
 
   printer->Print(
       "@java.lang.Override\n"

--- a/src/google/protobuf/compiler/java/java_message_builder.cc
+++ b/src/google/protobuf/compiler/java/java_message_builder.cc
@@ -385,7 +385,7 @@ void MessageBuilderGenerator::GenerateCommonBuilderMethods(
   printer->Print(
       "@java.lang.Override\n"
       "public $classname$ buildPartial() {\n"
-      "  $classname$ result = new $classname$(this);\n",
+      "  $classname$ result = $classname$.RECYCLER.get();\n",
       "classname", name_resolver_->GetImmutableClassName(descriptor_));
 
   printer->Indent();

--- a/src/google/protobuf/compiler/java/java_message_field.cc
+++ b/src/google/protobuf/compiler/java/java_message_field.cc
@@ -431,6 +431,11 @@ void ImmutableMessageFieldGenerator::GenerateBuilderClearCode(
   }
 }
 
+void ImmutableMessageFieldGenerator::GenerateMessageClearCode(
+        io::Printer* printer) const {
+    printer->Print(variables_, "$name$_ = null;\n");
+}
+
 void ImmutableMessageFieldGenerator::GenerateMergingCode(
     io::Printer* printer) const {
   printer->Print(variables_,
@@ -1236,6 +1241,11 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderClearCode(
                               "$clear_mutable_bit_builder$;\n",
 
                               "$name$Builder_.clear();\n");
+}
+
+void RepeatedImmutableMessageFieldGenerator::GenerateMessageClearCode(
+        io::Printer* printer) const {
+    printer->Print(variables_, "$name$_ = java.util.Collections.emptyList();\n");
 }
 
 void RepeatedImmutableMessageFieldGenerator::GenerateMergingCode(

--- a/src/google/protobuf/compiler/java/java_message_field.h
+++ b/src/google/protobuf/compiler/java/java_message_field.h
@@ -72,6 +72,7 @@ class ImmutableMessageFieldGenerator : public ImmutableFieldGenerator {
   void GenerateBuilderMembers(io::Printer* printer) const;
   void GenerateInitializationCode(io::Printer* printer) const;
   void GenerateBuilderClearCode(io::Printer* printer) const;
+  void GenerateMessageClearCode(io::Printer* printer) const;
   void GenerateMergingCode(io::Printer* printer) const;
   void GenerateBuildingCode(io::Printer* printer) const;
   void GenerateParsingCode(io::Printer* printer) const;
@@ -137,6 +138,7 @@ class RepeatedImmutableMessageFieldGenerator : public ImmutableFieldGenerator {
   void GenerateBuilderMembers(io::Printer* printer) const;
   void GenerateInitializationCode(io::Printer* printer) const;
   void GenerateBuilderClearCode(io::Printer* printer) const;
+  void GenerateMessageClearCode(io::Printer* printer) const;
   void GenerateMergingCode(io::Printer* printer) const;
   void GenerateBuildingCode(io::Printer* printer) const;
   void GenerateParsingCode(io::Printer* printer) const;

--- a/src/google/protobuf/compiler/java/java_primitive_field.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field.cc
@@ -316,6 +316,11 @@ void ImmutablePrimitiveFieldGenerator::GenerateBuilderClearCode(
                  "$clear_has_field_bit_builder$\n");
 }
 
+void ImmutablePrimitiveFieldGenerator::GenerateMessageClearCode(
+        io::Printer* printer) const {
+    printer->Print(variables_, "$name$_ = $default$;\n");
+}
+
 void ImmutablePrimitiveFieldGenerator::GenerateMergingCode(
     io::Printer* printer) const {
   if (SupportFieldPresence(descriptor_)) {
@@ -810,6 +815,11 @@ void RepeatedImmutablePrimitiveFieldGenerator::GenerateBuilderClearCode(
   printer->Print(variables_,
                  "$name$_ = $empty_list$;\n"
                  "$clear_mutable_bit_builder$;\n");
+}
+
+void RepeatedImmutablePrimitiveFieldGenerator::GenerateMessageClearCode(
+        io::Printer* printer) const {
+    printer->Print(variables_, "$name$_ = $empty_list$;\n");
 }
 
 void RepeatedImmutablePrimitiveFieldGenerator::GenerateMergingCode(

--- a/src/google/protobuf/compiler/java/java_primitive_field.h
+++ b/src/google/protobuf/compiler/java/java_primitive_field.h
@@ -72,6 +72,7 @@ class ImmutablePrimitiveFieldGenerator : public ImmutableFieldGenerator {
   void GenerateBuilderMembers(io::Printer* printer) const;
   void GenerateInitializationCode(io::Printer* printer) const;
   void GenerateBuilderClearCode(io::Printer* printer) const;
+  void GenerateMessageClearCode(io::Printer* printer) const;
   void GenerateMergingCode(io::Printer* printer) const;
   void GenerateBuildingCode(io::Printer* printer) const;
   void GenerateParsingCode(io::Printer* printer) const;
@@ -129,6 +130,7 @@ class RepeatedImmutablePrimitiveFieldGenerator
   void GenerateBuilderMembers(io::Printer* printer) const;
   void GenerateInitializationCode(io::Printer* printer) const;
   void GenerateBuilderClearCode(io::Printer* printer) const;
+  void GenerateMessageClearCode(io::Printer* printer) const;
   void GenerateMergingCode(io::Printer* printer) const;
   void GenerateBuildingCode(io::Printer* printer) const;
   void GenerateParsingCode(io::Printer* printer) const;

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -382,6 +382,11 @@ void ImmutableStringFieldGenerator::GenerateBuilderClearCode(
                  "$clear_has_field_bit_builder$\n");
 }
 
+void ImmutableStringFieldGenerator::GenerateMessageClearCode(
+        io::Printer* printer) const {
+    printer->Print(variables_, "$name$_ = $default$;\n");
+}
+
 void ImmutableStringFieldGenerator::GenerateMergingCode(
     io::Printer* printer) const {
   if (SupportFieldPresence(descriptor_)) {
@@ -934,6 +939,11 @@ void RepeatedImmutableStringFieldGenerator::GenerateBuilderClearCode(
   printer->Print(variables_,
                  "$name$_ = $empty_list$;\n"
                  "$clear_mutable_bit_builder$;\n");
+}
+
+void RepeatedImmutableStringFieldGenerator::GenerateMessageClearCode(
+                io::Printer* printer) const {
+    printer->Print(variables_, "$name$_ = $empty_list$;\n");
 }
 
 void RepeatedImmutableStringFieldGenerator::GenerateMergingCode(

--- a/src/google/protobuf/compiler/java/java_string_field.h
+++ b/src/google/protobuf/compiler/java/java_string_field.h
@@ -72,6 +72,7 @@ class ImmutableStringFieldGenerator : public ImmutableFieldGenerator {
   void GenerateBuilderMembers(io::Printer* printer) const;
   void GenerateInitializationCode(io::Printer* printer) const;
   void GenerateBuilderClearCode(io::Printer* printer) const;
+  void GenerateMessageClearCode(io::Printer* printer) const;
   void GenerateMergingCode(io::Printer* printer) const;
   void GenerateBuildingCode(io::Printer* printer) const;
   void GenerateParsingCode(io::Printer* printer) const;
@@ -128,6 +129,7 @@ class RepeatedImmutableStringFieldGenerator : public ImmutableFieldGenerator {
   void GenerateBuilderMembers(io::Printer* printer) const;
   void GenerateInitializationCode(io::Printer* printer) const;
   void GenerateBuilderClearCode(io::Printer* printer) const;
+  void GenerateMessageClearCode(io::Printer* printer) const;
   void GenerateMergingCode(io::Printer* printer) const;
   void GenerateBuildingCode(io::Printer* printer) const;
   void GenerateParsingCode(io::Printer* printer) const;


### PR DESCRIPTION
 Allow for alternative implementations of CodedOutputStream. One such
 implementation reduces garbage by using a pool byte buffer internally.