### PR TITLE
[Ruby] Fix for truncating behavior when converting Float to Duration.

### DIFF
--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -1287,7 +1287,7 @@ const upb_msg* Message_GetUpbMessage(VALUE value, const upb_msgdef* m,
         if (!rb_obj_is_kind_of(value, rb_cNumeric)) goto badtype;
 
         sec.int64_val = NUM2LL(value);
-        nsec.int32_val = (NUM2DBL(value) - NUM2LL(value)) * 1000000000;
+        nsec.int32_val = round((NUM2DBL(value) - NUM2LL(value)) * 1000000000);
         upb_msg_set(msg, sec_f, sec, arena);
         upb_msg_set(msg, nsec_f, nsec, arena);
         return msg;

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1701,6 +1701,12 @@ module CommonTests
     m = proto_module::TimeMessage.new(duration: 1.1)
     assert_equal Google::Protobuf::Duration.new(seconds: 1, nanos: 100_000_000), m.duration
 
+    m = proto_module::TimeMessage.new(duration: 123.321)
+    assert_equal Google::Protobuf::Duration.new(seconds: 123, nanos: 321_000_000), m.duration
+
+    m = proto_module::TimeMessage.new(duration: -123.321)
+    assert_equal Google::Protobuf::Duration.new(seconds: -123, nanos: -321_000_000), m.duration
+
     assert_raise(Google::Protobuf::TypeError) { m.duration = '2' }
     assert_raise(Google::Protobuf::TypeError) { m.duration = proto_module::TimeMessage.new }
   end


### PR DESCRIPTION
When porting the old code, I previously left out the `round()`.

Fixes: https://github.com/protocolbuffers/protobuf/issues/8314