### PR TITLE
Use modern JS tooling instead of Closure's deprecated Python scripts.

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -95,11 +95,8 @@ statements like:
 
     var message = proto.my.package.MyMessage();
 
-If unfamiliar with Closure or its compiler, consider reviewing Closure documentation
-https://developers.google.com/closure/library/docs/tutorial
-https://developers.google.com/closure/library/docs/closurebuilder
-https://developers.google.com/closure/library/docs/depswriter
-At a high level, closurebuilder.py can walk dependencies, and compile your code, and all dependencies for Protobuf into a single .js file.  Using depsbuilder.py to generate a dependency file can also be considered for non-production dev environments.
+If unfamiliar with Closure or its compiler, consider reviewing
+[Closure documentation](https://developers.google.com/closure/library).
 
 CommonJS imports
 ----------------

--- a/js/commonjs/export.js
+++ b/js/commonjs/export.js
@@ -5,8 +5,6 @@
  * the google-protobuf.js file that we build at distribution time.
  */
 
-// Include a dummy provide statement so that closurebuilder.py does not skip over this
-// file.
 goog.provide('jspb.Export');
 
 goog.require('goog.object');

--- a/js/commonjs/export_asserts.js
+++ b/js/commonjs/export_asserts.js
@@ -6,8 +6,6 @@
  * closure_asserts_commonjs.js that is only used at testing time.
  */
 
-// Include a dummy provide statement so that closurebuilder.py does not skip over this
-// file.
 goog.provide('jspb.ExportAsserts');
 
 goog.require('goog.testing.asserts');

--- a/js/commonjs/export_testdeps.js
+++ b/js/commonjs/export_testdeps.js
@@ -7,8 +7,6 @@
  * export_asserts.js.
  */
 
-// Include a dummy provide statement so that closurebuilder.py does not skip over this
-// file.
 goog.provide('jspb.ExportTestDeps');
 
 goog.require('goog.crypt.base64');

--- a/js/compatibility_tests/v3.0.0/test.sh
+++ b/js/compatibility_tests/v3.0.0/test.sh
@@ -53,8 +53,20 @@ for file in *_test.js binary/*_test.js; do
 done
 cp commonjs/{jasmine.json,import_test.js} commonjs_out/
 mkdir -p commonjs_out/test_node_modules
-../../node_modules/google-closure-library/closure/bin/calcdeps.py -i commonjs/export_asserts.js -p . -p ../../node_modules/google-closure-library/closure -o compiled --compiler_jar ../../node_modules/google-closure-compiler/compiler.jar > commonjs_out/test_node_modules/closure_asserts_commonjs.js
-../../node_modules/google-closure-library/closure/bin/calcdeps.py -i commonjs/export_testdeps.js -p ../.. -p ../../node_modules/google-closure-library/closure -o compiled --compiler_jar ../../node_modules/google-closure-compiler/compiler.jar > commonjs_out/test_node_modules/testdeps_commonjs.js
+../../node_modules/.bin/google-closure-compiler \
+  --entry_point=commonjs/export_asserts.js \
+  --js=commonjs/export_asserts.js \
+  --js=../../node_modules/google-closure-library/closure/goog/**.js \
+  --js=../../node_modules/google-closure-library/third_party/closure/goog/**.js \
+  > commonjs_out/test_node_modules/closure_asserts_commonjs.js
+../../node_modules/.bin/google-closure-compiler \
+  --entry_point=commonjs/export_testdeps.js \
+  --js=commonjs/export_testdeps.js \
+  --js=../../binary/*.js \
+  --js=!../../binary/*_test.js \
+  --js=../../node_modules/google-closure-library/closure/goog/**.js \
+  --js=../../node_modules/google-closure-library/third_party/closure/goog/**.js \
+  > commonjs_out/test_node_modules/testdeps_commonjs.js
 cp ../../google-protobuf.js commonjs_out/test_node_modules
 cp -r ../../commonjs_out/node_modules commonjs_out
 

--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -140,21 +140,31 @@ gulp.task('genproto_group3_commonjs_strict', function (cb) {
 });
 
 
-function getClosureBuilderCommand(exportsFile, outputFile) {
-  return './node_modules/google-closure-library/closure/bin/build/closurebuilder.py ' +
-  '--root node_modules ' +
-  '-o compiled ' +
-  '--compiler_jar node_modules/google-closure-compiler-java/compiler.jar ' +
-  '-i ' + exportsFile + ' ' +
-  'map.js message.js binary/arith.js binary/constants.js binary/decoder.js ' +
-  'binary/encoder.js binary/reader.js binary/utils.js binary/writer.js ' +
-  exportsFile  + ' > ' + outputFile;
+function getClosureCompilerCommand(exportsFile, outputFile) {
+  const closureLib = 'node_modules/google-closure-library';
+  return [
+    'node_modules/.bin/google-closure-compiler',
+    `--js=${closureLib}/closure/goog/**.js`,
+    `--js=${closureLib}/third_party/closure/goog/**.js`,
+    '--js=map.js',
+    '--js=message.js',
+    '--js=binary/arith.js',
+    '--js=binary/constants.js',
+    '--js=binary/decoder.js',
+    '--js=binary/encoder.js',
+    '--js=binary/reader.js',
+    '--js=binary/utils.js',
+    '--js=binary/writer.js',
+    `--js=${exportsFile}`,
+    `--entry_point=${exportsFile}`,
+    `> ${outputFile}`
+  ].join(' ');
 }
 
 gulp.task('dist', gulp.series(['genproto_wellknowntypes'], function(cb) {
   // TODO(haberman): minify this more aggressively.
   // Will require proper externs/exports.
-  exec(getClosureBuilderCommand('commonjs/export.js', 'google-protobuf.js'),
+  exec(getClosureCompilerCommand('commonjs/export.js', 'google-protobuf.js'),
        function (err, stdout, stderr) {
     console.log(stdout);
     console.log(stderr);
@@ -164,7 +174,7 @@ gulp.task('dist', gulp.series(['genproto_wellknowntypes'], function(cb) {
 
 gulp.task('commonjs_asserts', function (cb) {
   exec('mkdir -p commonjs_out/test_node_modules && ' +
-       getClosureBuilderCommand(
+       getClosureCompilerCommand(
            'commonjs/export_asserts.js',
            'commonjs_out/test_node_modules/closure_asserts_commonjs.js'),
        function (err, stdout, stderr) {
@@ -176,7 +186,7 @@ gulp.task('commonjs_asserts', function (cb) {
 
 gulp.task('commonjs_testdeps', function (cb) {
   exec('mkdir -p commonjs_out/test_node_modules && ' +
-       getClosureBuilderCommand(
+       getClosureCompilerCommand(
            'commonjs/export_testdeps.js',
            'commonjs_out/test_node_modules/testdeps_commonjs.js'),
        function (err, stdout, stderr) {
@@ -229,7 +239,7 @@ gulp.task(
         ],
         function(cb) {
           exec(
-              './node_modules/google-closure-library/closure/bin/build/depswriter.py binary/arith.js binary/constants.js binary/decoder.js binary/encoder.js binary/reader.js binary/utils.js binary/writer.js debug.js map.js message.js node_loader.js test_bootstrap.js > deps.js',
+              './node_modules/.bin/closure-make-deps --closure-path=. --file=node_modules/google-closure-library/closure/goog/deps.js binary/arith.js binary/constants.js binary/decoder.js binary/encoder.js binary/reader.js binary/utils.js binary/writer.js debug.js map.js message.js node_loader.js test_bootstrap.js > deps.js',
               function(err, stdout, stderr) {
                 console.log(stdout);
                 console.log(stderr);

--- a/js/package.json
+++ b/js/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "glob": "~7.1.4",
     "google-closure-compiler": "~20190819.0.0",
+    "google-closure-deps": "^20210406.0.0",
     "google-closure-library": "~20190819.0.0",
     "gulp": "~4.0.2",
     "jasmine": "~3.4.0"


### PR DESCRIPTION
In [Closure Library](https://github.com/google/closure-library), we will be removing the deprecated `depswriter.py`, `closurebuilder.py`, and `calcdeps.py` build scripts soon. This PR replaces them with modern equivalents.

### `depswriter.py`

`depswriter.py` is superceded by [`google-closure-deps`](https://www.npmjs.com/package/google-closure-deps), a similar tool we maintain that is implemented in Node.js. Here, I've substituted the `depswriter.py` command with a corresponding command from `google-closure-deps`; the CLI flags are similar. The difference in output is minimal (see below).

Explanation of "extra" flags:
* `--closure-path="node_modules/google-closure-library/closure/goog"` Path to Closure (now required)
* `--file="node_modules/google-closure-library/closure/goog/deps.js"` Use the deps.js file bundled with Closure as part of deps calculation

For reference, the diff of the resulting `deps.js` from running `gulp deps` (with lines sorted and formatted for diff clarity) is [here](https://github.com/kjin/protobuf/commit/46125af5574d093962a645d2538c2005b172da4e).

### `closurebuilder.py` and `calcdeps.py`

These scripts call through to the Closure Compiler, so their invocations are replaced with invocations of the compiler itself. In all cases, the compilation results should be byte-equal.