### PR TITLE
Remove trivial methods from the codebase

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_helpers.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.cc
@@ -1011,29 +1011,16 @@ bool IsWellKnownMessage(const FileDescriptor* file) {
   return well_known_files.find(file->name()) != well_known_files.end();
 }
 
-static bool FieldEnforceUtf8(const FieldDescriptor* field,
-                             const Options& options) {
-  return true;
-}
-
-static bool FileUtf8Verification(const FileDescriptor* file,
-                                 const Options& options) {
-  return true;
-}
-
 // Which level of UTF-8 enforcemant is placed on this file.
 Utf8CheckMode GetUtf8CheckMode(const FieldDescriptor* field,
                                const Options& options) {
-  if (field->file()->syntax() == FileDescriptor::SYNTAX_PROTO3 &&
-      FieldEnforceUtf8(field, options)) {
+  if (field->file()->syntax() == FileDescriptor::SYNTAX_PROTO3) {
     return Utf8CheckMode::kStrict;
-  } else if (GetOptimizeFor(field->file(), options) !=
-                 FileOptions::LITE_RUNTIME &&
-             FileUtf8Verification(field->file(), options)) {
-    return Utf8CheckMode::kVerify;
-  } else {
-    return Utf8CheckMode::kNone;
   }
+  if (GetOptimizeFor(field->file(), options) != FileOptions::LITE_RUNTIME) {
+    return Utf8CheckMode::kVerify;
+  }
+  return Utf8CheckMode::kNone;
 }
 
 static void GenerateUtf8CheckCode(const FieldDescriptor* field,


### PR DESCRIPTION
This simplifies the code in GetUtf8CheckMode dramatically.

This is part 2 / x in #8494 fix.