### PR TITLE
Fixed memory leak of Ruby arena objects.

### DIFF
--- a/ruby/ext/google/protobuf_c/protobuf.c
+++ b/ruby/ext/google/protobuf_c/protobuf.c
@@ -180,6 +180,7 @@ static void Arena_mark(void *data) {
 static void Arena_free(void *data) {
   Arena *arena = data;
   upb_arena_free(arena->arena);
+  xfree(arena);
 }
 
 static VALUE cArena;


### PR DESCRIPTION
In our `Arena_free()` function, we were freeing the memory from the
upb arena but we were failing to free the memory for the
Ruby arena object. This was causing every Ruby arena object
to leak: even though the objects were getting GC'd, the
underlying memory was not getting released.

Fixes: https://github.com/protocolbuffers/protobuf/issues/8455 https://github.com/protocolbuffers/protobuf/issues/8421