### PR TITLE
//:protobuf_java_util: discontinue JDK 7 compatibility support.

### DIFF
--- a/java/util/BUILD
+++ b/java/util/BUILD
@@ -5,10 +5,6 @@ java_library(
     srcs = glob([
         "src/main/java/com/google/protobuf/util/*.java",
     ]),
-    javacopts = [
-        "-source 7",
-        "-target 7",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         "//external:error_prone_annotations",


### PR DESCRIPTION
6bbd56dfd9600adc9b084028d99a0aed880d7622 removed the `-source 7 -target 7` javacopts from the //java:{core,lite} Bazel targets in order to improve compatibility with more recent versions of javac. (See that commit for more discussion of motivation.) But the commit left `-source 7 -target 7` javacopts on the related //java/util target. I've [confirmed](https://github.com/protocolbuffers/protobuf/commit/6bbd56dfd9600adc9b084028d99a0aed880d7622#commitcomment-41179138) with the commit author that this was just an oversight, so remove the flags from this target as well.

Tested: build //:protobuf_java_util and confirmed that major byte version 52 is produced, corresponding to Java 8:
```
$ bazel build protobuf_java_util
$ javap -v -cp bazel-bin/java/util/libutil.jar com.google.protobuf.util.Durations | grep major
  major version: 52
```