### PR TITLE
Fixed clone_obj for PHP8.

### DIFF
--- a/php/ext/google/protobuf/array.c
+++ b/php/ext/google/protobuf/array.c
@@ -118,8 +118,8 @@ static int RepeatedField_compare_objects(zval *rf1, zval *rf2) {
  *
  *   $rf2 = clone $rf1;
  */
-static zend_object *RepeatedField_clone_obj(zval *object) {
-  RepeatedField* intern = (RepeatedField*)Z_OBJ_P(object);
+static zend_object *RepeatedField_clone_obj(PROTO_VAL *object) {
+  RepeatedField* intern = PROTO_VAL_P(object);
   upb_arena *arena = Arena_Get(&intern->arena);
   upb_array *clone = upb_array_new(arena, intern->type.type);
   size_t n = upb_array_size(intern->array);

--- a/php/ext/google/protobuf/map.c
+++ b/php/ext/google/protobuf/map.c
@@ -133,8 +133,8 @@ static int MapField_compare_objects(zval *map1, zval *map2) {
  *
  *   $map2 = clone $map1;
  */
-static zend_object *MapField_clone_obj(zval *object) {
-  MapField* intern = (MapField*)Z_OBJ_P(object);
+static zend_object *MapField_clone_obj(PROTO_VAL *object) {
+  MapField* intern = PROTO_VAL_P(object);
   upb_arena *arena = Arena_Get(&intern->arena);
   upb_map *clone =
       upb_map_new(arena, intern->type.key_type, intern->type.val_type.type);

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -259,7 +259,7 @@ static int Message_compare_objects(zval *m1, zval *m2) {
 static int Message_has_property(PROTO_VAL *obj, PROTO_STR *member,
                                 int has_set_exists,
                                 void **cache_slot) {
-  Message* intern = PROTO_MSG_P(obj);
+  Message* intern = PROTO_VAL_P(obj);
   const upb_fielddef *f = get_field(intern, member);
 
   if (!f) return 0;
@@ -294,7 +294,7 @@ static int Message_has_property(PROTO_VAL *obj, PROTO_STR *member,
  */
 static void Message_unset_property(PROTO_VAL *obj, PROTO_STR *member,
                                    void **cache_slot) {
-  Message* intern = PROTO_MSG_P(obj);
+  Message* intern = PROTO_VAL_P(obj);
   const upb_fielddef *f = get_field(intern, member);
 
   if (!f) return;
@@ -331,7 +331,7 @@ static void Message_unset_property(PROTO_VAL *obj, PROTO_STR *member,
  */
 static zval *Message_read_property(PROTO_VAL *obj, PROTO_STR *member,
                                    int type, void **cache_slot, zval *rv) {
-  Message* intern = PROTO_MSG_P(obj);
+  Message* intern = PROTO_VAL_P(obj);
   const upb_fielddef *f = get_field(intern, member);
 
   if (!f) return NULL;
@@ -362,7 +362,7 @@ static zval *Message_read_property(PROTO_VAL *obj, PROTO_STR *member,
  */
 static PROTO_RETURN_VAL Message_write_property(
     PROTO_VAL *obj, PROTO_STR *member, zval *val, void **cache_slot) {
-  Message* intern = PROTO_MSG_P(obj);
+  Message* intern = PROTO_VAL_P(obj);
   const upb_fielddef *f = get_field(intern, member);
 
   if (f && Message_set(intern, f, val)) {
@@ -400,8 +400,8 @@ static zval *Message_get_property_ptr_ptr(PROTO_VAL *object, PROTO_STR *member,
  *
  *   $msg2 = clone $msg;
  */
-static zend_object *Message_clone_obj(zval *object) {
-  Message* intern = PROTO_MSG_P(object);
+static zend_object *Message_clone_obj(PROTO_VAL *object) {
+  Message* intern = PROTO_VAL_P(object);
   upb_msg *clone = upb_msg_new(intern->desc->msgdef, Arena_Get(&intern->arena));
 
   // TODO: copy unknown fields?

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -58,13 +58,13 @@ const zval *get_generated_pool();
 #if PHP_VERSION_ID < 80000
 #define PROTO_VAL zval
 #define PROTO_STR zval
-#define PROTO_MSG_P(obj) (Message*)Z_OBJ_P(obj)
+#define PROTO_VAL_P(obj) Z_OBJ_P(obj)
 #define PROTO_STRVAL_P(obj) Z_STRVAL_P(obj)
 #define PROTO_STRLEN_P(obj) Z_STRLEN_P(obj)
 #else
 #define PROTO_VAL zend_object
 #define PROTO_STR zend_string
-#define PROTO_MSG_P(obj) (Message*)(obj)
+#define PROTO_VAL_P(obj) (void*)(obj)
 #define PROTO_STRVAL_P(obj) ZSTR_VAL(obj)
 #define PROTO_STRLEN_P(obj) ZSTR_LEN(obj)
 #endif


### PR DESCRIPTION
PHP8 has a different method signature for clone_obj that takes a
zend_object* instead of a zval*.