### PR TITLE
Make Go example work out of the box

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -16,7 +16,7 @@ clean:
 	rm -f javac_middleman AddPerson*.class ListPeople*.class com/example/tutorial/*.class
 	rm -f protoc_middleman addressbook.pb.cc addressbook.pb.h addressbook_pb2.py com/example/tutorial/AddressBookProtos.java
 	rm -f *.pyc
-	rm -f protoc_middleman_go tutorial/*.pb.go add_person_go list_people_go
+	rm -f protoc_middleman_go tutorial/*.pb.go add_person_go list_people_go go.mod go.sum
 	rm -f protoc_middleman_dart dart_tutorial/*.pb*.dart
 	rmdir dart_tutorial 2>/dev/null || true
 	rmdir tutorial 2>/dev/null || true
@@ -51,16 +51,20 @@ add_person_dart: add_person.dart protoc_middleman_dart
 
 list_people_dart: list_people.dart protoc_middleman_dart
 
-add_person_go: add_person.go protoc_middleman_go
+go_mod:
+	go mod init github.com/protocolbuffers/protobuf/examples
+	go mod tidy
+
+add_person_go: add_person.go protoc_middleman_go go_mod
 	go build -o add_person_go add_person.go
 
-add_person_gotest: add_person_test.go add_person_go
+add_person_gotest: add_person_test.go add_person_go go_mod
 	go test add_person.go add_person_test.go
 
-list_people_go: list_people.go protoc_middleman_go
+list_people_go: list_people.go protoc_middleman_go go_mod
 	go build -o list_people_go list_people.go
 
-list_people_gotest: list_people.go list_people_go
+list_people_gotest: list_people.go list_people_go go_mod
 	go test list_people.go list_people_test.go
 
 javac_middleman: AddPerson.java ListPeople.java protoc_middleman

--- a/examples/addressbook.proto
+++ b/examples/addressbook.proto
@@ -23,6 +23,10 @@ option java_outer_classname = "AddressBookProtos";
 option csharp_namespace = "Google.Protobuf.Examples.AddressBook";
 // [END csharp_declaration]
 
+// [START go_declaration]
+option go_package = "../tutorial";
+// [END go_declaration]
+
 // [START messages]
 message Person {
   string name = 1;


### PR DESCRIPTION
This makes `make go` build the .pb.go file in the correct place and set up appropriate go.mod and go.sum files. `make clean` is updated to properly clean these up.

Please take a look.