### PR TITLE
Fix recursive symlink error

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,4 @@
 # These are fetched as external repositories.
 third_party/benchmark
 third_party/googletest
+_build/

--- a/php/generate_test_protos.sh
+++ b/php/generate_test_protos.sh
@@ -10,7 +10,7 @@ else
   # Bazel seems to be creating a problematic symlink in
   # _build/out/external/com_google_protobuf, so we remove the _build directory
   # before building protoc.
-  (cd .. && rm -rf _build && bazel build -c opt :protoc)
+  (cd .. && bazel build -c opt :protoc)
   PROTOC=bazel-bin/protoc
 fi
 


### PR DESCRIPTION
Fixes the recursive symlink error we were seeing by adding the _build directory to .bazelignore. Also removes the php workaround that was added to fix this problem.