### PR TITLE
Improvement: Changed to add setter method when message type 'map'

### DIFF
--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -34,6 +34,7 @@ var group1Protos = [
   'test13.proto',
   'test14.proto',
   'test15.proto',
+  'test16.proto',
   'testbinary.proto',
   'testempty.proto',
   'test.proto',

--- a/js/message_test.js
+++ b/js/message_test.js
@@ -42,6 +42,11 @@ goog.require('jspb.Message');
 // CommonJS-LoadFromFile: test15_pb proto.jspb.filenametest.package1
 goog.require('proto.jspb.filenametest.package1.b');
 
+// CommonJS-LoadFromFile: test16_pb proto.jspb.mapfunctiontest
+goog.require('proto.jspb.mapfunctiontest.TestStringMap');
+goog.require('proto.jspb.mapfunctiontest.TestMapItem');
+goog.require('proto.jspb.mapfunctiontest.TestMessageMap');
+
 // CommonJS-LoadFromFile: test14_pb proto.jspb.filenametest.package2
 goog.require('proto.jspb.filenametest.package2.TestMessage');
 
@@ -1107,5 +1112,32 @@ describe('Message test suite', function() {
 
     message.setAInt(42);
     assertEquals(42, message.getAInt());
+  });
+
+  it('testStringMapSetter', function() {
+    var message1 = new proto.jspb.mapfunctiontest.TestStringMap;
+
+    var map1 = {
+      0: 'test',
+      1: 'test2',
+    }
+    message1.setTestMapMap(map1);
+    assertEquals('test', message1.getTestMapMap().get(0));
+    assertEquals('test2', message1.getTestMapMap().get(1));
+  });
+
+  it('testMessageMapSetter', function() {
+    var message2 = new proto.jspb.mapfunctiontest.TestMessageMap;
+    var item1 = new proto.jspb.mapfunctiontest.TestMapItem;
+    item1.setId(111)
+    var item2 = new proto.jspb.mapfunctiontest.TestMapItem;
+    item2.setId(222)
+    var map2 = {
+      11: item1,
+      22: item2,
+    }
+    message2.setTestMapMap(map2);
+    assertObjectEquals(item1, message2.getTestMapMap().get(11));
+    assertObjectEquals(item2, message2.getTestMapMap().get(22));
   });
 });

--- a/js/test16.proto
+++ b/js/test16.proto
@@ -1,0 +1,45 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto2";
+
+package jspb.mapfunctiontest;
+
+message TestStringMap {
+  map<uint64, string> test_map = 1;
+}
+
+message TestMapItem {
+  optional uint64 id = 1;
+}
+
+message TestMessageMap {
+  map<string, TestMapItem> test_map = 1;
+}

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -2596,6 +2596,43 @@ void Generator::GenerateClassField(const GeneratorOptions& options,
         "};\n"
         "\n"
         "\n");
+
+    printer->Print(
+        "/**\n"
+        " * @param {!Object<$keytype$,$valuetype$>} value\n"
+        " * @return {$class$}\n"
+        " */\n",
+        "class", GetMessagePath(options, field->containing_type()),
+        "keytype", key_type,
+        "valuetype", value_type);
+    printer->Print(
+        "$class$.prototype.$settername$ = function(value) {\n"
+        "  var map = jspb.Message.getMapField(this, $index$, false",
+        "class", GetMessagePath(options, field->containing_type()),
+        "settername", "set" + JSGetterName(options, field), "oneoftag",
+        (InRealOneof(field) ? "Oneof" : ""), "index", JSFieldIndex(field));
+
+    if (value_field->type() == FieldDescriptor::TYPE_MESSAGE) {
+      printer->Print(
+          ",\n"
+          "      $messageType$",
+          "messageType", GetMessagePath(options, value_field->message_type()));
+    } else {
+      printer->Print(
+          ",\n"
+          "      null");
+    }
+
+    printer->Print(");\n");
+
+    printer->Print(
+        "  Object.keys(value).forEach((key) => {\n"
+        "      map.set(key, value[key])\n"
+        "  })\n"
+        "  return this;\n"
+        "};\n"
+        "\n"
+        "\n");
   } else if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
     // Message field: special handling in order to wrap the underlying data
     // array with a message object.


### PR DESCRIPTION
The current javascript-protoc is in a state where the setter method is not generated in the map field.
Merging this PR will add a setter method to the map.

## sample proto
```proto
syntax = "proto3";

package book;

message UpdateBooksRequest {
    map<uint64, Book> books = 1;
}

message Book {
    uint64 id = 1;
    string name = 2;
}

```

## current `BooksMap` methods
```javascript
/**
 * map<uint64, Book> books = 1;
 * @param {boolean=} opt_noLazyCreate Do not create the map if
 * empty, instead returning `undefined`
 * @return {!jspb.Map<number,!proto.book.Book>}
 */
proto.book.UpdateBooksRequest.prototype.getBooksMap = function(opt_noLazyCreate) {
  return /** @type {!jspb.Map<number,!proto.book.Book>} */ (
      jspb.Message.getMapField(this, 1, opt_noLazyCreate,
      proto.book.Book));
};


/**
 * Clears values from the map. The map will be non-null.
 * @return {!proto.book.UpdateBooksRequest} returns this
 */
proto.book.UpdateBooksRequest.prototype.clearBooksMap = function() {
  this.getBooksMap().clear();
  return this;};
```

## new `BooksMap` methods
```javascript
/**
 * map<uint64, Book> books = 1;
 * @param {boolean=} opt_noLazyCreate Do not create the map if
 * empty, instead returning `undefined`
 * @return {!jspb.Map<number,!proto.book.Book>}
 */
proto.book.UpdateBooksRequest.prototype.getBooksMap = function(opt_noLazyCreate) {
  return /** @type {!jspb.Map<number,!proto.book.Book>} */ (
      jspb.Message.getMapField(this, 1, opt_noLazyCreate,
      proto.book.Book));
};


/**
 * @param {!Object<number,!proto.book.Book>} value
 * @return {proto.book.UpdateBooksRequest}
 */
proto.book.UpdateBooksRequest.prototype.setBooksMap = function(value) {
  var map = jspb.Message.getMapField(this, 1, false,
      proto.book.Book);
  Object.keys(value).forEach((key) => {
      map.set(key, value[key])
  })
  return this;
};


/**
 * Clears values from the map. The map will be non-null.
 * @return {!proto.book.UpdateBooksRequest} returns this
 */
proto.book.UpdateBooksRequest.prototype.clearBooksMap = function() {
  this.getBooksMap().clear();
  return this;};
```