### PR TITLE
Add descriptive error for bytes as input to Timestamp.FromJsonString

### DIFF
--- a/python/google/protobuf/internal/well_known_types.py
+++ b/python/google/protobuf/internal/well_known_types.py
@@ -143,6 +143,13 @@ class Timestamp(object):
     Raises:
       ValueError: On parsing problems.
     """
+    try:
+      # Throwing a descriptive error for a bytes value.
+      if isinstance(value, bytes):
+        raise ValueError('Please supply a string value, not a value of type "bytes"')
+    except NameError:
+      pass
+
     timezone_offset = value.find('Z')
     if timezone_offset == -1:
       timezone_offset = value.find('+')


### PR DESCRIPTION
This change proposes a descriptive error for when a bytes value is passed to Timestamp.FromJsonString.

Without this code in place, users who pass a bytes object to Timestamp.FromJsonString will get an error telling them that the method requires a 'bytes' object in the first call to value.find.  This is because value.find has been passed a hardcoded string.  This code performs a quick typecheck, then throws a descriptive error.  The try-except is to catch if bytes is not available in the version of python used by the consumer (ref: https://www.python.org/dev/peps/pep-0358/).

Happy to discuss if there is a better method for handling this.  Did consider writing code to permit bytes type objects to be passed, but that would require knowledge of the appropriate encoding.