### PR TITLE
Revert "[bazel] Flip --incompatible_use_com_google_googletest"

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,7 +17,7 @@ exports_files(["LICENSE"])
 # TODO(yannic): Remove in 3.14.0.
 string_flag(
     name = "incompatible_use_com_google_googletest",
-    build_setting_default = "false",
+    build_setting_default = "true",
     values = ["true", "false"]
 )
 


### PR DESCRIPTION
Reverts protocolbuffers/protobuf#8352

The flag was already flipped in de371235c9f50eadad7a3562572b79a9422cd754.