### PR TITLE
[Ruby] Fixed quadratic memory usage when appending to arrays.

### DIFF
--- a/ruby/ext/google/protobuf_c/ruby-upb.c
+++ b/ruby/ext/google/protobuf_c/ruby-upb.c
@@ -6663,10 +6663,9 @@ void upb_array_set(upb_array *arr, size_t i, upb_msgval val) {
 }
 
 bool upb_array_append(upb_array *arr, upb_msgval val, upb_arena *arena) {
-  if (!_upb_array_realloc(arr, arr->len + 1, arena)) {
+  if (!upb_array_resize(arr, arr->len + 1, arena)) {
     return false;
   }
-  arr->len++;
   upb_array_set(arr, arr->len - 1, val);
   return true;
 }


### PR DESCRIPTION
The code mistakenly called realloc() instead of resize() on every
array append, causing quadratic memory usage.

This fixes the problem reported in https://github.com/protocolbuffers/protobuf/issues/8337#issuecomment-789119303