### PR TITLE
move PROTOBUF_MUST_USE_RESULT to first place in attr list

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -974,7 +974,7 @@ $annotate_extension_set$
 template <typename _proto_TypeTraits,
           ::PROTOBUF_NAMESPACE_ID::internal::FieldType _field_type,
           bool _is_packed>
-inline PROTOBUF_MUST_USE_RESULT
+PROTOBUF_MUST_USE_RESULT inline
     typename _proto_TypeTraits::Singular::MutableType
     ReleaseExtension(
         const ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier<

--- a/src/google/protobuf/descriptor.pb.h
+++ b/src/google/protobuf/descriptor.pb.h
@@ -1856,7 +1856,7 @@ class PROTOBUF_EXPORT ExtensionRangeOptions final :
   template <typename _proto_TypeTraits,
             ::PROTOBUF_NAMESPACE_ID::internal::FieldType _field_type,
             bool _is_packed>
-  inline PROTOBUF_MUST_USE_RESULT
+  PROTOBUF_MUST_USE_RESULT inline
       typename _proto_TypeTraits::Singular::MutableType
       ReleaseExtension(
           const ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier<
@@ -4281,7 +4281,7 @@ class PROTOBUF_EXPORT FileOptions final :
   template <typename _proto_TypeTraits,
             ::PROTOBUF_NAMESPACE_ID::internal::FieldType _field_type,
             bool _is_packed>
-  inline PROTOBUF_MUST_USE_RESULT
+  PROTOBUF_MUST_USE_RESULT inline
       typename _proto_TypeTraits::Singular::MutableType
       ReleaseExtension(
           const ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier<
@@ -4714,7 +4714,7 @@ class PROTOBUF_EXPORT MessageOptions final :
   template <typename _proto_TypeTraits,
             ::PROTOBUF_NAMESPACE_ID::internal::FieldType _field_type,
             bool _is_packed>
-  inline PROTOBUF_MUST_USE_RESULT
+  PROTOBUF_MUST_USE_RESULT inline
       typename _proto_TypeTraits::Singular::MutableType
       ReleaseExtension(
           const ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier<
@@ -5223,7 +5223,7 @@ class PROTOBUF_EXPORT FieldOptions final :
   template <typename _proto_TypeTraits,
             ::PROTOBUF_NAMESPACE_ID::internal::FieldType _field_type,
             bool _is_packed>
-  inline PROTOBUF_MUST_USE_RESULT
+  PROTOBUF_MUST_USE_RESULT inline
       typename _proto_TypeTraits::Singular::MutableType
       ReleaseExtension(
           const ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier<
@@ -5586,7 +5586,7 @@ class PROTOBUF_EXPORT OneofOptions final :
   template <typename _proto_TypeTraits,
             ::PROTOBUF_NAMESPACE_ID::internal::FieldType _field_type,
             bool _is_packed>
-  inline PROTOBUF_MUST_USE_RESULT
+  PROTOBUF_MUST_USE_RESULT inline
       typename _proto_TypeTraits::Singular::MutableType
       ReleaseExtension(
           const ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier<
@@ -5970,7 +5970,7 @@ class PROTOBUF_EXPORT EnumOptions final :
   template <typename _proto_TypeTraits,
             ::PROTOBUF_NAMESPACE_ID::internal::FieldType _field_type,
             bool _is_packed>
-  inline PROTOBUF_MUST_USE_RESULT
+  PROTOBUF_MUST_USE_RESULT inline
       typename _proto_TypeTraits::Singular::MutableType
       ReleaseExtension(
           const ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier<
@@ -6343,7 +6343,7 @@ class PROTOBUF_EXPORT EnumValueOptions final :
   template <typename _proto_TypeTraits,
             ::PROTOBUF_NAMESPACE_ID::internal::FieldType _field_type,
             bool _is_packed>
-  inline PROTOBUF_MUST_USE_RESULT
+  PROTOBUF_MUST_USE_RESULT inline
       typename _proto_TypeTraits::Singular::MutableType
       ReleaseExtension(
           const ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier<
@@ -6715,7 +6715,7 @@ class PROTOBUF_EXPORT ServiceOptions final :
   template <typename _proto_TypeTraits,
             ::PROTOBUF_NAMESPACE_ID::internal::FieldType _field_type,
             bool _is_packed>
-  inline PROTOBUF_MUST_USE_RESULT
+  PROTOBUF_MUST_USE_RESULT inline
       typename _proto_TypeTraits::Singular::MutableType
       ReleaseExtension(
           const ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier<
@@ -7133,7 +7133,7 @@ class PROTOBUF_EXPORT MethodOptions final :
   template <typename _proto_TypeTraits,
             ::PROTOBUF_NAMESPACE_ID::internal::FieldType _field_type,
             bool _is_packed>
-  inline PROTOBUF_MUST_USE_RESULT
+  PROTOBUF_MUST_USE_RESULT inline
       typename _proto_TypeTraits::Singular::MutableType
       ReleaseExtension(
           const ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier<

--- a/src/google/protobuf/extension_set.h
+++ b/src/google/protobuf/extension_set.h
@@ -583,7 +583,7 @@ class PROTOBUF_EXPORT ExtensionSet {
     virtual void SetAllocatedMessage(MessageLite* message, Arena* arena) = 0;
     virtual void UnsafeArenaSetAllocatedMessage(MessageLite* message,
                                                 Arena* arena) = 0;
-    virtual PROTOBUF_MUST_USE_RESULT MessageLite* ReleaseMessage(
+    PROTOBUF_MUST_USE_RESULT virtual MessageLite* ReleaseMessage(
         const MessageLite& prototype, Arena* arena) = 0;
     virtual MessageLite* UnsafeArenaReleaseMessage(const MessageLite& prototype,
                                                    Arena* arena) = 0;
@@ -1374,7 +1374,7 @@ class MessageTypeTraits {
                                              ExtensionSet* set) {
     set->UnsafeArenaSetAllocatedMessage(number, field_type, nullptr, message);
   }
-  static inline PROTOBUF_MUST_USE_RESULT MutableType
+  PROTOBUF_MUST_USE_RESULT static inline MutableType
   Release(int number, FieldType /* field_type */, ExtensionSet* set) {
     return static_cast<Type*>(
         set->ReleaseMessage(number, Type::default_instance()));

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -776,7 +776,7 @@ inline bool VerifyUTF8(const std::string* s, const char* field_name) {
 }
 
 // All the string parsers with or without UTF checking and for all CTypes.
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* InlineGreedyStringParser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* InlineGreedyStringParser(
     std::string* s, const char* ptr, ParseContext* ctx);
 
 
@@ -861,19 +861,19 @@ PROTOBUF_MUST_USE_RESULT const char* WireFormatParser(T& field_parser,
 // corresponding field
 
 // These are packed varints
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedInt32Parser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedInt32Parser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedUInt32Parser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedUInt32Parser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedInt64Parser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedInt64Parser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedUInt64Parser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedUInt64Parser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedSInt32Parser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedSInt32Parser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedSInt64Parser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedSInt64Parser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedEnumParser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedEnumParser(
     void* object, const char* ptr, ParseContext* ctx);
 
 template <typename T>
@@ -905,28 +905,28 @@ PROTOBUF_MUST_USE_RESULT const char* PackedEnumParserArg(
       });
 }
 
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedBoolParser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedBoolParser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedFixed32Parser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedFixed32Parser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedSFixed32Parser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedSFixed32Parser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedFixed64Parser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedFixed64Parser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedSFixed64Parser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedSFixed64Parser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedFloatParser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedFloatParser(
     void* object, const char* ptr, ParseContext* ctx);
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* PackedDoubleParser(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* PackedDoubleParser(
     void* object, const char* ptr, ParseContext* ctx);
 
 // This is the only recursive parser.
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* UnknownGroupLiteParse(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* UnknownGroupLiteParse(
     std::string* unknown, const char* ptr, ParseContext* ctx);
 // This is a helper to for the UnknownGroupLiteParse but is actually also
 // useful in the generated code. It uses overload on std::string* vs
 // UnknownFieldSet* to make the generated code isomorphic between full and lite.
-PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* UnknownFieldParse(
+PROTOBUF_MUST_USE_RESULT PROTOBUF_EXPORT const char* UnknownFieldParse(
     uint32_t tag, std::string* unknown, const char* ptr, ParseContext* ctx);
 
 }  // namespace internal


### PR DESCRIPTION
this change allow to define PROTOBUF_MUST_USE_RESULT as [[nodiscard]], without this change compilations fail. [[nodiscard]] is standertized variant of __attribute__((warn_unused_result))