### PR TITLE
JsonParser.withIgnoreUnknownFields true will now ignore unknown enums.

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
@@ -976,6 +976,26 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void UnknownEnum_Ignored()
+        {
+            var parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+            string json = "{ \"single_nested_enum\": \"NOT_VALID_ENUM\"" + ", \"singleString\": \"x\" }";
+            var actual = parser.Parse<TestAllTypes>(json);
+            var expected = new TestAllTypes { SingleString = "x" };
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void KnownEnum_NotIgnored()
+        {
+            var parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+            string json = "{ \"single_nested_enum\": \"FOO\"" + ", \"singleString\": \"x\" }";
+            var actual = parser.Parse<TestAllTypes>(json);
+            var expected = new TestAllTypes { SingleNestedEnum = TestAllTypes.Types.NestedEnum.Foo, SingleString = "x" };
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void NullValueOutsideStruct_NullLiteral()
         {
             string json = "{ \"nullValue\": null }";


### PR DESCRIPTION
There has been some debate in the Protobuf community about whether ignoreUnknownFields should ignore unknown JSON enum representations. Here's the Java unknown enum value issue: https://github.com/protocolbuffers/protobuf/issues/3012 And here's the Swift JSON Protobuf team debating about unknown enums: https://github.com/apple/swift-protobuf/issues/972

The Protobuf spec leaves it up to each language to decide the behavior https://developers.google.com/protocol-buffers/docs/proto3:
> During deserialization, unrecognized enum values will be preserved in the message, though how this is represented when the message is deserialized is language-dependent. In languages that support open enum types with values outside the range of specified symbols, such as C++ and Go, the unknown enum value is simply stored as its underlying integer representation. In languages with closed enum types such as Java, a case in the enum is used to represent an unrecognized value, and the underlying integer can be accessed with special accessors. In either case, if the message is serialized the unrecognized value will still be serialized with the message.

The justification for handling unrecognized enums is for backwards compatibility. For example, a client written against data v1 encounters a new data v2 that has newly added enum values that didn't exist in v1. The client will fail to parse, breaking backward compatibility. Instead, the unknown string could be replaced with some known enum value.

In my pull request, I have simply replaced the unknown enum value with enum value 0. Obviously, this is just a proof of concept as it somewhat breaks backwards compatibility with people who expect an InvalidProtocolBufferException to throw with unrecognized enums. So, to maintain backward compatibility, here are some proposals:

1) Add a JsonParser.Setting called "ignoreUnknownEnums" and set unknown enums to value 0. This is backwards compatible but any protos that use the enum value 0 can be confused as to whether they are unrecognized or simply the default value.
2) Allow an option on enums that specifies the "unrecognized" value for that enum type. If ignoreUnknownFields = true and that option is present, use the enum value specified in the option as the "unrecognized" value.
3) Introduce the concept of "unrecognized" value in enums. This is what Java does, however, it would also break backwards compatibility since Java's unrecognized is -1, and any C# clients that use -1 enum values will conflict.

Solution 1, 2, or 3 would solve the problem for my team. I believe #2 is the best solution but I don't know how to get an option allocated for this use. (#1 is the easiest solution, #3 is nice and similar to Java but causes problems and is quite involved.)