### PR TITLE
Fix OSS benchmarking script

### DIFF
--- a/kokoro/linux/benchmark/build.sh
+++ b/kokoro/linux/benchmark/build.sh
@@ -2,25 +2,4 @@
 
 cd $(dirname $0)/../../..
 
-# prepare php environments
-sudo apt-get update && sudo apt-get install -y --force-yes php5
-sudo ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
-mkdir php_temp
-cd php_temp
-curl -sS https://getcomposer.org/installer | php
-sudo mv composer.phar /usr/local/bin/composer
-git clone https://github.com/php/php-src
-cd php-src && git checkout PHP-7.2.13 && ./buildconf --force
-./configure \
-	--enable-bcmatch \
-	--with-gmp --with-openssl \
-	--with-zlib  \
-	--prefix=/usr/local/php-7.2 && \
-make -j8 && sudo make install && make clean
-wget -O phpunit https://phar.phpunit.de/phpunit-7.phar && \
-	chmod +x phpunit && \
-	sudo cp phpunit /usr/local/php-7.2/bin
-sudo apt-get install -y --force-yes valgrind
-cd ../..
-
 ./tests.sh benchmark

--- a/kokoro/linux/benchmark/run.sh
+++ b/kokoro/linux/benchmark/run.sh
@@ -58,6 +58,7 @@ make clean && make -j8
 
 # build Java protobuf
 pushd java
+# TODO: avoid unnecessarily running all java tests.
 mvn package
 popd
 
@@ -86,18 +87,10 @@ make js-benchmark
 echo "benchmarking js..."
 ./js-benchmark $datasets  --json_output=$(pwd)/tmp/node_result.json
 
-# php only supports a subset of benchmark datasets
-make -j8 generate_proto3_data
-proto3_datasets=$(for file in $datasets; do echo $(pwd)/tmp/proto3_data/${file#$(pwd)}; done | xargs)
-echo $proto3_datasets
-
-# build and run php benchmark
-make -j8 php-c-benchmark
-echo "benchmarking php_c..."
-./php-c-benchmark $proto3_datasets --json --behavior_prefix="php_c" > tmp/php_c_result.json
+# TODO(jtattermusch): add php-c-benchmark. Currently its build is broken.
 
 # upload results to bq
 make python_add_init
-env LD_LIBRARY_PATH="${repo_root}/src/.libs" python -m util.result_uploader -php_c="../tmp/php_c_result.json"  \
-	-cpp="../tmp/cpp_result.json" -java="../tmp/java_result.json" -go="../tmp/go_result.txt" -python="../tmp/python_result.json" -node="../tmp/node_result.json"
+env LD_LIBRARY_PATH="${repo_root}/src/.libs" python -m util.result_uploader \
+	-cpp="../tmp/cpp_result.json" -java="../tmp/java_result.json" -python="../tmp/python_result.json" -node="../tmp/node_result.json"
 popd

--- a/kokoro/linux/benchmark/run.sh
+++ b/kokoro/linux/benchmark/run.sh
@@ -3,36 +3,40 @@
 # Change to repo root
 cd $(dirname $0)/../../..
 
+set -ex
+
 export OUTPUT_DIR=testoutput
-oldpwd=`pwd`
+repo_root="$(pwd)"
 
 # tcmalloc
 if [ ! -f gperftools/.libs/libtcmalloc.so ]; then
   git clone https://github.com/gperftools/gperftools.git
-  cd gperftools
+  pushd gperftools
   ./autogen.sh
   ./configure
   make -j8
-  cd ..
+  popd
 fi
 
 # download datasets for benchmark
-cd benchmarks
+pushd benchmarks
 datasets=$(for file in $(find . -type f -name "dataset.*.pb" -not -path "./tmp/*"); do echo "$(pwd)/$file"; done | xargs)
 echo $datasets
-cd $oldpwd
+popd
 
 # build Python protobuf
 ./autogen.sh
 ./configure CXXFLAGS="-fPIC -O2"
 make -j8
-cd python
+pushd python
 python setup.py build --cpp_implementation
 pip install . --user
-
+popd
 
 # build and run Python benchmark
-cd ../benchmarks
+# We do this before building protobuf C++ since C++ build
+# will rewrite some libraries used by protobuf python.
+pushd benchmarks
 make python-pure-python-benchmark
 make python-cpp-reflection-benchmark
 make -j8 python-cpp-generated-code-benchmark
@@ -41,64 +45,59 @@ echo "benchmarking pure python..."
 ./python-pure-python-benchmark --json --behavior_prefix="pure-python-benchmark" $datasets  >> tmp/python_result.json
 echo "," >> "tmp/python_result.json"
 echo "benchmarking python cpp reflection..."
-env LD_PRELOAD="$oldpwd/gperftools/.libs/libtcmalloc.so" LD_LIBRARY_PATH="$oldpwd/src/.libs" ./python-cpp-reflection-benchmark --json --behavior_prefix="cpp-reflection-benchmark" $datasets  >> tmp/python_result.json
+env LD_PRELOAD="${repo_root}/gperftools/.libs/libtcmalloc.so" LD_LIBRARY_PATH="${repo_root}/src/.libs" ./python-cpp-reflection-benchmark --json --behavior_prefix="cpp-reflection-benchmark" $datasets  >> tmp/python_result.json
 echo "," >> "tmp/python_result.json"
 echo "benchmarking python cpp generated code..."
-env LD_PRELOAD="$oldpwd/gperftools/.libs/libtcmalloc.so" LD_LIBRARY_PATH="$oldpwd/src/.libs" ./python-cpp-generated-code-benchmark --json --behavior_prefix="cpp-generated-code-benchmark" $datasets >> tmp/python_result.json
+env LD_PRELOAD="${repo_root}/gperftools/.libs/libtcmalloc.so" LD_LIBRARY_PATH="${repo_root}/src/.libs" ./python-cpp-generated-code-benchmark --json --behavior_prefix="cpp-generated-code-benchmark" $datasets >> tmp/python_result.json
 echo "]" >> "tmp/python_result.json"
-cd $oldpwd
+popd
 
 # build CPP protobuf
 ./configure
 make clean && make -j8
 
 # build Java protobuf
-cd java
+pushd java
 mvn package
-cd ..
+popd
 
-# build CPP benchmark
-cd benchmarks
+pushd benchmarks
+
+# build and run C++ benchmark
+# TODO: avoid the magic with moving python_result.json
 mv tmp/python_result.json . && make clean && make -j8 cpp-benchmark && mv python_result.json tmp
 echo "benchmarking cpp..."
-env LD_PRELOAD="$oldpwd/gperftools/.libs/libtcmalloc.so" ./cpp-benchmark --benchmark_min_time=5.0 --benchmark_out_format=json --benchmark_out="tmp/cpp_result.json" $datasets
-cd $oldpwd
+env LD_PRELOAD="${repo_root}/gperftools/.libs/libtcmalloc.so" ./cpp-benchmark --benchmark_min_time=5.0 --benchmark_out_format=json --benchmark_out="tmp/cpp_result.json" $datasets
 
-# build go protobuf
-export PATH="`pwd`/src:$PATH"
-export GOPATH="$HOME/gocode"
-mkdir -p "$GOPATH/src/github.com/google"
-rm -f "$GOPATH/src/github.com/protocolbuffers/protobuf"
-ln -s "`pwd`" "$GOPATH/src/github.com/protocolbuffers/protobuf"
-export PATH="$GOPATH/bin:$PATH"
-go get github.com/golang/protobuf/protoc-gen-go
+# TODO(jtattermusch): add benchmarks for https://github.com/protocolbuffers/protobuf-go.
+# The original benchmarks for https://github.com/golang/protobuf were removed
+# because:
+# * they were broken and haven't been producing results for a long time
+# * the https://github.com/golang/protobuf implementation has been superseded by
+#   https://github.com/protocolbuffers/protobuf-go
 
-# build go benchmark
-cd benchmarks
-make go-benchmark
-echo "benchmarking go..."
-./go-benchmark $datasets > tmp/go_result.txt
-
-# build java benchmark
+# build and run java benchmark
 make java-benchmark
 echo "benchmarking java..."
 ./java-benchmark -Cresults.file.options.file="tmp/java_result.json" $datasets
 
+# build and run js benchmark
 make js-benchmark
 echo "benchmarking js..."
 ./js-benchmark $datasets  --json_output=$(pwd)/tmp/node_result.json
 
+# php only supports a subset of benchmark datasets
 make -j8 generate_proto3_data
 proto3_datasets=$(for file in $datasets; do echo $(pwd)/tmp/proto3_data/${file#$(pwd)}; done | xargs)
 echo $proto3_datasets
 
-# build php benchmark
+# build and run php benchmark
 make -j8 php-c-benchmark
 echo "benchmarking php_c..."
 ./php-c-benchmark $proto3_datasets --json --behavior_prefix="php_c" > tmp/php_c_result.json
 
-# upload result to bq
+# upload results to bq
 make python_add_init
-env LD_LIBRARY_PATH="$oldpwd/src/.libs" python -m util.result_uploader -php_c="../tmp/php_c_result.json"  \
+env LD_LIBRARY_PATH="${repo_root}/src/.libs" python -m util.result_uploader -php_c="../tmp/php_c_result.json"  \
 	-cpp="../tmp/cpp_result.json" -java="../tmp/java_result.json" -go="../tmp/go_result.txt" -python="../tmp/python_result.json" -node="../tmp/node_result.json"
-cd $oldpwd
+popd


### PR DESCRIPTION
There is a [kokoro job](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:protobuf%2Fgithub%2Fmaster%2Fubuntu%2Fbenchmark%2Fcontinuous) that runs protobuf OSS benchmarks continuously, but that job has silently been broken for a long time
(it appears green on kokoro because the failures aren't being reported correctly, but many of the benchmarks are actually broken).

- removed go benchmark since it's broken and also uses the legacy implementation of protobuf go (and corresponding benchmarks for protocolbuffer/protobuf-go AFAIK don't exist in OSS).
- removed PHP benchmark since it's broken and PHP was making the entire setup complicated (and arguably PHP benchmarks results aren't as important as results for e.g. C++, java, python etc.).
- did a bunch of cleanup and added some todos
- make the script fail if the benchmarks fail, so that breakages are actually noticeable.

Background: I need the protobuf OSS benchmarks to work so that I can compare the results for ARM64 vs x86. 

