### PR TITLE
Fixed message equality in cases where the message type is different.

### DIFF
--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -697,17 +697,13 @@ bool Message_Equal(const upb_msg *m1, const upb_msg *m2, const upb_msgdef *m) {
  * field is of a primitive type).
  */
 static VALUE Message_eq(VALUE _self, VALUE _other) {
-  if (TYPE(_self) != TYPE(_other)) {
-    return Qfalse;
-  }
+  if (CLASS_OF(_self) != CLASS_OF(_other)) return Qfalse;
 
   Message* self = ruby_to_Message(_self);
   Message* other = ruby_to_Message(_other);
+  assert(self->msgdef == other->msgdef);
 
-  return self->msgdef == other->msgdef &&
-                 Message_Equal(self->msg, other->msg, self->msgdef)
-             ? Qtrue
-             : Qfalse;
+  return Message_Equal(self->msg, other->msg, self->msgdef) ? Qtrue : Qfalse;
 }
 
 uint64_t Message_Hash(const upb_msg* msg, const upb_msgdef* m, uint64_t seed) {

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -704,7 +704,8 @@ static VALUE Message_eq(VALUE _self, VALUE _other) {
   Message* self = ruby_to_Message(_self);
   Message* other = ruby_to_Message(_other);
 
-  return Message_Equal(self->msg, other->msg, self->msgdef)
+  return self->msgdef == other->msgdef &&
+                 Message_Equal(self->msg, other->msg, self->msgdef)
              ? Qtrue
              : Qfalse;
 }

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -687,12 +687,13 @@ module CommonTests
     assert m.repeated_msg[0].object_id != m2.repeated_msg[0].object_id
   end
 
-  def test_eq
+  def test_message_eq
     m = proto_module::TestMessage.new(:optional_int32 => 42,
                                       :repeated_int32 => [1, 2, 3])
     m2 = proto_module::TestMessage.new(:optional_int32 => 43,
                                        :repeated_int32 => [1, 2, 3])
     assert m != m2
+    assert_not_equal proto_module::TestMessage.new, proto_module::TestMessage2.new
   end
 
   def test_enum_lookup


### PR DESCRIPTION
If the message types are different, equality comparison must return
false.

Fixes: https://github.com/protocolbuffers/protobuf/issues/8427