### PR TITLE
Make MessageToDict convert map keys to strings

### DIFF
--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -236,7 +236,7 @@ class _Printer(object):
               else:
                 recorded_key = 'false'
             else:
-              recorded_key = key
+              recorded_key = str(key)
             js_map[recorded_key] = self._FieldToJsonObject(
                 v_field, value[key])
           js[name] = js_map


### PR DESCRIPTION
According to the [language guide](https://developers.google.com/protocol-buffers/docs/proto3#json), the JSON map keys should be in string form.