### PR TITLE
Use ArrayList copy constructor

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/FieldSet.java
+++ b/java/core/src/main/java/com/google/protobuf/FieldSet.java
@@ -1078,8 +1078,7 @@ final class FieldSet<T extends FieldSet.FieldDescriptorLite<T>> {
 
         // Wrap the contents in a new list so that the caller cannot change
         // the list's contents after setting it.
-        final List newList = new ArrayList();
-        newList.addAll((List) value);
+        final List newList = new ArrayList((List) value);
         for (final Object element : newList) {
           verifyType(descriptor.getLiteType(), element);
           hasNestedBuilders = hasNestedBuilders || element instanceof MessageLite.Builder;


### PR DESCRIPTION
Right-size the list copy from the beginning, utilizing the ArrayList copy constructor, instead of creating a backing array of size 10 (default) and then potentially discarding it when copying a list larger than 10 elements.