### PR TITLE
Fix detecting file as directory on zOS issue #8051

### DIFF
--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -495,10 +495,17 @@ io::ZeroCopyInputStream* DiskSourceTree::OpenDiskFile(
   do {
     ret = stat(filename.c_str(), &sb);
   } while (ret != 0 && errno == EINTR);
+#if defined(_WIN32)
+  if (ret == 0 && sb.st_mode & S_IFDIR) {
+      last_error_message_ = "Input file is a directory.";
+      return NULL;
+  }
+#elif
   if (ret == 0 && S_ISDIR(sb.st_mode)) {
     last_error_message_ = "Input file is a directory.";
     return NULL;
   }
+#endif
   int file_descriptor;
   do {
     file_descriptor = open(filename.c_str(), O_RDONLY);

--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -495,7 +495,7 @@ io::ZeroCopyInputStream* DiskSourceTree::OpenDiskFile(
   do {
     ret = stat(filename.c_str(), &sb);
   } while (ret != 0 && errno == EINTR);
-  if (ret == 0 && sb.st_mode & S_IFDIR) {
+  if (ret == 0 && S_ISDIR(sb.st_mode)) {
     last_error_message_ = "Input file is a directory.";
     return NULL;
   }

--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -500,7 +500,7 @@ io::ZeroCopyInputStream* DiskSourceTree::OpenDiskFile(
       last_error_message_ = "Input file is a directory.";
       return NULL;
   }
-#elif
+#else
   if (ret == 0 && S_ISDIR(sb.st_mode)) {
     last_error_message_ = "Input file is a directory.";
     return NULL;


### PR DESCRIPTION
sys/stat.h provides macros like S_ISDIR to test for a directory. The macro S_IFDIR should not be used in this way since it has different result on zOS(Always detecting file as directory as a consequence).