### PR TITLE
Construct CodedInputStream with ReadOnlyMemory<byte>

### DIFF
--- a/csharp/src/Google.Protobuf.Test/CodedInputStreamTest.cs
+++ b/csharp/src/Google.Protobuf.Test/CodedInputStreamTest.cs
@@ -895,6 +895,13 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void Dispose_FromReadOnlyMemory()
+        {
+            var stream = new CodedInputStream(new byte[10].AsMemory());
+            stream.Dispose();
+        }
+
+        [Test]
         public void TestParseMessagesCloseTo2G()
         {
             byte[] serializedMessage = GenerateBigSerializedMessage();

--- a/csharp/src/Google.Protobuf/ParseContext.cs
+++ b/csharp/src/Google.Protobuf/ParseContext.cs
@@ -73,7 +73,7 @@ namespace Google.Protobuf
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void Initialize(CodedInputStream input, out ParseContext ctx)
         {
-            ctx.buffer = new ReadOnlySpan<byte>(input.InternalBuffer);
+            ctx.buffer = input.InternalMemory.Span;
             // ideally we would use a reference to the original state, but that doesn't seem possible
             // so we just copy the struct that holds the state. We will need to later store the state back
             // into CodedInputStream if we want to keep it usable.


### PR DESCRIPTION
This is a proposition to use ReadOnlyMemory<byte> inside CodedInputStream. This is useful to parse buffers returned as ReadOnlyMemory<byte> from some APIs without copying back to a byte array.
The rest of the code is already using Span<byte> so the change is of low impact.

When a stream is provided, a byte[] is still necessary to read the stream, and is stored in the internalBuffer field. When given directly a byte[], it is also stored in this field. In this case, the buffer field is just the .AsMemory() of this field.
