### PR TITLE
Utilize JDK StandardCharsets

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/ArrayDecoders.java
+++ b/java/core/src/main/java/com/google/protobuf/ArrayDecoders.java
@@ -31,6 +31,7 @@
 package com.google.protobuf;
 
 import static com.google.protobuf.MessageSchema.getMutableUnknownFields;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.protobuf.Internal.ProtobufList;
 import java.io.IOException;
@@ -191,7 +192,7 @@ final class ArrayDecoders {
       registers.object1 = "";
       return position;
     } else {
-      registers.object1 = new String(data, position, length, Internal.UTF_8);
+      registers.object1 = new String(data, position, length, UTF_8);
       return position + length;
     }
   }
@@ -577,7 +578,7 @@ final class ArrayDecoders {
     } else if (length == 0) {
       output.add("");
     } else {
-      String value = new String(data, position, length, Internal.UTF_8);
+      String value = new String(data, position, length, UTF_8);
       output.add(value);
       position += length;
     }
@@ -593,7 +594,7 @@ final class ArrayDecoders {
       } else if (nextLength == 0) {
         output.add("");
       } else {
-        String value = new String(data, position, nextLength, Internal.UTF_8);
+        String value = new String(data, position, nextLength, UTF_8);
         output.add(value);
         position += nextLength;
       }
@@ -619,7 +620,7 @@ final class ArrayDecoders {
       if (!Utf8.isValidUtf8(data, position, position + length)) {
         throw InvalidProtocolBufferException.invalidUtf8();
       }
-      String value = new String(data, position, length, Internal.UTF_8);
+      String value = new String(data, position, length, UTF_8);
       output.add(value);
       position += length;
     }
@@ -638,7 +639,7 @@ final class ArrayDecoders {
         if (!Utf8.isValidUtf8(data, position, position + nextLength)) {
           throw InvalidProtocolBufferException.invalidUtf8();
         }
-        String value = new String(data, position, nextLength, Internal.UTF_8);
+        String value = new String(data, position, nextLength, UTF_8);
         output.add(value);
         position += nextLength;
       }

--- a/java/core/src/main/java/com/google/protobuf/BinaryReader.java
+++ b/java/core/src/main/java/com/google/protobuf/BinaryReader.java
@@ -38,6 +38,7 @@ import static com.google.protobuf.WireFormat.WIRETYPE_FIXED64;
 import static com.google.protobuf.WireFormat.WIRETYPE_LENGTH_DELIMITED;
 import static com.google.protobuf.WireFormat.WIRETYPE_START_GROUP;
 import static com.google.protobuf.WireFormat.WIRETYPE_VARINT;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -226,7 +227,7 @@ abstract class BinaryReader implements Reader {
       if (requireUtf8 && !Utf8.isValidUtf8(buffer, pos, pos + size)) {
         throw InvalidProtocolBufferException.invalidUtf8();
       }
-      String result = new String(buffer, pos, size, Internal.UTF_8);
+      String result = new String(buffer, pos, size, UTF_8);
       pos += size;
       return result;
     }

--- a/java/core/src/main/java/com/google/protobuf/ByteString.java
+++ b/java/core/src/main/java/com/google/protobuf/ByteString.java
@@ -33,6 +33,7 @@ package com.google.protobuf;
 import static com.google.protobuf.TextFormatEscaper.escapeBytes;
 import static java.lang.Integer.toHexString;
 import static java.lang.System.identityHashCode;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -459,7 +460,7 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
    * @return new {@code ByteString}
    */
   public static ByteString copyFromUtf8(String text) {
-    return new LiteralByteString(text.getBytes(Internal.UTF_8));
+    return new LiteralByteString(text.getBytes(UTF_8));
   }
 
   // =================================================================
@@ -817,7 +818,7 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
    * @return new string using UTF-8 encoding
    */
   public final String toStringUtf8() {
-    return toString(Internal.UTF_8);
+    return toString(UTF_8);
   }
 
   /**

--- a/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -32,11 +32,11 @@ package com.google.protobuf;
 
 import static com.google.protobuf.Internal.EMPTY_BYTE_ARRAY;
 import static com.google.protobuf.Internal.EMPTY_BYTE_BUFFER;
-import static com.google.protobuf.Internal.UTF_8;
 import static com.google.protobuf.Internal.checkNotNull;
 import static com.google.protobuf.WireFormat.FIXED32_SIZE;
 import static com.google.protobuf.WireFormat.FIXED64_SIZE;
 import static com.google.protobuf.WireFormat.MAX_VARINT_SIZE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
@@ -35,6 +35,7 @@ import static com.google.protobuf.WireFormat.FIXED64_SIZE;
 import static com.google.protobuf.WireFormat.MAX_VARINT32_SIZE;
 import static com.google.protobuf.WireFormat.MAX_VARINT_SIZE;
 import static java.lang.Math.max;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.protobuf.Utf8.UnpairedSurrogateException;
 import java.io.IOException;
@@ -842,7 +843,7 @@ public abstract class CodedOutputStream extends ByteOutput {
       length = Utf8.encodedLength(value);
     } catch (UnpairedSurrogateException e) {
       // TODO(dweis): Consider using nio Charset methods instead.
-      final byte[] bytes = value.getBytes(Internal.UTF_8);
+      final byte[] bytes = value.getBytes(UTF_8);
       length = bytes.length;
     }
 
@@ -989,8 +990,7 @@ public abstract class CodedOutputStream extends ByteOutput {
     // Unfortunately there does not appear to be any way to tell Java to encode
     // UTF-8 directly into our buffer, so we have to let it create its own byte
     // array and then copy.
-    // TODO(dweis): Consider using nio Charset methods instead.
-    final byte[] bytes = value.getBytes(Internal.UTF_8);
+    final byte[] bytes = value.getBytes(UTF_8);
     try {
       writeUInt32NoTag(bytes.length);
       writeLazy(bytes, 0, bytes.length);

--- a/java/core/src/main/java/com/google/protobuf/Internal.java
+++ b/java/core/src/main/java/com/google/protobuf/Internal.java
@@ -30,10 +30,11 @@
 
 package com.google.protobuf;
 
-import java.io.IOException;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.AbstractList;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
@@ -54,9 +55,6 @@ import java.util.Set;
 public final class Internal {
 
   private Internal() {}
-
-  static final Charset UTF_8 = Charset.forName("UTF-8");
-  static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
 
   /** Throws an appropriate {@link NullPointerException} if the given objects is {@code null}. */
   static <T> T checkNotNull(T obj) {

--- a/java/core/src/main/java/com/google/protobuf/MessageSchema.java
+++ b/java/core/src/main/java/com/google/protobuf/MessageSchema.java
@@ -67,6 +67,7 @@ import static com.google.protobuf.ArrayDecoders.decodeVarint32List;
 import static com.google.protobuf.ArrayDecoders.decodeVarint64;
 import static com.google.protobuf.ArrayDecoders.decodeVarint64List;
 import static com.google.protobuf.ArrayDecoders.skipField;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.protobuf.ArrayDecoders.Registers;
 import com.google.protobuf.ByteString.CodedBuilder;
@@ -4765,7 +4766,7 @@ final class MessageSchema<T> implements Schema<T> {
                 && !Utf8.isValidUtf8(data, position, position + length)) {
               throw InvalidProtocolBufferException.invalidUtf8();
             }
-            final String value = new String(data, position, length, Internal.UTF_8);
+            final String value = new String(data, position, length, UTF_8);
             unsafe.putObject(message, fieldOffset, value);
             position += length;
           }

--- a/java/core/src/test/java/com/google/protobuf/BoundedByteStringTest.java
+++ b/java/core/src/test/java/com/google/protobuf/BoundedByteStringTest.java
@@ -30,6 +30,8 @@
 
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -61,14 +63,14 @@ public class BoundedByteStringTest extends LiteralByteStringTest {
   @Override
   public void testToString() throws UnsupportedEncodingException {
     String testString = "I love unicode \u1234\u5678 characters";
-    ByteString unicode = ByteString.wrap(testString.getBytes(Internal.UTF_8));
+    ByteString unicode = ByteString.wrap(testString.getBytes(UTF_8));
     ByteString chopped = unicode.substring(2, unicode.size() - 6);
     assertEquals(
         classUnderTest + ".substring() must have the expected type",
         classUnderTest,
         getActualClassName(chopped));
 
-    String roundTripString = chopped.toString(UTF_8);
+    String roundTripString = chopped.toString(UTF_8.name());
     assertEquals(
         classUnderTest + " unicode bytes must match",
         testString.substring(2, testString.length() - 6),
@@ -78,14 +80,14 @@ public class BoundedByteStringTest extends LiteralByteStringTest {
   @Override
   public void testCharsetToString() {
     String testString = "I love unicode \u1234\u5678 characters";
-    ByteString unicode = ByteString.wrap(testString.getBytes(Internal.UTF_8));
+    ByteString unicode = ByteString.wrap(testString.getBytes(UTF_8));
     ByteString chopped = unicode.substring(2, unicode.size() - 6);
     assertEquals(
         classUnderTest + ".substring() must have the expected type",
         classUnderTest,
         getActualClassName(chopped));
 
-    String roundTripString = chopped.toString(Internal.UTF_8);
+    String roundTripString = chopped.toString(UTF_8);
     assertEquals(
         classUnderTest + " unicode bytes must match",
         testString.substring(2, testString.length() - 6),

--- a/java/core/src/test/java/com/google/protobuf/ByteStringTest.java
+++ b/java/core/src/test/java/com/google/protobuf/ByteStringTest.java
@@ -30,6 +30,9 @@
 
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_16;
+
 import com.google.protobuf.ByteString.Output;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,7 +41,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -55,8 +57,6 @@ import junit.framework.TestCase;
  * @author carlanton@google.com (Carl Haverl)
  */
 public class ByteStringTest extends TestCase {
-
-  private static final Charset UTF_16 = Charset.forName("UTF-16");
 
   static byte[] getTestBytes(int size, long seed) {
     Random random = new Random(seed);
@@ -178,7 +178,7 @@ public class ByteStringTest extends TestCase {
   public void testCopyFrom_Utf8() {
     String testString = "I love unicode \u1234\u5678 characters";
     ByteString byteString = ByteString.copyFromUtf8(testString);
-    byte[] testBytes = testString.getBytes(Internal.UTF_8);
+    byte[] testBytes = testString.getBytes(UTF_8);
     assertTrue(
         "copyFromUtf8 string must respect the charset",
         isArrayRange(byteString.toByteArray(), testBytes, 0, testBytes.length));
@@ -480,7 +480,7 @@ public class ByteStringTest extends TestCase {
 
   public void testToStringUtf8() {
     String testString = "I love unicode \u1234\u5678 characters";
-    byte[] testBytes = testString.getBytes(Internal.UTF_8);
+    byte[] testBytes = testString.getBytes(UTF_8);
     ByteString byteString = ByteString.copyFrom(testBytes);
     assertEquals(
         "copyToStringUtf8 must respect the charset", testString, byteString.toStringUtf8());
@@ -488,7 +488,7 @@ public class ByteStringTest extends TestCase {
 
   public void testToString() {
     String toString =
-        ByteString.copyFrom("Here are some bytes: \t\u00a1".getBytes(Internal.UTF_8)).toString();
+        ByteString.copyFrom("Here are some bytes: \t\u00a1".getBytes(UTF_8)).toString();
     assertTrue(toString, toString.contains("size=24"));
     assertTrue(toString, toString.contains("contents=\"Here are some bytes: \\t\\302\\241\""));
   }
@@ -497,7 +497,7 @@ public class ByteStringTest extends TestCase {
     String toString =
         ByteString.copyFrom(
                 "123456789012345678901234567890123456789012345678901234567890"
-                    .getBytes(Internal.UTF_8))
+                    .getBytes(UTF_8))
             .toString();
     assertTrue(toString, toString.contains("size=60"));
     assertTrue(

--- a/java/core/src/test/java/com/google/protobuf/CodedOutputStreamTest.java
+++ b/java/core/src/test/java/com/google/protobuf/CodedOutputStreamTest.java
@@ -30,6 +30,8 @@
 
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.protobuf.CodedOutputStream.OutOfSpaceException;
 import protobuf_unittest.UnittestProto.SparseEnumMessage;
 import protobuf_unittest.UnittestProto.TestAllTypes;
@@ -398,7 +400,7 @@ public class CodedOutputStreamTest extends TestCase {
 
     // Write some some bytes (more than the buffer can hold) and verify that totalWritten
     // is correct.
-    byte[] value = "abcde".getBytes(Internal.UTF_8);
+    byte[] value = "abcde".getBytes(UTF_8);
     for (int i = 0; i < 1024; ++i) {
       coder.stream().writeRawBytes(value, 0, value.length);
     }
@@ -476,7 +478,7 @@ public class CodedOutputStreamTest extends TestCase {
   }
 
   public void testWriteByteBuffer() throws Exception {
-    byte[] value = "abcde".getBytes(Internal.UTF_8);
+    byte[] value = "abcde".getBytes(UTF_8);
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     CodedOutputStream codedStream = CodedOutputStream.newInstance(outputStream);
     ByteBuffer byteBuffer = ByteBuffer.wrap(value, 0, 1);
@@ -517,7 +519,7 @@ public class CodedOutputStreamTest extends TestCase {
     for (int pos = 0; pos < source.length(); pos += 2) {
       String substr = source.substring(pos, pos + 2);
       expectedBytesStream.write(2);
-      expectedBytesStream.write(substr.getBytes(Internal.UTF_8));
+      expectedBytesStream.write(substr.getBytes(UTF_8));
     }
     final byte[] expectedBytes = expectedBytesStream.toByteArray();
 

--- a/java/core/src/test/java/com/google/protobuf/DecodeUtf8Test.java
+++ b/java/core/src/test/java/com/google/protobuf/DecodeUtf8Test.java
@@ -1,5 +1,7 @@
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.protobuf.Utf8.Processor;
 import com.google.protobuf.Utf8.SafeProcessor;
 import com.google.protobuf.Utf8.UnsafeProcessor;
@@ -168,7 +170,7 @@ public class DecodeUtf8Test extends TestCase {
   }
 
   public void testInvalidBufferSlice() throws Exception {
-    byte[] bytes  = "The quick brown fox jumps over the lazy dog".getBytes(Internal.UTF_8);
+    byte[] bytes  = "The quick brown fox jumps over the lazy dog".getBytes(UTF_8);
     assertInvalidSlice(bytes, bytes.length - 3, 4);
     assertInvalidSlice(bytes, bytes.length, 1);
     assertInvalidSlice(bytes, bytes.length + 1, 0);
@@ -282,29 +284,29 @@ public class DecodeUtf8Test extends TestCase {
   }
 
   private void assertRoundTrips(String str, int index, int size) throws Exception {
-    byte[] bytes = str.getBytes(Internal.UTF_8);
+    byte[] bytes = str.getBytes(UTF_8);
     if (size == -1) {
       size = bytes.length;
     }
-    assertDecode(new String(bytes, index, size, Internal.UTF_8),
+    assertDecode(new String(bytes, index, size, UTF_8),
         UNSAFE_PROCESSOR.decodeUtf8(bytes, index, size));
-    assertDecode(new String(bytes, index, size, Internal.UTF_8),
+    assertDecode(new String(bytes, index, size, UTF_8),
         SAFE_PROCESSOR.decodeUtf8(bytes, index, size));
 
     ByteBuffer direct = ByteBuffer.allocateDirect(bytes.length);
     direct.put(bytes);
     direct.flip();
-    assertDecode(new String(bytes, index, size, Internal.UTF_8),
+    assertDecode(new String(bytes, index, size, UTF_8),
         UNSAFE_PROCESSOR.decodeUtf8(direct, index, size));
-    assertDecode(new String(bytes, index, size, Internal.UTF_8),
+    assertDecode(new String(bytes, index, size, UTF_8),
         SAFE_PROCESSOR.decodeUtf8(direct, index, size));
 
     ByteBuffer heap = ByteBuffer.allocate(bytes.length);
     heap.put(bytes);
     heap.flip();
-    assertDecode(new String(bytes, index, size, Internal.UTF_8),
+    assertDecode(new String(bytes, index, size, UTF_8),
         UNSAFE_PROCESSOR.decodeUtf8(heap, index, size));
-    assertDecode(new String(bytes, index, size, Internal.UTF_8),
+    assertDecode(new String(bytes, index, size, UTF_8),
         SAFE_PROCESSOR.decodeUtf8(heap, index, size));
   }
 

--- a/java/core/src/test/java/com/google/protobuf/IsValidUtf8TestUtil.java
+++ b/java/core/src/test/java/com/google/protobuf/IsValidUtf8TestUtil.java
@@ -30,6 +30,7 @@
 
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -267,8 +268,8 @@ final class IsValidUtf8TestUtil {
       }
       ByteString bs = factory.newByteString(bytes);
       boolean isRoundTrippable = bs.isValidUtf8();
-      String s = new String(bytes, Internal.UTF_8);
-      byte[] bytesReencoded = s.getBytes(Internal.UTF_8);
+      String s = new String(bytes, UTF_8);
+      byte[] bytesReencoded = s.getBytes(UTF_8);
       boolean bytesEqual = Arrays.equals(bytes, bytesReencoded);
 
       if (bytesEqual != isRoundTrippable) {
@@ -358,12 +359,12 @@ final class IsValidUtf8TestUtil {
   static void testBytesUsingByteBuffers(
       ByteStringFactory factory, int numBytes, long expectedCount, long start, long lim) {
     CharsetDecoder decoder =
-        Internal.UTF_8
+        UTF_8
             .newDecoder()
             .onMalformedInput(CodingErrorAction.REPLACE)
             .onUnmappableCharacter(CodingErrorAction.REPLACE);
     CharsetEncoder encoder =
-        Internal.UTF_8
+        UTF_8
             .newEncoder()
             .onMalformedInput(CodingErrorAction.REPLACE)
             .onUnmappableCharacter(CodingErrorAction.REPLACE);

--- a/java/core/src/test/java/com/google/protobuf/LiteralByteStringTest.java
+++ b/java/core/src/test/java/com/google/protobuf/LiteralByteStringTest.java
@@ -31,6 +31,7 @@
 package com.google.protobuf;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -55,7 +56,6 @@ import junit.framework.TestCase;
  * @author carlanton@google.com (Carl Haverl)
  */
 public class LiteralByteStringTest extends TestCase {
-  protected static final String UTF_8 = "UTF-8";
 
   protected String classUnderTest;
   protected byte[] referenceBytes;
@@ -417,23 +417,23 @@ public class LiteralByteStringTest extends TestCase {
 
   public void testToString() throws UnsupportedEncodingException {
     String testString = "I love unicode \u1234\u5678 characters";
-    ByteString unicode = ByteString.wrap(testString.getBytes(Internal.UTF_8));
-    String roundTripString = unicode.toString(UTF_8);
+    ByteString unicode = ByteString.wrap(testString.getBytes(UTF_8));
+    String roundTripString = unicode.toString(UTF_8.name());
     assertEquals(classUnderTest + " unicode must match", testString, roundTripString);
   }
 
   public void testCharsetToString() {
     String testString = "I love unicode \u1234\u5678 characters";
-    ByteString unicode = ByteString.wrap(testString.getBytes(Internal.UTF_8));
-    String roundTripString = unicode.toString(Internal.UTF_8);
+    ByteString unicode = ByteString.wrap(testString.getBytes(UTF_8));
+    String roundTripString = unicode.toString(UTF_8);
     assertEquals(classUnderTest + " unicode must match", testString, roundTripString);
   }
 
   public void testToString_returnsCanonicalEmptyString() {
     assertSame(
         classUnderTest + " must be the same string references",
-        ByteString.EMPTY.toString(Internal.UTF_8),
-        ByteString.wrap(new byte[] {}).toString(Internal.UTF_8));
+        ByteString.EMPTY.toString(UTF_8),
+        ByteString.wrap(new byte[] {}).toString(UTF_8));
   }
 
   public void testToString_raisesException() {

--- a/java/core/src/test/java/com/google/protobuf/NioByteStringTest.java
+++ b/java/core/src/test/java/com/google/protobuf/NioByteStringTest.java
@@ -30,7 +30,7 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/java/core/src/test/java/com/google/protobuf/RopeByteStringSubstringTest.java
+++ b/java/core/src/test/java/com/google/protobuf/RopeByteStringSubstringTest.java
@@ -30,6 +30,8 @@
 
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.UnsupportedEncodingException;
 import java.util.Iterator;
 
@@ -88,7 +90,7 @@ public class RopeByteStringSubstringTest extends LiteralByteStringTest {
         classUnderTest + " from string must have the expected type",
         classUnderTest,
         getActualClassName(unicode));
-    String roundTripString = unicode.toString(UTF_8);
+    String roundTripString = unicode.toString(UTF_8.name());
     assertEquals(classUnderTest + " unicode bytes must match", testString, roundTripString);
     ByteString flatString = ByteString.copyFromUtf8(testString);
     assertEquals(classUnderTest + " string must equal the flat string", flatString, unicode);
@@ -121,7 +123,7 @@ public class RopeByteStringSubstringTest extends LiteralByteStringTest {
         classUnderTest + " from string must have the expected type",
         classUnderTest,
         getActualClassName(unicode));
-    String roundTripString = unicode.toString(Internal.UTF_8);
+    String roundTripString = unicode.toString(UTF_8);
     assertEquals(classUnderTest + " unicode bytes must match", testString, roundTripString);
     ByteString flatString = ByteString.copyFromUtf8(testString);
     assertEquals(classUnderTest + " string must equal the flat string", flatString, unicode);

--- a/java/core/src/test/java/com/google/protobuf/RopeByteStringTest.java
+++ b/java/core/src/test/java/com/google/protobuf/RopeByteStringTest.java
@@ -30,6 +30,8 @@
 
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -132,7 +134,7 @@ public class RopeByteStringTest extends LiteralByteStringTest {
         classUnderTest + " from string must have the expected type",
         classUnderTest,
         getActualClassName(unicode));
-    String roundTripString = unicode.toString(UTF_8);
+    String roundTripString = unicode.toString(UTF_8.name());
     assertEquals(classUnderTest + " unicode bytes must match", testString, roundTripString);
     ByteString flatString = ByteString.copyFromUtf8(testString);
     assertEquals(classUnderTest + " string must equal the flat string", flatString, unicode);
@@ -161,7 +163,7 @@ public class RopeByteStringTest extends LiteralByteStringTest {
         classUnderTest + " from string must have the expected type",
         classUnderTest,
         getActualClassName(unicode));
-    String roundTripString = unicode.toString(Internal.UTF_8);
+    String roundTripString = unicode.toString(UTF_8);
     assertEquals(classUnderTest + " unicode bytes must match", testString, roundTripString);
     ByteString flatString = ByteString.copyFromUtf8(testString);
     assertEquals(classUnderTest + " string must equal the flat string", flatString, unicode);
@@ -177,8 +179,8 @@ public class RopeByteStringTest extends LiteralByteStringTest {
         RopeByteString.newInstanceForTest(ByteString.EMPTY, ByteString.EMPTY);
     assertSame(
         classUnderTest + " must be the same string references",
-        ByteString.EMPTY.toString(Internal.UTF_8),
-        ropeByteString.toString(Internal.UTF_8));
+        ByteString.EMPTY.toString(UTF_8),
+        ropeByteString.toString(UTF_8));
   }
 
   @Override

--- a/java/core/src/test/java/com/google/protobuf/TestUtil.java
+++ b/java/core/src/test/java/com/google/protobuf/TestUtil.java
@@ -208,6 +208,7 @@ import static protobuf_unittest.UnittestProto.repeatedStringExtension;
 import static protobuf_unittest.UnittestProto.repeatedStringPieceExtension;
 import static protobuf_unittest.UnittestProto.repeatedUint32Extension;
 import static protobuf_unittest.UnittestProto.repeatedUint64Extension;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.protobuf.UnittestImportLite.ImportEnumLite;
 import com.google.protobuf.UnittestLite.ForeignEnumLite;
@@ -261,7 +262,7 @@ public final class TestUtil {
 
   /** Helper to convert a String to ByteString. */
   static ByteString toBytes(String str) {
-    return ByteString.copyFrom(str.getBytes(Internal.UTF_8));
+    return ByteString.copyFrom(str.getBytes(UTF_8));
   }
 
   // BEGIN FULL-RUNTIME

--- a/java/core/src/test/java/com/google/protobuf/TestUtilLite.java
+++ b/java/core/src/test/java/com/google/protobuf/TestUtilLite.java
@@ -119,6 +119,7 @@ import static com.google.protobuf.UnittestLite.repeatedStringExtensionLite;
 import static com.google.protobuf.UnittestLite.repeatedStringPieceExtensionLite;
 import static com.google.protobuf.UnittestLite.repeatedUint32ExtensionLite;
 import static com.google.protobuf.UnittestLite.repeatedUint64ExtensionLite;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.protobuf.UnittestImportLite.ImportEnumLite;
 import com.google.protobuf.UnittestImportLite.ImportMessageLite;
@@ -143,7 +144,7 @@ public final class TestUtilLite {
 
   /** Helper to convert a String to ByteString. */
   static ByteString toBytes(String str) {
-    return ByteString.copyFrom(str.getBytes(Internal.UTF_8));
+    return ByteString.copyFrom(str.getBytes(UTF_8));
   }
 
   /**

--- a/java/core/src/test/java/com/google/protobuf/Utf8Test.java
+++ b/java/core/src/test/java/com/google/protobuf/Utf8Test.java
@@ -30,6 +30,8 @@
 
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
@@ -124,7 +126,7 @@ public class Utf8Test extends TestCase {
   }
 
   private static void assertEncoding(String message) {
-    byte[] expected = message.getBytes(Internal.UTF_8);
+    byte[] expected = message.getBytes(UTF_8);
     byte[] output = encodeToByteArray(message, expected.length, safeProcessor);
     assertTrue("encodeUtf8[ARRAY]", Arrays.equals(expected, output));
 

--- a/java/core/src/test/java/com/google/protobuf/WrappersLiteOfMethodTest.java
+++ b/java/core/src/test/java/com/google/protobuf/WrappersLiteOfMethodTest.java
@@ -30,6 +30,7 @@
 
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.protobuf.wrapperstest.WrappersTestProto.TopLevelMessage;
 import junit.framework.TestCase;
 
@@ -45,7 +46,7 @@ public class WrappersLiteOfMethodTest extends TestCase {
     builder.setFieldUint64(UInt64Value.of(23333333333333L));
     builder.setFieldBool(BoolValue.of(true));
     builder.setFieldString(StringValue.of("23333"));
-    builder.setFieldBytes(BytesValue.of(ByteString.wrap("233".getBytes(Internal.UTF_8))));
+    builder.setFieldBytes(BytesValue.of(ByteString.wrap("233".getBytes(UTF_8))));
 
     TopLevelMessage message = builder.build();
     assertTrue(2.333 == message.getFieldDouble().getValue());

--- a/java/core/src/test/java/com/google/protobuf/WrappersOfMethodTest.java
+++ b/java/core/src/test/java/com/google/protobuf/WrappersOfMethodTest.java
@@ -30,6 +30,8 @@
 
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.protobuf.wrapperstest.WrappersTestProto.TopLevelMessage;
 import junit.framework.TestCase;
 
@@ -45,7 +47,7 @@ public class WrappersOfMethodTest extends TestCase {
     builder.setFieldUint64(UInt64Value.of(23333333333333L));
     builder.setFieldBool(BoolValue.of(true));
     builder.setFieldString(StringValue.of("23333"));
-    builder.setFieldBytes(BytesValue.of(ByteString.wrap("233".getBytes(Internal.UTF_8))));
+    builder.setFieldBytes(BytesValue.of(ByteString.wrap("233".getBytes(UTF_8))));
 
     TopLevelMessage message = builder.build();
     assertTrue(2.333 == message.getFieldDouble().getValue());

--- a/java/lite/src/test/java/com/google/protobuf/LiteTest.java
+++ b/java/lite/src/test/java/com/google/protobuf/LiteTest.java
@@ -30,6 +30,7 @@
 
 package com.google.protobuf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -1632,7 +1633,7 @@ public class LiteTest extends TestCase {
   public void testMergeFromStream_invalidBytes() throws Exception {
     TestAllTypesLite.Builder builder = TestAllTypesLite.newBuilder().setDefaultBool(true);
     try {
-      builder.mergeFrom(CodedInputStream.newInstance("Invalid bytes".getBytes(Internal.UTF_8)));
+      builder.mergeFrom(CodedInputStream.newInstance("Invalid bytes".getBytes(UTF_8)));
       fail();
     } catch (InvalidProtocolBufferException expected) {
     }


### PR DESCRIPTION
Use StandardCharsets included in JDK 1.7 for character set handling.