### PR TITLE
Use template Delete<> for invoking a dependent template

### DIFF
--- a/src/google/protobuf/map_entry_lite.h
+++ b/src/google/protobuf/map_entry_lite.h
@@ -527,7 +527,7 @@ class MapEntryLite : public MapEntryImpl<T, MessageLite, Key, Value,
       SuperType;
   constexpr MapEntryLite() {}
   explicit MapEntryLite(Arena* arena) : SuperType(arena) {}
-  ~MapEntryLite() { MessageLite::_internal_metadata_.Delete<std::string>(); }
+  ~MapEntryLite() { MessageLite::_internal_metadata_.template Delete<std::string>(); }
   void MergeFrom(const MapEntryLite& other) { MergeFromInternal(other); }
 
  private:


### PR DESCRIPTION
This fixes MSVC (tested on MSVC2019 / 16.8) compilation error (line number is different, as I am working with protobuf 3.15.8):
```
google/protobuf/map_entry_lite.h:527: error C2760: syntax error: unexpected token ')', expected 'expression'
```

I believe [this](https://stackoverflow.com/questions/34696351/template-dependent-typename) explains why MSVC considers this to be a dependent template.