### PR TITLE
Added UnsafeByteOperations to protobuf-lite

### DIFF
--- a/java/core/BUILD
+++ b/java/core/BUILD
@@ -85,6 +85,7 @@ LITE_SRCS = [
     "src/main/java/com/google/protobuf/UnknownFieldSetLite.java",
     "src/main/java/com/google/protobuf/UnknownFieldSetLiteSchema.java",
     "src/main/java/com/google/protobuf/UnmodifiableLazyStringList.java",
+    "src/main/java/com/google/protobuf/UnsafeByteOperations.java",
     "src/main/java/com/google/protobuf/UnsafeUtil.java",
     "src/main/java/com/google/protobuf/Utf8.java",
     "src/main/java/com/google/protobuf/WireFormat.java",

--- a/java/lite/pom.xml
+++ b/java/lite/pom.xml
@@ -173,6 +173,7 @@
                     <include>UnknownFieldSetLite.java</include>
                     <include>UnknownFieldSetLiteSchema.java</include>
                     <include>UnmodifiableLazyStringList.java</include>
+                    <include>UnsafeByteOperations.java</include>
                     <include>UnsafeUtil.java</include>
                     <include>Utf8.java</include>
                     <include>WireFormat.java</include>


### PR DESCRIPTION
Adding `UnsafeByteOperations` to `protobuf-lite`. `UnsafeByteOperations` is needed for gRPC Java which relies on `protobuf-lite` to wrap a ByteBuffer when creating a ByteString. `UnsafeByteOperations` is a pretty small class so it won't increase the footprint of `protobuf-lite` much.