### PR TITLE
C++ port_def.inc: don't set PROTOBUF_CONSTINIT on mingw-w64

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -477,7 +477,7 @@
 #endif  // _MSC_VER
 
 #if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
-// Don't let Objective-C Macros interfere with proto identifiers with the same 
+// Don't let Objective-C Macros interfere with proto identifiers with the same
 // name.
 #pragma push_macro("DEBUG")
 #undef DEBUG
@@ -561,17 +561,6 @@
 // This experiment is purely for the purpose of gathering data. All code guarded
 // by this flag is supposed to be removed after this experiment.
 // #define PROTOBUF_MESSAGE_OWNED_ARENA_EXPERIMENT
-
-#if defined(__cpp_constinit)
-#define PROTOBUF_CONSTINIT constinit
-#elif defined(__has_cpp_attribute)
-#if __has_cpp_attribute(clang::require_constant_initialization)
-#define PROTOBUF_CONSTINIT [[clang::require_constant_initialization]]
-#endif
-#endif
-#ifndef PROTOBUF_CONSTINIT
-#define PROTOBUF_CONSTINIT
-#endif
 
 #if defined(__cpp_constinit)
 #define PROTOBUF_CONSTINIT constinit

--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -562,11 +562,13 @@
 // by this flag is supposed to be removed after this experiment.
 // #define PROTOBUF_MESSAGE_OWNED_ARENA_EXPERIMENT
 
+#ifndef __MINGW32__
 #if defined(__cpp_constinit)
 #define PROTOBUF_CONSTINIT constinit
 #elif defined(__has_cpp_attribute)
 #if __has_cpp_attribute(clang::require_constant_initialization)
 #define PROTOBUF_CONSTINIT [[clang::require_constant_initialization]]
+#endif
 #endif
 #endif
 #ifndef PROTOBUF_CONSTINIT


### PR DESCRIPTION
Currently errors out any clang compilation on windows with mingw-w64 as std::mutex is not set with constexpr

full error:
```c++
../../src/google/protobuf/struct.pb.cc:42:76: error: variable does not have a constant initializer
PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_NO_DESTROY StructDefaultTypeInternal _Struct_default_instance_;
                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~
../../src/google/protobuf/struct.pb.cc:42:1: note: required by 'require_constant_initialization' attribute here
PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_NO_DESTROY StructDefaultTypeInternal _Struct_default_instance_;
^~~~~~~~~~~~~~~~~~
../../src\google/protobuf/port_def.inc:580:30: note: expanded from macro 'PROTOBUF_CONSTINIT'
\#define PROTOBUF_CONSTINIT [[clang::require_constant_initialization]]
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../src\google/protobuf/stubs/mutex.h:132:17: note: non-constexpr constructor 'mutex' cannot be used in a constant expression
  std::mutex mu_{};
                ^
../../src\google/protobuf/map_field.h:336:9: note: in call to 'WrappedMutex()'
        mutex_(GOOGLE_PROTOBUF_LINKER_INITIALIZED),
        ^
../../src\google/protobuf/map_field.h:485:9: note: in call to 'MapFieldBase({})'
      : MapFieldBase(tag) {}
        ^
../../src\google/protobuf/map_field.h:546:9: note: in call to 'TypeDefinedMapFieldBase({})'
      : TypeDefinedMapFieldBase<Key, T>(tag), impl_() {}
        ^
../../src/google/protobuf/struct.pb.cc:33:5: note: in call to 'MapField({})'
  : fields_(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}){}
    ^
../../src/google/protobuf/struct.pb.cc:36:7: note: in call to 'Struct({})'
    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
      ^
../../src/google/protobuf/struct.pb.cc:42:76: note: in call to 'StructDefaultTypeInternal()'
PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_NO_DESTROY StructDefaultTypeInternal _Struct_default_instance_;
                                                                           ^
D:\mabs\msys64\mingw64\include\c++\10.2.0\bits/std_mutex.h:91:5: note: declared here
    mutex() noexcept = default;
    ^
1 error generated.
```
