### PR TITLE
js/binary/utils.js: Fix jspb.utils.joinUnsignedDecimalString to work with negative bitsLow and low but non-zero bitsHigh parameter.

### DIFF
--- a/js/binary/decoder_test.js
+++ b/js/binary/decoder_test.js
@@ -315,6 +315,9 @@ describe('binaryDecoderTest', function() {
         // 64-bit extremes, not in dev guide.
         {original: '9223372036854775807', zigzag: '18446744073709551614'},
         {original: '-9223372036854775808', zigzag: '18446744073709551615'},
+        // None of the above catch: bitsLow < 0 && bitsHigh > 0 && bitsHigh < 0x1FFFFF.
+        // The following used to be broken.
+        {original: '72000000000', zigzag: '144000000000'},
       ];
       var encoder = new jspb.BinaryEncoder();
       testCases.forEach(function(c) {

--- a/js/binary/utils.js
+++ b/js/binary/utils.js
@@ -511,7 +511,7 @@ jspb.utils.joinUnsignedDecimalString = function(bitsLow, bitsHigh) {
   // Skip the expensive conversion if the number is small enough to use the
   // built-in conversions.
   if (bitsHigh <= 0x1FFFFF) {
-    return '' + (jspb.BinaryConstants.TWO_TO_32 * bitsHigh + bitsLow);
+    return '' + jspb.utils.joinUint64(bitsLow, bitsHigh);
   }
 
   // What this code is doing is essentially converting the input number from


### PR DESCRIPTION
We noticed that our generated javascript message implementations decode certain number fields incorrectly for some values when the fields have `jstype = JS_STRING`. I tracked it down to `readZigzagVarint64String()`, which does not always decode a field correctly. In particular, it returns the wrong result when it calls into `jspb.utils.joinUnsignedDecimalString` with a `bitsLow` value that is negative and a `bitsHigh` value that is less than `0x1FFFFF`. None of the existing test cases appear to cover that case.

This PR changes `joinUnsignedDecimalString` to call `jspb.utils.joinUint64` on its fast path instead, which gets us the right result.

It's also possible to change the line to

```
return '' + (jspb.BinaryConstants.TWO_TO_32 * bitsHigh + (bitsLow >>> 0));
```

or similar instead.

This is my first contact with this code and it wasn't clear to me if the bug is actually in the caller of `joinUnsignedDecimalString`. If `joinUnsignedDecimalString` is expecting purely unsigned parameters then it's possible that this isn't the desired fix. But it would be great if we could get _a_ fix landed :).

Thanks for the awesome project which we make great use of throughout our stack :).