### PR TITLE
Fix compile error on darwin GCC due to an unsupported attribute init_priority

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -506,7 +506,7 @@
 #ifdef PROTOBUF_ATTRIBUTE_INIT_PRIORITY
 #error PROTOBUF_ATTRIBUTE_INIT_PRIORITY was previously defined
 #endif
-#if PROTOBUF_GNUC_MIN(3, 0)
+#if PROTOBUF_GNUC_MIN(3, 0) && (!defined(__APPLE__) || defined(__clang__))
 #define PROTOBUF_ATTRIBUTE_INIT_PRIORITY __attribute__((init_priority((102))))
 #else
 #define PROTOBUF_ATTRIBUTE_INIT_PRIORITY


### PR DESCRIPTION
### Motivation
My [CI](https://github.com/PragmaTwice/protopuf/runs/2553850775) is broken due to a compile error from a `.pb.cc` while using GCC on Mac OS X:
```
 /Users/runner/work/protopuf/protopuf/test/compatibility/message.pb.cc:96:131: error: 'init_priority' attribute is not supported on this platform
   96 | PROTOBUF_ATTRIBUTE_INIT_PRIORITY static ::PROTOBUF_NAMESPACE_ID::internal::AddDescriptorsRunner dynamic_init_dummy_message_2eproto(&descriptor_table_message_2eproto);
      |                                                                                                                                   ^
```

After some investigation, I found that under darwin, GCC gives a compile error for the use of init_priority.
We can get the explanation from the gcc source code, which comes from [gcc/config/darwin.h#L1084](https://github.com/gcc-mirror/gcc/blob/master/gcc/config/darwin.h#L1084)  (GCC trunk):
```c
/* The Apple assembler and linker do not support constructor priorities.  */
#undef SUPPORTS_INIT_PRIORITY
#define SUPPORTS_INIT_PRIORITY 0
```
This has been introduced from [Bug 34587](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=34587) and still exists today.

### Solution
We cannot use the macro `SUPPORTS_INIT_PRIORITY` (and `__has_attribute(init_priority)` returns true), so a workaround is to check the OS and compiler in order to skip the case of using darwin GCC:
```
__GNUC__ && (!defined(__APPLE__) || defined(__clang__))
```

### Links
https://trac.macports.org/ticket/37664
> the OS X linker ignores the init_priority() attribute and does not reorder the constructors