### PR TITLE
JS: Comply with CSP no-unsafe-eval.

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -3637,7 +3637,16 @@ void Generator::GenerateFile(const GeneratorOptions& options,
     if (options.import_style == GeneratorOptions::kImportCommonJsStrict) {
       printer->Print("var proto = {};\n\n");
     } else {
-      printer->Print("var global = Function('return this')();\n\n");
+      // To get the global object we call a function with .call(null), this will set "this" inside the
+      // function to the global object.
+      // This does not work if we are running in strict mode ("use strict"),
+      // so we fallback to the following things (in order from first to last):
+      // - window: defined in browsers
+      // - global: defined in most server side environments like NodeJS
+      // - self: defined inside Web Workers (WorkerGlobalScope)
+      // - Function('return this')(): this will work on most platforms, but it may be blocked by things like CSP.
+      //   Function('') is almost the same as eval('')
+      printer->Print("var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);\n\n");
     }
 
     for (int i = 0; i < file->dependency_count(); i++) {


### PR DESCRIPTION
The current implementation uses `Function('return this')()` to get the global object. This does not work if you are using protobuf on the web and you disallow `unsafe-eval` with a CSP header.

This PR changes the way the global object is retrieved: it calls a function and sets `this` to the global object by calling it with `.call(null)`. Then `this` is returned. 
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call#parameters

Note: this won't work when you are using js strict mode (`use strict`). 
If running in strict mode, it will use different fallbacks (that work with CSP settings that disallow eval), if none work it will fall back to the current way of getting the global object.

This fixes:
- https://github.com/protocolbuffers/protobuf/issues/5464
- https://github.com/protocolbuffers/protobuf/issues/6770
- https://github.com/protocolbuffers/protobuf/issues/7778 (partially, only the CSP part)

