### PR TITLE
Fixed a memory bug with RepeatedField#+.

### DIFF
--- a/ruby/ext/google/protobuf_c/repeated_field.c
+++ b/ruby/ext/google/protobuf_c/repeated_field.c
@@ -551,6 +551,7 @@ VALUE RepeatedField_plus(VALUE _self, VALUE list) {
     RepeatedField* dupped = ruby_to_RepeatedField(dupped_);
     upb_array *dupped_array = RepeatedField_GetMutable(dupped_);
     upb_arena* arena = Arena_get(dupped->arena);
+    Arena_fuse(list_rptfield->arena, arena);
     int size = upb_array_size(list_rptfield->array);
     int i;
 


### PR DESCRIPTION
We need to fuse the arrays so that the second array's data stays live.

Fixes: https://github.com/protocolbuffers/protobuf/issues/8420

I was only able to reproduce the failure under Valgrind. Our Ruby library doesn't have Valgrind tests at the moment, so I didn't add a regression test for now. When we are able to add Valgrind tests, the following snippet triggered the bug:

```
require 'google/protobuf'

GC.stress = true
x = Google::Protobuf::RepeatedField.new(:string, [])
y = Google::Protobuf::RepeatedField.new(:string, ["1", "2", "3"])
z = x + y
y = nil
puts z[0]
```