### PR TITLE
Remove JvmField annotations from Kotlin private properties (#8804)

### DIFF
--- a/java/kotlin/src/main/kotlin/com/google/protobuf/ExtensionList.kt
+++ b/java/kotlin/src/main/kotlin/com/google/protobuf/ExtensionList.kt
@@ -40,7 +40,7 @@ import com.google.protobuf.MessageLite
  */
 class ExtensionList<E, M : MessageLite> @OnlyForUseByGeneratedProtoCode constructor(
   val extension: ExtensionLite<M, List<E>>,
-  @JvmField private val delegate: List<E>
+  private val delegate: List<E>
 ) : List<E> by delegate {
   override fun iterator(): Iterator<E> = UnmodifiableIterator(delegate.iterator())
 

--- a/src/google/protobuf/compiler/java/java_message.cc
+++ b/src/google/protobuf/compiler/java/java_message.cc
@@ -1409,7 +1409,7 @@ void ImmutableMessageGenerator::GenerateKotlinDsl(io::Printer* printer) const {
       "@com.google.protobuf.kotlin.ProtoDslMarker\n");
   printer->Print(
       "class Dsl private constructor(\n"
-      "  @kotlin.jvm.JvmField private val _builder: $message$.Builder\n"
+      "  private val _builder: $message$.Builder\n"
       ") {\n"
       "  companion object {\n"
       "    @kotlin.jvm.JvmSynthetic\n"

--- a/src/google/protobuf/compiler/java/java_message_lite.cc
+++ b/src/google/protobuf/compiler/java/java_message_lite.cc
@@ -732,7 +732,7 @@ void ImmutableMessageLiteGenerator::GenerateKotlinDsl(
       "@com.google.protobuf.kotlin.ProtoDslMarker\n");
   printer->Print(
       "class Dsl private constructor(\n"
-      "  @kotlin.jvm.JvmField private val _builder: $message$.Builder\n"
+      "  private val _builder: $message$.Builder\n"
       ") {\n"
       "  companion object {\n"
       "    @kotlin.jvm.JvmSynthetic\n"


### PR DESCRIPTION
Fixes https://github.com/protocolbuffers/protobuf/issues/8804 ("Generated Kotlin files cause compilation to fail on Kotlin/JVM 1.5 with progressive mode enabled").

`@JvmField` on private properties is incorrect behaviour in Kotlin (see https://kotlinlang.org/docs/java-to-kotlin-interop.html#instance-fields), but doesn't seem to have caused compilation errors until Kotlin 1.5 + progressive mode.