### PR TITLE
Adding a build file to java/kotlin package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -533,6 +533,7 @@ java_EXTRA_DIST=                                                                
   java/core/src/test/proto/com/google/protobuf/wrappers_test.proto                 \
   java/internal/BUILD                                                              \
   java/internal/testing.bzl                                                        \
+  java/kotlin/BUILD                                                                \
   java/kotlin/generate-sources-build.xml                                           \
   java/kotlin/generate-test-sources-build.xml                                      \
   java/kotlin/pom.xml                                                              \

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,20 @@ http_archive(
     ],
 )
 
+rules_kotlin_version = "v1.5.0-beta-3"
+rules_kotlin_sha = "58edd86f0f3c5b959c54e656b8e7eb0b0becabd412465c37a2078693c2571f7f"
+http_archive(
+    name = "io_bazel_rules_kotlin",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/%s/rules_kotlin_release.tgz" % rules_kotlin_version],
+    sha256 = rules_kotlin_sha,
+)
+
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+kotlin_repositories()
+
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+kt_register_toolchains()
+
 # Load common dependencies.
 load("//:protobuf_deps.bzl", "protobuf_deps")
 protobuf_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,20 +26,6 @@ http_archive(
     ],
 )
 
-rules_kotlin_version = "v1.5.0-beta-3"
-rules_kotlin_sha = "58edd86f0f3c5b959c54e656b8e7eb0b0becabd412465c37a2078693c2571f7f"
-http_archive(
-    name = "io_bazel_rules_kotlin",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/%s/rules_kotlin_release.tgz" % rules_kotlin_version],
-    sha256 = rules_kotlin_sha,
-)
-
-load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
-kotlin_repositories()
-
-load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
-kt_register_toolchains()
-
 # Load common dependencies.
 load("//:protobuf_deps.bzl", "protobuf_deps")
 protobuf_deps()
@@ -110,3 +96,10 @@ bind(
 # For `cc_proto_blacklist_test` and `build_test`.
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
+
+# For kt_jvm_library
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+kotlin_repositories()
+
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+kt_register_toolchains()

--- a/java/core/BUILD
+++ b/java/core/BUILD
@@ -118,6 +118,18 @@ java_library(
     srcs = LITE_SRCS,
 )
 
+java_library(
+    name = "java_runtime",
+    srcs = glob(
+        [
+            "src/main/java/com/google/protobuf/*.java",
+        ],
+    ) + [
+        "//:gen_well_known_protos_java",
+    ],
+    visibility = ["//java/kotlin:__pkg__"],
+)
+
 java_export(
     name = "core",
     maven_coordinates = "com.google.protobuf:protobuf-java:%s" % PROTOBUF_VERSION,

--- a/java/core/BUILD
+++ b/java/core/BUILD
@@ -118,18 +118,6 @@ java_library(
     srcs = LITE_SRCS,
 )
 
-java_library(
-    name = "java_runtime",
-    srcs = glob(
-        [
-            "src/main/java/com/google/protobuf/*.java",
-        ],
-    ) + [
-        "//:gen_well_known_protos_java",
-    ],
-    visibility = ["//java/kotlin:__pkg__"],
-)
-
 java_export(
     name = "core",
     maven_coordinates = "com.google.protobuf:protobuf-java:%s" % PROTOBUF_VERSION,

--- a/java/kotlin-lite/BUILD
+++ b/java/kotlin-lite/BUILD
@@ -1,0 +1,5 @@
+alias(
+    name = "kt_lite",
+    actual = "//java/kotlin:kt_lite"
+    visibility = ["//visibility:public"],
+)

--- a/java/kotlin/BUILD
+++ b/java/kotlin/BUILD
@@ -1,10 +1,9 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 
-KT_SRCS = [
+KT_LITE_SRCS = [
     "src/main/kotlin/com/google/protobuf/DslList.kt",
     "src/main/kotlin/com/google/protobuf/DslMap.kt",
     "src/main/kotlin/com/google/protobuf/DslProxy.kt",
-    "src/main/kotlin/com/google/protobuf/ExtendableMessageExtensions.kt",
     "src/main/kotlin/com/google/protobuf/ExtendableMessageLiteExtensions.kt",
     "src/main/kotlin/com/google/protobuf/ExtensionList.kt",
     "src/main/kotlin/com/google/protobuf/OnlyForUseByGeneratedProtoCode.kt",
@@ -13,9 +12,25 @@ KT_SRCS = [
 ]
 
 kt_jvm_library(
-    name = "kt_runtime",
-    srcs = KT_SRCS,
+    name = "kt_lite",
+    srcs = KT_LITE_SRCS,
     deps = [
-        "//java/core:java_runtime",
-    ]
+        "//java/lite",
+    ],
+    visibility = ["//java/kotlin-lite:__pkg__"],
+)
+
+kt_jvm_library(
+    name = "kt_core",
+    srcs = glob(
+        [
+            "src/main/kotlin/com/google/protobuf/*.kt",
+        ],
+        exclude = KT_LITE_SRCS,
+    ),
+    deps = [
+        ":kt_lite",
+        "//java/core",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/java/kotlin/BUILD
+++ b/java/kotlin/BUILD
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+KT_SRCS = [
+    "src/main/kotlin/com/google/protobuf/DslList.kt",
+    "src/main/kotlin/com/google/protobuf/DslMap.kt",
+    "src/main/kotlin/com/google/protobuf/DslProxy.kt",
+    "src/main/kotlin/com/google/protobuf/ExtendableMessageExtensions.kt",
+    "src/main/kotlin/com/google/protobuf/ExtendableMessageLiteExtensions.kt",
+    "src/main/kotlin/com/google/protobuf/ExtensionList.kt",
+    "src/main/kotlin/com/google/protobuf/OnlyForUseByGeneratedProtoCode.kt",
+    "src/main/kotlin/com/google/protobuf/ProtoDslMarker.kt",
+    "src/main/kotlin/com/google/protobuf/UnmodifiableCollections.kt",
+]
+
+kt_jvm_library(
+    name = "kt_runtime",
+    srcs = KT_SRCS,
+    deps = [
+        "//java/core:java_runtime",
+    ]
+)

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -71,3 +71,9 @@ def protobuf_deps():
             strip_prefix = "rules_jvm_external-4.1",
             urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/4.1.zip"],
         )
+    if not native.existing_rule("io_bazel_rules_kotlin"):
+      http_archive(
+          name = "io_bazel_rules_kotlin",
+          urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.5.0-beta-3/rules_kotlin_release.tgz"],
+          sha256 = "58edd86f0f3c5b959c54e656b8e7eb0b0becabd412465c37a2078693c2571f7f"
+      )


### PR DESCRIPTION
Adding a bazel build file to the java/kotlin package so that it can be imported, see #8867 for more information on the request.