### PR TITLE
Include JRuby gem when building gem:native target

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -67,16 +67,18 @@ unless ENV['IN_DOCKER'] == 'true'
 end
 
 if RUBY_PLATFORM == "java"
-  if `which mvn` == ''
-    raise ArgumentError, "maven needs to be installed"
-  end
-  task :clean do
+  task :clean => :require_mvn do
     system("mvn --batch-mode clean")
   end
 
-  task :compile do
+  task :compile => :require_mvn do
     system("mvn --batch-mode package")
   end
+
+  task :require_mvn do
+    raise ArgumentError, "maven needs to be installed" if `which mvn` == ''
+  end
+
 else
   Rake::ExtensionTask.new("protobuf_c", spec) do |ext|
     unless RUBY_PLATFORM =~ /darwin/
@@ -95,7 +97,17 @@ else
     ]
   end
 
+  task 'gem:java' do
+    sh "rm Gemfile.lock"
+    require 'rake_compiler_dock'
+    RakeCompilerDock.sh <<-"EOT", platform: 'jruby', rubyvm: :jruby
+      bundle && \
+      IN_DOCKER=true rake gem
+    EOT
+  end
+
   task 'gem:windows' do
+    sh "rm Gemfile.lock"
     require 'rake_compiler_dock'
     ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux'].each do |plat|
       RakeCompilerDock.sh <<-"EOT", platform: plat
@@ -111,7 +123,7 @@ else
       system "rake cross native gem RUBY_CC_VERSION=3.0.0:2.7.0:2.6.0:2.5.1:2.4.0:2.3.0"
     end
   else
-    task 'gem:native' => [:genproto, 'gem:windows']
+    task 'gem:native' => [:genproto, 'gem:windows', 'gem:java']
   end
 end
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -101,8 +101,9 @@ else
     sh "rm Gemfile.lock"
     require 'rake_compiler_dock'
     RakeCompilerDock.sh <<-"EOT", platform: 'jruby', rubyvm: :jruby
+      sudo apt-get install maven -y && \
       bundle && \
-      IN_DOCKER=true rake gem
+      IN_DOCKER=true rake compile gem
     EOT
   end
 


### PR DESCRIPTION
Since this is the rake target used by kokoro, this will close the gem release gap for JRuby

Should help #7923 by making sure JRuby is built and released as part of the normal cadence.