### PR TITLE
[python] implement buffer protocol for repeated primitive fields

### DIFF
--- a/python/google/protobuf/internal/containers.py
+++ b/python/google/protobuf/internal/containers.py
@@ -291,6 +291,20 @@ class RepeatedScalarFieldContainer(BaseContainer):
     self._values.extend(other._values)
     self._message_listener.Modified()
 
+  def Resize(self, count):
+    """Resizes to the specified number of elements in the container. Only valid for primtive types."""
+    if len(self._values) >= count:
+      return
+
+    if count < 0:
+      raise ValueError("resize count was negative %d" % count)
+
+    if not hasattr(self._type_checker, 'DefaultValue'):
+      raise TypeError("resize not supported for this type")
+
+    while len(self._values) < count:
+      self.append(self._type_checker.DefaultValue())
+
   def remove(self, elem):
     """Removes an item from the list. Similar to list.remove()."""
     self._values.remove(elem)


### PR DESCRIPTION
This PR adds support for the buffer protocol (`memoryview`) and a `resize` method to the Python APIs, allowing much faster deserialization when interacting with other modules able to consume and produce raw memory. This gives moderate to massive speed up for deserialization (8x at 200 items, 80x! at 2000), with only moderate gains for serialization (~2.2 ~ 3.2).

The [buffer protocol](https://www.python.org/dev/peps/pep-3118/) is a Python API allowing objects to expose internal buffers, intended to improve interoperability between different C-level modules. These buffers are passed as `Py_buffer` objects, which annotate a {ptr, count} pair with information about the type and shape of the pointed-at data. In this PR I've implemented this based on CPP_TYPE, mapping each type I felt safe to expose to the corresponding Python buffer type. 

Unfortunately, this uses a deprecated API (`MutableRepeatedField(...)`), but it looks like the newer APIs are more restrictive and don't let you retrieve a pointer, or even access data when it's inside the buffer. I think the gains here speak for themselves in terms of usefulness - for us, we'd reduce the GRPC overhead by several milliseconds, so if this deprecated usage is a blocker we should try to forge another way forward.

This is potentially a resolution for #6782.

This is my benchmarking script if you'd like to validate the results.

```python3
import numpy as np
import timeit
from itertools import chain
from benchmark_pb2 import Collection, Data

# benchmark.proto
# syntax = "proto3";
# package benchmark;
# message Data {
#     repeated float values = 1;
# }
# message Collection {
#     repeated Data sets = 2;
# }


ITER_COUNT = 1000


def simple(collection):
    return np.array([list(d.values) for d in collection.sets])


def array_from_iter(collection):
    value_count = len(collection.sets[0].values)
    return np.array([np.fromiter(d.values, dtype=np.float32, count=value_count) for d in collection.sets])


def array_from_slice(collection):
    return np.array([d.values[:] for d in collection.sets])


def from_iter_reshape(collection):
    set_count = len(collection.sets)
    value_count = len(collection.sets[0].values)
    total = set_count * value_count
    return np.fromiter(chain.from_iterable(d.values for d in collection.sets), dtype=np.float32, count=total).reshape(set_count, value_count)


def from_buffer_array(collection):
    value_count = len(collection.sets[0].values)
    return np.array([np.frombuffer(memoryview(d.values), dtype=np.float32, count=value_count) for d in collection.sets])


def eval(func, collection):
    average_time = timeit.timeit(lambda: func(collection), number=ITER_COUNT)
    print(f'{func.__name__}: {average_time / ITER_COUNT * 1000} ms')
    return average_time


def simple_write(values):
    return Collection(sets=[Data(values=value.tolist()) for value in values])


def from_memory_view(values):
    sets = []
    value_count = len(values[0])
    for val in values:
        d = Data()
        d.values.Resize(value_count)  # n.b. this is type-sensitive
        memoryview(d.values)[:] = val.data
        sets.append(d)

    return Collection(sets=sets)


def eval_write(func, collection):
    average_time = timeit.timeit(lambda: func(collection), number=ITER_COUNT)
    print(f'{func.__name__}: {average_time / ITER_COUNT * 1000} ms')
    return average_time


def eval_count(n):
    collection = Collection(sets=[Data(values=list(range(n))) for _ in range(32)])
    values = [np.array(list(range(n)), dtype=np.float32) for _ in range(32)]
    print(f'Count == {n}')
    print('To numpy')
    t0 = eval(simple, collection)
    t1 = eval(array_from_iter, collection)
    t2 = eval(array_from_slice, collection)
    t3 = eval(from_iter_reshape, collection)
    t4 = eval(from_buffer_array, collection)

    maxv = max(t0, t1, t2, t3, t4)
    print(f'Perf gain vs best: {maxv/t4}')

    print('\nFrom numpy')
    t1 = eval_write(simple_write, values)
    t2 = eval_write(from_memory_view, values)
    print(f'Perf gain: {t1/t2}')
    print('\n\n')


eval_count(200)
eval_count(500)
eval_count(1000)
eval_count(2000)
```