### PR TITLE
fix: convert native PHP floats to single precision

### DIFF
--- a/php/src/Google/Protobuf/Internal/GPBUtil.php
+++ b/php/src/Google/Protobuf/Internal/GPBUtil.php
@@ -168,7 +168,7 @@ class GPBUtil
     public static function checkFloat(&$var)
     {
         if (is_float($var) || is_numeric($var)) {
-            $var = floatval($var);
+            $var = floatval(unpack("f", pack("f", $var)));
         } else {
             throw new \Exception("Expect float.");
         }

--- a/php/src/Google/Protobuf/Internal/GPBUtil.php
+++ b/php/src/Google/Protobuf/Internal/GPBUtil.php
@@ -168,7 +168,7 @@ class GPBUtil
     public static function checkFloat(&$var)
     {
         if (is_float($var) || is_numeric($var)) {
-            $var = floatval(unpack("f", pack("f", $var)));
+            $var = unpack("f", pack("f", $var))[1];
         } else {
             throw new \Exception("Expect float.");
         }


### PR DESCRIPTION
See https://github.com/protocolbuffers/protobuf/issues/8165

Converts PHP double-precision floats to single-precision for consistency with the protobuf C-extension