### PR TITLE
Make StringPiece constructible from std::string_view

### DIFF
--- a/src/google/protobuf/stubs/stringpiece.h
+++ b/src/google/protobuf/stubs/stringpiece.h
@@ -214,6 +214,13 @@ class PROTOBUF_EXPORT StringPiece {
       : ptr_(str.data()), length_(0) {
     length_ = CheckSize(str.size());
   }
+ 
+  StringPiece(  // NOLINT(runtime/explicit)
+      std::string_view str)
+      : ptr_(str.data()), length_(0) {
+    length_ = CheckSize(str.size());
+  }
+   
 
   StringPiece(const char* offset, size_type len)
       : ptr_(offset), length_(CheckSize(len)) {}

--- a/src/google/protobuf/stubs/stringpiece.h
+++ b/src/google/protobuf/stubs/stringpiece.h
@@ -148,6 +148,10 @@
 #include <limits>
 #include <string>
 
+#if defined(__cpp_lib_string_view)
+#include <string_view>
+#endif
+
 #include <google/protobuf/stubs/hash.h>
 
 #include <google/protobuf/port_def.inc>
@@ -214,13 +218,14 @@ class PROTOBUF_EXPORT StringPiece {
       : ptr_(str.data()), length_(0) {
     length_ = CheckSize(str.size());
   }
- 
+
+#if defined(__cpp_lib_string_view)
   StringPiece(  // NOLINT(runtime/explicit)
       std::string_view str)
       : ptr_(str.data()), length_(0) {
     length_ = CheckSize(str.size());
   }
-   
+#endif
 
   StringPiece(const char* offset, size_type len)
       : ptr_(offset), length_(CheckSize(len)) {}


### PR DESCRIPTION
This improves interop with certain string-like data structures, allowing to save extra allocation.