### PR TITLE
Allocated eigr/protocol protobuf extensions

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -280,3 +280,7 @@ with info about your project (name and website) so we can add an entry for you.
 1. Glitchdot (Currently Private)
    * Website: https://go.glitchdot.com
    * Extension: 1109
+
+1. eigr/protocol
+   * Website: https://eigr.io
+   * Extension: 1110-1114


### PR DESCRIPTION
I've requested a block of 5 extension numbers. We already have two concrete extensions that we need ids for. Our project is under active development and we can imagine a number of other extensions that we will want in future, so we thought we'd start by registering a block of 5, instead of raising a new PR here each time we need a new one.