### PR TITLE
Fix problem when restoring C# dependencies on win2016

### DIFF
--- a/kokoro/release/csharp/windows/build_nuget.bat
+++ b/kokoro/release/csharp/windows/build_nuget.bat
@@ -11,4 +11,7 @@ set PATH=%LOCALAPPDATA%\Microsoft\dotnet;%PATH%
 set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 set DOTNET_CLI_TELEMETRY_OPTOUT=true
 
+@rem Work around https://github.com/dotnet/core/issues/5881
+dotnet nuget locals all --clear
+
 call build_packages.bat

--- a/kokoro/windows/csharp/build.bat
+++ b/kokoro/windows/csharp/build.bat
@@ -11,4 +11,7 @@ set PATH=%LOCALAPPDATA%\Microsoft\dotnet;%PATH%
 set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 set DOTNET_CLI_TELEMETRY_OPTOUT=true
 
+@rem Work around https://github.com/dotnet/core/issues/5881
+dotnet nuget locals all --clear
+
 call buildall.bat


### PR DESCRIPTION
Hopefully this fixes https://github.com/protocolbuffers/protobuf/issues/8242.

What we know:
- It turns out the problem was happening even when dotnet SDK downloads worked just fine.
-  The issue started happening when the kokoro windows workers switched from win7 to win2016.

With extra debugging, I got this output:
```
         T:\src\github\protobuf\csharp\src\Google.Protobuf.Test\Google.Protobuf.Test.csproj : error NU1101: Unable to find package NUnit. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages [T:\src\github\protobuf\csharp\src\Google.Protobuf.sln]

         T:\src\github\protobuf\csharp\src\Google.Protobuf.Test\Google.Protobuf.Test.csproj : error NU1101: Unable to find package NUnit3TestAdapter. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages [T:\src\github\protobuf\csharp\src\Google.Protobuf.sln]

         T:\src\github\protobuf\csharp\src\Google.Protobuf.Test\Google.Protobuf.Test.csproj : error NU1101: Unable to find package Microsoft.NETFramework.ReferenceAssemblies. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages [T:\src\github\protobuf\csharp\src\Google.Protobuf.sln]

         T:\src\github\protobuf\csharp\src\Google.Protobuf.Test\Google.Protobuf.Test.csproj : error NU1101: Unable to find package System.Memory. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages [T:\src\github\protobuf\csharp\src\Google.Protobuf.sln]

         T:\src\github\protobuf\csharp\src\Google.Protobuf.Test\Google.Protobuf.Test.csproj : error NU1101: Unable to find package Microsoft.NETCore.App. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages [T:\src\github\protobuf\csharp\src\Google.Protobuf.sln]

         T:\src\github\protobuf\csharp\src\Google.Protobuf.Test\Google.Protobuf.Test.csproj : error NU1101: Unable to find package System.Runtime.CompilerServices.Unsafe. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages [T:\src\github\protobuf\csharp\src\Google.Protobuf.sln]

         T:\src\github\protobuf\csharp\src\Google.Protobuf.Test\Google.Protobuf.Test.csproj : error NU1102: Unable to find package System.Runtime.Loader with version (>= 4.0.0) [T:\src\github\protobuf\csharp\src\Google.Protobuf.sln]
```

That seems to match this issue: https://github.com/dotnet/core/issues/5881