### PR TITLE
Add class method Timestamp.from_time to ruby well known types

### DIFF
--- a/ruby/lib/google/protobuf/well_known_types.rb
+++ b/ruby/lib/google/protobuf/well_known_types.rb
@@ -85,6 +85,11 @@ module Google
       def from_time(time)
         self.seconds = time.to_i
         self.nanos = time.nsec
+        self
+      end
+
+      def self.from_time(time)
+        new.from_time(time)
       end
 
       def to_i

--- a/ruby/tests/well_known_types_test.rb
+++ b/ruby/tests/well_known_types_test.rb
@@ -15,16 +15,20 @@ class TestWellKnownTypes < Test::Unit::TestCase
 
     # millisecond accuracy
     time = Time.at(123456, 654321)
-    ts.from_time(time)
+    ts = Google::Protobuf::Timestamp.from_time(time)
     assert_equal 123456, ts.seconds
     assert_equal 654321000, ts.nanos
     assert_equal time, ts.to_time
 
     # nanosecond accuracy
     time = Time.at(123456, Rational(654321321, 1000))
-    ts.from_time(time)
+    ts = Google::Protobuf::Timestamp.from_time(time)
     assert_equal 654321321, ts.nanos
     assert_equal time, ts.to_time
+
+    # Instance method returns the same value as class method
+    assert_equal Google::Protobuf::Timestamp.new.from_time(time),
+                 Google::Protobuf::Timestamp.from_time(time)
   end
 
   def test_duration


### PR DESCRIPTION
I was surprised to find out that `from_time` was not a class method, but an instance method.
This limits its usefulness, as to create a new Timestamp you have to first instantiate the object, then call the from_time method, and then you need to return/use the saved instance, because the from_time method returns the self.nanos value, rather than the timestamp itself.

Code example

Before
```ruby
{
  updated_at: Google::Protobuf::Timestamp.new.tap { |t| t.from_time(updated_at) },
}
```

After
```ruby
{
  updated_at: Google::Protobuf::Timestamp.from_time(updated_at),
}
```

