### PR TITLE
Fix bug in parsing delimited messages at the end of an input stream

### DIFF
--- a/src/google/protobuf/util/delimited_message_util.cc
+++ b/src/google/protobuf/util/delimited_message_util.cc
@@ -74,6 +74,8 @@ bool ParseDelimitedFromCodedStream(MessageLite* message,
     return false;
   }
 
+  // Get the position after any size bytes have been read (and only the message
+  // itself remains).
   int position_after_size = input->CurrentPosition();
 
   // Tell the stream not to read beyond that size.
@@ -82,7 +84,8 @@ bool ParseDelimitedFromCodedStream(MessageLite* message,
   // Parse the message.
   if (!message->MergeFromCodedStream(input)) return false;
   if (!input->ConsumedEntireMessage()) return false;
-  if (input->CurrentPosition() - position_after_size != int{size}) return false;
+  if (input->CurrentPosition() - position_after_size != static_cast<int>(size))
+    return false;
 
   // Release the limit.
   input->PopLimit(limit);

--- a/src/google/protobuf/util/delimited_message_util.cc
+++ b/src/google/protobuf/util/delimited_message_util.cc
@@ -74,12 +74,15 @@ bool ParseDelimitedFromCodedStream(MessageLite* message,
     return false;
   }
 
+  int position_after_size = input->CurrentPosition();
+
   // Tell the stream not to read beyond that size.
   io::CodedInputStream::Limit limit = input->PushLimit(size);
 
   // Parse the message.
   if (!message->MergeFromCodedStream(input)) return false;
   if (!input->ConsumedEntireMessage()) return false;
+  if (input->CurrentPosition() - position_after_size != int{size}) return false;
 
   // Release the limit.
   input->PopLimit(limit);


### PR DESCRIPTION
Currently, there is a bug in parsing of delimited messages near the end of an input stream. For example:

Assume that an input stream has 3 remaining bytes:
  `7 4 12`
Calling  ParseDelimitedFromCodedStream() on this input will return true if `4 12` parses to a valid message, even though the input isn't of length 7, because <= 7 bytes are parsed

This PR adds validation that the length of the message matches what is denoted by the length byte(s)