### PR TITLE
run basic C++ aarch64 tests under qemu emulator

### DIFF
--- a/kokoro/linux/aarch64/cpp_crosscompile_and_run_tests_with_qemu_aarch64.sh
+++ b/kokoro/linux/aarch64/cpp_crosscompile_and_run_tests_with_qemu_aarch64.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Builds protobuf C++ with aarch64 crosscompiler and runs a basic set of tests under an emulator.
+# NOTE: This script is expected to run under the dockcross/linux-arm64 docker image.
+
+set -ex
+
+mkdir -p cmake/crossbuild_aarch64
+cd cmake/crossbuild_aarch64
+
+# the build commands are expected to run under dockcross docker image
+# where the CC, CXX and other toolchain variables already point to the crosscompiler
+cmake ..
+make -j8
+
+# check that the resulting test binary is indeed an aarch64 ELF
+(file ./tests | grep -q "ELF 64-bit LSB executable, ARM aarch64") || (echo "Test binary in not an aarch64 binary"; exit 1)
+
+# run the basic set of C++ tests under QEMU
+# there are other tests we could run (e.g. ./lite-test), but this is sufficient as a smoketest
+qemu-aarch64 ./tests

--- a/kokoro/linux/aarch64/dockcross_helpers/run_dockcross_linux_aarch64.sh
+++ b/kokoro/linux/aarch64/dockcross_helpers/run_dockcross_linux_aarch64.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+# go to the repo root
+cd $(dirname $0)/../../../..
+
+if [[ -t 0 ]]; then
+  DOCKER_TTY_ARGS="-it"
+else
+  # The input device on kokoro is not a TTY, so -it does not work.
+  DOCKER_TTY_ARGS=
+fi
+
+# running dockcross image without any arguments generates a wrapper
+# scripts that can be used to run commands under the dockcross image
+# easily.
+# See https://github.com/dockcross/dockcross#usage for details
+docker run $DOCKER_TTY_ARGS --rm dockcross/linux-arm64 >dockcross-linux-arm64.sh
+chmod +x dockcross-linux-arm64.sh
+
+# the wrapper script has CRLF line endings and bash doesn't like that
+# so we change CRLF line endings into LF.
+sed -i 's/\r//g' dockcross-linux-arm64.sh
+
+# The dockcross wrapper script runs arbitrary commands under the selected dockcross
+# image with the following properties which make its use very convenient:
+# * the current working directory is mounted under /work so the container can easily
+#   access the current workspace
+# * the processes in the container run under the same UID and GID as the host process so unlike
+#   vanilla "docker run" invocations, the workspace doesn't get polluted with files
+#   owned by root.
+./dockcross-linux-arm64.sh "$@"

--- a/kokoro/linux/aarch64/test_cpp_aarch64.sh
+++ b/kokoro/linux/aarch64/test_cpp_aarch64.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Crosscompiles protobuf C++ under dockcross docker image and runs the tests under an emulator.
+
+set -e
+
+# go to the repo root
+cd $(dirname $0)/../../..
+
+# Initialize any submodules.
+git submodule update --init --recursive
+
+# run the C++ build and test script under dockcross/linux-arm64 image
+kokoro/linux/aarch64/dockcross_helpers/run_dockcross_linux_aarch64.sh kokoro/linux/aarch64/cpp_crosscompile_and_run_tests_with_qemu_aarch64.sh

--- a/kokoro/linux/cpp_aarch64/build.sh
+++ b/kokoro/linux/cpp_aarch64/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# This is the top-level script we give to Kokoro as the entry point for
+# running the "continuous" and "presubmit" jobs.
+
+set -ex
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+kokoro/linux/aarch64/test_cpp_aarch64.sh

--- a/kokoro/linux/cpp_aarch64/continuous.cfg
+++ b/kokoro/linux/cpp_aarch64/continuous.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/cpp_aarch64/build.sh"
+timeout_mins: 120

--- a/kokoro/linux/cpp_aarch64/presubmit.cfg
+++ b/kokoro/linux/cpp_aarch64/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/cpp_aarch64/build.sh"
+timeout_mins: 120


### PR DESCRIPTION
Add a script that crosscompiles C++ under a crosscompiler  (and uses dockcross docker image for that) and then runs C++ test suite under QEMU emulator.

- the tests pass and the the whole build + tests only takes a few minutes (= faster than if we were compiled everything under and emulator, which would be quite slow).
- for now there's no kokoro job to actually run the tests, but setting up one is easy (I plan to do that as a followup PR)
- dockcross docker image is used since it makes everything much easier (see comments in the code)
- for manual run, just run `kokoro/linux/aarch64/test_cpp_aarch64.sh`


What the kokoro test output would look like if the kokoro job was already created (I used a hack to obtain an adhoc run):
sponge/988880f9-7e8f-465b-8ff9-9483d6ce2f0d