### PR TITLE
Fix the Docker build for our javascript Docker image

### DIFF
--- a/kokoro/linux/dockerfile/test/javascript/Dockerfile
+++ b/kokoro/linux/dockerfile/test/javascript/Dockerfile
@@ -27,7 +27,11 @@ RUN apt-get clean && apt-get update && apt-get install -y --force-yes \
 
 ##################
 # Javascript dependencies.
-RUN apt-get install -y \
+# We need to set these environment variables so that the Docker build does not
+# have to ask for this information while it is installing the tzdata package.
+RUN DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles" \
+  apt-get install -y \
   # -- For javascript and closure compiler -- \
   npm \
-  default-jre
+  default-jre \
+  python


### PR DESCRIPTION
I noticed that our JavaScript Docker image is a couple years old and
seems to have an old NPM version that may be causing problems on #8610,
so I went ahead and rebuilt the image. To do that successfully, I had to
set some environment variables in the Dockerfile so that it can build
successfully without having to ask for input about timezone
configuration. This seems to be a known issue described here:
https://serverfault.com/questions/949991/how-to-install-tzdata-on-a-ubuntu-docker-image