### PR TITLE
python/setup.py: remove unneeded wheel dependency

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -293,7 +293,6 @@ if __name__ == '__main__':
           'build_py': build_py,
           'test_conformance': test_conformance,
       },
-      setup_requires = ['wheel'],
       install_requires=install_requires,
       ext_modules=ext_module_list,
   )


### PR DESCRIPTION
wheel is required since version 3.13.0 and
https://github.com/protocolbuffers/protobuf/commit/ff92cee10bcae7533b573368f448e782fbd43f39

This will result in the following build failure when cross-compiling:

```
Download error on https://pypi.org/simple/wheel/: unknown url type: https -- Some packages may not be found!
Couldn't find index page for 'wheel' (maybe misspelled?)
Download error on https://pypi.org/simple/: unknown url type: https -- Some packages may not be found!
No local packages or working download links found for wheel
```

Remove wheel requirement from setup.py as it is only needed by
release.sh, not by setup.py

Fixes:
 - http://autobuild.buildroot.org/results/371c686a10d6870933011b46d36b1879d29046b9

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>