### PR TITLE
Fixed PHP version and release notes

### DIFF
--- a/php/ext/google/protobuf/package.xml
+++ b/php/ext/google/protobuf/package.xml
@@ -21,7 +21,6 @@
   <api>beta</api>
  </stability>
  <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
- <notes>GA release.</notes>
  <contents>
   <dir baseinstalldir="/" name="/">
     <file baseinstalldir="/" name="config.m4" role="src"/>

--- a/php/ext/google/protobuf/protobuf.c
+++ b/php/ext/google/protobuf/protobuf.c
@@ -311,7 +311,7 @@ zend_module_entry protobuf_module_entry = {
   PHP_RINIT(protobuf),      // request shutdown
   PHP_RSHUTDOWN(protobuf),  // request shutdown
   NULL,                     // extension info
-  "3.13.0",                 // extension version
+  PHP_PROTOBUF_VERSION,     // extension version
   PHP_MODULE_GLOBALS(protobuf),  // globals descriptor
   PHP_GINIT(protobuf),      // globals ctor
   PHP_GSHUTDOWN(protobuf),  // globals dtor


### PR DESCRIPTION
This commit updates protobuf.c to refer to the PHP version macro so that
it stays up to date. I also deleted the notes element near the top of
package.xml. This seems to be a global notes field rather than a
per-release field, so it was showing up on new releases where it doesn't
make sense.

Fixes #8017.