### PR TITLE
fix php Google\Protobuf\Internal\AnyBase::is for not message classes

### DIFF
--- a/php/src/Google/Protobuf/Internal/AnyBase.php
+++ b/php/src/Google/Protobuf/Internal/AnyBase.php
@@ -79,6 +79,9 @@ class AnyBase extends \Google\Protobuf\Internal\Message
     {
         $pool = \Google\Protobuf\Internal\DescriptorPool::getGeneratedPool();
         $desc = $pool->getDescriptorByClassName($klass);
+        if (is_null($desc)) {
+            return false;
+        }
         $fully_qualifed_name = $desc->getFullName();
         $type_url = GPBUtil::TYPE_URL_PREFIX . $fully_qualifed_name;
         return $this->type_url === $type_url;

--- a/php/tests/WellKnownTest.php
+++ b/php/tests/WellKnownTest.php
@@ -84,6 +84,7 @@ class WellKnownTest extends TestBase {
         // Test is.
         $this->assertTrue($any->is(TestMessage::class));
         $this->assertFalse($any->is(Any::class));
+        $this->assertFalse($any->is(NotMessage::class));
     }
 
     public function testAnyUnpackInvalidTypeUrl()


### PR DESCRIPTION
Fix `Call to a member function getFullName() on null` bug

```
PHPUnit 8.5.16 by Sebastian Bergmann and contributors.

..E....................                                           23 / 23 (100%)

Time: 84 ms, Memory: 6.00 MB

There was 1 error:

1) WellKnownTest::testAny
Error: Call to a member function getFullName() on null

/home/doc/projects/_forks/protobuf/php/src/Google/Protobuf/Internal/AnyBase.php:82
/home/doc/projects/_forks/protobuf/php/tests/WellKnownTest.php:87

```