### PR TITLE
Fix some -Wunused-parameter warnings which appeared in release 3.13.0.

### DIFF
--- a/src/google/protobuf/generated_message_reflection.h
+++ b/src/google/protobuf/generated_message_reflection.h
@@ -214,15 +214,15 @@ struct ReflectionSchema {
 
   // Returns true if the field's accessor is called by any external code (aka,
   // non proto library code).
-  bool IsFieldUsed(const FieldDescriptor* field) const {
+  bool IsFieldUsed(const FieldDescriptor* /* field */) const {
     return true;
   }
 
-  bool IsFieldStripped(const FieldDescriptor* field) const {
+  bool IsFieldStripped(const FieldDescriptor* /* field */) const {
     return false;
   }
 
-  bool IsMessageStripped(const Descriptor* descriptor) const {
+  bool IsMessageStripped(const Descriptor* /* descriptor */) const {
     return false;
   }
 

--- a/src/google/protobuf/message.h
+++ b/src/google/protobuf/message.h
@@ -1045,7 +1045,7 @@ class PROTOBUF_EXPORT Reflection final {
                              const OneofDescriptor* oneof_descriptor) const;
   inline uint32* MutableOneofCase(
       Message* message, const OneofDescriptor* oneof_descriptor) const;
-  inline bool HasExtensionSet(const Message& message) const {
+  inline bool HasExtensionSet(const Message& /* message */) const {
     return schema_.HasExtensionSet();
   }
   const internal::ExtensionSet& GetExtensionSet(const Message& message) const;


### PR DESCRIPTION
Note: the diff on branch 3.13.0 is slightly different (there is no method "IsFieldUsed" on this branch).