### PR TITLE
Allow `generate_py_protobufs` to find a custom protoc

### DIFF
--- a/python/protobuf_distutils/protobuf_distutils/generate_py_protobufs.py
+++ b/python/protobuf_distutils/protobuf_distutils/generate_py_protobufs.py
@@ -47,7 +47,7 @@ class generate_py_protobufs(Command):
         ('extra-proto-paths=', None,
          'Additional paths to resolve imports in .proto files.'),
 
-        ('protoc', None,
+        ('protoc=', None,
          'Path to a specific `protoc` command to use.'),
     ]
     boolean_options = ['recurse']

--- a/python/protobuf_distutils/protobuf_distutils/generate_py_protobufs.py
+++ b/python/protobuf_distutils/protobuf_distutils/generate_py_protobufs.py
@@ -128,6 +128,8 @@ class generate_py_protobufs(Command):
         self.ensure_string_list('proto_files')
 
         if self.protoc is None:
+            self.protoc = os.getenv('PROTOC')
+        if self.protoc is None:
             self.protoc = spawn.find_executable('protoc')
 
     def run(self):


### PR DESCRIPTION
Currently, the logic in `generate_py_protobufs` cannot find a custom `protoc` (even though it's supposed to be possible). Fixes:

1. Mark the `--protoc` flag as accepting an argument.
2. If the `--protoc` flag was not passed, try finding `PROTOC` in the environment.
3. (Existing behavior) Otherwise, fall back to `spawn.find_executable`.

Hat tip to @bobhancock for uncovering the problem(s).