### PR TITLE
Remove the ::pb namespace (alias).

### DIFF
--- a/src/google/protobuf/port.h
+++ b/src/google/protobuf/port.h
@@ -37,11 +37,4 @@
 #define GOOGLE_PROTOBUF_PORT_H__
 
 
-#include <google/protobuf/stubs/port.h>
-
-// Protobuf intends to move into the pb:: namespace.
-namespace protobuf_future_namespace_placeholder {}
-namespace pb = ::protobuf_future_namespace_placeholder;
-
-
 #endif  // GOOGLE_PROTOBUF_PORT_H__


### PR DESCRIPTION
This closes #8349, although we will probably still pursue some other name in the future.