### PR TITLE
Remove unused rubygems-tasks development dependency

### DIFF
--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3'
   s.add_development_dependency "rake-compiler", "~> 1.1.0"
   s.add_development_dependency "test-unit", '~> 3.0', '>= 3.0.9'
-  s.add_development_dependency "rubygems-tasks", "~> 0.2.4"
 end


### PR DESCRIPTION
Cannot find any occurrence of `require 'rubygems/tasks` or `Gem::Tasks` in the source code, so I am confident that this development dependency can safely be removed (even though I may be a little biased in favor of using [rubygems-tasks](https://github.com/postmodern/rubygems-tasks)).