### PR TITLE
Use a working docker image for build python release packages

### DIFF
--- a/kokoro/release/python/linux/build_artifacts.sh
+++ b/kokoro/release/python/linux/build_artifacts.sh
@@ -49,15 +49,9 @@ build_artifact_version() {
   sudo rm -rf $REPO_DIR
 }
 
-build_x86_64_artifact_version() {
-  # Stick to a working version
-  DOCKER_IMAGE=dockcross/manylinux-x64
-  build_artifact_version $@
-}
-
 build_crosscompiled_aarch64_artifact_version() {
   # crosscompilation is only supported with the dockcross manylinux2014 image
-  DOCKER_IMAGE=dockcross/manylinux2014-aarch64
+  DOCKER_IMAGE=dockcross/manylinux2014-aarch64:20210706-65bf2dd
   PLAT=aarch64
 
   # TODO(jtatermusch): currently when crosscompiling, "auditwheel repair" will be disabled
@@ -65,10 +59,10 @@ build_crosscompiled_aarch64_artifact_version() {
   build_artifact_version $@
 }
 
-build_x86_64_artifact_version 3.6
-build_x86_64_artifact_version 3.7
-build_x86_64_artifact_version 3.8
-build_x86_64_artifact_version 3.9
+build_artifact_version 3.6
+build_artifact_version 3.7
+build_artifact_version 3.8
+build_artifact_version 3.9
 
 build_crosscompiled_aarch64_artifact_version 3.7
 build_crosscompiled_aarch64_artifact_version 3.8

--- a/kokoro/release/python/linux/config.sh
+++ b/kokoro/release/python/linux/config.sh
@@ -9,8 +9,6 @@ function pre_build {
     if [ "$PLAT" == "aarch64" ]
     then
       local configure_host_flag="--host=aarch64"
-    else
-      yum install -y devtoolset-2-libatomic-devel
     fi
 
     # Build protoc and libprotobuf


### PR DESCRIPTION
1. No longer needs devtoolset-2-libatomic-devel (not available from manylinux2014)
2. The latest manylinux2014-aarch64 has link error. Point to a previous version.