### PR TITLE
Remove .bazelrc file containing the -std=c++11 flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,0 @@
-build --cxxopt='-std=c++11'


### PR DESCRIPTION
MSVC warns about that flag since it's not in the format it expects, and
the flag seems to be unnecessary anyway.