### PR TITLE
Standardize NPE checks on JDK Objects utility

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/AbstractMessageLite.java
+++ b/java/core/src/main/java/com/google/protobuf/AbstractMessageLite.java
@@ -30,8 +30,6 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,6 +37,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A partial implementation of the {@link MessageLite} interface which implements as many methods of
@@ -402,7 +401,7 @@ public abstract class AbstractMessageLite<
      *     null.
      */
     protected static <T> void addAll(final Iterable<T> values, final List<? super T> list) {
-      checkNotNull(values);
+      Objects.requireNonNull(values);
       if (values instanceof LazyStringList) {
         // For StringOrByteStringLists, check the underlying elements to avoid
         // forcing conversions of ByteStrings to Strings.

--- a/java/core/src/main/java/com/google/protobuf/AllocatedBuffer.java
+++ b/java/core/src/main/java/com/google/protobuf/AllocatedBuffer.java
@@ -30,9 +30,8 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /**
  * A buffer that was allocated by a {@link BufferAllocator}. For every buffer, it is guaranteed that
@@ -151,7 +150,7 @@ abstract class AllocatedBuffer {
    * returned buffer will have {@link #hasNioBuffer} == {@code true}.
    */
   public static AllocatedBuffer wrap(final ByteBuffer buffer) {
-    checkNotNull(buffer, "buffer");
+    Objects.requireNonNull(buffer, "buffer");
 
     return new AllocatedBuffer() {
 

--- a/java/core/src/main/java/com/google/protobuf/ArrayDecoders.java
+++ b/java/core/src/main/java/com/google/protobuf/ArrayDecoders.java
@@ -34,6 +34,7 @@ import static com.google.protobuf.MessageSchema.getMutableUnknownFields;
 
 import com.google.protobuf.Internal.ProtobufList;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Helper functions to decode protobuf wire format from a byte array.
@@ -64,10 +65,7 @@ final class ArrayDecoders {
     }
 
     Registers(ExtensionRegistryLite extensionRegistry) {
-      if (extensionRegistry == null) {
-        throw new NullPointerException();
-      }
-      this.extensionRegistry = extensionRegistry;
+      this.extensionRegistry = Objects.requireNonNull(extensionRegistry);
     }
   }
 

--- a/java/core/src/main/java/com/google/protobuf/BinaryWriter.java
+++ b/java/core/src/main/java/com/google/protobuf/BinaryWriter.java
@@ -30,7 +30,6 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
 import static com.google.protobuf.WireFormat.FIXED32_SIZE;
 import static com.google.protobuf.WireFormat.FIXED64_SIZE;
 import static com.google.protobuf.WireFormat.MAX_VARINT32_SIZE;
@@ -51,6 +50,7 @@ import java.nio.ByteOrder;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 
 /**
@@ -146,7 +146,7 @@ abstract class BinaryWriter extends ByteOutput implements Writer {
     if (chunkSize <= 0) {
       throw new IllegalArgumentException("chunkSize must be > 0");
     }
-    this.alloc = checkNotNull(alloc, "alloc");
+    this.alloc = Objects.requireNonNull(alloc, "alloc");
     this.chunkSize = chunkSize;
   }
 

--- a/java/core/src/main/java/com/google/protobuf/BooleanArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/BooleanArrayList.java
@@ -30,11 +30,10 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.Internal.BooleanList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.RandomAccess;
 
 /**
@@ -238,7 +237,7 @@ final class BooleanArrayList extends AbstractProtobufList<Boolean>
   public boolean addAll(Collection<? extends Boolean> collection) {
     ensureIsMutable();
 
-    checkNotNull(collection);
+    Objects.requireNonNull(collection);
 
     // We specialize when adding another BooleanArrayList to avoid boxing elements.
     if (!(collection instanceof BooleanArrayList)) {

--- a/java/core/src/main/java/com/google/protobuf/ByteString.java
+++ b/java/core/src/main/java/com/google/protobuf/ByteString.java
@@ -55,6 +55,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 /**
  * Immutable sequence of bytes. Provides conversions to and from {@code byte[]}, {@link
@@ -1311,10 +1312,7 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
      * @param bytes array to wrap
      */
     LiteralByteString(byte[] bytes) {
-      if (bytes == null) {
-        throw new NullPointerException();
-      }
-      this.bytes = bytes;
+      this.bytes = Objects.requireNonNull(bytes);
     }
 
     @Override

--- a/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -33,7 +33,6 @@ package com.google.protobuf;
 import static com.google.protobuf.Internal.EMPTY_BYTE_ARRAY;
 import static com.google.protobuf.Internal.EMPTY_BYTE_BUFFER;
 import static com.google.protobuf.Internal.UTF_8;
-import static com.google.protobuf.Internal.checkNotNull;
 import static com.google.protobuf.WireFormat.FIXED32_SIZE;
 import static com.google.protobuf.WireFormat.FIXED64_SIZE;
 import static com.google.protobuf.WireFormat.MAX_VARINT_SIZE;
@@ -46,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Reads and decodes protocol message fields.
@@ -2046,8 +2046,7 @@ public abstract class CodedInputStream {
     private int currentLimit = Integer.MAX_VALUE;
 
     private StreamDecoder(final InputStream input, int bufferSize) {
-      checkNotNull(input, "input");
-      this.input = input;
+      this.input = Objects.requireNonNull(input, "input");
       this.buffer = new byte[bufferSize];
       this.bufferSize = 0;
       pos = 0;

--- a/java/core/src/main/java/com/google/protobuf/CodedInputStreamReader.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedInputStreamReader.java
@@ -42,6 +42,7 @@ import static com.google.protobuf.WireFormat.WIRETYPE_VARINT;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /** An adapter between the {@link Reader} interface and {@link CodedInputStream}. */
 @ExperimentalApi
@@ -63,7 +64,7 @@ final class CodedInputStreamReader implements Reader {
   }
 
   private CodedInputStreamReader(CodedInputStream input) {
-    this.input = Internal.checkNotNull(input, "input");
+    this.input = Objects.requireNonNull(input, "input");
     this.input.wrapper = this;
   }
 

--- a/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
@@ -42,6 +42,7 @@ import java.io.OutputStream;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -1154,9 +1155,7 @@ public abstract class CodedOutputStream extends ByteOutput {
     private int position;
 
     ArrayEncoder(byte[] buffer, int offset, int length) {
-      if (buffer == null) {
-        throw new NullPointerException("buffer");
-      }
+      Objects.requireNonNull(buffer, "buffer");
       if ((offset | length | (buffer.length - (offset + length))) < 0) {
         throw new IllegalArgumentException(
             String.format(
@@ -2120,14 +2119,11 @@ public abstract class CodedOutputStream extends ByteOutput {
 
     @Override
     public void write(byte[] value, int offset, int length) throws IOException {
-      if (value == null
-          || offset < 0
+      Objects.requireNonNull(value, "value");
+      if (offset < 0
           || length < 0
           || (value.length - length) < offset
           || (limit - length) < position) {
-        if (value == null) {
-          throw new NullPointerException("value");
-        }
         throw new OutOfSpaceException(
             String.format("Pos: %d, limit: %d, len: %d", position, limit, length));
       }
@@ -2396,10 +2392,7 @@ public abstract class CodedOutputStream extends ByteOutput {
 
     ByteOutputEncoder(ByteOutput out, int bufferSize) {
       super(bufferSize);
-      if (out == null) {
-        throw new NullPointerException("out");
-      }
-      this.out = out;
+      this.out = Objects.requireNonNull(out, "out");
     }
 
     @Override
@@ -2710,10 +2703,7 @@ public abstract class CodedOutputStream extends ByteOutput {
 
     OutputStreamEncoder(OutputStream out, int bufferSize) {
       super(bufferSize);
-      if (out == null) {
-        throw new NullPointerException("out");
-      }
-      this.out = out;
+      this.out = Objects.requireNonNull(out, "out");
     }
 
     @Override

--- a/java/core/src/main/java/com/google/protobuf/CodedOutputStreamWriter.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedOutputStreamWriter.java
@@ -30,13 +30,13 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
 import static com.google.protobuf.WireFormat.WIRETYPE_LENGTH_DELIMITED;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /** An adapter between the {@link Writer} interface and {@link CodedOutputStream}. */
 @ExperimentalApi
@@ -51,7 +51,7 @@ final class CodedOutputStreamWriter implements Writer {
   }
 
   private CodedOutputStreamWriter(CodedOutputStream output) {
-    this.output = checkNotNull(output, "output");
+    this.output = Objects.requireNonNull(output, "output");
     this.output.wrapper = this;
   }
 

--- a/java/core/src/main/java/com/google/protobuf/Descriptors.java
+++ b/java/core/src/main/java/com/google/protobuf/Descriptors.java
@@ -30,8 +30,6 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.google.protobuf.DescriptorProtos.EnumDescriptorProto;
 import com.google.protobuf.DescriptorProtos.EnumOptions;
@@ -57,6 +55,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;
@@ -744,7 +743,7 @@ public final class Descriptors {
 
     /** Determines if the given field name is reserved. */
     public boolean isReservedName(final String name) {
-      checkNotNull(name);
+      Objects.requireNonNull(name);
       for (final String reservedName : proto.getReservedNameList()) {
         if (reservedName.equals(name)) {
           return true;

--- a/java/core/src/main/java/com/google/protobuf/DoubleArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/DoubleArrayList.java
@@ -30,11 +30,10 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.Internal.DoubleList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.RandomAccess;
 
 /**
@@ -238,7 +237,7 @@ final class DoubleArrayList extends AbstractProtobufList<Double>
   public boolean addAll(Collection<? extends Double> collection) {
     ensureIsMutable();
 
-    checkNotNull(collection);
+    Objects.requireNonNull(collection);
 
     // We specialize when adding another DoubleArrayList to avoid boxing elements.
     if (!(collection instanceof DoubleArrayList)) {

--- a/java/core/src/main/java/com/google/protobuf/DynamicMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/DynamicMessage.java
@@ -30,8 +30,6 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
@@ -41,6 +39,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An implementation of {@link Message} that can represent arbitrary types, given a {@link
@@ -624,7 +623,7 @@ public final class DynamicMessage extends AbstractMessage {
 
     /** Verifies that the value is EnumValueDescriptor and matches Enum Type. */
     private void ensureSingularEnumValueDescriptor(FieldDescriptor field, Object value) {
-      checkNotNull(value);
+      Objects.requireNonNull(value);
       if (!(value instanceof EnumValueDescriptor)) {
         throw new IllegalArgumentException(
             "DynamicMessage should use EnumValueDescriptor to set Enum Value.");

--- a/java/core/src/main/java/com/google/protobuf/FieldInfo.java
+++ b/java/core/src/main/java/com/google/protobuf/FieldInfo.java
@@ -30,10 +30,9 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.Internal.EnumVerifier;
 import java.lang.reflect.Field;
+import java.util.Objects;
 
 /** Information for a single field in a protobuf message class. */
 @ExperimentalApi
@@ -64,8 +63,8 @@ final class FieldInfo implements Comparable<FieldInfo> {
   public static FieldInfo forField(
       Field field, int fieldNumber, FieldType fieldType, boolean enforceUtf8) {
     checkFieldNumber(fieldNumber);
-    checkNotNull(field, "field");
-    checkNotNull(fieldType, "fieldType");
+    Objects.requireNonNull(field, "field");
+    Objects.requireNonNull(fieldType, "fieldType");
     if (fieldType == FieldType.MESSAGE_LIST || fieldType == FieldType.GROUP_LIST) {
       throw new IllegalStateException("Shouldn't be called for repeated message fields.");
     }
@@ -89,8 +88,8 @@ final class FieldInfo implements Comparable<FieldInfo> {
   public static FieldInfo forPackedField(
       Field field, int fieldNumber, FieldType fieldType, Field cachedSizeField) {
     checkFieldNumber(fieldNumber);
-    checkNotNull(field, "field");
-    checkNotNull(fieldType, "fieldType");
+    Objects.requireNonNull(field, "field");
+    Objects.requireNonNull(fieldType, "fieldType");
     if (fieldType == FieldType.MESSAGE_LIST || fieldType == FieldType.GROUP_LIST) {
       throw new IllegalStateException("Shouldn't be called for repeated message fields.");
     }
@@ -114,9 +113,9 @@ final class FieldInfo implements Comparable<FieldInfo> {
   public static FieldInfo forRepeatedMessageField(
       Field field, int fieldNumber, FieldType fieldType, Class<?> messageClass) {
     checkFieldNumber(fieldNumber);
-    checkNotNull(field, "field");
-    checkNotNull(fieldType, "fieldType");
-    checkNotNull(messageClass, "messageClass");
+    Objects.requireNonNull(field, "field");
+    Objects.requireNonNull(fieldType, "fieldType");
+    Objects.requireNonNull(messageClass, "messageClass");
     return new FieldInfo(
         field,
         fieldNumber,
@@ -136,7 +135,7 @@ final class FieldInfo implements Comparable<FieldInfo> {
   public static FieldInfo forFieldWithEnumVerifier(
       Field field, int fieldNumber, FieldType fieldType, EnumVerifier enumVerifier) {
     checkFieldNumber(fieldNumber);
-    checkNotNull(field, "field");
+    Objects.requireNonNull(field, "field");
     return new FieldInfo(
         field,
         fieldNumber,
@@ -160,7 +159,7 @@ final class FieldInfo implements Comparable<FieldInfo> {
       EnumVerifier enumVerifier,
       Field cachedSizeField) {
     checkFieldNumber(fieldNumber);
-    checkNotNull(field, "field");
+    Objects.requireNonNull(field, "field");
     return new FieldInfo(
         field,
         fieldNumber,
@@ -187,9 +186,9 @@ final class FieldInfo implements Comparable<FieldInfo> {
       boolean enforceUtf8,
       EnumVerifier enumVerifier) {
     checkFieldNumber(fieldNumber);
-    checkNotNull(field, "field");
-    checkNotNull(fieldType, "fieldType");
-    checkNotNull(presenceField, "presenceField");
+    Objects.requireNonNull(field, "field");
+    Objects.requireNonNull(fieldType, "fieldType");
+    Objects.requireNonNull(presenceField, "presenceField");
     if (presenceField != null && !isExactlyOneBitSet(presenceMask)) {
       throw new IllegalArgumentException(
           "presenceMask must have exactly one bit set: " + presenceMask);
@@ -230,9 +229,9 @@ final class FieldInfo implements Comparable<FieldInfo> {
       boolean enforceUtf8,
       EnumVerifier enumVerifier) {
     checkFieldNumber(fieldNumber);
-    checkNotNull(fieldType, "fieldType");
-    checkNotNull(oneof, "oneof");
-    checkNotNull(oneofStoredType, "oneofStoredType");
+    Objects.requireNonNull(fieldType, "fieldType");
+    Objects.requireNonNull(oneof, "oneof");
+    Objects.requireNonNull(oneofStoredType, "oneofStoredType");
     if (!fieldType.isScalar()) {
       throw new IllegalArgumentException(
           "Oneof is only supported for scalar fields. Field "
@@ -272,9 +271,9 @@ final class FieldInfo implements Comparable<FieldInfo> {
       boolean enforceUtf8,
       EnumVerifier enumVerifier) {
     checkFieldNumber(fieldNumber);
-    checkNotNull(field, "field");
-    checkNotNull(fieldType, "fieldType");
-    checkNotNull(presenceField, "presenceField");
+    Objects.requireNonNull(field, "field");
+    Objects.requireNonNull(fieldType, "fieldType");
+    Objects.requireNonNull(presenceField, "presenceField");
     if (presenceField != null && !isExactlyOneBitSet(presenceMask)) {
       throw new IllegalArgumentException(
           "presenceMask must have exactly one bit set: " + presenceMask);
@@ -297,9 +296,9 @@ final class FieldInfo implements Comparable<FieldInfo> {
 
   public static FieldInfo forMapField(
       Field field, int fieldNumber, Object mapDefaultEntry, EnumVerifier enumVerifier) {
-    checkNotNull(mapDefaultEntry, "mapDefaultEntry");
+    Objects.requireNonNull(mapDefaultEntry, "mapDefaultEntry");
     checkFieldNumber(fieldNumber);
-    checkNotNull(field, "field");
+    Objects.requireNonNull(field, "field");
     return new FieldInfo(
         field,
         fieldNumber,
@@ -489,7 +488,7 @@ final class FieldInfo implements Comparable<FieldInfo> {
 
     /** Specifies proto2 presence information. This should not be called for oneof fields. */
     public Builder withPresence(Field presenceField, int presenceMask) {
-      this.presenceField = checkNotNull(presenceField, "presenceField");
+      this.presenceField = Objects.requireNonNull(presenceField, "presenceField");
       this.presenceMask = presenceMask;
       return this;
     }

--- a/java/core/src/main/java/com/google/protobuf/FieldSet.java
+++ b/java/core/src/main/java/com/google/protobuf/FieldSet.java
@@ -30,8 +30,6 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.LazyField.LazyIterator;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,6 +37,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A class which represents an arbitrary set of fields of some message type. This is used to
@@ -405,7 +404,7 @@ final class FieldSet<T extends FieldSet.FieldDescriptorLite<T>> {
   }
 
   private static boolean isValidType(final WireFormat.FieldType type, final Object value) {
-    checkNotNull(value);
+    Objects.requireNonNull(value);
     switch (type.getJavaType()) {
       case INT:
         return value instanceof Integer;

--- a/java/core/src/main/java/com/google/protobuf/FloatArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/FloatArrayList.java
@@ -30,11 +30,10 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.Internal.FloatList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.RandomAccess;
 
 /**
@@ -237,7 +236,7 @@ final class FloatArrayList extends AbstractProtobufList<Float>
   public boolean addAll(Collection<? extends Float> collection) {
     ensureIsMutable();
 
-    checkNotNull(collection);
+    Objects.requireNonNull(collection);
 
     // We specialize when adding another FloatArrayList to avoid boxing elements.
     if (!(collection instanceof FloatArrayList)) {

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -30,8 +30,6 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.EnumDescriptor;
 import com.google.protobuf.Descriptors.EnumValueDescriptor;

--- a/java/core/src/main/java/com/google/protobuf/IntArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/IntArrayList.java
@@ -30,11 +30,10 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.Internal.IntList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.RandomAccess;
 
 /**
@@ -237,7 +236,7 @@ final class IntArrayList extends AbstractProtobufList<Integer>
   public boolean addAll(Collection<? extends Integer> collection) {
     ensureIsMutable();
 
-    checkNotNull(collection);
+    Objects.requireNonNull(collection);
 
     // We specialize when adding another IntArrayList to avoid boxing elements.
     if (!(collection instanceof IntArrayList)) {

--- a/java/core/src/main/java/com/google/protobuf/Internal.java
+++ b/java/core/src/main/java/com/google/protobuf/Internal.java
@@ -58,22 +58,6 @@ public final class Internal {
   static final Charset UTF_8 = Charset.forName("UTF-8");
   static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
 
-  /** Throws an appropriate {@link NullPointerException} if the given objects is {@code null}. */
-  static <T> T checkNotNull(T obj) {
-    if (obj == null) {
-      throw new NullPointerException();
-    }
-    return obj;
-  }
-
-  /** Throws an appropriate {@link NullPointerException} if the given objects is {@code null}. */
-  static <T> T checkNotNull(T obj, String message) {
-    if (obj == null) {
-      throw new NullPointerException(message);
-    }
-    return obj;
-  }
-
   /**
    * Helper called by generated code to construct default values for string fields.
    *

--- a/java/core/src/main/java/com/google/protobuf/LazyFieldLite.java
+++ b/java/core/src/main/java/com/google/protobuf/LazyFieldLite.java
@@ -31,6 +31,7 @@
 package com.google.protobuf;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * LazyFieldLite encapsulates the logic of lazily parsing message fields. It stores the message in a
@@ -116,9 +117,8 @@ public class LazyFieldLite {
 
   /** Constructs a LazyFieldLite with bytes that will be parsed lazily. */
   public LazyFieldLite(ExtensionRegistryLite extensionRegistry, ByteString bytes) {
-    checkArguments(extensionRegistry, bytes);
-    this.extensionRegistry = extensionRegistry;
-    this.delayedBytes = bytes;
+    this.extensionRegistry = Objects.requireNonNull(extensionRegistry, "found null ExtensionRegistry");
+    this.delayedBytes = Objects.requireNonNull(bytes, "found null ByteString");
   }
 
   /** Constructs a LazyFieldLite with no contents, and no ability to parse extensions. */
@@ -340,9 +340,8 @@ public class LazyFieldLite {
 
   /** Sets this field with bytes to delay-parse. */
   public void setByteString(ByteString bytes, ExtensionRegistryLite extensionRegistry) {
-    checkArguments(extensionRegistry, bytes);
-    this.delayedBytes = bytes;
-    this.extensionRegistry = extensionRegistry;
+    this.delayedBytes = Objects.requireNonNull(bytes, "found null ByteString");
+    this.extensionRegistry = Objects.requireNonNull(extensionRegistry, "found null ExtensionRegistry");
     this.value = null;
     this.memoizedBytes = null;
   }
@@ -427,15 +426,6 @@ public class LazyFieldLite {
         this.value = defaultInstance;
         this.memoizedBytes = ByteString.EMPTY;
       }
-    }
-  }
-
-  private static void checkArguments(ExtensionRegistryLite extensionRegistry, ByteString bytes) {
-    if (extensionRegistry == null) {
-      throw new NullPointerException("found null ExtensionRegistry");
-    }
-    if (bytes == null) {
-      throw new NullPointerException("found null ByteString");
     }
   }
 }

--- a/java/core/src/main/java/com/google/protobuf/LongArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/LongArrayList.java
@@ -30,11 +30,10 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.Internal.LongList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.RandomAccess;
 
 /**
@@ -237,7 +236,7 @@ final class LongArrayList extends AbstractProtobufList<Long>
   public boolean addAll(Collection<? extends Long> collection) {
     ensureIsMutable();
 
-    checkNotNull(collection);
+    Objects.requireNonNull(collection);
 
     // We specialize when adding another LongArrayList to avoid boxing elements.
     if (!(collection instanceof LongArrayList)) {

--- a/java/core/src/main/java/com/google/protobuf/ManifestSchemaFactory.java
+++ b/java/core/src/main/java/com/google/protobuf/ManifestSchemaFactory.java
@@ -30,7 +30,7 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
+import java.util.Objects;
 
 /**
  * Dynamically generates a manifest-based (i.e. table-based) schema for a given protobuf message.
@@ -45,7 +45,7 @@ final class ManifestSchemaFactory implements SchemaFactory {
   }
 
   private ManifestSchemaFactory(MessageInfoFactory messageInfoFactory) {
-    this.messageInfoFactory = checkNotNull(messageInfoFactory, "messageInfoFactory");
+    this.messageInfoFactory = Objects.requireNonNull(messageInfoFactory, "messageInfoFactory");
   }
 
   @Override

--- a/java/core/src/main/java/com/google/protobuf/MapField.java
+++ b/java/core/src/main/java/com/google/protobuf/MapField.java
@@ -30,8 +30,6 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,6 +37,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -320,8 +319,8 @@ public class MapField<K, V> implements MutabilityOracle {
     @Override
     public V put(K key, V value) {
       mutabilityOracle.ensureMutable();
-      checkNotNull(key);
-      checkNotNull(value);
+      Objects.requireNonNull(key);
+      Objects.requireNonNull(value);
       return delegate.put(key, value);
     }
 
@@ -335,8 +334,8 @@ public class MapField<K, V> implements MutabilityOracle {
     public void putAll(Map<? extends K, ? extends V> m) {
       mutabilityOracle.ensureMutable();
       for (K key : m.keySet()) {
-        checkNotNull(key);
-        checkNotNull(m.get(key));
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(m.get(key));
       }
       delegate.putAll(m);
     }

--- a/java/core/src/main/java/com/google/protobuf/MapFieldLite.java
+++ b/java/core/src/main/java/com/google/protobuf/MapFieldLite.java
@@ -30,13 +30,12 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import com.google.protobuf.Internal.EnumLite;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -92,9 +91,9 @@ public final class MapFieldLite<K, V> extends LinkedHashMap<K, V> {
   @Override
   public V put(K key, V value) {
     ensureMutable();
-    checkNotNull(key);
+    Objects.requireNonNull(key);
 
-    checkNotNull(value);
+    Objects.requireNonNull(value);
     return super.put(key, value);
   }
 
@@ -117,8 +116,8 @@ public final class MapFieldLite<K, V> extends LinkedHashMap<K, V> {
 
   private static void checkForNullKeysAndValues(Map<?, ?> m) {
     for (Object key : m.keySet()) {
-      checkNotNull(key);
-      checkNotNull(m.get(key));
+      Objects.requireNonNull(key);
+      Objects.requireNonNull(m.get(key));
     }
   }
 

--- a/java/core/src/main/java/com/google/protobuf/MessageSchema.java
+++ b/java/core/src/main/java/com/google/protobuf/MessageSchema.java
@@ -80,6 +80,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /** Schema used for standard messages. */
 final class MessageSchema<T> implements Schema<T> {
@@ -1176,9 +1177,7 @@ final class MessageSchema<T> implements Schema<T> {
 
   @Override
   public void mergeFrom(T message, T other) {
-    if (other == null) {
-      throw new NullPointerException();
-    }
+    Objects.requireNonNull(other);
     for (int i = 0; i < buffer.length; i += INTS_PER_FIELD) {
       // A separate method allows for better JIT optimizations
       mergeSingleField(message, other, i);
@@ -3850,9 +3849,7 @@ final class MessageSchema<T> implements Schema<T> {
   @Override
   public void mergeFrom(T message, Reader reader, ExtensionRegistryLite extensionRegistry)
       throws IOException {
-    if (extensionRegistry == null) {
-      throw new NullPointerException();
-    }
+    Objects.requireNonNull(extensionRegistry);
     mergeFromHelper(unknownFieldSchema, extensionSchema, message, reader, extensionRegistry);
   }
 

--- a/java/core/src/main/java/com/google/protobuf/NioByteString.java
+++ b/java/core/src/main/java/com/google/protobuf/NioByteString.java
@@ -30,8 +30,6 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InvalidObjectException;
@@ -43,13 +41,14 @@ import java.nio.InvalidMarkException;
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /** A {@link ByteString} that wraps around a {@link ByteBuffer}. */
 final class NioByteString extends ByteString.LeafByteString {
   private final ByteBuffer buffer;
 
   NioByteString(ByteBuffer buffer) {
-    checkNotNull(buffer, "buffer");
+    Objects.requireNonNull(buffer, "buffer");
 
     // Use native byte order for fast fixed32/64 operations.
     this.buffer = buffer.slice().order(ByteOrder.nativeOrder());

--- a/java/core/src/main/java/com/google/protobuf/Protobuf.java
+++ b/java/core/src/main/java/com/google/protobuf/Protobuf.java
@@ -30,9 +30,8 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -86,7 +85,7 @@ final class Protobuf {
 
   /** Gets the schema for the given message type. */
   public <T> Schema<T> schemaFor(Class<T> messageType) {
-    checkNotNull(messageType, "messageType");
+    Objects.requireNonNull(messageType, "messageType");
     @SuppressWarnings("unchecked")
     Schema<T> schema = (Schema<T>) schemaCache.get(messageType);
     if (schema == null) {
@@ -116,8 +115,8 @@ final class Protobuf {
    *     registered.
    */
   public Schema<?> registerSchema(Class<?> messageType, Schema<?> schema) {
-    checkNotNull(messageType, "messageType");
-    checkNotNull(schema, "schema");
+    Objects.requireNonNull(messageType, "messageType");
+    Objects.requireNonNull(schema, "schema");
     return schemaCache.putIfAbsent(messageType, schema);
   }
 
@@ -131,8 +130,8 @@ final class Protobuf {
    *     previously.
    */
   public Schema<?> registerSchemaOverride(Class<?> messageType, Schema<?> schema) {
-    checkNotNull(messageType, "messageType");
-    checkNotNull(schema, "schema");
+    Objects.requireNonNull(messageType, "messageType");
+    Objects.requireNonNull(schema, "schema");
     return schemaCache.put(messageType, schema);
   }
 

--- a/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilder.java
+++ b/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilder.java
@@ -30,13 +30,12 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * {@code RepeatedFieldBuilder} implements a structure that a protocol message uses to hold a
@@ -277,7 +276,7 @@ public class RepeatedFieldBuilder<
    * @return the builder
    */
   public RepeatedFieldBuilder<MType, BType, IType> setMessage(int index, MType message) {
-    checkNotNull(message);
+    Objects.requireNonNull(message);
     ensureMutableMessageList();
     messages.set(index, message);
     if (builders != null) {
@@ -298,7 +297,7 @@ public class RepeatedFieldBuilder<
    * @return the builder
    */
   public RepeatedFieldBuilder<MType, BType, IType> addMessage(MType message) {
-    checkNotNull(message);
+    Objects.requireNonNull(message);
     ensureMutableMessageList();
     messages.add(message);
     if (builders != null) {
@@ -319,7 +318,7 @@ public class RepeatedFieldBuilder<
    * @return the builder
    */
   public RepeatedFieldBuilder<MType, BType, IType> addMessage(int index, MType message) {
-    checkNotNull(message);
+    Objects.requireNonNull(message);
     ensureMutableMessageList();
     messages.add(index, message);
     if (builders != null) {
@@ -340,7 +339,7 @@ public class RepeatedFieldBuilder<
   public RepeatedFieldBuilder<MType, BType, IType> addAllMessages(
       Iterable<? extends MType> values) {
     for (final MType value : values) {
-      checkNotNull(value);
+      Objects.requireNonNull(value);
     }
 
     // If we can inspect the size, we can more efficiently add messages.

--- a/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
@@ -30,13 +30,12 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * {@code RepeatedFieldBuilderV3} implements a structure that a protocol message uses to hold a
@@ -277,7 +276,7 @@ public class RepeatedFieldBuilderV3<
    * @return the builder
    */
   public RepeatedFieldBuilderV3<MType, BType, IType> setMessage(int index, MType message) {
-    checkNotNull(message);
+    Objects.requireNonNull(message);
     ensureMutableMessageList();
     messages.set(index, message);
     if (builders != null) {
@@ -298,7 +297,7 @@ public class RepeatedFieldBuilderV3<
    * @return the builder
    */
   public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(MType message) {
-    checkNotNull(message);
+    Objects.requireNonNull(message);
     ensureMutableMessageList();
     messages.add(message);
     if (builders != null) {
@@ -319,7 +318,7 @@ public class RepeatedFieldBuilderV3<
    * @return the builder
    */
   public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(int index, MType message) {
-    checkNotNull(message);
+    Objects.requireNonNull(message);
     ensureMutableMessageList();
     messages.add(index, message);
     if (builders != null) {
@@ -340,7 +339,7 @@ public class RepeatedFieldBuilderV3<
   public RepeatedFieldBuilderV3<MType, BType, IType> addAllMessages(
       Iterable<? extends MType> values) {
     for (final MType value : values) {
-      checkNotNull(value);
+      Objects.requireNonNull(value);
     }
 
     // If we can inspect the size, we can more efficiently add messages.

--- a/java/core/src/main/java/com/google/protobuf/RopeByteString.java
+++ b/java/core/src/main/java/com/google/protobuf/RopeByteString.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 /**
  * Class to represent {@code ByteStrings} formed by concatenation of other ByteStrings, without
@@ -839,9 +840,8 @@ final class RopeByteString extends ByteString {
      */
     @Override
     public int read(byte[] b, int offset, int length) {
-      if (b == null) {
-        throw new NullPointerException();
-      } else if (offset < 0 || length < 0 || length > b.length - offset) {
+      Objects.requireNonNull(b);
+      if (offset < 0 || length < 0 || length > b.length - offset) {
         throw new IndexOutOfBoundsException();
       }
       int bytesRead = readSkipInternal(b, offset, length);

--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilder.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilder.java
@@ -30,7 +30,7 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
+import java.util.Objects;
 
 /**
  * {@code SingleFieldBuilder} implements a structure that a protocol message uses to hold a single
@@ -77,7 +77,7 @@ public class SingleFieldBuilder<
   private boolean isClean;
 
   public SingleFieldBuilder(MType message, GeneratedMessage.BuilderParent parent, boolean isClean) {
-    this.message = checkNotNull(message);
+    this.message = Objects.requireNonNull(message);
     this.parent = parent;
     this.isClean = isClean;
   }
@@ -157,7 +157,7 @@ public class SingleFieldBuilder<
    * @return the builder
    */
   public SingleFieldBuilder<MType, BType, IType> setMessage(MType message) {
-    this.message = checkNotNull(message);
+    this.message = Objects.requireNonNull(message);
     if (builder != null) {
       builder.dispose();
       builder = null;

--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
@@ -30,7 +30,7 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
+import java.util.Objects;
 
 /**
  * {@code SingleFieldBuilderV3} implements a structure that a protocol message uses to hold a single
@@ -77,7 +77,7 @@ public class SingleFieldBuilderV3<
   private boolean isClean;
 
   public SingleFieldBuilderV3(MType message, AbstractMessage.BuilderParent parent, boolean isClean) {
-    this.message = checkNotNull(message);
+    this.message = Objects.requireNonNull(message);
     this.parent = parent;
     this.isClean = isClean;
   }
@@ -157,7 +157,7 @@ public class SingleFieldBuilderV3<
    * @return the builder
    */
   public SingleFieldBuilderV3<MType, BType, IType> setMessage(MType message) {
-    this.message = checkNotNull(message);
+    this.message = Objects.requireNonNull(message);
     if (builder != null) {
       builder.dispose();
       builder = null;

--- a/java/core/src/main/java/com/google/protobuf/StructuralMessageInfo.java
+++ b/java/core/src/main/java/com/google/protobuf/StructuralMessageInfo.java
@@ -30,11 +30,10 @@
 
 package com.google.protobuf;
 
-import static com.google.protobuf.Internal.checkNotNull;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Information for the layout of a protobuf message class. This describes all of the fields
@@ -64,7 +63,7 @@ final class StructuralMessageInfo implements MessageInfo {
     this.messageSetWireFormat = messageSetWireFormat;
     this.checkInitialized = checkInitialized;
     this.fields = fields;
-    this.defaultInstance = (MessageLite) checkNotNull(defaultInstance, "defaultInstance");
+    this.defaultInstance = (MessageLite) Objects.requireNonNull(defaultInstance, "defaultInstance");
   }
 
   /** Gets the syntax for the message (e.g. PROTO2, PROTO3). */
@@ -129,7 +128,7 @@ final class StructuralMessageInfo implements MessageInfo {
     }
 
     public void withSyntax(ProtoSyntax syntax) {
-      this.syntax = checkNotNull(syntax, "syntax");
+      this.syntax = Objects.requireNonNull(syntax, "syntax");
     }
 
     public void withMessageSetWireFormat(boolean messageSetWireFormat) {


### PR DESCRIPTION
There are a few ways of doing a null pointer check in the protobuf code base.  This PR unifies them all on the JDK's `Objects.requireNonNull`

https://docs.oracle.com/javase/7/docs/api/java/util/Objects.html#requireNonNull(T)