### PR TITLE
Add zOS build support to protocolbuffer

### DIFF
--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -131,7 +131,9 @@
 #pragma runtime_checks("c", off)
 #endif
 #else
+#if !defined(__MVS__)
 #include <sys/param.h>  // __BYTE_ORDER
+#endif
 #if ((defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)) ||    \
      (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN)) && \
     !defined(PROTOBUF_DISABLE_LITTLE_ENDIAN_OPT_FOR_TEST)

--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -276,12 +276,14 @@
 #define PROTOBUF_COLD
 
 // Copied from ABSL.
-#if defined(__clang__) && defined(__has_warning)
+#if defined(__clang__) && defined(__has_warning) && !defined (__MVS__)
 #if __has_feature(cxx_attributes) && __has_warning("-Wimplicit-fallthrough")
 #define PROTOBUF_FALLTHROUGH_INTENDED [[clang::fallthrough]]
 #endif
 #elif defined(__GNUC__) && __GNUC__ >= 7
 #define PROTOBUF_FALLTHROUGH_INTENDED [[gnu::fallthrough]]
+#elif defined (__MVS__)
+#define PROTOBUF_FALLTHROUGH_INTENDED [[clang::fallthrough]]
 #endif
 
 #ifndef PROTOBUF_FALLTHROUGH_INTENDED

--- a/src/google/protobuf/stubs/mutex.h
+++ b/src/google/protobuf/stubs/mutex.h
@@ -47,7 +47,7 @@
 
 // Define thread-safety annotations for use below, if we are building with
 // Clang.
-#if defined(__clang__) && !defined(SWIG)
+#if defined(__clang__) && !defined(SWIG) && !defined(__MVS__)
 #define GOOGLE_PROTOBUF_ACQUIRE(...) \
   __attribute__((acquire_capability(__VA_ARGS__)))
 #define GOOGLE_PROTOBUF_RELEASE(...) \

--- a/src/google/protobuf/stubs/platform_macros.h
+++ b/src/google/protobuf/stubs/platform_macros.h
@@ -83,7 +83,7 @@
 # if (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4))
 // We fallback to the generic Clang/GCC >= 4.7 implementation in atomicops.h
 # elif defined(__clang__)
-#  if !__has_extension(c_atomic)
+#  if !__has_extension(c_atomic) && !defined(__MVS__)
 GOOGLE_PROTOBUF_PLATFORM_ERROR
 #  endif
 // We fallback to the generic Clang/GCC >= 4.7 implementation in atomicops.h

--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -57,7 +57,9 @@
 #pragma runtime_checks("c", off)
 #endif
 #else
+  #if !defined(__MVS__)
   #include <sys/param.h>   // __BYTE_ORDER
+  #endif
   #if defined(__OpenBSD__)
     #include <endian.h>
   #endif


### PR DESCRIPTION
This change is to enable building protocolbuffer on zOS. The change is not introducing any new features and build system . This means it would not break many people's projects and is safe.