### PR TITLE
Added "object" as a reserved name for PHP

### DIFF
--- a/php/ext/google/protobuf/names.c
+++ b/php/ext/google/protobuf/names.c
@@ -71,22 +71,22 @@ static void stringsink_uninit(stringsink *sink) { free(sink->ptr); }
 /* def name -> classname ******************************************************/
 
 const char *const kReservedNames[] = {
-    "abstract",     "and",        "array",      "as",           "break",
-    "callable",     "case",       "catch",      "class",        "clone",
-    "const",        "continue",   "declare",    "default",      "die",
-    "do",           "echo",       "else",       "elseif",       "empty",
-    "enddeclare",   "endfor",     "endforeach", "endif",        "endswitch",
-    "endwhile",     "eval",       "exit",       "extends",      "final",
-    "finally",      "fn",         "for",        "foreach",      "function",
-    "if",           "implements", "include",    "include_once", "instanceof",
-    "global",       "goto",       "insteadof",  "interface",    "isset",
-    "list",         "match",      "namespace",  "new",          "or",
-    "print",        "private",    "protected",  "public",       "require",
-    "require_once", "return",     "static",     "switch",       "throw",
-    "trait",        "try",        "unset",      "use",          "var",
-    "while",        "xor",        "yield",      "int",          "float",
-    "bool",         "string",     "true",       "false",        "null",
-    "void",         "iterable",   NULL};
+    "abstract",     "and",          "array",      "as",           "break",
+    "callable",     "case",         "catch",      "class",        "clone",
+    "const",        "continue",     "declare",    "default",      "die",
+    "do",           "echo",         "else",       "elseif",       "empty",
+    "enddeclare",   "endfor",       "endforeach", "endif",        "endswitch",
+    "endwhile",     "eval",         "exit",       "extends",      "final",
+    "finally",      "fn",           "for",        "foreach",      "function",
+    "if",           "implements",   "include",    "include_once", "instanceof",
+    "global",       "goto",         "insteadof",  "interface",    "isset",
+    "list",         "match",        "namespace",  "new",          "object",
+    "or",           "print",        "private",    "protected",    "public",
+    "require",      "require_once", "return",     "static",       "switch",
+    "throw",        "trait",        "try",        "unset",        "use",
+    "var",          "while",        "xor",        "yield",        "int",
+    "float",        "bool",         "string",     "true",         "false",
+    "null",         "void",         "iterable",   NULL};
 
 bool is_reserved_name(const char* name) {
   int i;

--- a/php/ext/google/protobuf/names.c
+++ b/php/ext/google/protobuf/names.c
@@ -71,22 +71,22 @@ static void stringsink_uninit(stringsink *sink) { free(sink->ptr); }
 /* def name -> classname ******************************************************/
 
 const char *const kReservedNames[] = {
-    "abstract",     "and",          "array",      "as",           "break",
-    "callable",     "case",         "catch",      "class",        "clone",
-    "const",        "continue",     "declare",    "default",      "die",
-    "do",           "echo",         "else",       "elseif",       "empty",
-    "enddeclare",   "endfor",       "endforeach", "endif",        "endswitch",
-    "endwhile",     "eval",         "exit",       "extends",      "final",
-    "finally",      "fn",           "for",        "foreach",      "function",
-    "if",           "implements",   "include",    "include_once", "instanceof",
-    "global",       "goto",         "insteadof",  "interface",    "isset",
-    "list",         "match",        "namespace",  "new",          "object",
-    "or",           "print",        "private",    "protected",    "public",
-    "require",      "require_once", "return",     "static",       "switch",
-    "throw",        "trait",        "try",        "unset",        "use",
-    "var",          "while",        "xor",        "yield",        "int",
-    "float",        "bool",         "string",     "true",         "false",
-    "null",         "void",         "iterable",   NULL};
+    "abstract",   "and",          "array",      "as",           "break",
+    "callable",   "case",         "catch",      "class",        "clone",
+    "const",      "continue",     "declare",    "default",      "die",
+    "do",         "echo",         "else",       "elseif",       "empty",
+    "enddeclare", "endfor",       "endforeach", "endif",        "endswitch",
+    "endwhile",   "eval",         "exit",       "extends",      "final",
+    "finally",    "fn",           "for",        "foreach",      "function",
+    "if",         "implements",   "include",    "include_once", "instanceof",
+    "global",     "goto",         "insteadof",  "interface",    "isset",
+    "list",       "match",        "namespace",  "new",          "object",
+    "or",         "print",        "private",    "protected",    "public",
+    "require",    "require_once", "return",     "static",       "switch",
+    "throw",      "trait",        "try",        "unset",        "use",
+    "var",        "while",        "xor",        "yield",        "int",
+    "float",      "bool",         "string",     "true",         "false",
+    "null",       "void",         "iterable",   NULL};
 
 bool is_reserved_name(const char* name) {
   int i;


### PR DESCRIPTION
"Object" is a reserved word as of PHP 7.2, as stated [here](https://www.php.net/manual/en/reserved.other-reserved-words.php)