### PR TITLE
Fix dist install test by ensuring that we use Python 3

### DIFF
--- a/kokoro/linux/dockerfile/test/java_stretch/Dockerfile
+++ b/kokoro/linux/dockerfile/test/java_stretch/Dockerfile
@@ -25,6 +25,6 @@ RUN apt-get update && apt-get install -y \
   openjdk-8-jdk \
   # Python dependencies
   python3-setuptools \
-  python-pip \
+  python3-pip \
   virtualenv \
   && apt-get clean

--- a/kokoro/linux/dockerfile/test/java_stretch/Dockerfile
+++ b/kokoro/linux/dockerfile/test/java_stretch/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
   maven \
   openjdk-8-jdk \
   # Python dependencies
-  python-setuptools \
+  python3-setuptools \
   python-pip \
   virtualenv \
   && apt-get clean

--- a/tests.sh
+++ b/tests.sh
@@ -113,7 +113,7 @@ build_dist_install() {
   source venv/bin/activate
   pushd python
   python3 setup.py clean build sdist
-  pip install dist/protobuf-*.tar.gz
+  pip3 install dist/protobuf-*.tar.gz
   popd
   deactivate
   rm -rf python/venv

--- a/tests.sh
+++ b/tests.sh
@@ -112,7 +112,7 @@ build_dist_install() {
   virtualenv --no-site-packages venv
   source venv/bin/activate
   pushd python
-  python setup.py clean build sdist
+  python3 setup.py clean build sdist
   pip install dist/protobuf-*.tar.gz
   popd
   deactivate


### PR DESCRIPTION
Now that we have dropped Python 2 support, we need to make sure this
install test uses Python 3.