### PR TITLE
Don't include sys/param.h for _BYTE_ORDER

### DIFF
--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -131,7 +131,11 @@
 #pragma runtime_checks("c", off)
 #endif
 #else
-#include <sys/param.h>  // __BYTE_ORDER
+#ifdef __APPLE__
+#include <machine/endian.h>  // __BYTE_ORDER
+#else
+#include <endian.h>  // __BYTE_ORDER
+#endif
 #if ((defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)) ||    \
      (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN)) && \
     !defined(PROTOBUF_DISABLE_LITTLE_ENDIAN_OPT_FOR_TEST)

--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -57,9 +57,10 @@
 #pragma runtime_checks("c", off)
 #endif
 #else
-  #include <sys/param.h>   // __BYTE_ORDER
-  #if defined(__OpenBSD__)
-    #include <endian.h>
+  #ifdef __APPLE__
+    #include <machine/endian.h>  // __BYTE_ORDER
+  #else
+    #include <endian.h>  // __BYTE_ORDER
   #endif
   #if ((defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)) || \
          (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN) || \


### PR DESCRIPTION
It includes a bunch of other files including a lot of macros which can
reduce the namespace available for actual protobuf.

For example, create a protobuf with a member called SIGSEGV. Since
macros cannot be namespaced in C++ this results in code which cannot be
compiled.

Fix this by just directly including endian.h