### PR TITLE
Add support for custom well-known handled types in JSON

### DIFF
--- a/csharp/src/Google.Protobuf.Benchmarks/ParseMessagesBenchmark.cs
+++ b/csharp/src/Google.Protobuf.Benchmarks/ParseMessagesBenchmark.cs
@@ -34,7 +34,6 @@ using BenchmarkDotNet.Attributes;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Buffers;
 using Google.Protobuf.WellKnownTypes;
 using Benchmarks.Proto3;

--- a/csharp/src/Google.Protobuf.Benchmarks/WriteMessagesBenchmark.cs
+++ b/csharp/src/Google.Protobuf.Benchmarks/WriteMessagesBenchmark.cs
@@ -33,9 +33,6 @@
 using BenchmarkDotNet.Attributes;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Buffers;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Google.Protobuf.Benchmarks

--- a/csharp/src/Google.Protobuf.Benchmarks/WriteRawPrimitivesBenchmark.cs
+++ b/csharp/src/Google.Protobuf.Benchmarks/WriteRawPrimitivesBenchmark.cs
@@ -32,10 +32,7 @@
 
 using BenchmarkDotNet.Attributes;
 using System;
-using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.IO;
-using System.Buffers;
 using System.Text;
 
 namespace Google.Protobuf.Benchmarks

--- a/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
@@ -39,8 +39,6 @@ using System.Collections;
 using System.Linq;
 using System.Buffers;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Runtime.CompilerServices;
 #if !NET35
 using System.Threading.Tasks;
 #endif

--- a/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
@@ -33,7 +33,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/csharp/src/Google.Protobuf.Test/FieldMaskTreeTest.cs
+++ b/csharp/src/Google.Protobuf.Test/FieldMaskTreeTest.cs
@@ -30,7 +30,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-using System.Collections.Generic;
 using Google.Protobuf.Collections;
 using Google.Protobuf.TestProtos;
 using NUnit.Framework;

--- a/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.cs
+++ b/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.cs
@@ -33,10 +33,7 @@
 using System;
 using System.IO;
 using Google.Protobuf.TestProtos;
-using Proto2 = Google.Protobuf.TestProtos.Proto2;
 using NUnit.Framework;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using Google.Protobuf.WellKnownTypes;
 

--- a/csharp/src/Google.Protobuf.Test/LegacyGeneratedCodeTest.cs
+++ b/csharp/src/Google.Protobuf.Test/LegacyGeneratedCodeTest.cs
@@ -29,14 +29,12 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
-using Google.Protobuf;
-using Google.Protobuf.Reflection;
+
 using System.Buffers;
 using pb = global::Google.Protobuf;
 using pbr = global::Google.Protobuf.Reflection;
 using NUnit.Framework;
 using System.IO;
-using System;
 using Google.Protobuf.Buffers;
 
 namespace Google.Protobuf

--- a/csharp/src/Google.Protobuf.Test/ReadOnlySequenceFactory.cs
+++ b/csharp/src/Google.Protobuf.Test/ReadOnlySequenceFactory.cs
@@ -33,9 +33,6 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Google.Protobuf
 {

--- a/csharp/src/Google.Protobuf.Test/Reflection/CustomOptionsTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Reflection/CustomOptionsTest.cs
@@ -31,13 +31,10 @@
 #endregion
 
 using Google.Protobuf.Reflection;
-using Google.Protobuf.WellKnownTypes;
 using NUnit.Framework;
 using System;
-using System.IO;
 using System.Linq;
 using UnitTest.Issues.TestProtos;
-using static Google.Protobuf.WireFormat;
 using static UnitTest.Issues.TestProtos.ComplexOptionType2.Types;
 using static UnitTest.Issues.TestProtos.UnittestCustomOptionsProto3Extensions;
 using static UnitTest.Issues.TestProtos.DummyMessageContainingEnum.Types;

--- a/csharp/src/Google.Protobuf.Test/Reflection/DescriptorsTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Reflection/DescriptorsTest.cs
@@ -35,7 +35,6 @@ using NUnit.Framework;
 using ProtobufUnittest;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using UnitTest.Issues.TestProtos;
 

--- a/csharp/src/Google.Protobuf.Test/UnknownFieldSetTest.cs
+++ b/csharp/src/Google.Protobuf.Test/UnknownFieldSetTest.cs
@@ -33,7 +33,6 @@
 using System;
 using System.IO;
 using Google.Protobuf.TestProtos;
-using Proto2 = Google.Protobuf.TestProtos.Proto2;
 using NUnit.Framework;
 
 namespace Google.Protobuf

--- a/csharp/src/Google.Protobuf/ByteStringAsync.cs
+++ b/csharp/src/Google.Protobuf/ByteStringAsync.cs
@@ -30,7 +30,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -32,10 +32,7 @@
 
 using Google.Protobuf.Collections;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Security;
 
 namespace Google.Protobuf

--- a/csharp/src/Google.Protobuf/CodedOutputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedOutputStream.cs
@@ -30,11 +30,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-using Google.Protobuf.Collections;
 using System;
 using System.IO;
 using System.Security;
-using System.Text;
 
 namespace Google.Protobuf
 {

--- a/csharp/src/Google.Protobuf/Collections/Lists.cs
+++ b/csharp/src/Google.Protobuf/Collections/Lists.cs
@@ -31,7 +31,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Google.Protobuf.Collections
 {

--- a/csharp/src/Google.Protobuf/Collections/MapField.cs
+++ b/csharp/src/Google.Protobuf/Collections/MapField.cs
@@ -31,9 +31,7 @@
 #endregion
 
 using Google.Protobuf.Compatibility;
-using Google.Protobuf.Reflection;
 using System;
-using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;

--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -35,7 +35,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Security;
-using System.Threading;
 
 namespace Google.Protobuf.Collections
 {

--- a/csharp/src/Google.Protobuf/ExtensionSet.cs
+++ b/csharp/src/Google.Protobuf/ExtensionSet.cs
@@ -31,7 +31,6 @@
 #endregion
 
 using Google.Protobuf.Collections;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security;

--- a/csharp/src/Google.Protobuf/ExtensionValue.cs
+++ b/csharp/src/Google.Protobuf/ExtensionValue.cs
@@ -32,7 +32,6 @@
 
 using Google.Protobuf.Collections;
 using System;
-using System.Linq;
 
 namespace Google.Protobuf
 {

--- a/csharp/src/Google.Protobuf/FieldCodec.cs
+++ b/csharp/src/Google.Protobuf/FieldCodec.cs
@@ -31,7 +31,6 @@
 #endregion
 
 using Google.Protobuf.Collections;
-using Google.Protobuf.Compatibility;
 using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Collections.Generic;

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -196,7 +196,7 @@ namespace Google.Protobuf
             ProtoPreconditions.CheckNotNull(message, nameof(message));
             ProtoPreconditions.CheckNotNull(writer, nameof(writer));
 
-            if (message.Descriptor.IsWellKnownType)
+            if (IsWellKnownType(message.Descriptor))
             {
                 WriteWellKnownTypeValue(writer, message.Descriptor, message);
             }
@@ -204,6 +204,15 @@ namespace Google.Protobuf
             {
                 WriteMessage(writer, message);
             }
+        }
+
+        /// <summary>
+        /// Checks if the given message descriptor has a special well-known type handler.
+        /// </summary>
+        /// <param name="descriptor">Descriptor of message type to check.</param>
+        private bool IsWellKnownType(MessageDescriptor descriptor)
+        {
+            return WellKnownTypeHandlers.ContainsKey(descriptor.FullName);
         }
 
         /// <summary>
@@ -549,7 +558,7 @@ namespace Google.Protobuf
             writer.Write(NameValueSeparator);
             WriteString(writer, typeUrl);
 
-            if (descriptor.IsWellKnownType)
+            if (IsWellKnownType(descriptor))
             {
                 writer.Write(PropertySeparator);
                 WriteString(writer, AnyWellKnownTypeValueField);

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -61,7 +61,6 @@ namespace Google.Protobuf
         internal const string AnyTypeUrlField = "@type";
         internal const string AnyDiagnosticValueField = "@value";
         internal const string AnyWellKnownTypeValueField = "value";
-        private const string TypeUrlPrefix = "type.googleapis.com";
         private const string NameValueSeparator = ": ";
         private const string PropertySeparator = ", ";
 

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -111,7 +111,7 @@ namespace Google.Protobuf
           "\\u009c", "\\u009d", "\\u009e", "\\u009f"
         };
 
-        private static readonly Dictionary<string, Action<JsonFormatter, TextWriter, MessageDescriptor, object>>
+        private readonly Dictionary<string, Action<JsonFormatter, TextWriter, MessageDescriptor, object>>
             WellKnownTypeHandlers = new Dictionary<string, Action<JsonFormatter, TextWriter, MessageDescriptor, object>>
             {
                 { Timestamp.Descriptor.FullName, (formatter, writer, descriptor, value) => formatter.WriteTimestamp(writer, (IMessage)value) },
@@ -204,6 +204,28 @@ namespace Google.Protobuf
             {
                 WriteMessage(writer, message);
             }
+        }
+
+        /// <summary>
+        /// Adds a new well-known type with it's handler to the formatter.
+        /// </summary>
+        /// <param name="handler">Handler to execute for parsing messages of the well-known type.</param>
+        /// <typeparam name="T">The well-known type of message.</typeparam>
+        public void AddWellKnownTypeHandlers<T>(Action<JsonFormatter, TextWriter, MessageDescriptor, object> handler) where T : IMessage, new()
+        {
+            T message = new T();
+            AddWellKnownTypeHandlers(message.Descriptor, handler);
+        }
+
+        /// <summary>
+        /// Adds a new well-known type with it's handler to the formatter.
+        /// </summary>
+        /// <param name="descriptor">Descriptor of the well-known type.</param>
+        /// <param name="handler">Handler to execute for parsing messages of the well-known type.</param>
+        /// <exception cref="ArgumentException">An handler for the same well-known type is already registered.</exception>
+        public void AddWellKnownTypeHandlers(MessageDescriptor descriptor, Action<JsonFormatter, TextWriter, MessageDescriptor, object> handler)
+        {
+            WellKnownTypeHandlers.Add(descriptor.FullName, handler);
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -156,8 +156,7 @@ namespace Google.Protobuf
             }
             if (message.Descriptor.IsWellKnownType)
             {
-                Action<JsonParser, IMessage, JsonTokenizer> handler;
-                if (WellKnownTypeHandlers.TryGetValue(message.Descriptor.FullName, out handler))
+                if (WellKnownTypeHandlers.TryGetValue(message.Descriptor.FullName, out var handler))
                 {
                     handler(this, message, tokenizer);
                     return;

--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -142,6 +142,15 @@ namespace Google.Protobuf
         }
 
         /// <summary>
+        /// Checks if the given message descriptor has a special well-known type handler.
+        /// </summary>
+        /// <param name="descriptor">Descriptor of message type to check.</param>
+        private bool IsWellKnownType(MessageDescriptor descriptor)
+        {
+            return WellKnownTypeHandlers.ContainsKey(descriptor.FullName);
+        }
+
+        /// <summary>
         /// Merges the given message using data from the given tokenizer. In most cases, the next
         /// token should be a "start object" token, but wrapper types and nullity can invalidate
         /// that assumption. This is implemented as an LL(1) recursive descent parser over the stream
@@ -154,7 +163,7 @@ namespace Google.Protobuf
             {
                 throw InvalidProtocolBufferException.JsonRecursionLimitExceeded();
             }
-            if (message.Descriptor.IsWellKnownType)
+            if (IsWellKnownType(message.Descriptor))
             {
                 if (WellKnownTypeHandlers.TryGetValue(message.Descriptor.FullName, out var handler))
                 {
@@ -543,7 +552,7 @@ namespace Google.Protobuf
             // as normal. Our original tokenizer should end up at the end of the object.
             var replay = JsonTokenizer.FromReplayedTokens(tokens, tokenizer);
             var body = descriptor.Parser.CreateTemplate();
-            if (descriptor.IsWellKnownType)
+            if (IsWellKnownType(descriptor))
             {
                 MergeWellKnownTypeAnyBody(body, replay);
             }

--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -70,7 +70,7 @@ namespace Google.Protobuf
 
         // TODO: Consider introducing a class containing parse state of the parser, tokenizer and depth. That would simplify these handlers
         // and the signatures of various methods.
-        private static readonly Dictionary<string, Action<JsonParser, IMessage, JsonTokenizer>>
+        private readonly Dictionary<string, Action<JsonParser, IMessage, JsonTokenizer>>
             WellKnownTypeHandlers = new Dictionary<string, Action<JsonParser, IMessage, JsonTokenizer>>
         {
             { Timestamp.Descriptor.FullName, (parser, message, tokenizer) => MergeTimestamp(message, tokenizer.Next()) },
@@ -448,6 +448,28 @@ namespace Google.Protobuf
             IMessage message = descriptor.Parser.CreateTemplate();
             Merge(message, jsonReader);
             return message;
+        }
+
+        /// <summary>
+        /// Adds a new well-known type with it's handler to the parser.
+        /// </summary>
+        /// <param name="handler">Handler to execute for parsing messages of the well-known type.</param>
+        /// <typeparam name="T">The well-known type of message.</typeparam>
+        public void AddWellKnownTypeHandlers<T>(Action<JsonParser, IMessage, JsonTokenizer> handler) where T : IMessage, new()
+        {
+            T message = new T();
+            AddWellKnownTypeHandlers(message.Descriptor, handler);
+        }
+
+        /// <summary>
+        /// Adds a new well-known type with it's handler to the parser.
+        /// </summary>
+        /// <param name="descriptor">Descriptor of the well-known type.</param>
+        /// <param name="handler">Handler to execute for parsing messages of the well-known type.</param>
+        /// <exception cref="ArgumentException">An handler for the same well-known type is already registered.</exception>
+        public void AddWellKnownTypeHandlers(MessageDescriptor descriptor, Action<JsonParser, IMessage, JsonTokenizer> handler)
+        {
+            WellKnownTypeHandlers.Add(descriptor.FullName, handler);
         }
 
         private void MergeStructValue(IMessage message, JsonTokenizer tokenizer)

--- a/csharp/src/Google.Protobuf/JsonToken.cs
+++ b/csharp/src/Google.Protobuf/JsonToken.cs
@@ -34,7 +34,10 @@ using System;
 
 namespace Google.Protobuf
 {
-    internal sealed class JsonToken : IEquatable<JsonToken>
+    /// <summary>
+    /// Represents one JSON tokenizer.
+    /// </summary>
+    public sealed class JsonToken : IEquatable<JsonToken>
     {
         // Tokens with no value can be reused.
         private static readonly JsonToken _true = new JsonToken(TokenType.True);

--- a/csharp/src/Google.Protobuf/JsonTokenizer.cs
+++ b/csharp/src/Google.Protobuf/JsonTokenizer.cs
@@ -50,7 +50,7 @@ namespace Google.Protobuf
     /// <para>Implementation details: the base class handles single token push-back and </para>
     /// <para>Not thread-safe.</para>
     /// </remarks>
-    internal abstract class JsonTokenizer
+    public abstract class JsonTokenizer
     {
         private JsonToken bufferedToken;
 

--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -194,9 +194,9 @@ namespace Google.Protobuf
             new MessageParser(factory, discardUnknownFields, Extensions);
 
         /// <summary>
-        /// Creates a new message parser which registers extensions from the specified registry upon creating the message instance
+        /// Creates a new message parser which registers extensions from the specified registry upon creating the message instance.
         /// </summary>
-        /// <param name="registry">The extensions to register</param>
+        /// <param name="registry">The extensions to register.</param>
         /// <returns>A newly configured message parser.</returns>
         public MessageParser WithExtensionRegistry(ExtensionRegistry registry) =>
             new MessageParser(factory, DiscardUnknownFields, registry);
@@ -366,9 +366,9 @@ namespace Google.Protobuf
             new MessageParser<T>(factory, discardUnknownFields, Extensions);
 
         /// <summary>
-        /// Creates a new message parser which registers extensions from the specified registry upon creating the message instance
+        /// Creates a new message parser which registers extensions from the specified registry upon creating the message instance.
         /// </summary>
-        /// <param name="registry">The extensions to register</param>
+        /// <param name="registry">The extensions to register.</param>
         /// <returns>A newly configured message parser.</returns>
         public new MessageParser<T> WithExtensionRegistry(ExtensionRegistry registry) =>
             new MessageParser<T>(factory, DiscardUnknownFields, registry);

--- a/csharp/src/Google.Protobuf/ParseContext.cs
+++ b/csharp/src/Google.Protobuf/ParseContext.cs
@@ -32,14 +32,8 @@
 
 using System;
 using System.Buffers;
-using System.Buffers.Binary;
-using System.Collections.Generic;
-using System.IO;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Security;
-using System.Text;
-using Google.Protobuf.Collections;
 
 namespace Google.Protobuf
 {

--- a/csharp/src/Google.Protobuf/ParserInternalState.cs
+++ b/csharp/src/Google.Protobuf/ParserInternalState.cs
@@ -30,17 +30,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-using System;
-using System.Buffers;
-using System.Buffers.Binary;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
-using Google.Protobuf.Collections;
-
 namespace Google.Protobuf
 {
 

--- a/csharp/src/Google.Protobuf/ParsingPrimitives.cs
+++ b/csharp/src/Google.Protobuf/ParsingPrimitives.cs
@@ -34,13 +34,10 @@ using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
-using System.Text;
-using Google.Protobuf.Collections;
 
 namespace Google.Protobuf
 {

--- a/csharp/src/Google.Protobuf/ParsingPrimitivesMessages.cs
+++ b/csharp/src/Google.Protobuf/ParsingPrimitivesMessages.cs
@@ -33,8 +33,6 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.IO;
-using System.Runtime.CompilerServices;
 using System.Security;
 using Google.Protobuf.Collections;
 

--- a/csharp/src/Google.Protobuf/ParsingPrimitivesWrappers.cs
+++ b/csharp/src/Google.Protobuf/ParsingPrimitivesWrappers.cs
@@ -31,15 +31,7 @@
 #endregion
 
 using System;
-using System.Buffers;
-using System.Buffers.Binary;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Security;
-using System.Text;
-using Google.Protobuf.Collections;
 
 namespace Google.Protobuf
 {

--- a/csharp/src/Google.Protobuf/Reflection/CustomOptions.cs
+++ b/csharp/src/Google.Protobuf/Reflection/CustomOptions.cs
@@ -31,7 +31,6 @@
 #endregion
 
 using Google.Protobuf.Collections;
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/csharp/src/Google.Protobuf/Reflection/DescriptorDeclaration.cs
+++ b/csharp/src/Google.Protobuf/Reflection/DescriptorDeclaration.cs
@@ -30,11 +30,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
 using static Google.Protobuf.Reflection.SourceCodeInfo.Types;
 
 namespace Google.Protobuf.Reflection

--- a/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
@@ -35,7 +35,6 @@ using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using static Google.Protobuf.Reflection.SourceCodeInfo.Types;

--- a/csharp/src/Google.Protobuf/Reflection/MessageDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/MessageDescriptor.cs
@@ -34,7 +34,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Reflection;
+
 #if NET35
 // Needed for ReadOnlyDictionary, which does not exist in .NET 3.5
 using Google.Protobuf.Collections;

--- a/csharp/src/Google.Protobuf/Reflection/ServiceDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ServiceDescriptor.cs
@@ -33,7 +33,6 @@
 using Google.Protobuf.Collections;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Google.Protobuf.Reflection
 {

--- a/csharp/src/Google.Protobuf/UnknownField.cs
+++ b/csharp/src/Google.Protobuf/UnknownField.cs
@@ -30,9 +30,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using Google.Protobuf.Collections;
 
 namespace Google.Protobuf

--- a/csharp/src/Google.Protobuf/UnknownFieldSet.cs
+++ b/csharp/src/Google.Protobuf/UnknownFieldSet.cs
@@ -32,9 +32,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Security;
-using Google.Protobuf.Reflection;
 
 namespace Google.Protobuf
 {

--- a/csharp/src/Google.Protobuf/WriteBufferHelper.cs
+++ b/csharp/src/Google.Protobuf/WriteBufferHelper.cs
@@ -32,7 +32,6 @@
 
 using System;
 using System.Buffers;
-using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security;
 

--- a/csharp/src/Google.Protobuf/WriteContext.cs
+++ b/csharp/src/Google.Protobuf/WriteContext.cs
@@ -32,14 +32,8 @@
 
 using System;
 using System.Buffers;
-using System.Buffers.Binary;
-using System.Collections.Generic;
-using System.IO;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Security;
-using System.Text;
-using Google.Protobuf.Collections;
 
 namespace Google.Protobuf
 {

--- a/csharp/src/Google.Protobuf/WriterInternalState.cs
+++ b/csharp/src/Google.Protobuf/WriterInternalState.cs
@@ -30,17 +30,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-using System;
-using System.Buffers;
-using System.Buffers.Binary;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
-using Google.Protobuf.Collections;
-
 namespace Google.Protobuf
 {
     

--- a/csharp/src/Google.Protobuf/WritingPrimitives.cs
+++ b/csharp/src/Google.Protobuf/WritingPrimitives.cs
@@ -32,7 +32,6 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if GOOGLE_PROTOBUF_SIMD

--- a/csharp/src/Google.Protobuf/WritingPrimitivesMessages.cs
+++ b/csharp/src/Google.Protobuf/WritingPrimitivesMessages.cs
@@ -30,9 +30,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-using System;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices.ComTypes;
 using System.Security;
 
 namespace Google.Protobuf


### PR DESCRIPTION
We need custom well-known types in a project since we need to handle some oneOfs differently based on the type. The current code base already support well-known types (for types well-known to protobuf) but doesn't allow to add custom well-known types. We first thought about using `ICustomDiagnosticMessage`, but this changes the behavior of the `JsonFormatter` and also doesn't allow parsing.

- Cleanup of unused code
- Unification of `JsonFormatter` and `JsonParser` code for well-known type handling
- Support for `AddWellKnownTypeHandlers` in `JsonFormatter` and `JsonParser` to allow custom handling
- Made `JsonTokenizer` and `JsonToken` public as they are needed for `JsonParser` handlers
- Added tests for new code