### PR TITLE
docs: register Coach Client Connect extension number (1107)

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -268,3 +268,7 @@ with info about your project (name and website) so we can add an entry for you.
 1. Protoc-gen-sanitize
    * Website: https://github.com/Intrinsec/protoc-gen-sanitize
    * Extension: 1102-1106
+
+1. Coach Client Connect (planned release in March 2021)
+   * Website: https://www.coachclientconnect.com
+   * Extension: 1107


### PR DESCRIPTION
Hi -- I'm the CTO at a startup (Coach Client Connect) and we're getting ready to release our product this month. In a nutshell, our software helps manage and run coaching and training programs. We have a GRPC API and we use custom protobuf options for various purposes; if possible, I'd like to register an extension number to avoid conflicts. 

Our website (www.coachclientconnect.com) is not up yet but will be very soon, can I go ahead and reserve a number now or should I wait until the site is up?

Also, I noticed the guidelines say that a contributor's license is required. I'm happy to fill one out but just wanted to check first if it's required for this change (i.e. no code, just a change to the docs).

Thanks!