### PR TITLE
creating a single target to rollup maven artifacts

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -1,8 +1,16 @@
 test_suite(
-  name = "tests",
-  tests = [
-    "//java/core:tests",
-    "//java/lite:tests",
-    "//java/util:tests",
-  ],
+    name = "tests",
+    tests = [
+        "//java/core:tests",
+        "//java/lite:tests",
+        "//java/util:tests",
+    ],
+)
+
+filegroup(
+    name = "release",
+    srcs = [
+        "//java/core:release", # contains lite.
+        "//java/util:release",
+    ]
 )

--- a/java/core/BUILD
+++ b/java/core/BUILD
@@ -142,6 +142,21 @@ java_export(
     ],
 )
 
+filegroup(
+    name = "release",
+    visibility = ["//java:__pkg__"],
+    srcs = [
+        ":core-pom",
+        ":core-maven-source",
+        ":core-docs",
+        ":core-project",
+        ":lite-pom",
+        ":lite-maven-source",
+        ":lite-docs",
+        ":lite-project",
+    ]
+)
+
 proto_lang_toolchain(
     name = "toolchain",
     command_line = "--java_out=$(OUT)",

--- a/java/util/BUILD
+++ b/java/util/BUILD
@@ -20,6 +20,17 @@ java_export(
     ],
 )
 
+filegroup(
+    name = "release",
+    visibility = ["//java:__pkg__"],
+    srcs = [
+        ":util-pom",
+        ":util-maven-source",
+        ":util-docs",
+        ":util-project",
+    ]
+)
+
 proto_library(
     name = "test_protos",
     srcs = glob(["src/test/proto/**/*.proto"]),


### PR DESCRIPTION
This just makes it easier for our build scripts to use a single entrypoint to produce all the required content:

```
$ bazel build //java:release
INFO: Analyzed target //java:release (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //java:release up-to-date:
  bazel-bin/java/core/core-pom.xml
  bazel-bin/java/core/core-project-src.jar
  bazel-bin/java/core/core-docs.jar
  bazel-bin/java/core/core-project.jar
  bazel-bin/java/core/lite-pom.xml
  bazel-bin/java/core/lite-project-src.jar
  bazel-bin/java/core/lite-docs.jar
  bazel-bin/java/core/lite-project.jar
  bazel-bin/java/util/util-pom.xml
  bazel-bin/java/util/util-project-src.jar
  bazel-bin/java/util/util-docs.jar
  bazel-bin/java/util/util-project.jar
```