### PR TITLE
Ruby: build extensions for arm64-darwin

### DIFF
--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -60,7 +60,8 @@ set -x
 ruby --version | grep 'ruby 2.7.0'
 for v in 3.0.0 2.7.0 ; do
   ccache -c
-  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
+  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin MAKE="$MAKE"
+  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=arm64-darwin MAKE="$MAKE"
 done
 set +x
 rvm use 2.5.0
@@ -68,11 +69,9 @@ set -x
 ruby --version | grep 'ruby 2.5.0'
 for v in 2.6.0 2.5.1 2.4.0 2.3.0; do
   ccache -c
-  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
+  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin MAKE="$MAKE"
+  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=arm64-darwin MAKE="$MAKE"
 done
 set +x
 rvm use 2.7.0
 set -x
-
-sed 's/x86_64-darwin-11/universal-darwin/' ~/.rake-compiler/config.yml > "$CROSS_RUBY"
-mv "$CROSS_RUBY" ~/.rake-compiler/config.yml

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -70,7 +70,7 @@ else
     ext.cross_platform = [
       'x86-mingw32', 'x64-mingw32',
       'x86_64-linux', 'x86-linux',
-      'universal-darwin'
+      'x86_64-darwin', 'arm64-darwin',
     ]
   end
 


### PR DESCRIPTION
This PR adds builds for arm64-darwin. It also renames `universal-darwin` back to `x86_64-darwin` to avoid confusion. These arch names are already used in nokogiri, so I think it's fine to rename it back to them.

See https://github.com/protocolbuffers/protobuf/pull/8231 for a different approach.