### PR TITLE
update rules_python dependency to version 0.1.0

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -59,7 +59,6 @@ def protobuf_deps():
     if not native.existing_rule("rules_python"):
         http_archive(
             name = "rules_python",
-            sha256 = "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
-            strip_prefix = "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
-            urls = ["https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz"],
+            sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+            urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz"],
         )


### PR DESCRIPTION
other bazel libraries (e.g. rules_docker 0.15.0) require rules_python 0.1.0
or above. running protobuf_deps() before importing rules_docker
will lead to errors.

upgrading rules_python fixes this problem.