### PR TITLE
Stop using GG_ prefixed macros

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_helpers.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.cc
@@ -664,9 +664,9 @@ std::string UInt64ToString(const std::string& macro_prefix, uint64_t number) {
 std::string DefaultValue(const FieldDescriptor* field) {
   switch (field->cpp_type()) {
     case FieldDescriptor::CPPTYPE_INT64:
-      return Int64ToString("GG", field->default_value_int64());
+      return Int64ToString("PROTOBUF", field->default_value_int64());
     case FieldDescriptor::CPPTYPE_UINT64:
-      return UInt64ToString("GG", field->default_value_uint64());
+      return UInt64ToString("PROTOBUF", field->default_value_uint64());
     default:
       return DefaultValue(Options(), field);
   }

--- a/src/google/protobuf/compiler/cpp/cpp_helpers.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.cc
@@ -662,14 +662,7 @@ std::string UInt64ToString(const std::string& macro_prefix, uint64_t number) {
 }
 
 std::string DefaultValue(const FieldDescriptor* field) {
-  switch (field->cpp_type()) {
-    case FieldDescriptor::CPPTYPE_INT64:
-      return Int64ToString("PROTOBUF", field->default_value_int64());
-    case FieldDescriptor::CPPTYPE_UINT64:
-      return UInt64ToString("PROTOBUF", field->default_value_uint64());
-    default:
-      return DefaultValue(Options(), field);
-  }
+  return DefaultValue(Options(), field);
 }
 
 std::string DefaultValue(const Options& options, const FieldDescriptor* field) {


### PR DESCRIPTION
`GG_ULONGLONG` was renamed to `PROTOBUF_ULONGLONG` some time ago.

This PR fixes the generated code for `uint64 field = 1 [default = 0];` stanza.