### PR TITLE
Improvements to the benchmark script

### DIFF
--- a/kokoro/linux/benchmark/build.sh
+++ b/kokoro/linux/benchmark/build.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
-
+#
+# Change to repo root
 cd $(dirname $0)/../../..
+
+set -ex
+
+# Install openJDK 11 (required by the java benchmarks)
+sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 78BD65473CB3BD13
+sudo add-apt-repository ppa:openjdk-r/ppa
+sudo apt-get update
+sudo apt-get install -y openjdk-11-jdk-headless
+
+# use java 11
+sudo update-java-alternatives --set /usr/lib/jvm/java-1.11.0-openjdk-amd64
+java -version
 
 ./tests.sh benchmark

--- a/kokoro/linux/benchmark/run.sh
+++ b/kokoro/linux/benchmark/run.sh
@@ -8,15 +8,9 @@ set -ex
 export OUTPUT_DIR=testoutput
 repo_root="$(pwd)"
 
-# tcmalloc
-if [ ! -f gperftools/.libs/libtcmalloc.so ]; then
-  git clone https://github.com/gperftools/gperftools.git
-  pushd gperftools
-  ./autogen.sh
-  ./configure
-  make -j8
-  popd
-fi
+# TODO(jtattermusch): Add back support for benchmarking with tcmalloc for C++ and python.
+# This feature was removed since it used to use tcmalloc from https://github.com/gperftools/gperftools.git
+# which is very outdated. See https://github.com/protocolbuffers/protobuf/issues/8725.
 
 # download datasets for benchmark
 pushd benchmarks
@@ -45,10 +39,10 @@ echo "benchmarking pure python..."
 ./python-pure-python-benchmark --json --behavior_prefix="pure-python-benchmark" $datasets  >> tmp/python_result.json
 echo "," >> "tmp/python_result.json"
 echo "benchmarking python cpp reflection..."
-env LD_PRELOAD="${repo_root}/gperftools/.libs/libtcmalloc.so" LD_LIBRARY_PATH="${repo_root}/src/.libs" ./python-cpp-reflection-benchmark --json --behavior_prefix="cpp-reflection-benchmark" $datasets  >> tmp/python_result.json
+env LD_LIBRARY_PATH="${repo_root}/src/.libs" ./python-cpp-reflection-benchmark --json --behavior_prefix="cpp-reflection-benchmark" $datasets  >> tmp/python_result.json
 echo "," >> "tmp/python_result.json"
 echo "benchmarking python cpp generated code..."
-env LD_PRELOAD="${repo_root}/gperftools/.libs/libtcmalloc.so" LD_LIBRARY_PATH="${repo_root}/src/.libs" ./python-cpp-generated-code-benchmark --json --behavior_prefix="cpp-generated-code-benchmark" $datasets >> tmp/python_result.json
+env LD_LIBRARY_PATH="${repo_root}/src/.libs" ./python-cpp-generated-code-benchmark --json --behavior_prefix="cpp-generated-code-benchmark" $datasets >> tmp/python_result.json
 echo "]" >> "tmp/python_result.json"
 popd
 
@@ -56,7 +50,6 @@ popd
 ./configure
 make clean && make -j8
 
-# build Java protobuf
 pushd java
 mvn package -B -Dmaven.test.skip=true
 popd
@@ -68,7 +61,7 @@ pushd benchmarks
 # TODO(jtattermusch): find a less clumsy way of protecting python_result.json contents
 mv tmp/python_result.json . && make clean && make -j8 cpp-benchmark && mv python_result.json tmp
 echo "benchmarking cpp..."
-env LD_PRELOAD="${repo_root}/gperftools/.libs/libtcmalloc.so" ./cpp-benchmark --benchmark_min_time=5.0 --benchmark_out_format=json --benchmark_out="tmp/cpp_result.json" $datasets
+env ./cpp-benchmark --benchmark_min_time=5.0 --benchmark_out_format=json --benchmark_out="tmp/cpp_result.json" $datasets
 
 # TODO(jtattermusch): add benchmarks for https://github.com/protocolbuffers/protobuf-go.
 # The original benchmarks for https://github.com/golang/protobuf were removed
@@ -77,15 +70,16 @@ env LD_PRELOAD="${repo_root}/gperftools/.libs/libtcmalloc.so" ./cpp-benchmark --
 # * the https://github.com/golang/protobuf implementation has been superseded by
 #   https://github.com/protocolbuffers/protobuf-go
 
-# build and run java benchmark
+# build and run java benchmark (java 11 is required)
 make java-benchmark
 echo "benchmarking java..."
 ./java-benchmark -Cresults.file.options.file="tmp/java_result.json" $datasets
 
+# TODO(jtattermusch): re-enable JS benchmarks once https://github.com/protocolbuffers/protobuf/issues/8747 is fixed.
 # build and run js benchmark
-make js-benchmark
-echo "benchmarking js..."
-./js-benchmark $datasets  --json_output=$(pwd)/tmp/node_result.json
+# make js-benchmark
+# echo "benchmarking js..."
+# ./js-benchmark $datasets  --json_output=$(pwd)/tmp/node_result.json
 
 # TODO(jtattermusch): add php-c-benchmark. Currently its build is broken.
 
@@ -93,12 +87,11 @@ echo "benchmarking js..."
 cat tmp/cpp_result.json
 cat tmp/java_result.json
 cat tmp/python_result.json
-cat tmp/node_result.json
 
 # print the postprocessed results to the build job log
 # TODO(jtattermusch): re-enable uploading results to bigquery (it is currently broken)
 make python_add_init
 env LD_LIBRARY_PATH="${repo_root}/src/.libs" python -m util.result_parser \
-	-cpp="../tmp/cpp_result.json" -java="../tmp/java_result.json" -python="../tmp/python_result.json" -node="../tmp/node_result.json"
+	-cpp="../tmp/cpp_result.json" -java="../tmp/java_result.json" -python="../tmp/python_result.json"
 popd
 


### PR DESCRIPTION
The continuous benchmark run is currently broken (see e.g. https://source.cloud.google.com/results/invocations/cc45a56f-54fb-440a-84ec-c2caa1bfb925), this PR makes it green again (and also removes some technical debt along the way, or at least adds comments to places that need some work in the future).