### PR TITLE
Remove GOOGLE_PROTOBUF_SUPPORT_SYSTEM_MEMORY

### DIFF
--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -111,7 +111,6 @@ namespace Google.Protobuf
             get { return Length == 0; }
         }
 
-#if GOOGLE_PROTOBUF_SUPPORT_SYSTEM_MEMORY
         /// <summary>
         /// Provides read-only access to the data of this <see cref="ByteString"/>.
         /// No data is copied so this is the most efficient way of accessing.
@@ -137,7 +136,6 @@ namespace Google.Protobuf
                 return new ReadOnlyMemory<byte>(bytes);
             }
         }
-#endif
 
         /// <summary>
         /// Converts this <see cref="ByteString"/> into a byte array.
@@ -239,7 +237,6 @@ namespace Google.Protobuf
             return new ByteString(portion);
         }
 
-#if GOOGLE_PROTOBUF_SUPPORT_SYSTEM_MEMORY
         /// <summary>
         /// Constructs a <see cref="ByteString" /> from a read only span. The contents
         /// are copied, so further modifications to the span will not
@@ -250,7 +247,6 @@ namespace Google.Protobuf
         {
             return new ByteString(bytes.ToArray());
         }
-#endif
 
         /// <summary>
         /// Creates a new <see cref="ByteString" /> by encoding the specified text with

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -19,7 +19,6 @@
     <PackageLicenseUrl>https://github.com/protocolbuffers/protobuf/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/protocolbuffers/protobuf.git</RepositoryUrl>
-    <DefineConstants>$(DefineConstants);GOOGLE_PROTOBUF_SUPPORT_SYSTEM_MEMORY</DefineConstants>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/csharp/src/Google.Protobuf/IBufferMessage.cs
+++ b/csharp/src/Google.Protobuf/IBufferMessage.cs
@@ -32,7 +32,6 @@
 
 namespace Google.Protobuf
 {
-#if GOOGLE_PROTOBUF_SUPPORT_SYSTEM_MEMORY
     /// <summary>
     /// Interface for a Protocol Buffers message, supporting
     /// parsing from <see cref="ParseContext"/> and writing to <see cref="WriteContext"/>.
@@ -51,5 +50,4 @@ namespace Google.Protobuf
         /// </summary>        
         void InternalWriteTo(ref WriteContext ctx);
     }
-#endif
 }


### PR DESCRIPTION
Compiler flag `GOOGLE_PROTOBUF_SUPPORT_SYSTEM_MEMORY` is no longer needed. It is always true.