### PR TITLE
Start publishing python aarch64 manylinux wheels normally

### DIFF
--- a/kokoro/release/python/linux/build_artifacts.sh
+++ b/kokoro/release/python/linux/build_artifacts.sh
@@ -69,11 +69,3 @@ build_artifact_version 3.9
 build_crosscompiled_aarch64_artifact_version 3.7
 build_crosscompiled_aarch64_artifact_version 3.8
 build_crosscompiled_aarch64_artifact_version 3.9
-
-# Put the aarch64 manylinux wheels under the "unofficial" subdirectory.
-# Only wheels directly under the artifacts/ directory will be published
-# to PyPI as part of the protobuf release process.
-# TODO(jtattermusch): include aarch64 wheels in the release
-# once they are sufficiently tested.
-mkdir -p $ARTIFACT_DIR/unofficial
-mv $ARTIFACT_DIR/protobuf-*-manylinux*_aarch64.whl $ARTIFACT_DIR/unofficial


### PR DESCRIPTION
For now, they are never uploaded to pip and it's difficult for external users to get access to them.

Since we now have a passing continuous job that runs unit tests and also checks the wheels (https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:protobuf%2Fgithub%2Fmaster%2Fubuntu%2Fpython_aarch64%2Fcontinuous, as introduced by https://github.com/protocolbuffers/protobuf/pull/8479), it seems fair to make these wheels public.

