### PR TITLE
c++: let destructor in the Message class be Virtual

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ Unreleased Changes (C++/Java/Python/PHP/Objective-C/C#/Ruby/JavaScript)
     implementation detail users must not rely on. It should not be used in
     unit tests.
   * Change the signature of Any::PackFrom() to return false on error.
+  * Let destructor of Message class be virtual 
 
   Java
   * Avoid possible UnsupportedOperationException when using CodedInputSteam

--- a/src/google/protobuf/message.h
+++ b/src/google/protobuf/message.h
@@ -232,6 +232,7 @@ bool CreateUnknownEnumValues(const FieldDescriptor* field);
 class PROTOBUF_EXPORT Message : public MessageLite {
  public:
   constexpr Message() = default;
+  virtual ~Message() = default;
 
   // Basic Operations ------------------------------------------------
 


### PR DESCRIPTION
let destructor in the Message class be Virtual, because when deleting a derived class object using a pointer of base class type that has a non-virtual destructor results in undefined behavior

Signed-off-by: wujing <jing.woo@outlook.com>