### PR TITLE
Remove link to unmaintained TypeScript library

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -101,7 +101,6 @@ These are projects we know about implementing Protocol Buffers for other program
 * Solidity: https://github.com/celer-network/pb3-gen-sol
 * Swift: https://github.com/alexeyxo/protobuf-swift
 * Swift: https://github.com/apple/swift-protobuf/
-* Typescript: https://github.com/y3llowcake/protoc-gen-ts
 * Vala: https://launchpad.net/protobuf-vala
 * Visual Basic: http://code.google.com/p/protobuf-net/
 


### PR DESCRIPTION
y3llowcake/protoc-gen-ts is no longer maintained:  
https://github.com/y3llowcake/protoc-gen-ts/issues/2#issuecomment-758215154

FWIW, neither is this one w/ a similar name: thesayyn/protoc-gen-ts:  
https://github.com/thesayyn/protoc-gen-ts/issues/31#issuecomment-781681955

https://github.com/improbable-eng/ts-protoc-gen exists, but has [some issues]  (in particular [this one]) which make me hesitant to suggest including it here.

[some issues]: https://github.com/improbable-eng/ts-protoc-gen/issues
[this one]: https://github.com/improbable-eng/ts-protoc-gen/issues/249