### PR TITLE
Fixes #8828.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -25,7 +25,7 @@ if (CYGWIN)
 else()
   set(CMAKE_CXX_STANDARD 11)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
+  set(CMAKE_CXX_EXTENSIONS ON)
 endif()
 
 # The Intel compiler isn't able to deal with noinline member functions of


### PR DESCRIPTION
According to the [CMake doc](https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html#prop_tgt:CXX_EXTENSIONS), CMAKE_CXX_EXTENSIONS must be set to ON to match -std=gnu++11 instead of -std=c++11.