### PR TITLE
#8492 constexpr defaulted default constructor of WrappedMutex

### DIFF
--- a/src/google/protobuf/stubs/mutex.h
+++ b/src/google/protobuf/stubs/mutex.h
@@ -116,7 +116,7 @@ class CallOnceInitializedMutex {
 // mutexes.
 class GOOGLE_PROTOBUF_CAPABILITY("mutex") PROTOBUF_EXPORT WrappedMutex {
  public:
-  constexpr WrappedMutex() = default;
+  constexpr WrappedMutex() {}
   void Lock() GOOGLE_PROTOBUF_ACQUIRE() { mu_.lock(); }
   void Unlock() GOOGLE_PROTOBUF_RELEASE() { mu_.unlock(); }
   // Crash if this Mutex is not held exclusively by this thread.


### PR DESCRIPTION
constexpr defaulted default constructor of WrappedMutex causes compile errors #8492