### PR TITLE
Reserve extension id for protoc-gen-psql & protoc-gen-sanitize

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -252,11 +252,19 @@ with info about your project (name and website) so we can add an entry for you.
 1. Confluent Schema Registry
    * Website: https://github.com/confluentinc/schema-registry
    * Extensions: 1088
-   
+
 1. ScalaPB Validate
    * Website: https://scalapb.github.io/docs/validation
    * Extension: 1089
-   
+
 1. Astounding (Currently Private)
-   * Website: https://github.com/PbPipes/Astounding 
+   * Website: https://github.com/PbPipes/Astounding
    * Extension: 1090
+
+1. Protoc-gen-psql
+   * Website: https://github.com/Intrinsec/protoc-gen-psql
+   * Extension: 1091
+
+1. Protoc-gen-sanitize
+   * Website: https://github.com/Intrinsec/protoc-gen-sanitize
+   * Extension: 1092


### PR DESCRIPTION
We have created 2 projects we expect might be used by others so we would like to avoid extension id collision.