### PR TITLE
Use C++11 enum class for Utf8CheckMode

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_helpers.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.cc
@@ -1026,13 +1026,13 @@ Utf8CheckMode GetUtf8CheckMode(const FieldDescriptor* field,
                                const Options& options) {
   if (field->file()->syntax() == FileDescriptor::SYNTAX_PROTO3 &&
       FieldEnforceUtf8(field, options)) {
-    return Utf8CheckMode::Strict;
+    return Utf8CheckMode::kStrict;
   } else if (GetOptimizeFor(field->file(), options) !=
                  FileOptions::LITE_RUNTIME &&
              FileUtf8Verification(field->file(), options)) {
-    return Utf8CheckMode::Verify;
+    return Utf8CheckMode::kVerify;
   } else {
-    return Utf8CheckMode::None;
+    return Utf8CheckMode::kNone;
   }
 }
 
@@ -1043,7 +1043,7 @@ static void GenerateUtf8CheckCode(const FieldDescriptor* field,
                                   const char* verify_function,
                                   const Formatter& format) {
   switch (GetUtf8CheckMode(field, options)) {
-    case Utf8CheckMode::Strict: {
+    case Utf8CheckMode::kStrict: {
       if (for_parse) {
         format("DO_(");
       }
@@ -1063,7 +1063,7 @@ static void GenerateUtf8CheckCode(const FieldDescriptor* field,
       format.Outdent();
       break;
     }
-    case Utf8CheckMode::Verify: {
+    case Utf8CheckMode::kVerify: {
       format("::$proto_ns$::internal::WireFormat::$1$(\n", verify_function);
       format.Indent();
       format(parameters);
@@ -1076,7 +1076,7 @@ static void GenerateUtf8CheckCode(const FieldDescriptor* field,
       format.Outdent();
       break;
     }
-    case Utf8CheckMode::None:
+    case Utf8CheckMode::kNone:
       break;
   }
 }
@@ -1478,12 +1478,12 @@ class ParseLoopGenerator {
     if (!check_utf8) return;  // return if this is a bytes field
     auto level = GetUtf8CheckMode(field, options_);
     switch (level) {
-      case Utf8CheckMode::None:
+      case Utf8CheckMode::kNone:
         return;
-      case Utf8CheckMode::Verify:
+      case Utf8CheckMode::kVerify:
         format_("#ifndef NDEBUG\n");
         break;
-      case Utf8CheckMode::Strict:
+      case Utf8CheckMode::kStrict:
         format_("CHK_(");
         break;
     }
@@ -1494,14 +1494,14 @@ class ParseLoopGenerator {
     }
     format_("$pi_ns$::VerifyUTF8(str, $1$)", field_name);
     switch (level) {
-      case Utf8CheckMode::None:
+      case Utf8CheckMode::kNone:
         return;
-      case Utf8CheckMode::Verify:
+      case Utf8CheckMode::kVerify:
         format_(
             ";\n"
             "#endif  // !NDEBUG\n");
         break;
-      case Utf8CheckMode::Strict:
+      case Utf8CheckMode::kStrict:
         format_(");\n");
         break;
     }

--- a/src/google/protobuf/compiler/cpp/cpp_helpers.h
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.h
@@ -774,10 +774,10 @@ class PROTOC_EXPORT NamespaceOpener {
   std::vector<std::string> name_stack_;
 };
 
-enum Utf8CheckMode {
-  STRICT = 0,  // Parsing will fail if non UTF-8 data is in string fields.
-  VERIFY = 1,  // Only log an error but parsing will succeed.
-  NONE = 2,    // No UTF-8 check.
+enum class Utf8CheckMode {
+  Strict = 0,  // Parsing will fail if non UTF-8 data is in string fields.
+  Verify = 1,  // Only log an error but parsing will succeed.
+  None = 2,    // No UTF-8 check.
 };
 
 Utf8CheckMode GetUtf8CheckMode(const FieldDescriptor* field,

--- a/src/google/protobuf/compiler/cpp/cpp_helpers.h
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.h
@@ -775,9 +775,9 @@ class PROTOC_EXPORT NamespaceOpener {
 };
 
 enum class Utf8CheckMode {
-  Strict = 0,  // Parsing will fail if non UTF-8 data is in string fields.
-  Verify = 1,  // Only log an error but parsing will succeed.
-  None = 2,    // No UTF-8 check.
+  kStrict = 0,  // Parsing will fail if non UTF-8 data is in string fields.
+  kVerify = 1,  // Only log an error but parsing will succeed.
+  kNone = 2,    // No UTF-8 check.
 };
 
 Utf8CheckMode GetUtf8CheckMode(const FieldDescriptor* field,

--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -1017,8 +1017,8 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
         "$classname$*>(&_$classname$_default_instance_); }\n");
     auto utf8_check = GetUtf8CheckMode(descriptor_->field(0), options_);
     if (descriptor_->field(0)->type() == FieldDescriptor::TYPE_STRING &&
-        utf8_check != Utf8CheckMode::None) {
-      if (utf8_check == Utf8CheckMode::Strict) {
+        utf8_check != Utf8CheckMode::kNone) {
+      if (utf8_check == Utf8CheckMode::kStrict) {
         format(
             "  static bool ValidateKey(std::string* s) {\n"
             "    return ::$proto_ns$::internal::WireFormatLite::"
@@ -1027,7 +1027,7 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
             " }\n",
             descriptor_->field(0)->full_name());
       } else {
-        GOOGLE_CHECK_EQ(utf8_check, Utf8CheckMode::Verify);
+        GOOGLE_CHECK_EQ(utf8_check, Utf8CheckMode::kVerify);
         format(
             "  static bool ValidateKey(std::string* s) {\n"
             "#ifndef NDEBUG\n"
@@ -1046,8 +1046,8 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
       format("  static bool ValidateKey(void*) { return true; }\n");
     }
     if (descriptor_->field(1)->type() == FieldDescriptor::TYPE_STRING &&
-        utf8_check != Utf8CheckMode::None) {
-      if (utf8_check == Utf8CheckMode::Strict) {
+        utf8_check != Utf8CheckMode::kNone) {
+      if (utf8_check == Utf8CheckMode::kStrict) {
         format(
             "  static bool ValidateValue(std::string* s) {\n"
             "    return ::$proto_ns$::internal::WireFormatLite::"
@@ -1056,7 +1056,7 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
             " }\n",
             descriptor_->field(1)->full_name());
       } else {
-        GOOGLE_CHECK_EQ(utf8_check, Utf8CheckMode::Verify);
+        GOOGLE_CHECK_EQ(utf8_check, Utf8CheckMode::kVerify);
         format(
             "  static bool ValidateValue(std::string* s) {\n"
             "#ifndef NDEBUG\n"

--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -1017,8 +1017,8 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
         "$classname$*>(&_$classname$_default_instance_); }\n");
     auto utf8_check = GetUtf8CheckMode(descriptor_->field(0), options_);
     if (descriptor_->field(0)->type() == FieldDescriptor::TYPE_STRING &&
-        utf8_check != NONE) {
-      if (utf8_check == STRICT) {
+        utf8_check != Utf8CheckMode::None) {
+      if (utf8_check == Utf8CheckMode::Strict) {
         format(
             "  static bool ValidateKey(std::string* s) {\n"
             "    return ::$proto_ns$::internal::WireFormatLite::"
@@ -1027,7 +1027,7 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
             " }\n",
             descriptor_->field(0)->full_name());
       } else {
-        GOOGLE_CHECK_EQ(utf8_check, VERIFY);
+        GOOGLE_CHECK_EQ(utf8_check, Utf8CheckMode::Verify);
         format(
             "  static bool ValidateKey(std::string* s) {\n"
             "#ifndef NDEBUG\n"
@@ -1046,8 +1046,8 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
       format("  static bool ValidateKey(void*) { return true; }\n");
     }
     if (descriptor_->field(1)->type() == FieldDescriptor::TYPE_STRING &&
-        utf8_check != NONE) {
-      if (utf8_check == STRICT) {
+        utf8_check != Utf8CheckMode::None) {
+      if (utf8_check == Utf8CheckMode::Strict) {
         format(
             "  static bool ValidateValue(std::string* s) {\n"
             "    return ::$proto_ns$::internal::WireFormatLite::"
@@ -1056,7 +1056,7 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
             " }\n",
             descriptor_->field(1)->full_name());
       } else {
-        GOOGLE_CHECK_EQ(utf8_check, VERIFY);
+        GOOGLE_CHECK_EQ(utf8_check, Utf8CheckMode::Verify);
         format(
             "  static bool ValidateValue(std::string* s) {\n"
             "#ifndef NDEBUG\n"


### PR DESCRIPTION
At the time this enum includes members named STRICT  and NONE, both of which are known to have problems under Windows (at least `port_undef.inc` has workaround for this macro).

As protobuf now builds in C++11 mode, `enum class` is a better solution to avoid name conflicts.

This is part 1 / x in #8494 fix.