### PR TITLE
Fix json name oneof in ruby implementation

### DIFF
--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -2190,6 +2190,13 @@ static VALUE OneofBuilderContext_optional(int argc, VALUE* argv, VALUE _self) {
 
   rb_scan_args(argc, argv, "32", &name, &type, &number, &type_class, &options);
 
+  // Allow passing (name, type, number, options) or
+  // (name, type, number, type_class, options)
+  if (argc == 4 && RB_TYPE_P(type_class, T_HASH)) {
+    options = type_class;
+    type_class = Qnil;
+  }
+
   msgdef_add_field(self->message_builder, UPB_LABEL_OPTIONAL, name, type,
                    number, type_class, options, self->oneof_index, false);
 

--- a/ruby/tests/generated_code.proto
+++ b/ruby/tests/generated_code.proto
@@ -86,4 +86,7 @@ message TestUnknown {
 
 message TestJsonName {
   int32 value = 1 [json_name = "CustomJsonName"];
+  oneof jsonname_oneof {
+    string name = 2 [json_name = "OneOfCustomJsonName"];
+  }
 }


### PR DESCRIPTION
Hi there, I add the case where with a proto like the following, the ruby implementation would breal with the following exception: `optional': wrong argument type Hash (expected String) (TypeError)`.

``` proto
message TestJsonName {
  int32 value = 1 [json_name = "CustomJsonName"];
  oneof jsonname_oneof {
    string name = 2 [json_name = "OneOfCustomJsonName"];
  }
 }
```

This pull-request should fix this issue.

Cheers!