### PR TITLE
Update Objective-C ProtocolBuffers_iOS.xcodeproj To Skip Install

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_helpers.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.cc
@@ -662,14 +662,7 @@ std::string UInt64ToString(const std::string& macro_prefix, uint64_t number) {
 }
 
 std::string DefaultValue(const FieldDescriptor* field) {
-  switch (field->cpp_type()) {
-    case FieldDescriptor::CPPTYPE_INT64:
-      return Int64ToString("GG", field->default_value_int64());
-    case FieldDescriptor::CPPTYPE_UINT64:
-      return UInt64ToString("GG", field->default_value_uint64());
-    default:
-      return DefaultValue(Options(), field);
-  }
+  return DefaultValue(Options(), field);
 }
 
 std::string DefaultValue(const Options& options, const FieldDescriptor* field) {


### PR DESCRIPTION
Fixes an issue with the objective-c iOS .xcodeproj, where archiving a project using this repository as a submodule resulted in a generic Xcode archive being created, rather than an iOS App Archive. Setting the `SKIP_INSTALL` build setting to `YES` results in the iOS App Archive being generated correctly when archiving an application for submission.