### PR TITLE
Update the CI test script to skip Kotlin tests on Oracle 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,10 +82,7 @@ src/**/*.log
 src/**/*.trs
 
 # JavaBuild output.
-java/core/target
-java/lite/target
-java/util/target
-javanano/target
+java/**/target
 java/.idea
 java/**/*.iml
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,7 +26,7 @@
   * Optimize Descriptor.isExtensionNumber.
 
   Python
-  * [python-runtime] Add MethodDescriptor.CopyToProto() (#8327)
+  * Add MethodDescriptor.CopyToProto() (#8327)
   * Remove unused python_protobuf.{cc,h} (#8513)
   * Start publishing python aarch64 manylinux wheels normally (#8530)
   * Fix constness issue detected by MSVC standard conforming mode (#8568)
@@ -34,11 +34,11 @@
     oneof are present and all but one is null.
 
   Ruby
-  * Ruby: Add support for proto3 json_name in compiler and field definitions (#8356)
+  * Add support for proto3 json_name in compiler and field definitions (#8356)
   * Fixed memory leak of Ruby arena objects. (#8461)
   * Fix source gem compilation (#8471)
-  * fix(ruby): Fix various exceptions in Ruby on 64-bit Windows (#8563)
-  * fix(ruby): Fix crash when calculating Message hash values on 64-bit Windows (#8565)
+  * Fix various exceptions in Ruby on 64-bit Windows (#8563)
+  * Fix crash when calculating Message hash values on 64-bit Windows (#8565)
 
   Conformance Tests
   * Added a conformance test for the case of multiple fields from the same

--- a/tests.sh
+++ b/tests.sh
@@ -208,7 +208,13 @@ build_java() {
   # Java build needs `protoc`.
   internal_build_cpp
   cp -r java $dir
-  cd $dir && $MVN clean && $MVN test
+  cd $dir && $MVN clean
+  # Skip the Kotlin tests on Oracle 7
+  if [ "$version" == "oracle7" ]; then
+    $MVN test -pl bom,lite,core,util
+  else
+    $MVN test
+  fi
   cd ../..
 }
 


### PR DESCRIPTION
This should fix the failing CI test runs. I also updated the .gitignore and the 3.17.0 changelog.