### PR TITLE
fix: dynamic field generation in python respects json_name

### DIFF
--- a/python/google/protobuf/descriptor_pool.py
+++ b/python/google/protobuf/descriptor_pool.py
@@ -1003,6 +1003,7 @@ class DescriptorPool(object):
         is_extension=is_extension,
         extension_scope=None,
         options=_OptionsOrNone(field_proto),
+        json_name=field_proto.json_name,
         file=file_desc,
         # pylint: disable=protected-access
         create_key=descriptor._internal_create_key)

--- a/python/google/protobuf/internal/descriptor_pool_test.py
+++ b/python/google/protobuf/internal/descriptor_pool_test.py
@@ -1014,6 +1014,25 @@ class AddDescriptorTest(unittest.TestCase):
     self.assertEqual('TopEnum', pool.FindEnumTypeByName('TopEnum').name)
     self.assertEqual('TopService', pool.FindServiceByName('TopService').name)
 
+  def testJsonNamePassedToFieldDescriptor(self):
+    pool = descriptor_pool.DescriptorPool()
+    file_pb2 = descriptor_pb2.FileDescriptorProto(
+      name='some/file.proto',
+      package='package',
+    )
+    msg_pb2 = file_pb2.message_type.add(name='Message')
+    field_pb2 = msg_pb2.field.add(
+      name='bb',
+      number=1,
+      type=descriptor_pb2.FieldDescriptorProto.TYPE_INT32,
+      json_name='my_json_name',
+      label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+    )
+    pool.Add(file_pb2)
+    msg_descriptor = pool.FindMessageTypeByName('package.Message')
+    field_descriptor = msg_descriptor.fields_by_name['bb']
+    assert field_descriptor.json_name == field_pb2.json_name
+
   def testFileDescriptorOptionsWithCustomDescriptorPool(self):
     # Create a descriptor pool, and add a new FileDescriptorProto to it.
     pool = descriptor_pool.DescriptorPool()


### PR DESCRIPTION
This bug is visible if a user creates a FileDescriptorProto,
DescriptorProto, and FieldDescriptorProto dynamically and adds the
file descriptor to a descriptor pool.
The field descriptor has a custom json_name.
The user then retreives the
message descriptor from the pool via FindMessageTypeByName and queries
the Descriptor's fields.
The FieldDescriptor should preserve the custom json_name.