### PR TITLE
Update protokt options link

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -206,7 +206,7 @@ with info about your project (name and website) so we can add an entry for you.
    * Extensions: 1071
 
 1. protokt
-   * Website: https://github.com/toasttab/protokt (Currently Private but will be open soon.)
+   * Website: https://github.com/open-toast/protokt
    * Extensions: 1072
 
 1. Dart port of protocol buffers


### PR DESCRIPTION
We've open-sourced the protokt code generator under a different GitHub organization than originally planned.