### PR TITLE
Fix errorprone conflict

### DIFF
--- a/java/util/pom.xml
+++ b/java/util/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Protobuf-java-util has a dependency on errorprone v2.3.4 and 2.5.1 which causes a dependency convergence problem (#8721). This updates one of the dependencies so that the versions match.