### PR TITLE
Add 'java/lite/target' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ src/**/*.trs
 
 # JavaBuild output.
 java/core/target
+java/lite/target
 java/util/target
 javanano/target
 java/.idea


### PR DESCRIPTION
The artifacts of `java/lite` were not added to the `.gitignore`.