### PR TITLE
Fix Mac tests by making an unshallow copy of Homebrew repos

### DIFF
--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -37,9 +37,13 @@ sudo rm -rf \
 sudo rm -rf \
     /usr/local/bin/2to3* \
     /usr/local/bin/idle3* \
+    /usr/local/bin/pip3 \
     /usr/local/bin/pydoc3* \
     /usr/local/bin/python3* \
     /usr/local/bin/pyvenv*
+
+git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
+git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
 
 brew update
 brew upgrade


### PR DESCRIPTION
It seems that updating shallow Git clones is expensive, and as a result
Homebrew recently started refusing to update shallow clones (see
https://github.com/Homebrew/discussions/discussions/226). This commit
tries to fix the problem by making these repos into full clones before
running "brew update".

I also came across another error about there being a conflicting version
of pip3 in /usr/local. I suspect that is related to the other Python
binaries that the script has to delete, so I added pip3 to the list and
that seemed to solve the problem.