### PR TITLE
Fix failing java7 linux test

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -228,7 +228,7 @@ build_java_with_conformance_tests() {
   cd ../..
   cd java/core && $MVN test && $MVN install
   cd ../lite && $MVN test && $MVN install
-  cd ../util && $MVN package assembly:single
+  cd ../util && $MVN test && $MVN install && $MVN package assembly:single
   if [ "$version" == "jdk8" ]; then
     cd ../kotlin && $MVN test && $MVN install
     cd ../kotlin-lite && $MVN test && $MVN install

--- a/tests.sh
+++ b/tests.sh
@@ -226,8 +226,13 @@ build_java_with_conformance_tests() {
   # This local installation avoids the problem caused by a new version not yet in Maven Central
   cd java/bom && $MVN install
   cd ../..
-  cd java && $MVN test && $MVN install
-  cd util && $MVN package assembly:single
+  cd java/core && $MVN test && $MVN install
+  cd ../lite && $MVN test && $MVN install
+  cd ../util && $MVN package assembly:single
+  if [ "$version" == "jdk8" ]; then
+    cd ../kotlin && $MVN test && $MVN install
+    cd ../kotlin-lite && $MVN test && $MVN install
+  fi
   cd ../..
   cd conformance && make test_java && cd ..
 }


### PR DESCRIPTION
Only run maven kotlin tests when testing jdk8. The kotlin failure was causing the install to error out, which was stopping a local jar from being made which then caused more bugs. 