### PR TITLE
Fix build with PHP 7.4

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -265,14 +265,14 @@ static PROTO_RETURN_VAL Message_write_property(
   }
 
   upb_msg_set(intern->msg, f, msgval, arena);
-#if PHP_VERSION_ID < 704000
+#if PHP_VERSION_ID < 70400
   return;
 #else
   return val;
 #endif
 
 error:
-#if PHP_VERSION_ID < 704000
+#if PHP_VERSION_ID < 70400
   return;
 #else
   return &EG(error_zval);


### PR DESCRIPTION
There is a typo in PHP_VERSION_ID check.

The error message (on FreeBSD) looks like:
```
/wrkdirs/usr/ports/devel/pecl-protobuf/work-php74/protobuf-3.13.0/message.c:269:3: error: non-void function 'Message_write_property' should return a value [-Wreturn-type]
  return;
  ^
/wrkdirs/usr/ports/devel/pecl-protobuf/work-php74/protobuf-3.13.0/message.c:276:3: error: non-void function 'Message_write_property' should return a value [-Wreturn-type]
  return;
  ^
2 errors generated.
*** Error code 1

Stop.
make[1]: stopped in /wrkdirs/usr/ports/devel/pecl-protobuf/work-php74/protobuf-3.13.0
*** Error code 1

Stop.
make: stopped in /usr/ports/devel/pecl-protobuf
```