### PR TITLE
Use cfg="exec" instead of cfg="host" in internal rules.

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -190,13 +190,13 @@ proto_gen = rule(
         "deps": attr.label_list(providers = ["proto"]),
         "includes": attr.string_list(),
         "protoc": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             allow_single_file = True,
             mandatory = True,
         ),
         "plugin": attr.label(
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
             executable = True,
         ),
@@ -378,7 +378,7 @@ internal_gen_well_known_protos_java = rule(
         ),
         "_protoc": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = "@com_google_protobuf//:protoc",
         ),
     },


### PR DESCRIPTION
Bazel has switched its protobuf rules to make them use the proto
compiler in the exec configuration instead of the host configuration.

However, if rules in protobuf still use the host configuration then
multiple copies of the compiler can end up being built.

cfg="host" is deprecated in any case and being replaced with cfg="exec"
where possible.
https://docs.bazel.build/versions/master/skylark/rules.html#configurations