### PR TITLE
read_property() handler is not supposed to return NULL

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -334,7 +334,7 @@ static zval *Message_read_property(PROTO_VAL *obj, PROTO_STR *member,
   Message* intern = PROTO_VAL_P(obj);
   const upb_fielddef *f = get_field(intern, member);
 
-  if (!f) return NULL;
+  if (!f) return &EG(uninitialized_zval);
   Message_get(intern, f, rv);
   return rv;
 }


### PR DESCRIPTION
This handler is called throughout the Zend engine code and in none of the cases the result is checked for NULL because the engine expects it to be a valid zval.
If there is no such property, the object has to return &EG(uninitialized_zval).
