### PR TITLE
Make glob recursive if option is enabled

### DIFF
--- a/python/protobuf_distutils/protobuf_distutils/generate_py_protobufs.py
+++ b/python/protobuf_distutils/protobuf_distutils/generate_py_protobufs.py
@@ -120,7 +120,7 @@ class generate_py_protobufs(Command):
         if self.proto_files is None:
             files = glob.glob(os.path.join(self.source_dir, '*.proto'))
             if self.recurse:
-                files.extend(glob.glob(os.path.join(self.source_dir, '**', '*.proto')))
+                files.extend(glob.glob(os.path.join(self.source_dir, '**', '*.proto'), recursive=True))
             self.proto_files = [f.partition(self.proto_root_path + os.path.sep)[-1] for f in files]
             if not self.proto_files:
                 raise DistutilsOptionError('no .proto files were found under ' + self.source_dir)


### PR DESCRIPTION
This PR fixes #8247.
The documentation says `The default behavior is to generate sources for all .proto files found under source_dir, recursively` but this is not working as the issue describes.