### PR TITLE
Delete root-owned files in Kokoro builds

### DIFF
--- a/kokoro/linux/cpp_distcheck/build.sh
+++ b/kokoro/linux/cpp_distcheck/build.sh
@@ -16,6 +16,10 @@ until docker pull $DOCKER_IMAGE_NAME; do sleep 10; done
 docker run -v $(pwd):/var/local/protobuf --rm $DOCKER_IMAGE_NAME \
   bash -l /var/local/protobuf/tests.sh cpp || FAILED="true"
 
+# This directory is owned by root. We need to delete it, because otherwise
+# Kokoro will attempt to rsync it and fail with a permission error.
+rm -rf src/core
+
 if [ "$FAILED" = "true" ]; then
   exit 1
 fi

--- a/kokoro/release/python/linux/build_artifacts.sh
+++ b/kokoro/release/python/linux/build_artifacts.sh
@@ -30,10 +30,6 @@ cp kokoro/release/python/linux/config.sh config.sh
 
 build_artifact_version() {
   MB_PYTHON_VERSION=$1
-
-  # Clean up env
-  rm -rf venv
-  sudo rm -rf $REPO_DIR
   cp -R $STAGE_DIR $REPO_DIR
 
   source multibuild/common_utils.sh
@@ -47,6 +43,10 @@ build_artifact_version() {
   build_wheel $REPO_DIR/python $PLAT
 
   mv wheelhouse/* $ARTIFACT_DIR
+
+  # Clean up env
+  rm -rf venv
+  sudo rm -rf $REPO_DIR
 }
 
 build_artifact_version 2.7


### PR DESCRIPTION
Some of our Kokoro builds have been failing because Kokoro is unable to
copy root-owned files when the build is complete. This commit fixes the
problem by deleting these files at the end.