### PR TITLE
Fix js generator for commonjs_strict

### DIFF
--- a/js/commonjs/strict_test.js
+++ b/js/commonjs/strict_test.js
@@ -44,8 +44,8 @@ var test10_pb = require('./test10_pb');
 
 describe('Strict test suite', function() {
   it('testImportedMessage', function() {
-    var simple1 = new test9_pb.jspb.exttest.strict.nine.Simple9()
-    var simple2 = new test9_pb.jspb.exttest.strict.nine.Simple9()
+    var simple1 = new test9_pb.Simple9();
+    var simple2 = new test9_pb.Simple9();
     assertObjectEquals(simple1.toObject(), simple2.toObject());
   });
 
@@ -55,8 +55,8 @@ describe('Strict test suite', function() {
 
   describe('with imports', function() {
     it('testImportedMessage', function() {
-      var simple1 = new test10_pb.jspb.exttest.strict.ten.Simple10()
-      var simple2 = new test10_pb.jspb.exttest.strict.ten.Simple10()
+      var simple1 = new test10_pb.Simple10();
+      var simple2 = new test10_pb.Simple10();
       assertObjectEquals(simple1.toObject(), simple2.toObject());
     });
 

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -2967,13 +2967,13 @@ void Generator::GenerateRepeatedMessageHelperMethods(
 
   printer->Annotate("addername", field);
   printer->Print(
-      "this, $index$$oneofgroup$, opt_value, $ctor$, opt_index);\n"
+      "this, $index$$oneofgroup$, opt_value, $wrapperclass$, opt_index);\n"
       "};\n"
       "\n"
       "\n",
       "index", JSFieldIndex(field), "oneofgroup",
-      (InRealOneof(field) ? (", " + JSOneofArray(options, field)) : ""), "ctor",
-      GetMessagePath(options, field->message_type()));
+      (InRealOneof(field) ? (", " + JSOneofArray(options, field)) : ""), "wrapperclass",
+      SubmessageTypeRef(options, field));
 }
 
 void Generator::GenerateClassExtensionFieldInfo(const GeneratorOptions& options,
@@ -3647,8 +3647,7 @@ void Generator::GenerateFile(const GeneratorOptions& options,
     for (int i = 0; i < file->dependency_count(); i++) {
       const std::string& name = file->dependency(i)->name();
       printer->Print(
-          "var $alias$ = require('$file$');\n"
-          "goog.object.extend(proto, $alias$);\n",
+          "var $alias$ = require('$file$');\n",
           "alias", ModuleAlias(name), "file",
           GetRootPath(file->name(), name) + GetJSFilename(options, name));
     }
@@ -3687,12 +3686,10 @@ void Generator::GenerateFile(const GeneratorOptions& options,
   }
 
   // if provided is empty, do not export anything
-  if (options.import_style == GeneratorOptions::kImportCommonJs &&
+  if ((options.import_style == GeneratorOptions::kImportCommonJs ||
+       options.import_style == GeneratorOptions::kImportCommonJsStrict) &&
       !provided.empty()) {
     printer->Print("goog.object.extend(exports, $package$);\n", "package",
-                   GetNamespace(options, file));
-  } else if (options.import_style == GeneratorOptions::kImportCommonJsStrict) {
-    printer->Print("goog.object.extend(exports, proto);\n", "package",
                    GetNamespace(options, file));
   }
 


### PR DESCRIPTION
This resolves js issues when generator used with `import_style=commonjs_strict`.
The problem was in js-exports that are have nested namespaces. For comparison, when using `import_style=commonjs`, there is no addiontal nesting in exported objects. So, now js-export is unified, and the use of imported modules is fixed.
This fixes #6801.
Initially, the incorrect generation was made by a commit 13f94b4092cff9bc36a62adb4bf2e362b4f85979. In current pr this commit is partially reverted with the correction of incorrect tests.