### PR TITLE
Fix constness issue detected by MSVC standard conforming mode

### DIFF
--- a/python/google/protobuf/pyext/descriptor_pool.cc
+++ b/python/google/protobuf/pyext/descriptor_pool.cc
@@ -219,7 +219,7 @@ static int GcClear(PyObject* pself) {
 }
 
 PyObject* SetErrorFromCollector(DescriptorPool::ErrorCollector* self,
-                                char* name, char* error_type) {
+                                const char* name, const char* error_type) {
   BuildFileErrorCollector* error_collector =
       reinterpret_cast<BuildFileErrorCollector*>(self);
   if (error_collector && !error_collector->error_message.empty()) {


### PR DESCRIPTION
This is the continuation of #8344

Original error is (formatting is mine):

```
error C2664: 'PyObject* google::protobuf::python::cdescriptor_pool::SetErrorFromCollector(
  google::protobuf::DescriptorPool::ErrorCollector *,
  char *,
  char*
)': cannot convert argument 3 from 'const char [5]' to 'char *'
```