### PR TITLE
Detect Windows vs Non-Windows execution context in tests.

### DIFF
--- a/java/core/src/test/java/com/google/protobuf/TestUtil.java
+++ b/java/core/src/test/java/com/google/protobuf/TestUtil.java
@@ -3770,9 +3770,18 @@ public final class TestUtil {
     } catch (IOException e) {
       throw new RuntimeException("Couldn't get canonical name of working directory.", e);
     }
+    
+    String srcRootCheck = "src/google/protobuf";
+
+    // If we're running w/ Bazel on Windows, we're not in a sandbox, so we
+    // we must change our source root check condition to find the true test data dir.
+    String testBinaryName = System.getenv("TEST_BINARY");
+    if (testBinaryName != null && testBinaryName.endsWith(".exe")) {
+      srcRootCheck = srcRootCheck + "/descriptor.cc";
+    }
     while (ancestor != null && ancestor.exists()) {
       // Identify the true source root.
-      if (new File(ancestor, "src/google/protobuf/descriptor.cc").exists()) {
+      if (new File(ancestor, srcRootCheck).exists()) {
         return new File(ancestor, "src/google/protobuf/testdata");
       }
       ancestor = ancestor.getParentFile();


### PR DESCRIPTION
Fixes #8754 once and for all.