### PR TITLE
[javalite] Add R8 rule to documentation

### DIFF
--- a/java/lite.md
+++ b/java/lite.md
@@ -34,6 +34,22 @@ protobuf Java runtime. If you are using Maven, use the following:
 </dependency>
 ```
 
+## R8 rule to make production app builds work
+
+The Lite runtime internally uses reflection to avoid generating hashCode/equals/(de)serialization methods. 
+R8 by default obfuscates the field names, which makes the reflection fail causing exceptions of the form 
+`java.lang.RuntimeException: Field {NAME}_ for {CLASS} not found. Known fields are [ {FIELDS} ]` in MessageSchema.java.
+
+There are open issues for this on the [protobuf Github project](https://github.com/protocolbuffers/protobuf/issues/6463) and [R8](https://issuetracker.google.com/issues/144631039).
+
+Until the issues is resolved you need to add the following line to your `proguard-rules.pro` file inside your project:
+
+```
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
+```
+
+## Older versions
+
 For the older version of Java Lite (v3.0.0), please refer to:
 
     https://github.com/protocolbuffers/protobuf/blob/javalite/java/lite.md


### PR DESCRIPTION
Using default production Android build and protobuf-lite leads to RuntimeExceptions. The workarounds are documented in issues and I took those discussions and summarized them in the lite.md file.