### PR TITLE
Display beta version in "protoc --version"

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -1715,7 +1715,7 @@ CommandLineInterface::InterpretArgument(const std::string& name,
       std::cout << version_info_ << std::endl;
     }
     std::cout << "libprotoc " << internal::VersionString(PROTOBUF_VERSION)
-              << std::endl;
+              << PROTOBUF_VERSION_SUFFIX << std::endl;
     return PARSE_ARGUMENT_DONE_AND_EXIT;  // Exit without running compiler.
 
   } else if (name == "--disallow_services") {

--- a/update_version.py
+++ b/update_version.py
@@ -110,6 +110,15 @@ def UpdateCpp():
       r'^#define PROTOBUF_VERSION .*$',
       '#define PROTOBUF_VERSION %s' % cpp_version,
       line)
+    if RC_VERSION != -1:
+      line = re.sub(
+          r'^#define GOOGLE_PROTOBUF_VERSION_SUFFIX .*$',
+          '#define GOOGLE_PROTOBUF_VERSION_SUFFIX %s' % RC_VERSION,
+          line)
+      line = re.sub(
+          r'^#define PROTOBUF_VERSION_SUFFIX .*$',
+          '#define PROTOBUF_VERSION_SUFFIX %s' % RC_VERSION,
+          line)
     if NEW_VERSION_INFO[2] == 0:
       line = re.sub(
         r'^#define PROTOBUF_MIN_HEADER_VERSION_FOR_PROTOC .*$',
@@ -134,6 +143,11 @@ def UpdateCpp():
       r'^#define PROTOBUF_VERSION .*$',
       '#define PROTOBUF_VERSION %s' % cpp_version,
       line)
+    if RC_VERSION != -1:
+      line = re.sub(
+          r'^#define PROTOBUF_VERSION_SUFFIX .*$',
+          '#define PROTOBUF_VERSION_SUFFIX %s' % RC_VERSION,
+          line)
     if NEW_VERSION_INFO[2] == 0:
       line = re.sub(
         r'^#define PROTOBUF_MIN_HEADER_VERSION_FOR_PROTOC .*$',


### PR DESCRIPTION
Display the beta version when "protoc --version" is executed. Use
PROTOBUF_VERSION_SUFFIX for this purpose. #1639