### PR TITLE
Removed conflicting C# version line

### DIFF
--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -5,7 +5,6 @@
     <Copyright>Copyright 2015, Google Inc.</Copyright>
     <AssemblyTitle>Google Protocol Buffers</AssemblyTitle>
     <VersionPrefix>3.13.0-rc3</VersionPrefix>
-    <VersionPrefix>3.12.3</VersionPrefix>
     <!-- C# 7.2 is required for Span/BufferWriter/ReadOnlySequence -->
     <LangVersion>7.2</LangVersion>
     <Authors>Google Inc.</Authors>


### PR DESCRIPTION
Somehow we ended up with two conflicting versions listed for C#, so this
commit removes the incorrect one (the correct one is 3.13.0-rc3).