### PR TITLE
Update Gradle dependency reference format

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -45,7 +45,7 @@ protobuf-java-util package:
 
 If you are using Gradle, add the following to your `build.gradle` file's dependencies:
 ```
-    compile 'com.google.protobuf:protobuf-java:3.11.0'
+    implementation 'com.google.protobuf:protobuf-java:3.11.0'
 ```
 Again, be sure to check that the version number matches (or is newer than) the version number of protoc that you are using.
 


### PR DESCRIPTION
See https://docs.gradle.org/current/userguide/java_library_plugin.html
> The compile, testCompile, runtime and testRuntime configurations inherited from the Java plugin are still available but are deprecated. You should avoid using them, as they are only kept for backwards compatibility.