### PR TITLE
Add cmake to the path to fix the build on kokoro

### DIFF
--- a/kokoro/release/python/windows/build_single_artifact.bat
+++ b/kokoro/release/python/windows/build_single_artifact.bat
@@ -27,7 +27,7 @@ if %PYTHON%==C:\python38 set vcplatform=x64
 REM Prepend newly installed Python to the PATH of this build (this cannot be
 REM done from inside the powershell script as it would require to restart
 REM the parent CMD process).
-SET PATH=%PYTHON%;%PYTHON%\Scripts;%OLD_PATH%
+SET PATH=C:\Program Files\CMake\bin;%PYTHON%;%PYTHON%\Scripts;%OLD_PATH%
 python -m pip install -U pip
 pip install wheel
 


### PR DESCRIPTION
We have a failing kokoro test, I don't know how to test this locally on my linux laptop. But this is the same fix I used internally to fix our failing windows kokoro tests.

release notes: no