### PR TITLE
fix arm64 tests broken by dockcross image update

### DIFF
--- a/kokoro/linux/aarch64/dockcross_helpers/run_dockcross_linux_aarch64.sh
+++ b/kokoro/linux/aarch64/dockcross_helpers/run_dockcross_linux_aarch64.sh
@@ -12,11 +12,14 @@ else
   DOCKER_TTY_ARGS=
 fi
 
+# Pin the dockcross image since newer versions of the image break the build
+PINNED_DOCKCROSS_IMAGE_VERSION=dockcross/linux-arm64:20210625-795dd4d
+
 # running dockcross image without any arguments generates a wrapper
 # scripts that can be used to run commands under the dockcross image
 # easily.
 # See https://github.com/dockcross/dockcross#usage for details
-docker run $DOCKER_TTY_ARGS --rm dockcross/linux-arm64 >dockcross-linux-arm64.sh
+docker run $DOCKER_TTY_ARGS --rm $PINNED_DOCKCROSS_IMAGE_VERSION >dockcross-linux-arm64.sh
 chmod +x dockcross-linux-arm64.sh
 
 # the wrapper script has CRLF line endings and bash doesn't like that
@@ -30,4 +33,4 @@ sed -i 's/\r//g' dockcross-linux-arm64.sh
 # * the processes in the container run under the same UID and GID as the host process so unlike
 #   vanilla "docker run" invocations, the workspace doesn't get polluted with files
 #   owned by root.
-./dockcross-linux-arm64.sh "$@"
+./dockcross-linux-arm64.sh --image $PINNED_DOCKCROSS_IMAGE_VERSION -- "$@"

--- a/kokoro/linux/aarch64/dockcross_helpers/run_dockcross_manylinux2014_aarch64.sh
+++ b/kokoro/linux/aarch64/dockcross_helpers/run_dockcross_manylinux2014_aarch64.sh
@@ -12,11 +12,14 @@ else
   DOCKER_TTY_ARGS=
 fi
 
+# Pin the dockcross image since newer versions of the image break the build
+PINNED_DOCKCROSS_IMAGE_VERSION=dockcross/manylinux2014-aarch64:20210803-41e5c69
+
 # running dockcross image without any arguments generates a wrapper
 # scripts that can be used to run commands under the dockcross image
 # easily.
 # See https://github.com/dockcross/dockcross#usage for details
-docker run $DOCKER_TTY_ARGS --rm dockcross/manylinux2014-aarch64 >dockcross-manylinux2014-aarch64.sh
+docker run $DOCKER_TTY_ARGS --rm $PINNED_DOCKCROSS_IMAGE_VERSION >dockcross-manylinux2014-aarch64.sh
 chmod +x dockcross-manylinux2014-aarch64.sh
 
 # the wrapper script has CRLF line endings and bash doesn't like that
@@ -30,4 +33,4 @@ sed -i 's/\r//g' dockcross-manylinux2014-aarch64.sh
 # * the processes in the container run under the same UID and GID as the host process so unlike
 #   vanilla "docker run" invocations, the workspace doesn't get polluted with files
 #   owned by root.
-./dockcross-manylinux2014-aarch64.sh "$@"
+./dockcross-manylinux2014-aarch64.sh --image $PINNED_DOCKCROSS_IMAGE_VERSION -- "$@"


### PR DESCRIPTION
Currently ARM64 tests are broken for C++, java, javascript, python, php and ruby (e.g. https://source.cloud.google.com/results/invocations/33696bce-f922-4572-bc3e-9a369ce3d721)
Pinning dockcross image to a version that's known to work fixes them and also avoid issues with the tests suddenly breaking in the future.