### PR TITLE
Update maven-surefire-plugin to 3.0.0-M5.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -166,6 +166,10 @@
           <artifactId>maven-antrun-plugin</artifactId>
           <version>1.8</version>
         </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M5</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
This avoids https://issues.apache.org/jira/browse/SUREFIRE-1439,
which I hit while investigating
https://github.com/protocolbuffers/protobuf/issues/7827