### PR TITLE
Override Map.clone to use Map's dup method

### DIFF
--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -827,6 +827,8 @@ void Map_register(VALUE module) {
   rb_define_method(klass, "clear", Map_clear, 0);
   rb_define_method(klass, "length", Map_length, 0);
   rb_define_method(klass, "dup", Map_dup, 0);
+  // Also define #clone so that we don't inherit Object#clone.
+  rb_define_method(klass, "clone", Map_dup, 0);
   rb_define_method(klass, "==", Map_eq, 1);
   rb_define_method(klass, "hash", Map_hash, 0);
   rb_define_method(klass, "to_h", Map_to_h, 0);


### PR DESCRIPTION
Message and Repeated field override clone so that it uses the internal implementation of dup but Map is missing this and only implements dup.  This can lead to unexpected behavior since two out of three complex types behave correctly.