### PR TITLE
OSS benchmarks: print benchmarks JSON results to build job log

### DIFF
--- a/benchmarks/util/result_parser.py
+++ b/benchmarks/util/result_parser.py
@@ -1,5 +1,6 @@
 # This import depends on the automake rule protoc_middleman, please make sure
 # protoc_middleman has been built before run this file.
+import argparse
 import json
 import re
 import os.path
@@ -298,3 +299,39 @@ def get_result_from_file(cpp_file="",
     __parse_php_result(php_c_file, "php")
 
   return __results
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument("-cpp", "--cpp_input_file",
+                      help="The CPP benchmark result file's name",
+                      default="")
+  parser.add_argument("-java", "--java_input_file",
+                      help="The Java benchmark result file's name",
+                      default="")
+  parser.add_argument("-python", "--python_input_file",
+                      help="The Python benchmark result file's name",
+                      default="")
+  parser.add_argument("-go", "--go_input_file",
+                      help="The golang benchmark result file's name",
+                      default="")
+  parser.add_argument("-node", "--node_input_file",
+                      help="The node.js benchmark result file's name",
+                      default="")
+  parser.add_argument("-php", "--php_input_file",
+                      help="The pure php benchmark result file's name",
+                      default="")
+  parser.add_argument("-php_c", "--php_c_input_file",
+                      help="The php with c ext benchmark result file's name",
+                      default="")
+  args = parser.parse_args()
+
+  results = get_result_from_file(
+      cpp_file=args.cpp_input_file,
+      java_file=args.java_input_file,
+      python_file=args.python_input_file,
+      go_file=args.go_input_file,
+      node_file=args.node_input_file,
+      php_file=args.php_input_file,
+      php_c_file=args.php_c_input_file,
+  )
+  print(json.dumps(results, indent=2))

--- a/kokoro/linux/benchmark/run.sh
+++ b/kokoro/linux/benchmark/run.sh
@@ -89,15 +89,16 @@ echo "benchmarking js..."
 
 # TODO(jtattermusch): add php-c-benchmark. Currently its build is broken.
 
-# upload results to bq
-# TODO(jtattermusch): the upload to bq is currently broken.
+# persist raw the results in the build job log (for better debuggability)
+cat tmp/cpp_result.json
+cat tmp/java_result.json
+cat tmp/python_result.json
+cat tmp/node_result.json
+
+# print the postprocessed results to the build job log
+# TODO(jtattermusch): re-enable uploading results to bigquery (it is currently broken)
 make python_add_init
-env LD_LIBRARY_PATH="${repo_root}/src/.libs" python -m util.result_uploader \
+env LD_LIBRARY_PATH="${repo_root}/src/.libs" python -m util.result_parser \
 	-cpp="../tmp/cpp_result.json" -java="../tmp/java_result.json" -python="../tmp/python_result.json" -node="../tmp/node_result.json"
 popd
 
-# also persist the results in the build job log (for better debuggability)
-cat benchmarks/tmp/cpp_result.json
-cat benchmarks/tmp/java_result.json
-cat benchmarks/tmp/python_result.json
-cat benchmarks/tmp/node_result.json


### PR DESCRIPTION
- uploading the benchmark results to bigquery is currently broken (I think it's because it's trying to upload to bq table in "grpc-testing" project without having access).
- for now, instead of uploading the results, just print the formatted JSON results to the build log (that way the data remains available).