### PR TITLE
fix(splitFloat32): Fix incorrect exponent when converting double to float

### DIFF
--- a/js/binary/utils.js
+++ b/js/binary/utils.js
@@ -202,7 +202,11 @@ jspb.utils.splitFloat32 = function(value) {
 
   exp = Math.floor(Math.log(value) / Math.LN2);
   mant = value * Math.pow(2, -exp);
-  mant = Math.round(mant * jspb.BinaryConstants.TWO_TO_23) & 0x7FFFFF;
+  mant = Math.round(mant * jspb.BinaryConstants.TWO_TO_23);
+  if (mant >= 0x1000000) {
+    ++exp;
+  }
+  mant = mant & 0x7FFFFF;
 
   jspb.utils.split64High = 0;
   jspb.utils.split64Low = ((sign << 31) | ((exp + 127) << 23) | mant) >>> 0;

--- a/js/binary/utils_test.js
+++ b/js/binary/utils_test.js
@@ -391,6 +391,11 @@ describe('binaryUtilsTest', function() {
     // Pi.
     test(f32_pi, 0x40490fdb);
 
+    // corner cases
+    test(0.9999999762949594, 0x3f800000);
+    test(7.99999999999999, 0x41000000);
+    test(Math.sin(30 * Math.PI / 180), 0x3f000000); // sin(30 degrees)
+
     // Various positive values.
     var cursor = f32_eps * 10;
     while (cursor != Infinity) {


### PR DESCRIPTION
Submitted on behalf of a third-party: Ihor Darkov
See https://github.com/protocolbuffers/protobuf/issues/6887#issue-522941516 for original source

Closes #6887 