### PR TITLE
Update param type for PHP Internal Mapfield::offsetGet

### DIFF
--- a/php/src/Google/Protobuf/Internal/MapField.php
+++ b/php/src/Google/Protobuf/Internal/MapField.php
@@ -129,7 +129,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * This will also be called for: $ele = $arr[$key]
      *
-     * @param object $key The key of the element to be fetched.
+     * @param int|bool|string $key The key of the element to be fetched.
      * @return object The stored element at given key.
      * @throws \ErrorException Invalid type for index.
      * @throws \ErrorException Non-existing index.


### PR DESCRIPTION
This is a minor doctype change for the PHP codebase, Internal\Mapfield::offsetGet method

The param was typed as `object` which is invalid as when items are set in the container the key passes through `checkKey` where it enforces the key must be various classes of integer, bool or string. Thus I have replaced it with a union type (in future this can be a proper PHP level typehint, but for now only doctype)

I encountered this whilst using a client that consumes protocol buffers, and found that my IDE was telling me that `$item->offsetGet('key')` was invalid, yet on running the code I got the expected output from the Map container.