### PR TITLE
Add override to C++ code generation for InternalGetTable

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -1174,7 +1174,7 @@ void MessageGenerator::GenerateClassDefinition(io::Printer* printer) {
   if (options_.table_driven_serialization) {
     format(
         "private:\n"
-        "const void* InternalGetTable() const;\n"
+        "const void* InternalGetTable() const override;\n"
         "public:\n"
         "\n");
   }


### PR DESCRIPTION
Improve on the fixes from issue #8612 to avoid warnings in Clang 12.