### PR TITLE
Run java aarch64 tests on the CI (with an emulator)

### DIFF
--- a/kokoro/linux/aarch64/protoc_crosscompile_aarch64.sh
+++ b/kokoro/linux/aarch64/protoc_crosscompile_aarch64.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Builds protobuf C++ with aarch64 crosscompiler.
+
+set -ex
+
+./autogen.sh
+CXXFLAGS="-fPIC -g -O2" ./configure --host=aarch64
+make -j8

--- a/kokoro/linux/aarch64/test_java_aarch64.sh
+++ b/kokoro/linux/aarch64/test_java_aarch64.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -ex
+
+# go to the repo root
+cd $(dirname $0)/../../..
+
+if [[ -t 0 ]]; then
+  DOCKER_TTY_ARGS="-it"
+else
+  # The input device on kokoro is not a TTY, so -it does not work.
+  DOCKER_TTY_ARGS=
+fi
+
+# crosscompile protoc as we will later need it for the java build.
+# we build it under the dockcross/manylinux2014-aarch64 image so that the resulting protoc binary is compatible
+# with a wide range of linux distros (including any docker images we will use later to build and test java)
+kokoro/linux/aarch64/dockcross_helpers/run_dockcross_manylinux2014_aarch64.sh kokoro/linux/aarch64/protoc_crosscompile_aarch64.sh
+
+# the command that will be used to build and test java under an emulator
+# * IsValidUtf8Test and DecodeUtf8Test tests are being skipped because that take very long under an emulator.
+TEST_JAVA_COMMAND="mvn --batch-mode -DskipTests install && mvn --batch-mode -Dtest='**/*Test, !**/*IsValidUtf8Test, !**/*DecodeUtf8Test' -DfailIfNoTests=false surefire:test"
+
+# use an actual aarch64 docker image (with a real aarch64 java and maven) to run build & test protobuf java under an emulator
+# * mount the protobuf root as /work to be able to access the crosscompiled files
+# * to avoid running the process inside docker as root (which can pollute the workspace with files owned by root), we force
+#   running under current user's UID and GID. To be able to do that, we need to provide a home directory for the user
+#   otherwise the UID would be homeless under the docker container and pip install wouldn't work. For simplicity,
+#   we just run map the user's home to a throwaway temporary directory
+# * the JAVA_OPTS and MAVEN_CONFIG variables are being set mostly to silence warnings about non-existent home directory
+#   and to avoid polluting the workspace.
+docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -e "JAVA_OPTS=-Duser.home=/home/fake-user" -e "MAVEN_CONFIG=/home/fake-user/.m2" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work arm64v8/maven:3.8-openjdk-11 bash -c "cd java && $TEST_JAVA_COMMAND"

--- a/kokoro/linux/java_aarch64/build.sh
+++ b/kokoro/linux/java_aarch64/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# This is the top-level script we give to Kokoro as the entry point for
+# running the "continuous" and "presubmit" jobs.
+
+set -ex
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Initialize any submodules.
+git submodule update --init --recursive
+
+kokoro/linux/aarch64/qemu_helpers/prepare_qemu.sh
+
+kokoro/linux/aarch64/test_java_aarch64.sh

--- a/kokoro/linux/java_aarch64/continuous.cfg
+++ b/kokoro/linux/java_aarch64/continuous.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/java_aarch64/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/linux/java_aarch64/presubmit.cfg
+++ b/kokoro/linux/java_aarch64/presubmit.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/java_aarch64/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}


### PR DESCRIPTION
Based on https://github.com/protocolbuffers/protobuf/pull/8479 (only the last few commits need to be reviewed).

- build protoc under crosscompiler
- then build & tests java code under qemu emulator.

Example passing adhoc run: http://sponge2.corp.google.com/95eaabd8-a929-4dfd-839a-4b4bef078391