### PR TITLE
fix(chsarp): actually discard unknown fields when parsing JSON via MessageParser<T>

### DIFF
--- a/csharp/src/Google.Protobuf.Test/MessageParserTest.cs
+++ b/csharp/src/Google.Protobuf.Test/MessageParserTest.cs
@@ -46,7 +46,7 @@ namespace Google.Protobuf
     public class MessageParserTest
     {
         [Test]
-        public void JsonUnknownField_NotIgnored()
+        public void ParseJsonUnknownField_NotIgnored()
         {
             var parser = new MessageParser<TestAllTypes>(() => new TestAllTypes());
             string json = "{ \"unknownField\": 10, \"singleString\": \"x\" }";
@@ -58,7 +58,7 @@ namespace Google.Protobuf
         [TestCase("\"text\"")]
         [TestCase("[0, 1, 2]")]
         [TestCase("{ \"a\": { \"b\": 10 } }")]
-        public void UnknownField_Ignored(string value)
+        public void ParseJsonUnknownField_Ignored(string value)
         {
             var parser = new MessageParser<TestAllTypes>(() => new TestAllTypes()).WithDiscardUnknownFields(true);
             string json = "{ \"unknownField\": " + value + ", \"singleString\": \"x\" }";

--- a/csharp/src/Google.Protobuf.Test/MessageParserTest.cs
+++ b/csharp/src/Google.Protobuf.Test/MessageParserTest.cs
@@ -1,0 +1,70 @@
+﻿#region Copyright notice and license
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+using Google.Protobuf.TestProtos;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Protobuf
+{
+    /// <summary>
+    /// Unit tests for MessageParser.
+    /// </summary>
+    public class MessageParserTest
+    {
+        [Test]
+        public void JsonUnknownField_NotIgnored()
+        {
+            var parser = new MessageParser<TestAllTypes>(() => new TestAllTypes());
+            string json = "{ \"unknownField\": 10, \"singleString\": \"x\" }";
+            Assert.Throws<InvalidProtocolBufferException>(() => parser.ParseJson(json));
+        }
+
+        [Test]
+        [TestCase("5")]
+        [TestCase("\"text\"")]
+        [TestCase("[0, 1, 2]")]
+        [TestCase("{ \"a\": { \"b\": 10 } }")]
+        public void UnknownField_Ignored(string value)
+        {
+            var parser = new MessageParser<TestAllTypes>(() => new TestAllTypes()).WithDiscardUnknownFields(true);
+            string json = "{ \"unknownField\": " + value + ", \"singleString\": \"x\" }";
+            var actual = parser.ParseJson(json);
+            var expected = new TestAllTypes { SingleString = "x" };
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -379,7 +379,16 @@ namespace Google.Protobuf
         public new T ParseJson(string json)
         {
             T message = factory();
-            JsonParser.Default.Merge(message, json);
+            JsonParser parser;
+            if (DiscardUnknownFields)
+            {
+                parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+            }
+            else
+            {
+                parser = JsonParser.Default;
+            }
+            parser.Merge(message, json);
             return message;
         }
 


### PR DESCRIPTION
As per #8316, unknown fields are not discarded when using `MessageParser<T>.WithDiscardUnknownFields(true).ParseJson()`

This PR corrects the behavior of JSON parsing using MessageParser when discarding unknown fields is requested.

This also includes some unit tests which are derived from unit tests in JsonParserTest.

Just a note: I created a new file MessageParserTest.cs, as there were no tests for this class. I copied the copyright header from another file - not sure if this is right :)