### PR TITLE
typo in src/google/protobuf/stubs/port.h

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -263,14 +263,14 @@ static inline uint32 bswap_32(uint32 x) {
 
 #ifndef bswap_64
 static inline uint64 bswap_64(uint64 x) {
-  return (((x & uint64_t{0xFFu)) << 56) |
-          ((x & uint64_t{0xFF00u)) << 40) |
-          ((x & uint64_t{0xFF0000u)) << 24) |
-          ((x & uint64_t{0xFF000000u)) << 8) |
-          ((x & uint64_t{0xFF00000000u)) >> 8) |
-          ((x & uint64_t{0xFF0000000000u)) >> 24) |
-          ((x & uint64_t{0xFF000000000000u)) >> 40) |
-          ((x & uint64_t{0xFF00000000000000u)) >> 56));
+  return (((x & uint64_t(0xFFu)) << 56) |
+          ((x & uint64_t(0xFF00u)) << 40) |
+          ((x & uint64_t(0xFF0000u)) << 24) |
+          ((x & uint64_t(0xFF000000u)) << 8) |
+          ((x & uint64_t(0xFF00000000u)) >> 8) |
+          ((x & uint64_t(0xFF0000000000u)) >> 24) |
+          ((x & uint64_t(0xFF000000000000u)) >> 40) |
+          ((x & uint64_t(0xFF00000000000000u)) >> 56));
 }
 #define bswap_64(x) bswap_64(x)
 #endif


### PR DESCRIPTION
typo in src/google/protobuf/stubs/port.h resulting in the latest release not compiling here.

commited here 22 days ago:
https://github.com/protocolbuffers/protobuf/commit/f5fd897c1dccda0d5fca614616452b0ba191a859

do I miss something?