### PR TITLE
Fix -Wunused-parameter in map<string, int> fields (fixes #8494)

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_map_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_map_field.cc
@@ -230,9 +230,9 @@ void MapFieldGenerator::GenerateSerializeWithCachedSizesToArray(
     format(
         "struct Utf8Check {\n"
         "  static void Check(ConstPtr p) {\n"
-		// p may be unused when GetUtf8CheckMode evaluates to kNone,
-		// thus disabling the validation.
-		"    (void)p;\n");
+        // p may be unused when GetUtf8CheckMode evaluates to kNone,
+        // thus disabling the validation.
+        "    (void)p;\n");
     format.Indent();
     format.Indent();
     if (string_key) {

--- a/src/google/protobuf/compiler/cpp/cpp_map_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_map_field.cc
@@ -229,7 +229,10 @@ void MapFieldGenerator::GenerateSerializeWithCachedSizesToArray(
   if (utf8_check) {
     format(
         "struct Utf8Check {\n"
-        "  static void Check(ConstPtr p) {\n");
+        "  static void Check(ConstPtr p) {\n"
+		// p may be unused when GetUtf8CheckMode evaluates to kNone,
+		// thus disabling the validation.
+		"    (void)p;\n");
     format.Indent();
     format.Indent();
     if (string_key) {


### PR DESCRIPTION
This is a clumsy fix for #8494.
MWE is as follows:

```
syntax = "proto2";
optimize_for = "lite_runtime";
message M {
   map<string, int> field = 1;
}
```

During code generation, protoc will check for key / value types (corresponds to string_key / string_value variables all around).
If Utf8 validation will be disabled due to evaluation of `GetUtf8CheckMode()` to `kNone`, the `Check()` method will be generated as follows:
```
static void Check(ConstPtr p) {
}
```

This will trigger `-Wunused-parameter`.
