### PR TITLE
Make MSVC treats the source files as UTF-8

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -210,6 +210,8 @@ if (MSVC)
   )
   # Allow big object
   add_definitions(/bigobj)
+  # Assume all files utf-8
+  add_definitions(/utf-8)
   string(REPLACE "/" "\\" PROTOBUF_SOURCE_WIN32_PATH ${protobuf_SOURCE_DIR})
   string(REPLACE "/" "\\" PROTOBUF_BINARY_WIN32_PATH ${protobuf_BINARY_DIR})
   string(REPLACE "." ","  protobuf_RC_FILEVERSION "${protobuf_VERSION}")


### PR DESCRIPTION
You have to specify explicitly to build UTF-8 encoded files in some locales.
If you do not do so, you will get a compile error.