### PR TITLE
Mark some Bazel targets as "manual."

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -368,7 +368,15 @@ cc_library(
 
 cc_proto_blacklist_test(
     name = "cc_proto_blacklist_test",
-    deps = [proto + "_cc_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()]
+    deps = [proto + "_cc_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()],
+    tags = [
+        # Exclude this target from wildcard expansion (//...). Due to
+        # https://github.com/bazelbuild/bazel/issues/10590, this test has to
+        # be nominated using the `@com_google_protobuf//` prefix. We do that,
+        # e.g., in kokoro/linux/bazel/build.sh.
+        # See also https://github.com/protocolbuffers/protobuf/pull/7096.
+        "manual",
+    ],
 )
 
 ################################################################################
@@ -756,6 +764,13 @@ cc_binary(
     copts = COPTS + [
         "-DPYTHON_PROTO2_CPP_IMPL_V2",
     ],
+    tags = [
+        # Exclude this target from wildcard expansion (//...) because it may
+        # not even be buildable. It will be built if it is needed according
+        # to :use_fast_cpp_protos.
+        # https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes
+        "manual",
+    ],
     linkshared = 1,
     linkstatic = 1,
     deps = select({
@@ -779,6 +794,13 @@ cc_binary(
     includes = [
         "python/",
         "src/",
+    ],
+    tags = [
+        # Exclude this target from wildcard expansion (//...) because it may
+        # not even be buildable. It will be built if it is needed according
+        # to :use_fast_cpp_protos.
+        # https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes
+        "manual",
     ],
     linkshared = 1,
     linkstatic = 1,


### PR DESCRIPTION
The Python C++ extension targets are not used unless
`--@:use_fast_cpp_protos=true`, and may not even be able to build
if the Python headers are missing (note that
`//util/python:python_headers`, bound to `@python_headers//` in
`//:WORKSPACE`, is not currently sufficient). This change adds the
`"manual"` tag to these targets, so that they do not cause
`bazel test ...` to fail when Python headers are missing. Without
the manual tag, the targets are always selected, even if
`--@:use_fast_cpp_protos=false`.

The `:cc_proto_blacklist_test` target is metastable, depending on
whether the `--proto_toolchain_for_cc=` flag names a target with
or without the `@com_google_protobuf//` prefix. We use the correct
prefix for Bazel's default in `kokoro/linux/bazel/build.sh`, but
the `bazel test :cc_proto_blacklist_test` (with or without `//`)
fails consistently. Hopefully, this will be fixed when
bazelbuild/bazel#10590 is addressed.