### PR TITLE
ObjC: Add stdin/stdout/stderr to reserved word list.

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -213,6 +213,10 @@ const char* const kReservedWordList[] = {
   // Not a keyword, but will break you
   "NULL",
 
+  // C88+ specs call for these to be macros, so depending on what they are
+  // defined to be it can lead to odd errors for some Xcode/SDK versions.
+  "stdin", "stdout", "stderr",
+
   // Objective-C Runtime typedefs
   // From <obc/runtime.h>
   "Category", "Ivar", "Method", "Protocol",


### PR DESCRIPTION
This will cause fields named exactly these names to get `_p` appended to them.
This is being done since the C89/C99/etc specs say these name should be macros,
so in an ObjC context, trying to access the fields would result in runtime
failures for unknown selectors. The only way the fields were usable was to use
KVC or via the descriptor based apis, but if someone hit that they likely would
have reported the general issue also.
