### PR TITLE
Fix gcc error: comparison of unsigned expression in '>= 0' is always …

### DIFF
--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -348,7 +348,6 @@ class PROTOBUF_EXPORT EpsCopyInputStream {
     if (ptr - buffer_end_ > limit_) return nullptr;
     while (limit_ > kSlopBytes) {
       size_t chunk_size = buffer_end_ + kSlopBytes - ptr;
-      GOOGLE_DCHECK_GE(chunk_size, static_cast<size_t>(0));
       append(ptr, chunk_size);
       ptr = Next();
       if (ptr == nullptr) return limit_end_;


### PR DESCRIPTION
…true [-Werror=type-limits]

This fixes the following build error:
```
In file included from no_warning_test.cc:7:
../../src/google/protobuf/parse_context.h: In instantiation of 'const char* google::protobuf::internal::EpsCopyInputStream::AppendUntilEnd(const char*, const A&) [with A = google::protobuf::internal::EpsCopyInputStream::AppendString(const char*, std::string*)::<lambda(const char*, ptrdiff_t)>]':
../../src/google/protobuf/parse_context.h:366:70:   required from here
../../src/google/protobuf/stubs/logging.h:161:48: error: comparison of unsigned expression in '>= 0' is always true [-Werror=type-limits]
  161 | #define GOOGLE_CHECK_GE(A, B) GOOGLE_CHECK((A) >= (B))
      |                                                ^
../../src/google/protobuf/stubs/logging.h:151:5: note: in definition of macro 'GOOGLE_LOG_IF'
  151 |   !(CONDITION) ? (void)0 : GOOGLE_LOG(LEVEL)
      |     ^~~~~~~~~
../../src/google/protobuf/stubs/logging.h:161:31: note: in expansion of macro 'GOOGLE_CHECK'
  161 | #define GOOGLE_CHECK_GE(A, B) GOOGLE_CHECK((A) >= (B))
      |                               ^~~~~~~~~~~~
../../src/google/protobuf/stubs/logging.h:201:26: note: in expansion of macro 'GOOGLE_CHECK_GE'
  201 | #define GOOGLE_DCHECK_GE GOOGLE_CHECK_GE
      |                          ^~~~~~~~~~~~~~~
../../src/google/protobuf/parse_context.h:351:7: note: in expansion of macro 'GOOGLE_DCHECK_GE'
  351 |       GOOGLE_DCHECK_GE(chunk_size, static_cast<size_t>(0));
      |       ^~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

Indeed gcc is true, comparing size_t value >= 0 is always true.

Cheers,
Romain