### PR TITLE
Work around -Werror=type-limits under gcc 10.2

### DIFF
--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -428,7 +428,7 @@ class PROTOBUF_EXPORT ParseContext : public EpsCopyInputStream {
 template <uint32 tag>
 bool ExpectTag(const char* ptr) {
   if (tag < 128) {
-    return *ptr == tag;
+    return *ptr == tag % 128;
   } else {
     static_assert(tag < 128 * 128, "We only expect tags for 1 or 2 bytes");
     char buf[2] = {static_cast<char>(tag | 0x80), static_cast<char>(tag >> 7)};

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -428,7 +428,7 @@ class PROTOBUF_EXPORT ParseContext : public EpsCopyInputStream {
 template <uint32 tag>
 bool ExpectTag(const char* ptr) {
   if (tag < 128) {
-    return *ptr == tag % 128;
+    return *ptr == static_cast<char>(tag);
   } else {
     static_assert(tag < 128 * 128, "We only expect tags for 1 or 2 bytes");
     char buf[2] = {static_cast<char>(tag | 0x80), static_cast<char>(tag >> 7)};


### PR DESCRIPTION
This is an error when tag is greater than 128 under gcc 10.2:   if (tag < 128) return *ptr == tag;
It's an error even though the comparison occurs in a branch of code we know won't be taken.  See https://godbolt.org/z/1eaP86
This works around the problem by clipping tag to within bounds.