### PR TITLE
fix: missing comma in PHP names.c and generator.cc

### DIFF
--- a/php/ext/google/protobuf/names.c
+++ b/php/ext/google/protobuf/names.c
@@ -77,7 +77,7 @@ const char *const kReservedNames[] = {
     "do",           "echo",       "else",       "elseif",       "empty",
     "enddeclare",   "endfor",     "endforeach", "endif",        "endswitch",
     "endwhile",     "eval",       "exit",       "extends",      "final",
-    "finally",      "fn"          "for",        "foreach",      "function",
+    "finally",      "fn",         "for",        "foreach",      "function",
     "if",           "implements", "include",    "include_once", "instanceof",
     "global",       "goto",       "insteadof",  "interface",    "isset",
     "list",         "match",      "namespace",  "new",          "or",

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -61,7 +61,7 @@ const char* const kReservedNames[] = {
     "print",        "private",    "protected",  "public",     "require",
     "require_once", "return",     "static",     "switch",     "throw",
     "trait",        "try",        "unset",      "use",        "var",
-    "while",        "xor",        "yield"       "int",        "float",
+    "while",        "xor",        "yield",      "int",        "float",
     "bool",         "string",     "true",       "false",      "null",
     "void",         "iterable"};
 const char* const kValidConstantNames[] = {


### PR DESCRIPTION
How did the tests pass without this??

See #7268 