### PR TITLE
Fix syntax errors in bswap_64

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -263,14 +263,14 @@ static inline uint32 bswap_32(uint32 x) {
 
 #ifndef bswap_64
 static inline uint64 bswap_64(uint64 x) {
-  return (((x & uint64_t{0xFFu)) << 56) |
-          ((x & uint64_t{0xFF00u)) << 40) |
-          ((x & uint64_t{0xFF0000u)) << 24) |
-          ((x & uint64_t{0xFF000000u)) << 8) |
-          ((x & uint64_t{0xFF00000000u)) >> 8) |
-          ((x & uint64_t{0xFF0000000000u)) >> 24) |
-          ((x & uint64_t{0xFF000000000000u)) >> 40) |
-          ((x & uint64_t{0xFF00000000000000u)) >> 56));
+  return (((x & uint64_t{0xFFu}) << 56) |
+          ((x & uint64_t{0xFF00u}) << 40) |
+          ((x & uint64_t{0xFF0000u}) << 24) |
+          ((x & uint64_t{0xFF000000u}) << 8) |
+          ((x & uint64_t{0xFF00000000u}) >> 8) |
+          ((x & uint64_t{0xFF0000000000u}) >> 24) |
+          ((x & uint64_t{0xFF000000000000u}) >> 40) |
+          ((x & uint64_t{0xFF00000000000000u}) >> 56));
 }
 #define bswap_64(x) bswap_64(x)
 #endif


### PR DESCRIPTION
It looks like some syntax errors were introduced by mistake because some
left parentheses were changed to curly braces without the right parens
being changed accordingly. This fixes #8611.