### PR TITLE
Include python/google/__init__.py in python sources.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -834,7 +834,7 @@ py_library(
     name = "python_srcs",
     srcs = glob(
         [
-            "python/google/protobuf/**/*.py",
+            "python/google/**/*.py",
         ],
         exclude = [
             "python/google/protobuf/internal/*_test.py",


### PR DESCRIPTION
This file is critical for resolving imports. While python scripts run
from within bazel will run correctly without this file being declared,
packaging python sources with transitive deps currently omits this,
leading to broken packages.

Note that __init__.py is the only file in python/google other than the "protobuf" directory which is already globbed over.