### PR TITLE
Added Java JsonFormat.merge() overload for JsonElement

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -490,6 +490,16 @@ public class JsonFormat {
           .merge(json, builder);
     }
 
+    /**
+     * Parses from JsonElement into a protobuf message.
+     *
+     * @throws InvalidProtocolBufferException if there are unknown fields in the input.
+     */
+    public void merge(JsonElement json, Message.Builder builder) throws IOException {
+      new ParserImpl(registry, oldRegistry, ignoringUnknownFields, recursionLimit)
+          .merge(json, builder);
+    }
+
     // For testing only.
     Parser usingRecursionLimit(int recursionLimit) {
       return new Parser(registry, oldRegistry, ignoringUnknownFields, recursionLimit);


### PR DESCRIPTION
JsonFormat.merge() already supports plain text and Reader, but there are cases which I've faced where I already have parsed the JSON and I just need to put the `JsonElement` to the parser which is currently impossible with the public API, although it is well supported by the private one.

What I did here is just a very simple new function to expose the `JsonElement` to the public API.