### PR TITLE
Enable testing via CTest

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -283,6 +283,7 @@ if (protobuf_BUILD_TESTS OR protobuf_BUILD_CONFORMANCE OR protobuf_BUILD_EXAMPLE
 endif ()
 
 if (protobuf_BUILD_TESTS)
+  enable_testing()
   include(tests.cmake)
 endif (protobuf_BUILD_TESTS)
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -164,7 +164,11 @@ Testing
 To run unit-tests, first you must compile protobuf as described above.
 Then run:
 
-     C:\Path\to\protobuf\cmake\build\release>nmake check
+     C:\Path\to\protobuf\cmake\build\release>ctest --progress --output-on-failure
+
+You can also build the `check` target (not idiomatic CMake usage, though):
+
+     C:\Path\to\protobuf\cmake\build\release>cmake --build . --target check
 
 or
 
@@ -183,7 +187,7 @@ You should see output similar to:
      [==========] 1546 tests from 165 test cases ran. (2529 ms total)
      [  PASSED  ] 1546 tests.
 
-To run specific tests:
+To run specific tests, you need to pass some command line arguments to the test program itself:
 
      C:\Path\to\protobuf>cmake\build\release\tests.exe --gtest_filter=AnyTest*
      Running main() from gmock_main.cc

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -254,3 +254,7 @@ add_custom_target(check
   COMMAND tests
   DEPENDS tests test_plugin
   WORKING_DIRECTORY ${protobuf_source_dir})
+
+add_test(NAME check
+  COMMAND tests
+  WORKING_DIRECTORY "${protobuf_source_dir}")


### PR DESCRIPTION
Convenience feature: enable users to test via the familiar `ctest` command rather than making the `check` target.

They would be able to use the familiar CMake pattern:
```
cmake -S source/protobuf -B build/protobuf ...
cmake --build build/protobuf
ctest --test-dir build/protobuf
cmake --install build/protobuf
```

This is a follow-up to 9f447fc9d3da93da29b8301f1a8ca57b1ea812d7