### PR TITLE
remove CMAKE_THREAD_LIBS_INIT from pkgconfig CFLAGS

### DIFF
--- a/cmake/protobuf-lite.pc.cmake
+++ b/cmake/protobuf-lite.pc.cmake
@@ -7,5 +7,5 @@ Name: Protocol Buffers
 Description: Google's Data Interchange Format
 Version: @protobuf_VERSION@
 Libs: -L${libdir} -lprotobuf-lite @CMAKE_THREAD_LIBS_INIT@
-Cflags: -I${includedir} @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir}
 Conflicts: protobuf

--- a/cmake/protobuf.pc.cmake
+++ b/cmake/protobuf.pc.cmake
@@ -7,5 +7,5 @@ Name: Protocol Buffers
 Description: Google's Data Interchange Format
 Version: @protobuf_VERSION@
 Libs: -L${libdir} -lprotobuf @CMAKE_THREAD_LIBS_INIT@
-Cflags: -I${includedir} @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir}
 Conflicts: protobuf-lite


### PR DESCRIPTION
This is a linker flag and does not belong in CFLAGS.

Fixes an issue with ola and protobuf.

Signed-off-by: Rosen Penev <rosenp@gmail.com>