### PR TITLE
Fix #8748 tests.exe link failure under mingw/mingw64

### DIFF
--- a/src/google/protobuf/map_test.cc
+++ b/src/google/protobuf/map_test.cc
@@ -30,7 +30,7 @@
 
 // A hack to include windows.h first, which ensures the GetMessage macro can
 // be undefined when we include <google/protobuf/stubs/common.h>
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 #define _WINSOCKAPI_  // to avoid re-definition in WinSock2.h
 #define NOMINMAX      // to avoid defining min/max macros
 #include <windows.h>


### PR DESCRIPTION
It for issue #8748
mingw/mingw64 doesn't defines _MSC_VER and defines _WIN32 macro. When it comes to map_test.cc:

> https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/map_test.cc#L33

It will include windows.h  and thus the GetMessage macro and GetMessageA WINAPI. 

I changed the _WIN32 macro in map_test.cc to _MSC_VER and it linked well for both visual studio and mingw64.