### PR TITLE
[CMake] Fix a CMake module for support RelWithDebInfo and MinSizeRel install

### DIFF
--- a/cmake/protobuf-module.cmake.in
+++ b/cmake/protobuf-module.cmake.in
@@ -97,6 +97,10 @@ function(_protobuf_find_libraries name filename)
   else()
     get_target_property(${name}_LIBRARY_RELEASE protobuf::lib${filename}
       LOCATION_RELEASE)
+    get_target_property(${name}_LIBRARY_RELWITHDEBINFO protobuf::lib${filename}
+      LOCATION_RELWITHDEBINFO)
+    get_target_property(${name}_LIBRARY_MINSIZEREL protobuf::lib${filename}
+      LOCATION_MINSIZEREL)
     get_target_property(${name}_LIBRARY_DEBUG protobuf::lib${filename}
       LOCATION_DEBUG)
 
@@ -146,6 +150,14 @@ get_target_property(Protobuf_INCLUDE_DIRS protobuf::libprotobuf
 # Set the protoc Executable
 get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
   IMPORTED_LOCATION_RELEASE)
+if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
+  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
+    IMPORTED_LOCATION_RELWITHDEBINFO)
+endif()
+if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
+  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
+    IMPORTED_LOCATION_MINSIZEREL)
+endif()
 if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
   get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
     IMPORTED_LOCATION_DEBUG)


### PR DESCRIPTION
If installed as RelWithDebInfo or MinSizeRel, CMake won't find Protobuf.

```
  CMake Error at C:/Program Files/CMake/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
    Could NOT find Protobuf (missing: Protobuf_PROTOC_EXECUTABLE) (found version "3.13.0.0")
  Call Stack (most recent call first):
    C:/Program Files/CMake/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:393 (_FPHSA_FAILURE_MESSAGE)
    (...)/protobuf-module.cmake:162 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
    (...)/protobuf-config.cmake:149 (include)
    (...)/FindProtobuf.cmake:2 (include)
    cmake/protobuf.cmake:58 (find_package)
    CMakeLists.txt:207 (include)
```