### PR TITLE
Fix .NET SourceLink and warnings in NuGet package

### DIFF
--- a/csharp/build_packages.bat
+++ b/csharp/build_packages.bat
@@ -1,7 +1,7 @@
 @rem Builds Google.Protobuf NuGet packages
 
 dotnet restore src/Google.Protobuf.sln
-dotnet pack -c Release src/Google.Protobuf.sln || goto :error
+dotnet pack -c Release src/Google.Protobuf.sln -p:ContinuousIntegrationBuild=true || goto :error
 
 goto :EOF
 

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -15,10 +15,11 @@
     <PackageTags>Protocol;Buffers;Binary;Serialization;Format;Google;proto;proto3</PackageTags>
     <PackageReleaseNotes>C# proto3 support</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/protocolbuffers/protobuf</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/protocolbuffers/protobuf/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/protocolbuffers/protobuf.git</RepositoryUrl>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>


### PR DESCRIPTION
* Include untracked sources in NuGet packages
* Create NuGet package using a deterministic build
* Fix NuGet warning by updating license URL to license expression
* Update .NET SDK so reproducable build metadata is added to package

Below is a comparison in NuGet Package Explorer.

**Before:**

![image](https://user-images.githubusercontent.com/303201/113954182-7d8a3980-986d-11eb-8aa8-307474485f77.png)

**After: (note, package built locally on my PC so missing signatures from Google and NuGet)**

![image](https://user-images.githubusercontent.com/303201/113954263-a90d2400-986d-11eb-825e-e7e221e3e6a6.png)
