### PR TITLE
Update default dependency for gtest.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -14,10 +14,10 @@ exports_files(["LICENSE"])
 # build configuration
 ################################################################################
 
+# TODO(yannic): Remove in 3.14.0.
 string_flag(
     name = "incompatible_use_com_google_googletest",
-    # TODO(yannic): Flip to `true` for `3.13.0`.
-    build_setting_default = "false",
+    build_setting_default = "true",
     values = ["true", "false"]
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,13 +29,13 @@ bind(
     actual = "//util/python:python_headers",
 )
 
-# TODO(yannic): Remove in 3.13.0.
+# TODO(yannic): Remove in 3.14.0.
 bind(
     name = "gtest",
     actual = "@com_google_googletest//:gtest",
 )
 
-# TODO(yannic): Remove in 3.13.0.
+# TODO(yannic): Remove in 3.14.0.
 bind(
     name = "gtest_main",
     actual = "@com_google_googletest//:gtest_main",


### PR DESCRIPTION
The gtest source was changed in #7237 on an opt-in basis, and has been
released since 3.12.0. The comments state that the default should change
in 3.13.0, but that didn't quite happen.

This change does flip the default, and updates comments to say 3.14.0.