### PR TITLE
protoc maven artifacts: reuse osx-x86_64 for osx-aarch_64

### DIFF
--- a/protoc-artifacts/pom.xml
+++ b/protoc-artifacts/pom.xml
@@ -71,6 +71,15 @@
                   <type>exe</type>
                 </artifact>
                 <artifact>
+                  <!-- Reuse a compatible osx-x86_64 version until binary
+                       support for osx-aarch_64 is added. TODO: use
+                       <file>${basedir}/target/osx/aarch_64/protoc.exe</file>
+                       -->
+                  <file>${basedir}/target/osx/x86_64/protoc.exe</file>
+                  <classifier>osx-aarch_64</classifier>
+                  <type>exe</type>
+                </artifact>
+                <artifact>
                   <file>${basedir}/target/linux/aarch_64/protoc.exe</file>
                   <classifier>linux-aarch_64</classifier>
                   <type>exe</type>


### PR DESCRIPTION
Fixes https://github.com/google/protobuf-gradle-plugin/issues/492

The main rationale is to fix [this](https://github.com/grpc/grpc-java/issues/7690) and not have users need to manually and/or conditionally point at the x86_64 classifier. The M1 macs are able to run x86_64 binaries in rosetta compatibility mode.

@ejona86 had a good idea, so I attempt here to upload the same file used in the osx-x86_64 classifier for the osx-aarch_64 classifier.

One day if a native M1 build comes along and solves [this](https://github.com/protocolbuffers/protobuf/issues/8062), modify this to upload a real M1 build.