### PR TITLE
Update version number to 3.13.0.1 for php

### DIFF
--- a/php/ext/google/protobuf/package.xml
+++ b/php/ext/google/protobuf/package.xml
@@ -10,11 +10,11 @@
   <email>protobuf-opensource@google.com</email>
   <active>yes</active>
  </lead>
- <date>2020-08-14</date>
+ <date>2020-10-08</date>
  <time>14:07:59</time>
  <version>
-  <release>3.13.0</release>
-  <api>3.13.0</api>
+  <release>3.13.0.1</release>
+  <api>3.13.0.1</api>
  </version>
  <stability>
   <release>stable</release>
@@ -671,6 +671,20 @@ G  A release.
     <api>stable</api>
    </stability>
    <date>2020-08-14</date>
+   <time>14:07:59</time>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <notes>GA release.</notes>
+  </release>
+  <release>
+   <version>
+    <release>3.13.0.1</release>
+    <api>3.13.0.1</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <date>2020-10-08</date>
    <time>14:07:59</time>
    <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
    <notes>GA release.</notes>

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -56,7 +56,7 @@ const zval *get_generated_pool();
 // instead of zval* and zend_string* instead of zval* for property names.
 // https://github.com/php/php-src/blob/php-8.0.0beta1/UPGRADING.INTERNALS#L37-L39
 #if PHP_VERSION_ID < 80000
-#define PROTO_VAL zval 
+#define PROTO_VAL zval
 #define PROTO_STR zval
 #define PROTO_MSG_P(obj) (Message*)Z_OBJ_P(obj)
 #define PROTO_STRVAL_P(obj) Z_STRVAL_P(obj)
@@ -69,7 +69,7 @@ const zval *get_generated_pool();
 #define PROTO_STRLEN_P(obj) ZSTR_LEN(obj)
 #endif
 
-#define PHP_PROTOBUF_VERSION "3.13.0"
+#define PHP_PROTOBUF_VERSION "3.13.0.1"
 
 // ptr -> PHP object cache. This is a weak map that caches lazily-created
 // wrapper objects around upb types:


### PR DESCRIPTION
This release is to fix https://github.com/protocolbuffers/protobuf/issues/7926 and https://github.com/protocolbuffers/protobuf/issues/7812