### PR TITLE
bazel: make `*.bzl` files publicly visible targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1301,3 +1301,9 @@ exports_files([
     "conformance/text_format_failure_list_java.txt",
     "conformance/text_format_failure_list_java_lite.txt",
 ])
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This allows these files to be used in [stardoc](https://github.com/bazelbuild/stardoc) docs generation.