### PR TITLE
fix(ruby): Fix crash when calculating Message hash values on 64-bit Windows

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem "irb", "~> 1.1", "< 1.2.0" if RUBY_VERSION < "2.5"

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -735,9 +735,13 @@ uint64_t Message_Hash(const upb_msg* msg, const upb_msgdef* m, uint64_t seed) {
 static VALUE Message_hash(VALUE _self) {
   Message* self = ruby_to_Message(_self);
   uint64_t hash_value = Message_Hash(self->msg, self->msgdef, 0);
+  // Fixnum is restricted to signed long, so downcast if necessary.
   long long_value = (long)hash_value;
-  if (!RB_FIXABLE(long_value)) {
-    long_value = long_value >> 1;
+  // Ensure we stay within the range allowed by Fixnum.
+  if (long_value < RUBY_FIXNUM_MIN) {
+    long_value = long_value + RUBY_FIXNUM_MAX + 1;
+  } else if (long_value > RUBY_FIXNUM_MAX) {
+    long_value = long_value - RUBY_FIXNUM_MAX - 1;
   }
   return INT2FIX(long_value);
 }

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -735,15 +735,9 @@ uint64_t Message_Hash(const upb_msg* msg, const upb_msgdef* m, uint64_t seed) {
 static VALUE Message_hash(VALUE _self) {
   Message* self = ruby_to_Message(_self);
   uint64_t hash_value = Message_Hash(self->msg, self->msgdef, 0);
-  // Fixnum is restricted to signed long, so downcast if necessary.
-  long long_value = (long)hash_value;
-  // Ensure we stay within the range allowed by Fixnum.
-  if (long_value < RUBY_FIXNUM_MIN) {
-    long_value = long_value + RUBY_FIXNUM_MAX + 1;
-  } else if (long_value > RUBY_FIXNUM_MAX) {
-    long_value = long_value - RUBY_FIXNUM_MAX - 1;
-  }
-  return INT2FIX(long_value);
+  // RUBY_FIXNUM_MAX should be one less than a power of 2.
+  assert(RUBY_FIXNUM_MAX & (RUBY_FIXNUM_MAX + 1) == 0);
+  return INT2FIX(hash_value & RUBY_FIXNUM_MAX);
 }
 
 /*

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -736,7 +736,7 @@ static VALUE Message_hash(VALUE _self) {
   Message* self = ruby_to_Message(_self);
   uint64_t hash_value = Message_Hash(self->msg, self->msgdef, 0);
   // RUBY_FIXNUM_MAX should be one less than a power of 2.
-  assert(RUBY_FIXNUM_MAX & (RUBY_FIXNUM_MAX + 1) == 0);
+  assert((RUBY_FIXNUM_MAX & (RUBY_FIXNUM_MAX + 1)) == 0);
   return INT2FIX(hash_value & RUBY_FIXNUM_MAX);
 }
 

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -734,7 +734,12 @@ uint64_t Message_Hash(const upb_msg* msg, const upb_msgdef* m, uint64_t seed) {
  */
 static VALUE Message_hash(VALUE _self) {
   Message* self = ruby_to_Message(_self);
-  return INT2FIX(Message_Hash(self->msg, self->msgdef, 0));
+  uint64_t hash_value = Message_Hash(self->msg, self->msgdef, 0);
+  long long_value = (long)hash_value;
+  if (!RB_FIXABLE(long_value)) {
+    long_value = long_value >> 1;
+  }
+  return INT2FIX(long_value);
 }
 
 /*


### PR DESCRIPTION
Fixes #8564

On 64-bit Windows, it is unsafe to try to create a Fixnum from a 64-bit integer, because longs can hold only 32 bits. The code change below:
* Downcasts the original unsigned 64-bit hash to a signed long (which may be either 64 bits or 32 bits depending on the platform).
* Checks the value to see if it's in the half of the range of long that corresponds to a valid Fixnum, and moves it into range if not.
* Only then does it pass the result into `INT2FIX`.

/attn @haberman 