### PR TITLE
stubs/mutex: Fix compilation by initializing variable in WrappedMutex class (backport to 3.14.x)

### DIFF
--- a/src/google/protobuf/stubs/mutex.h
+++ b/src/google/protobuf/stubs/mutex.h
@@ -124,12 +124,12 @@ class GOOGLE_PROTOBUF_CAPABILITY("mutex") PROTOBUF_EXPORT WrappedMutex {
   void AssertHeld() const {}
 
  private:
-#if defined(_MSC_VER)
-  CallOnceInitializedMutex<std::mutex> mu_;
-#elif defined(GOOGLE_PROTOBUF_SUPPORT_WINDOWS_XP)
-  CallOnceInitializedMutex<CriticalSectionLock> mu_;
+#if defined(GOOGLE_PROTOBUF_SUPPORT_WINDOWS_XP)
+  CallOnceInitializedMutex<CriticalSectionLock> mu_ {};
+#elif defined(_MSC_VER)
+  CallOnceInitializedMutex<std::mutex> mu_ {};
 #else
-  std::mutex mu_;
+  std::mutex mu_ {};
 #endif
 };
 


### PR DESCRIPTION
Cherry pick https://github.com/protocolbuffers/protobuf/pull/8098 into 3.14.x

(to unblock https://github.com/grpc/grpc/pull/25131)