### PR TITLE
Raise DecodeError on attemt to parse invalid bytestream from Python

### DIFF
--- a/python/google/protobuf/pyext/message.cc
+++ b/python/google/protobuf/pyext/message.cc
@@ -1976,15 +1976,13 @@ static PyObject* MergeFromString(CMessage* self, PyObject* arg) {
   if (ptr == nullptr || ctx.BytesUntilLimit(ptr) < 0) {
     // Parse error or the parser overshoot the limit.
     PyErr_Format(DecodeError_class, "Error parsing message");
-    return NULL;
+    return nullptr;
   }
   // ctx has an explicit limit set (length of string_view), so we have to
   // check we ended at that limit.
   if (!ctx.EndedAtLimit()) {
-    // TODO(jieluo): Raise error and return NULL instead.
-    // b/27494216
-    PyErr_Warn(nullptr, "Unexpected end-group tag: Not all data was converted");
-    return PyInt_FromLong(data.len - ctx.BytesUntilLimit(ptr));
+    PyErr_Format(DecodeError_class, "Unexpected end-group tag: Not all data was converted");
+    return nullptr;
   }
   return PyInt_FromLong(data.len);
 }


### PR DESCRIPTION
At the time an attempt to parse `proto3` message from `b"data"` will silently exit reporting success.

At least in protobuf=3.4.x this resulted in DecodeError.