### PR TITLE
Made some small fixes for MinGW and for C++20 with GCC

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -562,7 +562,9 @@
 // by this flag is supposed to be removed after this experiment.
 // #define PROTOBUF_MESSAGE_OWNED_ARENA_EXPERIMENT
 
-#if defined(__cpp_constinit)
+// Our use of constinit does not yet work with GCC:
+// https://github.com/protocolbuffers/protobuf/issues/8310
+#if defined(__cpp_constinit) && !defined(__GNUC__)
 #define PROTOBUF_CONSTINIT constinit
 #elif defined(__has_cpp_attribute)
 #if __has_cpp_attribute(clang::require_constant_initialization)

--- a/src/google/protobuf/stubs/mutex.h
+++ b/src/google/protobuf/stubs/mutex.h
@@ -126,7 +126,7 @@ class GOOGLE_PROTOBUF_CAPABILITY("mutex") PROTOBUF_EXPORT WrappedMutex {
  private:
 #if defined(GOOGLE_PROTOBUF_SUPPORT_WINDOWS_XP)
   CallOnceInitializedMutex<CriticalSectionLock> mu_{};
-#elif defined(_MSC_VER)
+#elif defined(_WIN32)
   CallOnceInitializedMutex<std::mutex> mu_{};
 #else
   std::mutex mu_{};


### PR DESCRIPTION
Our use of constinit does not seem to work with GCC yet (see
https://github.com/protocolbuffers/protobuf/issues/8310), so this
commit disables it on GCC for now.

This commit also updates mutex.h to work around the fact that MinGW's
std::mutex apparently does not have a constexpr constructor. We already
have this kind of workaround for MSVC, so we can just use the same
workaround.