### PR TITLE
Allow CodedOutputStream to use Array Slices

### DIFF
--- a/csharp/src/Google.Protobuf/CodedOutputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedOutputStream.cs
@@ -87,6 +87,15 @@ namespace Google.Protobuf
         /// </summary>
         public CodedOutputStream(byte[] buffer, int offset, int length)
         {
+            if (offset < 0 || offset > buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException("offset", "Offset must be within the buffer");
+            }
+            if (length < 0 || offset + length > buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException("length", "Length must be non-negative and within the buffer");
+            }
+
             this.output = null;
             this.buffer = ProtoPreconditions.CheckNotNull(buffer, nameof(buffer));
             this.state.position = offset;


### PR DESCRIPTION
The constructor for `CodedOutputStream` (which takes in a given array offset) is `private`. As it stands, it is only used via one other constructor (which always passes 0 as the offset), making the offset always hard-coded to the initial value of 0. Making this constructor `public` allows for client applications to serialize messages into arrays without superfluous array copies. It is also worth noting that the corresponding constructor on `CodedInputStream` is already public (`public CodedInputStream(byte[] buffer, int offset, int length)`).

Looking through the history, it seems that this constructor was originally marked private when the library used static factory methods. When migrating over to using constructors directly, this constructor [was not made public](https://github.com/protocolbuffers/protobuf/commit/0e0e0c97e7d5a70b3307c2fcea8793983b6e0680#diff-edc376d7570e8db3f8d8745ef37719f3R82) (perhaps because there was no corresponding factory method?).