### PR TITLE
Run ruby aarch64 tests on the CI (with an emulator)

### DIFF
--- a/kokoro/linux/aarch64/protoc_crosscompile_aarch64.sh
+++ b/kokoro/linux/aarch64/protoc_crosscompile_aarch64.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Builds protobuf C++ with aarch64 crosscompiler.
+
+set -ex
+
+./autogen.sh
+CXXFLAGS="-fPIC -g -O2" ./configure --host=aarch64
+make -j8

--- a/kokoro/linux/aarch64/ruby_build_and_run_tests_with_qemu_aarch64.sh
+++ b/kokoro/linux/aarch64/ruby_build_and_run_tests_with_qemu_aarch64.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -ex
+
+# go to the repo root
+cd $(dirname $0)/../../..
+
+gem install bundler
+
+cd ruby
+
+bundle
+rake
+rake clobber_package gem
+
+# run all the tests
+rake test

--- a/kokoro/linux/aarch64/test_ruby_aarch64.sh
+++ b/kokoro/linux/aarch64/test_ruby_aarch64.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -ex
+
+# go to the repo root
+cd $(dirname $0)/../../..
+
+if [[ -t 0 ]]; then
+  DOCKER_TTY_ARGS="-it"
+else
+  # The input device on kokoro is not a TTY, so -it does not work.
+  DOCKER_TTY_ARGS=
+fi
+
+# crosscompile protoc as we will later need it for the ruby build.
+# we build it under the dockcross/manylinux2014-aarch64 image so that the resulting protoc binary is compatible
+# with a wide range of linux distros (including any docker images we will use later to build and test ruby)
+kokoro/linux/aarch64/dockcross_helpers/run_dockcross_manylinux2014_aarch64.sh kokoro/linux/aarch64/protoc_crosscompile_aarch64.sh
+
+# use an actual aarch64 docker image (with a real aarch64 ruby) to run build & test protobuf ruby under an emulator
+# * mount the protobuf root as /work to be able to access the crosscompiled files
+# * to avoid running the process inside docker as root (which can pollute the workspace with files owned by root), we force
+#   running under current user's UID and GID. To be able to do that, we need to provide a home directory for the user
+#   otherwise the UID would be homeless under the docker container and pip install wouldn't work. For simplicity,
+#   we just run map the user's home to a throwaway temporary directory
+
+docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work arm64v8/ruby:2.7.3-buster kokoro/linux/aarch64/ruby_build_and_run_tests_with_qemu_aarch64.sh

--- a/kokoro/linux/ruby_aarch64/build.sh
+++ b/kokoro/linux/ruby_aarch64/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# This is the top-level script we give to Kokoro as the entry point for
+# running the "continuous" and "presubmit" jobs.
+
+set -ex
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Initialize any submodules.
+git submodule update --init --recursive
+
+kokoro/linux/aarch64/qemu_helpers/prepare_qemu.sh
+
+kokoro/linux/aarch64/test_ruby_aarch64.sh

--- a/kokoro/linux/ruby_aarch64/continuous.cfg
+++ b/kokoro/linux/ruby_aarch64/continuous.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/ruby_aarch64/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/linux/ruby_aarch64/presubmit.cfg
+++ b/kokoro/linux/ruby_aarch64/presubmit.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/ruby_aarch64/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}


### PR DESCRIPTION
Based on https://github.com/protocolbuffers/protobuf/pull/8485 (only the few last commits are ruby related).

Ruby's native build is very simple (it only compiles a few .c files), so running ruby's build directly under an emulator is the simplest solution and it's quick enough. Only the protoc binaries get crosscompiled since building protoc under an emulator would be slow.