### PR TITLE
[bazel] Add option to depend on Abseil

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -14,6 +14,19 @@ exports_files(["LICENSE"])
 # build configuration
 ################################################################################
 
+string_flag(
+    name = "with_abseil",
+    build_setting_default = "false",
+    values = ["true", "false"]
+)
+
+config_setting(
+    name = "use_abseil",
+    flag_values = {
+        "//:with_abseil": "true"
+    },
+)
+
 ################################################################################
 # ZLIB configuration
 ################################################################################
@@ -168,6 +181,18 @@ cc_library(
     includes = ["src/"],
     linkopts = LINK_OPTS,
     visibility = ["//visibility:public"],
+    deps = select({
+        "//:use_abseil": [
+            "@com_google_absl//absl/numeric:int128",
+        ],
+        "//conditions:default": [],
+    }),
+    defines = select({
+        "//:use_abseil": [
+            "PROTOBUF_USE_ABSEIL=1",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 PROTOBUF_DEPS = select({

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,16 @@ local_repository(
     path = "examples",
 )
 
+# 2021-03-25T15:05:20Z
+http_archive(
+    name = "com_google_absl",
+    urls = [
+         "https://github.com/abseil/abseil-cpp/archive/a09b5de0d57d7b2179210989ab63361c3c1894f5.zip",
+    ],
+    strip_prefix = "abseil-cpp-a09b5de0d57d7b2179210989ab63361c3c1894f5",
+    sha256 = "595a502009b3f97f9407ff0557abc0fc4a9d9a574662353ccb2971c539ddb2e3",
+)
+
 http_archive(
     name = "com_google_googletest",
     sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",

--- a/kokoro/linux/bazel/build.sh
+++ b/kokoro/linux/bazel/build.sh
@@ -7,31 +7,25 @@ set -ex
 use_bazel.sh latest
 bazel version
 
-# Print bazel testlogs to stdout when tests failed.
-function print_test_logs {
-  # TODO(yannic): Only print logs of failing tests.
-  testlogs_dir=$(bazel info bazel-testlogs)
-  testlogs=$(find "${testlogs_dir}" -name "*.log")
-  for log in $testlogs; do
-    cat "${log}"
-  done
+function run_tests {
+  bazel test \
+    --test_summary=testcase \
+    --test_output=errors \
+      //:build_files_updated_unittest \
+      //java/... \
+      //:protoc \
+      //:protobuf \
+      //:protobuf_python \
+      //:protobuf_test \
+      @com_google_protobuf//:cc_proto_blacklist_test \
+    $@
 }
 
 # Change to repo root
 cd $(dirname $0)/../../..
 
-git submodule update --init --recursive
-
-trap print_test_logs EXIT
-bazel test --copt=-Werror --host_copt=-Werror \
-  //:build_files_updated_unittest \
-  //java/... \
-  //:protoc \
-  //:protobuf \
-  //:protobuf_python \
-  //:protobuf_test \
-  @com_google_protobuf//:cc_proto_blacklist_test
-trap - EXIT
+run_tests "--//:with_abseil=false"
+run_tests "--//:with_abseil=true"
 
 cd examples
 bazel build //...

--- a/src/google/protobuf/stubs/int128.cc
+++ b/src/google/protobuf/stubs/int128.cc
@@ -30,6 +30,8 @@
 
 #include <google/protobuf/stubs/int128.h>
 
+#if !defined(PROTOBUF_USE_ABSEIL)
+
 #include <iomanip>
 #include <ostream>  // NOLINT(readability/streams)
 #include <sstream>
@@ -197,3 +199,5 @@ void VerifyValidShift(std::string op, int amount) {
 }  // namespace google
 
 #include <google/protobuf/port_undef.inc>  // NOLINT
+
+#endif  // !defined(PROTOBUF_USE_ABSEIL)

--- a/src/google/protobuf/stubs/int128.h
+++ b/src/google/protobuf/stubs/int128.h
@@ -27,8 +27,25 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #ifndef GOOGLE_PROTOBUF_STUBS_INT128_H_
 #define GOOGLE_PROTOBUF_STUBS_INT128_H_
+
+#if defined(PROTOBUF_USE_ABSEIL)
+
+#include "absl/numeric/int128.h"
+
+namespace google {
+namespace protobuf {
+
+using absl::uint128;
+using absl::Uint128Max;
+using absl::MakeUint128;
+
+}  // namespace protobuf
+}  // namespace google
+
+#else  // !defined(PROTOBUF_USE_ABSEIL)
 
 #include <google/protobuf/stubs/common.h>
 
@@ -372,5 +389,7 @@ using google::protobuf::int128_internal::MakeUint128;
 }  // namespace google
 
 #include <google/protobuf/port_undef.inc>
+
+#endif  // !defined(PROTOBUF_USE_ABSEIL)
 
 #endif  // GOOGLE_PROTOBUF_STUBS_INT128_H_


### PR DESCRIPTION
For now, this is experimental and only used to ensure we don't regress
the parts that we already made compatible with the Abseil types.

Progress on #3688