### PR TITLE
fix for PHP 8.1

### DIFF
--- a/php/ext/google/protobuf/array.c
+++ b/php/ext/google/protobuf/array.c
@@ -640,8 +640,13 @@ void Array_ModuleInit() {
                    repeated_field_methods);
 
   RepeatedField_class_entry = zend_register_internal_class(&tmp_ce);
+#if PHP_VERSION_ID < 80100
   zend_class_implements(RepeatedField_class_entry, 3, spl_ce_ArrayAccess,
                         zend_ce_aggregate, spl_ce_Countable);
+#else
+  zend_class_implements(RepeatedField_class_entry, 3, zend_ce_arrayaccess,
+                        zend_ce_aggregate, zend_ce_countable);
+#endif
   RepeatedField_class_entry->ce_flags |= ZEND_ACC_FINAL;
   RepeatedField_class_entry->create_object = RepeatedField_create;
 

--- a/php/ext/google/protobuf/map.c
+++ b/php/ext/google/protobuf/map.c
@@ -636,8 +636,13 @@ void Map_ModuleInit() {
                    MapField_methods);
 
   MapField_class_entry = zend_register_internal_class(&tmp_ce);
+#if PHP_VERSION_ID < 80000
   zend_class_implements(MapField_class_entry, 3, spl_ce_ArrayAccess,
                         zend_ce_aggregate, spl_ce_Countable);
+#else
+  zend_class_implements(MapField_class_entry, 3, zend_ce_arrayaccess,
+                        zend_ce_aggregate, zend_ce_countable);
+#endif
   MapField_class_entry->ce_flags |= ZEND_ACC_FINAL;
   MapField_class_entry->create_object = MapField_create;
 


### PR DESCRIPTION
From UPGRADING.INTERNALS

```
  a. The following APIs have been removed from the Zend Engine:
     - The spl_ce_Aggregate, spl_ce_ArrayAccess, spl_ce_Countable, spl_ce_Iterator, spl_ce_Serializable,
       spl_ce_Stringable, spl_ce_Traversable alias class entries have been removed in favor of zend_ce_aggregate,
       zend_ce_arrayaccess, zend_ce_countable, zend_ce_iterator, zend_ce_serializable, zend_ce_stringable,
       zend_ce_traversable.

```