### PR TITLE
Improve SFINAE for RepeatedPtrField сtor

### DIFF
--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -938,7 +938,7 @@ class RepeatedPtrField final : private internal::RepeatedPtrFieldBase {
 
   template <typename Iter,
             typename = typename std::enable_if<std::is_constructible<
-                Element, decltype(*std::declval<Iter>())>::value>::type>
+                Element, typename std::iterator_traits<Iter>::value_type>::value>::type>
   RepeatedPtrField(Iter begin, Iter end);
 
   ~RepeatedPtrField();


### PR DESCRIPTION
NB: There is ONE BIG IF in this PR. I will understand if this PR will not be accepted.

At the time RepeatedPtrField<string> is implicitly constructible in the following case if string is constructible from char:
```
RepeatedPtrField<string> vector({"first", "second"});
```

Though std::string is not constructible from single char, we use custom string type internally and this code gives us problem. I think there are also more valid cases where such syntax will break.

I have copied the idea from libc++ implementation of std::vector.