### PR TITLE
fixed warning about missing pragma warning push

### DIFF
--- a/src/google/protobuf/wire_format_lite.h
+++ b/src/google/protobuf/wire_format_lite.h
@@ -66,12 +66,11 @@
 // #pragma pop_macro("TYPE_BOOL")
 #undef TYPE_BOOL
 
+#include <google/protobuf/port_def.inc>
 
 namespace google {
 namespace protobuf {
 namespace internal {
-
-#include <google/protobuf/port_def.inc>
 
 // This class is for internal use by the protocol buffer library and by
 // protocol-compiler-generated message classes.  It must not be called


### PR DESCRIPTION
The line
```c++
#include <google/protobuf/port_def.inc>
```
is inside the namespaces, and therefore sometimes doesn't get read for some reason, resulting in a missing `#pragma warning(push)`.
Putting the line before the namespaces, as in other headers, solves this problem.

cheers.
