### PR TITLE
fix uint32 values on 64bit arch

### DIFF
--- a/php/ext/google/protobuf/convert.c
+++ b/php/ext/google/protobuf/convert.c
@@ -446,8 +446,7 @@ void Convert_UpbToPhp(upb_msgval upb_val, zval *php_val, upb_fieldtype_t type,
       ZVAL_LONG(php_val, upb_val.int32_val);
       break;
     case UPB_TYPE_UINT32: {
-      // Sign-extend for consistency between 32/64-bit builds.
-      zend_long val = (int32_t)upb_val.uint32_val;
+      zend_long val = upb_val.uint32_val;
       ZVAL_LONG(php_val, val);
       break;
     }


### PR DESCRIPTION
At the moment protobuf PHP extension casts all uint32 values to int32_t before assigning the result to zend_long (aka int64_t). The comment in the sources say it's done to for consistency between 32/64-bit builds.

I suggest a patch that removes this code since it in fact renders uint32 type pretty useless on 64bit arch - all values greater than INT32_MAX become negative, so one has to fix them manually before using in other places like databases or requests to other services not involving gRPC (or protobuf at all).

It looks like the code tried to keep the 32bit behaviour on 64bit (please correct me if I'm wrong), but I can't think of any reason to do it. 
I mean, yes, PHP doesn't have an "unsigned integer" type, it just uses the biggest integer available, so it's int32 on 32bit and int64 on 64bit. Yes, int32 used by 32bit PHP cannot fit all the values of uint32 properly. But this is something that should be worked around on 32bit machines, not cause problems while running the same code on 64bit.

I haven't seen 32bit machines for about 15 years now, maybe more. 
I think it's a good moment to drop 32bit support and live in the future world :)