### PR TITLE
Resolve more java field accessor name conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ src/**/*.trs
 # JavaBuild output.
 java/core/target
 java/util/target
-javanano/target
+java/lite/target
 java/.idea
 java/**/*.iml
 

--- a/java/core/src/test/proto/com/google/protobuf/test_bad_identifiers.proto
+++ b/java/core/src/test/proto/com/google/protobuf/test_bad_identifiers.proto
@@ -43,10 +43,42 @@ option java_generic_services = true;  // auto-added
 option java_package = "com.google.protobuf";
 option java_outer_classname = "TestBadIdentifiersProto";
 
-message TestMessage {
-  optional string cached_size = 1;
-  optional string serialized_size = 2;
-  optional string class = 3;
+// Message with field names using underscores that conflict with accessors in the base message class in java.
+// See kForbiddenWordList in src/google/protobuf/compiler/java/java_helpers.cc
+message ForbiddenWordsUnderscoreMessage {
+  // java.lang.Object
+  optional bool class = 1;
+  // com.google.protobuf.MessageLiteOrBuilder
+  optional bool default_instance_for_type = 2;
+  // com.google.protobuf.MessageLite
+  optional bool parser_for_type = 3;
+  optional bool serialized_size = 4;
+  // com.google.protobuf.MessageOrBuilder
+  optional bool all_fields = 5;
+  optional bool descriptor_for_type = 6;
+  optional bool initialization_error_string = 7;
+  optional bool unknown_fields = 8;
+  // obsolete. kept for backwards compatibility of generated code
+  optional bool cached_size = 9;
+}
+
+// Message with field names in camel case that conflict with accessors in the base message class in java.
+// See kForbiddenWordList in src/google/protobuf/compiler/java/java_helpers.cc
+message ForbiddenWordsCamelMessage {
+  // java.lang.Object
+  optional bool class = 1;
+  // com.google.protobuf.MessageLiteOrBuilder
+  optional bool defaultInstanceForType = 2;
+  // com.google.protobuf.MessageLite
+  optional bool serializedSize = 3;
+  optional bool parserForType = 4;
+  // com.google.protobuf.MessageOrBuilder:
+  optional bool initializationErrorString = 5;
+  optional bool descriptorForType = 6;
+  optional bool allFields = 7;
+  optional bool unknownFields = 8;
+  // obsolete. kept for backwards compatibility of generated code
+  optional bool cachedSize = 9;
 }
 
 message Descriptor {
@@ -84,7 +116,7 @@ message Deprecated {
 
   optional int32 field1 = 1 [deprecated = true];
   optional TestEnum field2 = 2 [deprecated = true];
-  optional TestMessage field3 = 3 [deprecated = true];
+  optional ForbiddenWordsUnderscoreMessage field3 = 3 [deprecated = true];
 }
 
 message Override {
@@ -117,7 +149,7 @@ message Double {
 }
 
 service TestConflictingMethodNames {
-  rpc Override(TestMessage) returns (TestMessage);
+  rpc Override(ForbiddenWordsUnderscoreMessage) returns (ForbiddenWordsUnderscoreMessage);
 }
 
 message TestConflictingFieldNames {
@@ -125,24 +157,24 @@ message TestConflictingFieldNames {
     UNKNOWN = 0;
     FOO = 1;
   }
-  message TestMessage {}
+  message ForbiddenWordsUnderscoreMessage {}
   repeated int32 int32_field = 1;
   repeated TestEnum enum_field = 2;
   repeated string string_field = 3;
   repeated bytes bytes_field = 4;
-  repeated TestMessage message_field = 5;
+  repeated ForbiddenWordsUnderscoreMessage message_field = 5;
 
   optional int32 int32_field_count = 11;
   optional TestEnum enum_field_count = 12;
   optional string string_field_count = 13;
   optional bytes bytes_field_count = 14;
-  optional TestMessage message_field_count = 15;
+  optional ForbiddenWordsUnderscoreMessage message_field_count = 15;
 
   repeated int32 Int32Field = 21;          // NO_PROTO3
   repeated TestEnum EnumField = 22;        // NO_PROTO3
   repeated string StringField = 23;        // NO_PROTO3
   repeated bytes BytesField = 24;          // NO_PROTO3
-  repeated TestMessage MessageField = 25;  // NO_PROTO3
+  repeated ForbiddenWordsUnderscoreMessage MessageField = 25;  // NO_PROTO3
 
   // This field conflicts with "int32_field" as they both generate
   // the method getInt32FieldList().

--- a/src/google/protobuf/compiler/java/java_helpers.cc
+++ b/src/google/protobuf/compiler/java/java_helpers.cc
@@ -64,15 +64,24 @@ namespace {
 
 const char* kDefaultPackage = "";
 
-// Names that should be avoided as field names.
+// Names that should be avoided as field names (in lowerCamelCase format).
 // Using them will cause the compiler to generate accessors whose names are
 // colliding with methods defined in base classes.
 const char* kForbiddenWordList[] = {
-    // message base class:
-    "cached_size",
-    "serialized_size",
     // java.lang.Object:
     "class",
+    // com.google.protobuf.MessageLiteOrBuilder:
+    "defaultInstanceForType",
+    // com.google.protobuf.MessageLite:
+    "parserForType",
+    "serializedSize",
+    // com.google.protobuf.MessageOrBuilder:
+    "allFields",
+    "descriptorForType",
+    "initializationErrorString",
+    "unknownFields",
+    // obsolete. kept for backwards compatibility of generated code
+    "cachedSize",
 };
 
 const std::unordered_set<std::string>* kReservedNames =
@@ -102,7 +111,7 @@ const std::unordered_set<std::string>* kKotlinForbiddenNames =
 
 bool IsForbidden(const std::string& field_name) {
   for (int i = 0; i < GOOGLE_ARRAYSIZE(kForbiddenWordList); ++i) {
-    if (field_name == kForbiddenWordList[i]) {
+    if (UnderscoresToCamelCase(field_name, false) == kForbiddenWordList[i]) {
       return true;
     }
   }


### PR DESCRIPTION
Previously, some proto field names would cause the java code generator to generate accessor names that conflict with method names from the message super classes/interfaces, leading to java code that would not compile.
A list of field names that cause such conflicts previously existed, but the list did not contain every field name that would cause a conflict.
Additionally, only snake_case field names would be detected. If the field name was in camelCase, the conflict would not be detected.

This change adds the complete set of field names that will cause assessor name conflicts, and detects conflicts in both snake_case and camelCase field names.

Fixes #8142