### PR TITLE
fix(ruby): Fix various exceptions in Ruby on 64-bit Windows

### DIFF
--- a/ruby/ext/google/protobuf_c/protobuf.c
+++ b/ruby/ext/google/protobuf_c/protobuf.c
@@ -344,11 +344,9 @@ static VALUE SecondaryMap_Get(VALUE key, bool create) {
 
 // Requires: secondary_map_mutex is held by this thread iff create == true.
 static VALUE ObjectCache_GetKey(const void* key, bool create) {
-  char buf[sizeof(key)];
-  memcpy(&buf, &key, sizeof(key));
-  intptr_t key_int = (intptr_t)key;
-  PBRUBY_ASSERT((key_int & 3) == 0);
-  VALUE ret = LL2NUM(key_int >> 2);
+  VALUE key_val = (VALUE)key;
+  PBRUBY_ASSERT((key_val & 3) == 0);
+  VALUE ret = LL2NUM(key_val >> 2);
 #if USE_SECONDARY_MAP
   ret = SecondaryMap_Get(ret, create);
 #endif

--- a/ruby/ext/google/protobuf_c/protobuf.c
+++ b/ruby/ext/google/protobuf_c/protobuf.c
@@ -334,7 +334,7 @@ static VALUE SecondaryMap_Get(VALUE key, bool create) {
   VALUE ret = rb_hash_lookup(secondary_map, key);
   if (ret == Qnil && create) {
     SecondaryMap_MaybeGC();
-    ret = rb_eval_string("Object.new");
+    ret = rb_class_new_instance(0, NULL, rb_cObject);
     rb_hash_aset(secondary_map, key, ret);
   }
   return ret;


### PR DESCRIPTION
Activates the secondary ObjectCache map on this platform, to prevent weak keys from being garbage collected. This happened on 64-bit Windows because pointers don't necessarily fit in a Fixnum, and were being represented as GC-able Bignums on that platform.

Fixes #8554

/attn @haberman 