### PR TITLE
Register mark objects so Protobuf is compaction friendly

### DIFF
--- a/ruby/ext/google/protobuf_c/protobuf.c
+++ b/ruby/ext/google/protobuf_c/protobuf.c
@@ -30,7 +30,6 @@
 
 #include "protobuf.h"
 
-VALUE cError;
 VALUE cParseError;
 VALUE cTypeError;
 VALUE c_only_cookie = Qnil;
@@ -113,9 +112,10 @@ void Init_protobuf_c() {
   RepeatedField_register(protobuf);
   Map_register(protobuf);
 
-  cError = rb_const_get(protobuf, rb_intern("Error"));
   cParseError = rb_const_get(protobuf, rb_intern("ParseError"));
+  rb_gc_register_mark_object(cParseError);
   cTypeError = rb_const_get(protobuf, rb_intern("TypeError"));
+  rb_gc_register_mark_object(cTypeError);
 
   rb_define_singleton_method(protobuf, "discard_unknown",
                              Google_Protobuf_discard_unknown, 1);

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -183,7 +183,6 @@ extern VALUE cEnumBuilderContext;
 extern VALUE cFileBuilderContext;
 extern VALUE cBuilder;
 
-extern VALUE cError;
 extern VALUE cParseError;
 extern VALUE cTypeError;
 


### PR DESCRIPTION
This is a rebased version of #6073

Since that PR was originally sent GC compaction has shipped with Ruby 2.7 and many tools will use it by default (for example `puma` and `sidekiq`). This gem is now unsafe and has potential for memory errors because this has not been fixed.

This commit removes an unused reference and registers globals with the GC so that they will never die.  Ruby is getting a compacting GC, and it means that these references can move.  Registering them with `rb_gc_register_mark_object` will ensure the constants don't move and will not be collected.