### PR TITLE
Allow CodedOutputStream to be Extended

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
@@ -220,9 +220,6 @@ public abstract class CodedOutputStream extends ByteOutput {
     return new ByteOutputEncoder(byteOutput, bufferSize);
   }
 
-  // Disallow construction outside of this class.
-  private CodedOutputStream() {}
-
   // -----------------------------------------------------------------
 
   /** Encode and write a tag. */


### PR DESCRIPTION
Allow for alternative implementations of CodedOutputStream. One such
implementation reduces garbage by using a pool byte buffer internally.