### PR TITLE
Fix uninitialized variable warnings in descriptor.cc

### DIFF
--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -1720,7 +1720,7 @@ DescriptorPool::Tables::AllocateFieldNames(const std::string& name,
   const int total_count = 2 + (lower_eq_name ? 0 : 1) +
                           (camel_eq_name ? 0 : 1) +
                           (json_eq_name || json_eq_camel ? 0 : 1);
-  FieldNamesResult result{};
+  FieldNamesResult result{nullptr, 0, 0, 0};
   // We use std::array to allow handling of the destruction of the strings.
   switch (total_count) {
     case 2:

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -794,7 +794,7 @@ class TableArena {
     size = RoundUp(size);
 
     Block* to_relocate = nullptr;
-    Block* to_use;
+    Block* to_use = nullptr;
 
     for (size_t i = 0; i < kSmallSizes.size(); ++i) {
       if (small_size_blocks_[i] != nullptr && size <= kSmallSizes[i]) {
@@ -1720,7 +1720,7 @@ DescriptorPool::Tables::AllocateFieldNames(const std::string& name,
   const int total_count = 2 + (lower_eq_name ? 0 : 1) +
                           (camel_eq_name ? 0 : 1) +
                           (json_eq_name || json_eq_camel ? 0 : 1);
-  FieldNamesResult result;
+  FieldNamesResult result{};
   // We use std::array to allow handling of the destruction of the strings.
   switch (total_count) {
     case 2:


### PR DESCRIPTION
Fix warning about using potentially uninitialized variables in `AllocateFieldNames` and `AllocRawInternal`