### PR TITLE
Fix TextFormatMapTest.DynamicMessage issue#5136

### DIFF
--- a/src/google/protobuf/map_test.cc
+++ b/src/google/protobuf/map_test.cc
@@ -3528,6 +3528,7 @@ TEST(TextFormatMapTest, DynamicMessage) {
                                                   "testdata/map_test_data.txt"),
                         &expected_text, true));
 
+  CleanStringLineEndings(&expected_text, false);
   EXPECT_EQ(message->DebugString(), expected_text);
 }
 


### PR DESCRIPTION
Clean up a multi-line string to conform to Unix line endings.