### PR TITLE
Create a CMake option to control whether or not RTTI is enabled

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 if(WITH_PROTOC)
   set(protobuf_PROTOC_EXE ${WITH_PROTOC} CACHE FILEPATH "Protocol Buffer Compiler executable" FORCE)
 endif()
+option(protobuf_DISABLE_RTTI "Remove runtime type information in the binaries" ON)
 option(protobuf_BUILD_TESTS "Build tests" ON)
 option(protobuf_BUILD_CONFORMANCE "Build conformance tests" OFF)
 option(protobuf_BUILD_EXAMPLES "Build examples" OFF)
@@ -116,6 +117,10 @@ if(protobuf_VERBOSE)
 endif()
 
 add_definitions(-DGOOGLE_PROTOBUF_CMAKE_BUILD)
+
+if (protobuf_DISABLE_RTTI)
+  add_definitions(-DGOOGLE_PROTOBUF_NO_RTTI=1)
+endif()
 
 find_package(Threads REQUIRED)
 if (CMAKE_USE_PTHREADS_INIT)


### PR DESCRIPTION
This is useful for Conan recipes that build Protobuf, in which
whatever we want to enable has to be enabled in the initial command line.
Without this, the people maintaining the recipe have to patch the CMake
setup of Protobuf before building the binaries.

Closes #5541