### PR TITLE
Updated collect_all_artifacts.sh to avoid installing apt-transport-https

### DIFF
--- a/kokoro/release/collect_all_artifacts.sh
+++ b/kokoro/release/collect_all_artifacts.sh
@@ -49,7 +49,6 @@ cp ${INPUT_ARTIFACTS_DIR}/build64/src/protoc protoc/macosx_x64/protoc
 # Install nuget (will also install  mono)
 # TODO(jtattermusch): use "mono:5.14" docker image instead so we don't have to apt-get install
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt install apt-transport-https
 echo "deb https://download.mono-project.com/repo/ubuntu stable-trusty main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
 sudo apt update
 sudo apt-get install -y nuget


### PR DESCRIPTION
The installation of apt-transport-https is failing and causing this
script to exit early. I suspect the package is no longer needed since
recent versions have moved it into the apt package, so this change
updates the script to stop trying to install apt-transport-https.