### PR TITLE
Disallow missing field initializers

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -48,6 +48,7 @@ COPTS = select({
     "//conditions:default": [
         "-DHAVE_PTHREAD",
         "-DHAVE_ZLIB",
+        "-Wmissing-field-initializers",
         "-Woverloaded-virtual",
         "-Wno-sign-compare",
     ],

--- a/src/google/protobuf/arena_impl.h
+++ b/src/google/protobuf/arena_impl.h
@@ -206,13 +206,15 @@ class PROTOBUF_EXPORT SerialArena {
   // Blocks are variable length malloc-ed objects.  The following structure
   // describes the common header for all blocks.
   struct Block {
+    Block(Block* next, size_t size) : next(next), size(size), start(nullptr) {}
+
     char* Pointer(size_t n) {
       GOOGLE_DCHECK(n <= size);
       return reinterpret_cast<char*>(this) + n;
     }
 
-    Block* next;
-    size_t size;
+    Block* const next;
+    const size_t size;
     CleanupNode* start;
     // data follows
   };

--- a/src/google/protobuf/compiler/cpp/cpp_helpers.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.cc
@@ -1130,7 +1130,7 @@ bool IsImplicitWeakField(const FieldDescriptor* field, const Options& options,
 
 MessageAnalysis MessageSCCAnalyzer::GetSCCAnalysis(const SCC* scc) {
   if (analysis_cache_.count(scc)) return analysis_cache_[scc];
-  MessageAnalysis result{};
+  MessageAnalysis result;
   if (UsingImplicitWeakFields(scc->GetFile(), options_)) {
     result.contains_weak = true;
   }

--- a/src/google/protobuf/compiler/cpp/cpp_helpers.h
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.h
@@ -545,11 +545,11 @@ inline static bool ShouldIgnoreRequiredFieldCheck(const FieldDescriptor* field,
 }
 
 struct MessageAnalysis {
-  bool is_recursive;
-  bool contains_cord;
-  bool contains_extension;
-  bool contains_required;
-  bool contains_weak;  // Implicit weak as well.
+  bool is_recursive = false;
+  bool contains_cord = false;
+  bool contains_extension = false;
+  bool contains_required = false;
+  bool contains_weak = false;  // Implicit weak as well.
 };
 
 // This class is used in FileGenerator, to ensure linear instead of

--- a/src/google/protobuf/io/tokenizer_unittest.cc
+++ b/src/google/protobuf/io/tokenizer_unittest.cc
@@ -325,10 +325,7 @@ TEST_1D(TokenizerTest, FloatSuffix, kBlockSizes) {
 // last token in "output" must have type TYPE_END.
 struct MultiTokenCase {
   std::string input;
-  Tokenizer::Token output[10];  // The compiler wants a constant array
-                                // size for initialization to work.  There
-                                // is no reason this can't be increased if
-                                // needed.
+  std::vector<Tokenizer::Token> output;
 };
 
 inline std::ostream& operator<<(std::ostream& out,


### PR DESCRIPTION
This warning is enabled in Fuchsia, and appeasing it is quite trivial.

@haberman @fowles 