### PR TITLE
Revert "[C++] Refactor uint128 (#8416)"

### DIFF
--- a/src/google/protobuf/stubs/int128.cc
+++ b/src/google/protobuf/stubs/int128.cc
@@ -33,7 +33,6 @@
 #include <iomanip>
 #include <ostream>  // NOLINT(readability/streams)
 #include <sstream>
-#include <string>
 
 #include <google/protobuf/stubs/logging.h>
 
@@ -41,7 +40,11 @@
 
 namespace google {
 namespace protobuf {
-namespace int128_internal {
+
+const uint128_pod kuint128max = {
+    static_cast<uint64>(PROTOBUF_LONGLONG(0xFFFFFFFFFFFFFFFF)),
+    static_cast<uint64>(PROTOBUF_LONGLONG(0xFFFFFFFFFFFFFFFF))
+};
 
 // Returns the 0-based position of the last set bit (i.e., most significant bit)
 // in the given uint64. The argument may not be 0.
@@ -185,14 +188,6 @@ std::ostream& operator<<(std::ostream& o, const uint128& b) {
   return o << rep;
 }
 
-void VerifyValidShift(std::string op, int amount) {
-  // Shifting more than 127 is UB in Abseil, just crash for now to verify
-  // callers don't depend on it returning 0.
-  GOOGLE_CHECK_LT(amount, 128) << "Error executing operator " << op
-                               << ": shifts of more than 127 are undefined";
-}
-
-}  // namespace int128_internal
 }  // namespace protobuf
 }  // namespace google
 

--- a/src/google/protobuf/stubs/logging.h
+++ b/src/google/protobuf/stubs/logging.h
@@ -31,7 +31,6 @@
 #ifndef GOOGLE_PROTOBUF_STUBS_LOGGING_H_
 #define GOOGLE_PROTOBUF_STUBS_LOGGING_H_
 
-#include <google/protobuf/stubs/int128.h>
 #include <google/protobuf/stubs/macros.h>
 #include <google/protobuf/stubs/port.h>
 #include <google/protobuf/stubs/status.h>
@@ -66,6 +65,7 @@ enum LogLevel {
 #endif
 };
 
+class uint128;
 namespace internal {
 
 class LogFinisher;


### PR DESCRIPTION
This reverts commit b604419d269887e0f34ff4d5fa0d14342a7e680d.

The original change broke some projects (see discussion on #8416), so let's roll it back until we can come up with a fix.