### PR TITLE
Fix comment syntax in any.proto

### DIFF
--- a/src/google/protobuf/any.proto
+++ b/src/google/protobuf/any.proto
@@ -64,7 +64,7 @@ option objc_class_prefix = "GPB";
 //       foo = any.unpack(Foo.class);
 //     }
 //
-//  Example 3: Pack and unpack a message in Python.
+// Example 3: Pack and unpack a message in Python.
 //
 //     foo = Foo(...)
 //     any = Any()
@@ -74,7 +74,7 @@ option objc_class_prefix = "GPB";
 //       any.Unpack(foo)
 //       ...
 //
-//  Example 4: Pack and unpack a message in Go
+// Example 4: Pack and unpack a message in Go
 //
 //      foo := &pb.Foo{...}
 //      any, err := anypb.New(foo)
@@ -95,7 +95,7 @@ option objc_class_prefix = "GPB";
 //
 //
 // JSON
-// ====
+//
 // The JSON representation of an `Any` value uses the regular
 // representation of the deserialized, embedded message, with an
 // additional field `@type` which contains the type URL. Example:


### PR DESCRIPTION
Remove extra spaces which cause incorrect indentation in godoc.
Remove the "====" style title which is not rendered by godoc.