### PR TITLE
Added more information to "file already loaded" warning.

### DIFF
--- a/php/ext/google/protobuf/def.c
+++ b/php/ext/google/protobuf/def.c
@@ -916,7 +916,10 @@ static void add_descriptor(DescriptorPool *pool,
 
   if (upb_symtab_lookupfile2(pool->symtab, name.data, name.size)) {
     // Already added.
-    fprintf(stderr, "WARNING: file was already added\n");
+    zend_error(E_USER_WARNING,
+               "proto descriptor was previously loaded (included in multiple "
+               "metadata bundles?): " UPB_STRVIEW_FORMAT,
+               UPB_STRVIEW_ARGS(name));
     return;
   }
 


### PR DESCRIPTION
Also changed it to zend_error() so it is more easily suppressed.

Errors will now look like:

> PHP Warning:  proto descriptor was previously loaded (included in multiple metadata bundles?): google/ads/googleads/v6/errors/feed_item_validation_error.proto in /usr/local/google/home/haberman/code/google-ads-php/metadata/Google/Ads/GoogleAds/V6/Services/GoogleAdsService.php on line 29

Fixes https://github.com/protocolbuffers/protobuf/issues/8124