### PR TITLE
files ...tar.gz or ..tar.gz cause trouble

### DIFF
--- a/post_process_dist.sh
+++ b/post_process_dist.sh
@@ -25,6 +25,12 @@ if [ ! -e $1 ]; then
   exit 1
 fi
 
+if [ "${1:0:2}" == ".." ]; then
+  echo "Illegal filename" >&2
+  exit 1
+fi
+
+
 set -ex
 
 LANGUAGES="cpp csharp java js objectivec python ruby php all"


### PR DESCRIPTION
Probably pedantic, but with a file named '...tar.gz' this script seems to do a

```
chmod -R u+w ..
cd ..

# etc..
```
Which I think should be prevented.