### PR TITLE
Added missing "options" parameter.

### DIFF
--- a/ruby/lib/google/protobuf/descriptor_dsl.rb
+++ b/ruby/lib/google/protobuf/descriptor_dsl.rb
@@ -301,8 +301,8 @@ module Google
           internal_add_field(:LABEL_REQUIRED, name, type, number, type_class, options)
         end
 
-        def repeated(name, type, number, type_class = nil)
-          internal_add_field(:LABEL_REPEATED, name, type, number, type_class, nil)
+        def repeated(name, type, number, type_class = nil, options=nil)
+          internal_add_field(:LABEL_REPEATED, name, type, number, type_class, options)
         end
 
         def oneof(name, &block)

--- a/ruby/tests/basic_test.proto
+++ b/ruby/tests/basic_test.proto
@@ -208,3 +208,8 @@ message MyStruct {
   string string = 1;
   google.protobuf.Struct struct = 2;
 }
+
+message WithJsonName {
+  optional int32 foo_bar = 1 [json_name="jsonFooBar"];
+  repeated WithJsonName baz = 2 [json_name="jsonBaz"];
+}


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/protocolbuffers/protobuf/pull/8850. The new DSL code was not accepting an `options` parameter for repeated fields, which made the generated code fail to load when options such as `json_name` were present.

Fixes: https://github.com/protocolbuffers/protobuf/issues/8935