### PR TITLE
Optimize writing small strings

### DIFF
--- a/csharp/src/Google.Protobuf.Test/CodedOutputStreamTest.cs
+++ b/csharp/src/Google.Protobuf.Test/CodedOutputStreamTest.cs
@@ -35,6 +35,7 @@ using System.IO;
 using Google.Protobuf.TestProtos;
 using Google.Protobuf.Buffers;
 using NUnit.Framework;
+using System.Text;
 
 namespace Google.Protobuf
 {
@@ -515,6 +516,29 @@ namespace Google.Protobuf
         {
             var stream = new CodedOutputStream(new byte[10]);
             stream.Dispose();
+        }
+
+        [Test]
+        public void WriteStringsOfDifferentSizes()
+        {
+            for (int i = 1; i <= 1024; i++)
+            {
+                var buffer = new byte[4096];
+                var output = new CodedOutputStream(buffer);
+                var sb = new StringBuilder();
+                for (int j = 0; j < i; j++)
+                {
+                    sb.Append((j % 10).ToString()); // incrementing numbers, repeating
+                }
+                var s = sb.ToString();
+                output.WriteString(s);
+
+                output.Flush();
+
+                // Verify written content
+                var input = new CodedInputStream(buffer);
+                Assert.AreEqual(s, input.ReadString());
+            }
         }
     }
 }

--- a/csharp/src/Google.Protobuf/WritingPrimitives.cs
+++ b/csharp/src/Google.Protobuf/WritingPrimitives.cs
@@ -163,10 +163,26 @@ namespace Google.Protobuf
         /// </summary>
         public static void WriteString(ref Span<byte> buffer, ref WriterInternalState state, string value)
         {
-            // Optimise the case where we have enough space to write
-            // the string directly to the buffer, which should be common.
+            const int MaxBytesPerChar = 3;
+            const int MaxSmallStringLength = 128 / MaxBytesPerChar;
+
+            // The string is small enough that the length will always be a 1 byte varint.
+            // Also there is enough space to write length + bytes to buffer.
+            // Write string directly to the buffer, and then write length.
+            // This saves calling GetByteCount on the string. We get the string length from GetBytes.
+            if (value.Length <= MaxSmallStringLength && buffer.Length - state.position - 1 >= value.Length * MaxBytesPerChar)
+            {
+                // Get the original position, then increment it on state by 1, then write string to buffer.
+                // Method will return byte length, which is then set to the original position.
+                buffer[state.position++] = (byte)WriteStringToBuffer(buffer, ref state, value);
+                return;
+            }
+
             int length = Utf8Encoding.GetByteCount(value);
             WriteLength(ref buffer, ref state, length);
+
+            // Optimise the case where we have enough space to write
+            // the string directly to the buffer, which should be common.
             if (buffer.Length - state.position >= length)
             {
                 if (length == value.Length) // Must be all ASCII...
@@ -179,23 +195,7 @@ namespace Google.Protobuf
                 }
                 else
                 {
-#if NETSTANDARD1_1
-                    // slowpath when Encoding.GetBytes(Char*, Int32, Byte*, Int32) is not available
-                    byte[] bytes = Utf8Encoding.GetBytes(value);
-                    WriteRawBytes(ref buffer, ref state, bytes);
-#else
-                    ReadOnlySpan<char> source = value.AsSpan();
-                    int bytesUsed;
-                    unsafe
-                    {
-                        fixed (char* sourceChars = &MemoryMarshal.GetReference(source))
-                        fixed (byte* destinationBytes = &MemoryMarshal.GetReference(buffer.Slice(state.position)))
-                        {
-                            bytesUsed = Utf8Encoding.GetBytes(sourceChars, source.Length, destinationBytes, buffer.Length);
-                        }
-                    }
-                    state.position += bytesUsed;
-#endif
+                    WriteStringToBuffer(buffer, ref state, value);
                 }
             }
             else
@@ -207,6 +207,33 @@ namespace Google.Protobuf
                 byte[] bytes = Utf8Encoding.GetBytes(value);
                 WriteRawBytes(ref buffer, ref state, bytes);
             }
+        }
+
+        private static int WriteStringToBuffer(Span<byte> buffer, ref WriterInternalState state, string value)
+        {
+#if NETSTANDARD1_1
+            // slowpath when Encoding.GetBytes(Char*, Int32, Byte*, Int32) is not available
+            byte[] bytes = Utf8Encoding.GetBytes(value);
+            WriteRawBytes(ref buffer, ref state, bytes);
+            return bytes.Length;
+#else
+            ReadOnlySpan<char> source = value.AsSpan();
+            int bytesUsed;
+            unsafe
+            {
+                fixed (char* sourceChars = &MemoryMarshal.GetReference(source))
+                fixed (byte* destinationBytes = &MemoryMarshal.GetReference(buffer))
+                {
+                    bytesUsed = Utf8Encoding.GetBytes(
+                        sourceChars,
+                        source.Length,
+                        destinationBytes + state.position,
+                        buffer.Length - state.position);
+                }
+            }
+            state.position += bytesUsed;
+            return bytesUsed;
+#endif
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/WritingPrimitives.cs
+++ b/csharp/src/Google.Protobuf/WritingPrimitives.cs
@@ -172,9 +172,8 @@ namespace Google.Protobuf
             // This saves calling GetByteCount on the string. We get the string length from GetBytes.
             if (value.Length <= MaxSmallStringLength && buffer.Length - state.position - 1 >= value.Length * MaxBytesPerChar)
             {
-                // Get the original position, then increment it on state by 1, then write string to buffer.
-                // Method will return byte length, which is then set to the original position.
-                buffer[state.position++] = (byte)WriteStringToBuffer(buffer, ref state, value);
+                int indexOfLengthDelimiter = state.position++;
+                buffer[indexOfLengthDelimiter] = (byte)WriteStringToBuffer(buffer, ref state, value);
                 return;
             }
 


### PR DESCRIPTION
If a string is 42 characters or less then its length will always fit in 1 byte. If there is space available in the buffer, write directly to the buffer, then write the length afterwards based on the number of bytes written. Avoids having to calculate the size.

Slightly slower for 1 byte ASCII strings, faster for all other strings 42 chars or less.

@jtattermusch 

Before
```
|                           Method | BytesToWrite | encodedSize |       Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------- |------------- |------------ |-----------:|----------:|----------:|------:|------:|------:|----------:|
|         WriteString_WriteContext |        10080 |           1 | 149.235 us | 1.5862 us | 1.4061 us |     - |     - |     - |       2 B |
|         WriteString_WriteContext |        10080 |           4 |  48.668 us | 0.4787 us | 0.4478 us |     - |     - |     - |       1 B |
| WriteNonAsciiString_WriteContext |        10080 |           4 |  99.273 us | 1.4526 us | 1.2877 us |     - |     - |     - |       1 B |
|         WriteString_WriteContext |        10080 |          10 |  25.254 us | 0.2668 us | 0.2365 us |     - |     - |     - |         - |
| WriteNonAsciiString_WriteContext |        10080 |          10 |  61.336 us | 0.3819 us | 0.3573 us |     - |     - |     - |         - |
|         WriteString_WriteContext |        10080 |         105 |  11.158 us | 0.1050 us | 0.0931 us |     - |     - |     - |         - |
| WriteNonAsciiString_WriteContext |        10080 |         105 |   9.676 us | 0.1001 us | 0.0937 us |     - |     - |     - |         - |
|         WriteString_WriteContext |        10080 |       10080 |   8.997 us | 0.0433 us | 0.0405 us |     - |     - |     - |         - |
| WriteNonAsciiString_WriteContext |        10080 |       10080 |   4.459 us | 0.0446 us | 0.0418 us |     - |     - |     - |         - |
```

After
```
|                           Method | BytesToWrite | encodedSize |       Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------- |------------- |------------ |-----------:|----------:|----------:|------:|------:|------:|----------:|
|         WriteString_WriteContext |        10080 |           1 | 173.719 us | 2.6596 us | 2.4878 us |     - |     - |     - |       2 B |
|         WriteString_WriteContext |        10080 |           4 |  44.960 us | 0.6183 us | 0.5481 us |     - |     - |     - |       1 B |
| WriteNonAsciiString_WriteContext |        10080 |           4 |  56.988 us | 0.2900 us | 0.2571 us |     - |     - |     - |         - |
|         WriteString_WriteContext |        10080 |          10 |  19.008 us | 0.3009 us | 0.2349 us |     - |     - |     - |         - |
| WriteNonAsciiString_WriteContext |        10080 |          10 |  24.667 us | 0.2239 us | 0.2094 us |     - |     - |     - |         - |
|         WriteString_WriteContext |        10080 |         105 |  11.563 us | 0.0841 us | 0.0745 us |     - |     - |     - |         - |
| WriteNonAsciiString_WriteContext |        10080 |         105 |   9.856 us | 0.0580 us | 0.0543 us |     - |     - |     - |         - |
|         WriteString_WriteContext |        10080 |       10080 |   9.143 us | 0.0960 us | 0.0851 us |     - |     - |     - |         - |
| WriteNonAsciiString_WriteContext |        10080 |       10080 |   4.458 us | 0.0306 us | 0.0256 us |     - |     - |     - |         - |
```