### PR TITLE
Reintroduce setup.py changes from #8280 erased by piper import #8617

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -18,6 +18,7 @@ from setuptools import setup, Extension, find_packages
 
 from distutils.command.build_py import build_py as _build_py
 from distutils.command.clean import clean as _clean
+from distutils.command.build_ext import build_ext as _build_ext
 from distutils.spawn import find_executable
 
 # Find the Protocol Compiler.
@@ -157,6 +158,22 @@ class build_py(_build_py):
             if not any(fnmatch.fnmatchcase(fil, pat=pat) for pat in exclude)]
 
 
+class build_ext(_build_ext):
+  def get_ext_filename(self, ext_name):
+      # since python3.5, python extensions' shared libraries use a suffix that corresponds to the value
+      # of sysconfig.get_config_var('EXT_SUFFIX') and contains info about the architecture the library targets.
+      # E.g. on x64 linux the suffix is ".cpython-XYZ-x86_64-linux-gnu.so"
+      # When crosscompiling python wheels, we need to be able to override this suffix
+      # so that the resulting file name matches the target architecture and we end up with a well-formed
+      # wheel.
+      filename = _build_ext.get_ext_filename(self, ext_name)
+      orig_ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+      new_ext_suffix = os.getenv("PROTOCOL_BUFFERS_OVERRIDE_EXT_SUFFIX")
+      if new_ext_suffix and filename.endswith(orig_ext_suffix):
+        filename = filename[:-len(orig_ext_suffix)] + new_ext_suffix
+      return filename
+
+
 class test_conformance(_build_py):
   target = 'test_python'
   def run(self):
@@ -291,6 +308,7 @@ if __name__ == '__main__':
       cmdclass={
           'clean': clean,
           'build_py': build_py,
+          'build_ext': build_ext,
           'test_conformance': test_conformance,
       },
       install_requires=install_requires,


### PR DESCRIPTION
Fixes https://github.com/protocolbuffers/protobuf/issues/8667.

For an unknown reason (am I missing something?), setup.py changes from #8280 have been erased by piper import #8617 (see https://github.com/protocolbuffers/protobuf/issues/8667#issuecomment-863936224).

These changes are actually necessary for correct build of aarch64 python wheels.
without them, the aarch64 wheels will have python extension .so files with wrong arch suffix `x86_64-linux-gnu.so`,
which results in failing to load the python C++ extension.
This is also basically what the broken tests reported by #8667 have detected.

This PR fixes the problem - as proven by a green adhoc run of the kokoro job (https://fusion2.corp.google.com/invocations/c1e5e71e-e779-48e7-8f0a-23b1d33a06b0/targets/protobuf%2Fgithub%2Fmaster%2Fubuntu%2Fpython_aarch64%2Fcontinuous/log)

One thing I haven't been able to explain is:
- why did the piper import erase the changes made to setup.py (was that intentional or perhaps a bad merge?)
- was there any other important changes that ended up being deleted?

