### PR TITLE
Fix more -Wunused-parameter warnings

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -1054,6 +1054,8 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
             "       s->data(), static_cast<int>(s->size()), "
             "::$proto_ns$::internal::"
             "WireFormatLite::PARSE, \"$1$\");\n"
+            "#else\n"
+            "    (void) s;\n"
             "#endif\n"
             "    return true;\n"
             " }\n",
@@ -1081,6 +1083,8 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
             "       s->data(), static_cast<int>(s->size()), "
             "::$proto_ns$::internal::"
             "WireFormatLite::PARSE, \"$1$\");\n"
+            "#else\n"
+            "    (void) s;\n"
             "#endif\n"
             "    return true;\n"
             " }\n",

--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -826,6 +826,7 @@ class Map {
     // non-determinism to the map ordering.
     bool ShouldInsertAfterHead(void* node) {
 #ifdef NDEBUG
+      (void) node;
       return false;
 #else
       // Doing modulo with a prime mixes the bits more.


### PR DESCRIPTION
While some of the warnings have been fixed in 76f9074c1c947c6f6773c5095e977572de514821, more remains.