### PR TITLE
Use if constexpr in template functions

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -766,6 +766,8 @@
 #pragma warning(disable : 4073)
 // To silence the fact that we will pop this push from another file
 #pragma warning(disable : 5031)
+// Conditional expression is constant
+#pragma warning(disable: 4127)
 #endif
 
 // We don't want code outside port_def doing complex testing, so

--- a/src/google/protobuf/stubs/stringprintf.cc
+++ b/src/google/protobuf/stubs/stringprintf.cc
@@ -44,14 +44,11 @@ namespace google {
 namespace protobuf {
 
 #ifdef _MSC_VER
-enum { IS_COMPILER_MSVC = 1 };
 #ifndef va_copy
 // Define va_copy for MSVC. This is a hack, assuming va_list is simply a
 // pointer into the stack and is safe to copy.
 #define va_copy(dest, src) ((dest) = (src))
 #endif
-#else
-enum { IS_COMPILER_MSVC = 0 };
 #endif
 
 void StringAppendV(std::string* dst, const char* format, va_list ap) {
@@ -74,13 +71,15 @@ void StringAppendV(std::string* dst, const char* format, va_list ap) {
       return;
     }
 
-    if (IS_COMPILER_MSVC) {
+#ifdef _MSC_VER
+    {
       // Error or MSVC running out of space.  MSVC 8.0 and higher
       // can be asked about space needed with the special idiom below:
       va_copy(backup_ap, ap);
       result = vsnprintf(nullptr, 0, format, backup_ap);
       va_end(backup_ap);
     }
+#endif
 
     if (result < 0) {
       // Just an error.


### PR DESCRIPTION
This allows users to not have to disable certain warnings (e.g. 4127 on MSVC)