### PR TITLE
default

### DIFF
--- a/protobuf-lite.pc.in
+++ b/protobuf-lite.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
+exec_prefix=${prefix}
+libdir=${prefix}/lib64
+includedir=${prefix}/include
 
 Name: Protocol Buffers
 Description: Google's Data Interchange Format

--- a/protobuf.pc.in
+++ b/protobuf.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
+exec_prefix=${prefix}
+libdir=${prefix}/lib64
+includedir=${prefix}/include
 
 Name: Protocol Buffers
 Description: Google's Data Interchange Format


### PR DESCRIPTION
protobuf  **libdir** and **includedir** should support prefix, just like setting in grpc pc file