### PR TITLE
Comment out unused variable in repeated_field_unittest.cc

### DIFF
--- a/src/google/protobuf/repeated_field_unittest.cc
+++ b/src/google/protobuf/repeated_field_unittest.cc
@@ -889,8 +889,8 @@ TEST(RepeatedPtrField, UnambiguousConstructor) {
 
   // Construction from string iterators for the unique string overload "g"
   // works.
-  std::string b[2] = {"abc", "xyz"};
   // Disabling this for now, this is actually ambiguous with libstdc++.
+  // std::string b[2] = {"abc", "xyz"};
   // EXPECT_TRUE(X::g({b, b + 2}));
 
   // Construction from string iterators for "f" is ambiguous, since both


### PR DESCRIPTION
The test assertion is commented out, but this is causing some warnings
about an unused variable. This commit comments out the variable to fix
that problem.