### PR TITLE
Bump the podspec iOS min to 9.0

### DIFF
--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.user_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1' }
   s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1' }
 
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'

--- a/objectivec/Tests/CocoaPods/iOSCocoaPodsTester/Podfile-framework
+++ b/objectivec/Tests/CocoaPods/iOSCocoaPodsTester/Podfile-framework
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/objectivec/Tests/CocoaPods/iOSCocoaPodsTester/Podfile-static
+++ b/objectivec/Tests/CocoaPods/iOSCocoaPodsTester/Podfile-static
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 


### PR DESCRIPTION
Xcode 12+ issue a warning when targeting older iOS versions, so avoid
the issue. #7980 updated the Xcode projects already.