### PR TITLE
Add python-requires in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -308,5 +308,5 @@ if __name__ == '__main__':
       },
       install_requires=install_requires,
       ext_modules=ext_module_list,
-      python_requires='>=3.3',
+      python_requires='>=3.5',
   )

--- a/python/setup.py
+++ b/python/setup.py
@@ -308,4 +308,5 @@ if __name__ == '__main__':
       },
       install_requires=install_requires,
       ext_modules=ext_module_list,
+      python_requires='>=3.3',
   )


### PR DESCRIPTION
I saw protobuf have some commits which stop testing and building wheels for python2:

https://github.com/protocolbuffers/protobuf/commit/2fbc07b2439c2518a4985972c9e78d07b44603c2
https://github.com/protocolbuffers/protobuf/pull/8891

And the codes does not support python2 now: https://github.com/protocolbuffers/protobuf/issues/8984

So I think I can assume protobuf does not support python2 for now. I think we should add a `python_requires` field in setup.py, pip and poetry will check this field and fallback to older version if it in python2 environment.