### PR TITLE
Install examples in `/usr/local/share/protobuf/examples`.

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -102,12 +102,16 @@ endforeach()
 
 # Install configuration
 set(_cmakedir_desc "Directory relative to CMAKE_INSTALL to install the cmake configuration files")
+set(_exampledir_desc "Directory relative to CMAKE_INSTALL_DATA to install examples")
 if(NOT MSVC)
   set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/protobuf" CACHE STRING "${_cmakedir_desc}")
+  set(CMAKE_INSTALL_EXAMPLEDIR "${CMAKE_INSTALL_DATADIR}/protobuf/examples" CACHE STRING "${_exampledir_desc}")
 else()
   set(CMAKE_INSTALL_CMAKEDIR "cmake" CACHE STRING "${_cmakedir_desc}")
+  set(CMAKE_INSTALL_EXAMPLEDIR "examples" CACHE STRING "${_exampledir_desc}")
 endif()
 mark_as_advanced(CMAKE_INSTALL_CMAKEDIR)
+mark_as_advanced(CMAKE_INSTALL_EXAMPLEDIR)
 
 configure_file(protobuf-config.cmake.in
   ${CMAKE_INSTALL_CMAKEDIR}/protobuf-config.cmake @ONLY)
@@ -145,6 +149,7 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/
 
 option(protobuf_INSTALL_EXAMPLES "Install the examples folder" OFF)
 if(protobuf_INSTALL_EXAMPLES)
-  install(DIRECTORY ../examples/ DESTINATION examples
+  install(DIRECTORY ../examples/
+    DESTINATION "${CMAKE_INSTALL_EXAMPLEDIR}"
     COMPONENT protobuf-examples)
 endif()


### PR DESCRIPTION
`/usr/local/example` should not be used without protobuf subdir.
Resolve https://github.com/protocolbuffers/protobuf/issues/8073