### PR TITLE
Allocate extension 1089 to ScalaPB validate

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -252,3 +252,7 @@ with info about your project (name and website) so we can add an entry for you.
 1. Confluent Schema Registry
    * Website: https://github.com/confluentinc/schema-registry
    * Extensions: 1088
+   
+1. ScalaPB Validate
+   * Website: https://scalapb.github.io/docs/validation
+   * Extension: 1089


### PR DESCRIPTION
ScalaPB validate is a sub-package of ScalaPB that allows user to generate data validation code for ScalaPB generated classes.