### PR TITLE
Adding protobuf_version.bzl to update_version.py

### DIFF
--- a/update_version.py
+++ b/update_version.py
@@ -364,6 +364,13 @@ def UpdateRuby():
       '  s.version     = "%s"' % GetFullVersion(rc_suffix = '.rc.'),
       line))
 
+def UpdateBazel():
+  RewriteTextFile('protobuf_version.bzl',
+    lambda line : re.sub(
+     r"^PROTOBUF_VERSION = '.*'$",
+     "PROTOBUF_VERSION = '%s'" % GetFullVersion(),
+     line))
+
 
 UpdateConfigure()
 UpdateCsharp()
@@ -375,3 +382,4 @@ UpdateObjectiveC()
 UpdatePhp()
 UpdatePython()
 UpdateRuby()
+UpdateBazel()


### PR DESCRIPTION
protobuf_version.bzl was recently added to export the version of protobuf to different BUILD files. This PR adds it to the list of files that are automatically updated by update_version.py when the version of protobuf is updated.