### PR TITLE
Tweak tests to allow common protos to evolve more.

### DIFF
--- a/objectivec/Tests/GPBDescriptorTests.m
+++ b/objectivec/Tests/GPBDescriptorTests.m
@@ -304,12 +304,6 @@
 - (void)testOneofDescriptor {
   GPBDescriptor *descriptor = [TestOneof2 descriptor];
 
-  // All fields should be listed.
-  XCTAssertEqual(descriptor.fields.count, 21U);
-
-  // There are two oneofs in there.
-  XCTAssertEqual(descriptor.oneofs.count, 2U);
-
   GPBFieldDescriptor *fooStringField =
       [descriptor fieldWithNumber:TestOneof2_FieldNumber_FooString];
   XCTAssertNotNil(fooStringField);
@@ -317,22 +311,24 @@
       [descriptor fieldWithNumber:TestOneof2_FieldNumber_BarString];
   XCTAssertNotNil(barStringField);
 
-  // Check the oneofs to have what is expected.
+  // Check the oneofs to have what is expected but not other onesofs
 
   GPBOneofDescriptor *oneofFoo = [descriptor oneofWithName:@"foo"];
   XCTAssertNotNil(oneofFoo);
-  XCTAssertEqual(oneofFoo.fields.count, 9U);
+  XCTAssertNotNil([oneofFoo fieldWithName:@"fooString"]);
+  XCTAssertNil([oneofFoo fieldWithName:@"barString"]);
 
-  // Pointer comparisons.
+  GPBOneofDescriptor *oneofBar = [descriptor oneofWithName:@"bar"];
+  XCTAssertNotNil(oneofBar);
+  XCTAssertNil([oneofBar fieldWithName:@"fooString"]);
+  XCTAssertNotNil([oneofBar fieldWithName:@"barString"]);
+
+  // Pointer comparisons against lookups from message.
+
   XCTAssertEqual([oneofFoo fieldWithNumber:TestOneof2_FieldNumber_FooString],
                  fooStringField);
   XCTAssertEqual([oneofFoo fieldWithName:@"fooString"], fooStringField);
 
-  GPBOneofDescriptor *oneofBar = [descriptor oneofWithName:@"bar"];
-  XCTAssertNotNil(oneofBar);
-  XCTAssertEqual(oneofBar.fields.count, 10U);
-
-  // Pointer comparisons.
   XCTAssertEqual([oneofBar fieldWithNumber:TestOneof2_FieldNumber_BarString],
                  barStringField);
   XCTAssertEqual([oneofBar fieldWithName:@"barString"], barStringField);


### PR DESCRIPTION
Don't check field counts, instead only test based on the fields that exists (and
likely will never exist). This allows the protos to evolve with almost zero
chance of the tests breaking for those other changes.