### PR TITLE
Add test for php5 for pure php implementation

### DIFF
--- a/kokoro/linux/dockerfile/test/php/Dockerfile
+++ b/kokoro/linux/dockerfile/test/php/Dockerfile
@@ -55,6 +55,26 @@ RUN mv composer.phar /usr/local/bin/composer
 # Download php source code
 RUN git clone https://github.com/php/php-src
 
+# php 5.6
+RUN cd php-src \
+  && git checkout PHP-5.6.39 \
+  && ./buildconf --force
+RUN cd php-src \
+  && ./configure \
+  --enable-bcmath \
+  --enable-mbstring \
+  --with-gmp \
+  --with-openssl \
+  --with-zlib \
+  --prefix=/usr/local/php-5.6 \
+  && make \
+  && make install \
+  && make clean
+
+RUN wget -O phpunit https://phar.phpunit.de/phpunit-5.phar \
+  && chmod +x phpunit \
+  && mv phpunit /usr/local/php-5.6/bin
+
 # php 7.0
 RUN cd php-src \
   && git checkout PHP-7.0.33 \

--- a/kokoro/linux/dockerfile/test/php_32bit/Dockerfile
+++ b/kokoro/linux/dockerfile/test/php_32bit/Dockerfile
@@ -53,6 +53,25 @@ RUN mv composer.phar /usr/local/bin/composer
 # Download php source code
 RUN git clone https://github.com/php/php-src
 
+# php 5.6
+RUN cd php-src \
+  && git checkout PHP-5.6.39 \
+  && ./buildconf --force
+RUN cd php-src \
+  && ./configure \
+  --enable-bcmath \
+  --enable-mbstring \
+  --with-openssl \
+  --with-zlib \
+  --prefix=/usr/local/php-5.6 \
+  && make \
+  && make install \
+  && make clean
+
+RUN wget -O phpunit https://phar.phpunit.de/phpunit-5.phar \
+  && chmod +x phpunit \
+  && mv phpunit /usr/local/php-5.6/bin
+
 # php 7.0
 RUN wget https://github.com/php/php-src/archive/php-7.0.33.tar.gz -O /var/local/php-7.0.33.tar.gz
 

--- a/php/composer.json
+++ b/php/composer.json
@@ -6,10 +6,10 @@
   "homepage": "https://developers.google.com/protocol-buffers/",
   "license": "BSD-3-Clause",
   "require": {
-    "php": ">=7.0.0"
+    "php": ">=5.5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=6.0.0"
+    "phpunit/phpunit": ">=5.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests.sh
+++ b/tests.sh
@@ -484,6 +484,16 @@ use_php_zts() {
   internal_build_cpp
 }
 
+build_php5.6() {
+  use_php 5.6
+  pushd php
+  rm -rf vendor
+  composer update
+  composer test
+  popd
+  (cd conformance && make test_php)
+}
+
 build_php7.0() {
   use_php 7.0
   pushd php
@@ -683,6 +693,7 @@ build_php8.0_all() {
 }
 
 build_php_all_32() {
+  build_php5.6
   build_php7.0
   build_php7.1
   build_php7.4


### PR DESCRIPTION
Test for pure php5 implementation was removed by mistake in https://github.com/protocolbuffers/protobuf/pull/7956