### PR TITLE
[Python] Add GetEntryClass method to RepeatedCompositeFieldContainer

### DIFF
--- a/python/google/protobuf/internal/containers.py
+++ b/python/google/protobuf/internal/containers.py
@@ -457,6 +457,9 @@ class RepeatedCompositeFieldContainer(BaseContainer):
                       'other repeated composite fields.')
     return self._values == other._values
 
+  def GetEntryClass(self):
+    return self._entry_descriptor._concrete_class
+
 
 class ScalarMap(MutableMapping):
 


### PR DESCRIPTION
Implements the public [`GetEntryClass`](https://github.com/protocolbuffers/protobuf/blob/9647a7c2356a9529754c07235a2877ee676c2fd0/python/google/protobuf/internal/containers.py#L547-L548) method for [`RepeatedCompositeFieldContainer`](https://github.com/protocolbuffers/protobuf/blob/9647a7c2356a9529754c07235a2877ee676c2fd0/python/google/protobuf/internal/containers.py#L351-L458), following the footsteps of its quasi-sibling, [`ScalarMap`](https://github.com/protocolbuffers/protobuf/blob/9647a7c2356a9529754c07235a2877ee676c2fd0/python/google/protobuf/internal/containers.py#L461-L548).

Useful for https://github.com/googleapis/proto-plus-python/issues/173.