### PR TITLE
Reintroduce setup.py changes from #8280 erased by piper import #8902

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -16,6 +16,7 @@ import platform
 # namespace_packages option for the "google" package.
 from setuptools import setup, Extension, find_packages
 
+from distutils.command.build_ext import build_ext as _build_ext
 from distutils.command.build_py import build_py as _build_py
 from distutils.command.clean import clean as _clean
 from distutils.spawn import find_executable
@@ -156,6 +157,20 @@ class build_py(_build_py):
     return [(pkg, mod, fil) for (pkg, mod, fil) in modules
             if not any(fnmatch.fnmatchcase(fil, pat=pat) for pat in exclude)]
 
+class build_ext(_build_ext):
+  def get_ext_filename(self, ext_name):
+      # since python3.5, python extensions' shared libraries use a suffix that corresponds to the value
+      # of sysconfig.get_config_var('EXT_SUFFIX') and contains info about the architecture the library targets.
+      # E.g. on x64 linux the suffix is ".cpython-XYZ-x86_64-linux-gnu.so"
+      # When crosscompiling python wheels, we need to be able to override this suffix
+      # so that the resulting file name matches the target architecture and we end up with a well-formed
+      # wheel.
+      filename = _build_ext.get_ext_filename(self, ext_name)
+      orig_ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+      new_ext_suffix = os.getenv("PROTOCOL_BUFFERS_OVERRIDE_EXT_SUFFIX")
+      if new_ext_suffix and filename.endswith(orig_ext_suffix):
+        filename = filename[:-len(orig_ext_suffix)] + new_ext_suffix
+      return filename
 
 class test_conformance(_build_py):
   target = 'test_python'
@@ -286,6 +301,7 @@ if __name__ == '__main__':
       cmdclass={
           'clean': clean,
           'build_py': build_py,
+          'build_ext': build_ext,
           'test_conformance': test_conformance,
       },
       install_requires=install_requires,


### PR DESCRIPTION
This fixes the broken python aarch64 linux tests (see https://source.cloud.google.com/results/invocations/861e900c-12ad-4998-9489-18f5cfbf76ee)

For some reason (bad merge?), the changes needed for crosscompiling aarch64 python wheels have been removed in piper import https://github.com/protocolbuffers/protobuf/pull/8902/files#diff-eb8b42d9346d0a5d371facf21a8bfa2d16fb49e213ae7c21f03863accebe0fcfL161.

This is actually the second time this happened (see https://github.com/protocolbuffers/protobuf/issues/8667 and the fix https://github.com/protocolbuffers/protobuf/pull/8746). What can we do to make sure this won't happen again?