### PR TITLE
Fix some -Wunused-parameter warnings

### DIFF
--- a/src/google/protobuf/arenastring.h
+++ b/src/google/protobuf/arenastring.h
@@ -329,6 +329,8 @@ inline void ArenaStringPtr::Swap(ArenaStringPtr* other,
     this_ptr->swap(*other_ptr);
   }
 #else
+  (void) default_value;
+  (void) arena;
   std::swap(tagged_ptr_, other->tagged_ptr_);
 #endif
 }

--- a/src/google/protobuf/generated_message_reflection.h
+++ b/src/google/protobuf/generated_message_reflection.h
@@ -236,7 +236,7 @@ struct ReflectionSchema {
 
   // We tag offset values to provide additional data about fields (such as
   // "unused").
-  static uint32 OffsetValue(uint32 v, FieldDescriptor::Type type) {
+  static uint32 OffsetValue(uint32 v, FieldDescriptor::Type /* type */) {
     return v & 0x7FFFFFFFu;
   }
 };

--- a/src/google/protobuf/map_type_handler.h
+++ b/src/google/protobuf/map_type_handler.h
@@ -569,7 +569,7 @@ inline bool MapTypeHandler<WireFormatLite::TYPE_MESSAGE, Type>::IsInitialized(
   }                                                                           \
   template <typename Type>                                                    \
   inline void MapTypeHandler<WireFormatLite::TYPE_##FieldType, Type>::Clear(  \
-      TypeOnMemory* value, Arena* arena) {                                    \
+      TypeOnMemory* value, Arena* /* arena */) {                              \
     value->ClearToEmpty();                                                    \
   }                                                                           \
   template <typename Type>                                                    \


### PR DESCRIPTION
With every release new unused parameters appear in the codebase (the previous one was fixed in #7878).

@acozzette, is there any option to ensure the absence of such parameters via CI / testing?