### PR TITLE
Added support for PHP 8.1 (currently in RC1) to the C extension

### DIFF
--- a/php/ext/google/protobuf/array.c
+++ b/php/ext/google/protobuf/array.c
@@ -640,8 +640,8 @@ void Array_ModuleInit() {
                    repeated_field_methods);
 
   RepeatedField_class_entry = zend_register_internal_class(&tmp_ce);
-  zend_class_implements(RepeatedField_class_entry, 3, spl_ce_ArrayAccess,
-                        zend_ce_aggregate, spl_ce_Countable);
+  zend_class_implements(RepeatedField_class_entry, 3, zend_ce_arrayaccess,
+                        zend_ce_aggregate, zend_ce_countable);
   RepeatedField_class_entry->ce_flags |= ZEND_ACC_FINAL;
   RepeatedField_class_entry->create_object = RepeatedField_create;
 

--- a/php/ext/google/protobuf/map.c
+++ b/php/ext/google/protobuf/map.c
@@ -636,8 +636,8 @@ void Map_ModuleInit() {
                    MapField_methods);
 
   MapField_class_entry = zend_register_internal_class(&tmp_ce);
-  zend_class_implements(MapField_class_entry, 3, spl_ce_ArrayAccess,
-                        zend_ce_aggregate, spl_ce_Countable);
+  zend_class_implements(MapField_class_entry, 3, zend_ce_arrayaccess,
+                        zend_ce_aggregate, zend_ce_countable);
   MapField_class_entry->ce_flags |= ZEND_ACC_FINAL;
   MapField_class_entry->create_object = MapField_create;
 

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -52,7 +52,7 @@ const zval *get_generated_pool();
 #define PROTO_RETURN_VAL zval*
 #endif
 
-// Sine php 8.0, the Object Handlers API was changed to receive zend_object*
+// Since php 8.0, the Object Handlers API was changed to receive zend_object*
 // instead of zval* and zend_string* instead of zval* for property names.
 // https://github.com/php/php-src/blob/php-8.0.0beta1/UPGRADING.INTERNALS#L37-L39
 #if PHP_VERSION_ID < 80000
@@ -72,6 +72,16 @@ const zval *get_generated_pool();
 #define PROTO_VAL_P(obj) (void*)(obj)
 #define PROTO_STRVAL_P(obj) ZSTR_VAL(obj)
 #define PROTO_STRLEN_P(obj) ZSTR_LEN(obj)
+#endif
+
+// In PHP 8.1, several old interfaces are removed:
+// https://github.com/php/php-src/blob/14f599ea7def7c7a59c40aff763ce8b105573e7a/UPGRADING.INTERNALS#L27-L31
+//
+// We now use the new interfaces (zend_ce_arrayaccess and zend_ce_countable).
+// However we have to polyfill zend_ce_countable, which was only introduced in
+// PHP 7.2.0.
+#if PHP_VERSION_ID < 70200
+#define zend_ce_countable spl_ce_Countable
 #endif
 
 ZEND_BEGIN_ARG_INFO(arginfo_void, 0)

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -565,7 +565,7 @@ class GeneratedClassTest extends TestBase
         $m->setMapInt32Int32($dict);
         $this->assertSame(0, count($m->getMapInt32Int32()));
 
-        $dict = array(5 => 5, 6.1 => 6.1, "7" => "7");
+        $dict = array(5 => 5, 6 => 6.1, "7" => "7");
         $m->setMapInt32Int32($dict);
         $this->assertTrue($m->getMapInt32Int32() instanceof MapField);
         $this->assertSame(3, count($m->getMapInt32Int32()));


### PR DESCRIPTION
This switches to new interfaces for `spl_ce_ArrayAccess` and `spl_ce_Countable` (`zend_ce_arrayaccess` and `zend_ce_countable`, respectively). It polyfills `zend_ce_countable` for old versions of PHP.

There is also a small fix for the tests to fix the following error:

```
1) GeneratedClassTest::testMapFieldViaArray
Implicit conversion from float 6.1 to int loses precision
```

In PHP float array keys are truncated to integer, and this has nothing to do with protobuf.

The pure PHP library may require further fixes to support 8.1. I was not able to resolve those issues at this time.

Fixes: https://github.com/protocolbuffers/protobuf/issues/8711