### PR TITLE
Make the dist_install test use Java 8

### DIFF
--- a/kokoro/linux/dist_install/build.sh
+++ b/kokoro/linux/dist_install/build.sh
@@ -7,8 +7,8 @@ set -ex  # exit immediately on error
 # Change to repo root
 cd $(dirname $0)/../../..
 
-# Run tests under release docker image.
-export DOCKERFILE_DIR=kokoro/linux/64-bit
+export DOCKERHUB_ORGANIZATION=protobuftesting
+export DOCKERFILE_DIR=kokoro/linux/dockerfile/test/java_stretch
 export DOCKER_RUN_SCRIPT=kokoro/linux/pull_request_in_docker.sh
 export OUTPUT_DIR=testoutput
 export TEST_SET="dist_install"

--- a/kokoro/linux/dockerfile/test/java_stretch/Dockerfile
+++ b/kokoro/linux/dockerfile/test/java_stretch/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch
 
-# Install dependencies.  We start with the basic ones require to build protoc
+# Install dependencies.  We start with the basic ones required to build protoc
 # and the C++ build
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -20,12 +20,11 @@ RUN apt-get update && apt-get install -y \
   parallel \
   time \
   wget \
-  && apt-get clean
-
-# Java dependencies
-RUN apt-get install -y \
-  # -- For all Java builds -- \
+  # Java dependencies
   maven \
-  # -- For java_linkage_monitor \
   openjdk-8-jdk \
+  # Python dependencies
+  python-setuptools \
+  python-pip \
+  virtualenv \
   && apt-get clean

--- a/tests.sh
+++ b/tests.sh
@@ -104,7 +104,7 @@ build_dist_install() {
 
   # Try to install Java
   pushd java
-  use_java jdk7
+  use_java jdk8
   $MVN install
   popd
 


### PR DESCRIPTION
This is necessary because the Kotlin support requires Java 8 or
higher.