### PR TITLE
Add type definitions to php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ php/tests/multirequest.result
 php/tests/nohup.out
 php/tests/.phpunit.result.cache
 php/tests/phpunit-*
+php/tmp
 php/ext/google/protobuf/.libs/
 php/ext/google/protobuf/Makefile.fragments
 php/ext/google/protobuf/Makefile.global

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -969,7 +969,7 @@ void GenerateAddFileToPool(const FileDescriptor* file, const Options& options,
                            io::Printer* printer) {
   printer->Print(
       "public static $is_initialized = false;\n\n"
-      "public static function initOnce() {\n");
+      "public static function initOnce(): void {\n");
   Indent(printer);
 
   if (options.aggregate_metadata) {
@@ -1372,7 +1372,7 @@ void GenerateEnumFile(const FileDescriptor* file, const EnumDescriptor* en,
   printer.Print("];\n");
 
   printer.Print(
-      "\npublic static function name($value)\n"
+      "\npublic static function name(int $value): string\n"
       "{\n");
   Indent(&printer);
   printer.Print("if (!isset(self::$valueToName[$value])) {\n");
@@ -1390,7 +1390,7 @@ void GenerateEnumFile(const FileDescriptor* file, const EnumDescriptor* en,
   printer.Print("}\n\n");
 
   printer.Print(
-      "\npublic static function value($name)\n"
+      "\npublic static function value(string $name): int\n"
       "{\n");
   Indent(&printer);
   printer.Print("$const = __CLASS__ . '::' . strtoupper($name);\n"

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -649,35 +649,44 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
   std::string deprecation_trigger = (field->options().deprecated()) ? "@trigger_error('" +
       field->name() + " is deprecated.', E_USER_DEPRECATED);\n        " : "";
 
+  bool can_return_null = field->has_presence() &&
+                         field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE;
+
   // Emit getter.
   if (oneof != NULL) {
     printer->Print(
-        "public function get^camel_name^()\n"
+        "public function get^camel_name^(): ^maybe_null^^php_type^\n"
         "{\n"
         "    ^deprecation_trigger^return $this->readOneof(^number^);\n"
         "}\n\n",
         "camel_name", UnderscoresToCamelCase(field->name(), true),
         "number", IntToString(field->number()),
-        "deprecation_trigger", deprecation_trigger);
+        "deprecation_trigger", deprecation_trigger,
+        "php_type", PhpGetterTypeName(field, options),
+        "maybe_null", can_return_null ? "?" : "");
   } else if (field->has_presence() && !field->message_type()) {
     printer->Print(
-        "public function get^camel_name^()\n"
+        "public function get^camel_name^(): ^maybe_null^^php_type^\n"
         "{\n"
         "    ^deprecation_trigger^return isset($this->^name^) ? $this->^name^ : ^default_value^;\n"
         "}\n\n",
         "camel_name", UnderscoresToCamelCase(field->name(), true),
         "name", field->name(),
         "default_value", DefaultForField(field),
-        "deprecation_trigger", deprecation_trigger);
+        "deprecation_trigger", deprecation_trigger,
+        "php_type", PhpGetterTypeName(field, options),
+        "maybe_null", can_return_null ? "?" : "");
   } else {
     printer->Print(
-        "public function get^camel_name^()\n"
+        "public function get^camel_name^(): ^maybe_null^^php_type^\n"
         "{\n"
         "    ^deprecation_trigger^return $this->^name^;\n"
         "}\n\n",
         "camel_name", UnderscoresToCamelCase(field->name(), true),
         "name", field->name(),
-        "deprecation_trigger", deprecation_trigger);
+        "deprecation_trigger", deprecation_trigger,
+        "php_type", PhpGetterTypeName(field, options),
+        "maybe_null", can_return_null ? "?" : "");
   }
 
   // Emit hazzers/clear.

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -639,7 +639,7 @@ void GenerateOneofField(const OneofDescriptor* oneof, io::Printer* printer) {
 }
 
 void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
-                           io::Printer* printer) {
+                           const std::string className, io::Printer* printer) {
   const OneofDescriptor* oneof = field->real_containing_oneof();
 
   // Generate getter.
@@ -737,9 +737,11 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
   // Generate setter.
   GenerateFieldDocComment(printer, field, options, kFieldSetter);
   printer->Print(
-      "public function set^camel_name^($var)\n"
+      "public function set^camel_name^(^php_type^ $var): ^class_name^\n"
       "{\n",
-      "camel_name", UnderscoresToCamelCase(field->name(), true));
+      "camel_name", UnderscoresToCamelCase(field->name(), true),
+      "php_type", PhpGetterTypeName(field, options),
+      "class_name", className);
 
   Indent(printer);
 
@@ -1502,7 +1504,7 @@ void GenerateMessageFile(const FileDescriptor* file, const Descriptor* message,
   // Field and oneof accessors.
   for (int i = 0; i < message->field_count(); i++) {
     const FieldDescriptor* field = message->field(i);
-    GenerateFieldAccessor(field, options, &printer);
+    GenerateFieldAccessor(field, options, fullname, &printer);
   }
   for (int i = 0; i < message->real_oneof_decl_count(); i++) {
     const OneofDescriptor* oneof = message->oneof_decl(i);

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -720,15 +720,18 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
       !field->is_repeated() &&
       field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE &&
       IsWrapperType(field)) {
+    const FieldDescriptor* primitiveField = field->message_type()->FindFieldByName("value");
     GenerateWrapperFieldGetterDocComment(printer, field);
     printer->Print(
-        "public function get^camel_name^Unwrapped()\n"
+        "public function get^camel_name^Unwrapped(): ^maybe_null^^php_type^\n"
         "{\n"
         "    ^deprecation_trigger^return $this->readWrapperValue(\"^field_name^\");\n"
         "}\n\n",
         "camel_name", UnderscoresToCamelCase(field->name(), true),
         "field_name", field->name(),
-        "deprecation_trigger", deprecation_trigger);
+        "deprecation_trigger", deprecation_trigger,
+        "php_type", PhpGetterTypeName(primitiveField, options),
+        "maybe_null", can_return_null ? "?" : "");
   }
 
   // Generate setter.

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -692,7 +692,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
   // Emit hazzers/clear.
   if (oneof) {
     printer->Print(
-        "public function has^camel_name^()\n"
+        "public function has^camel_name^(): bool\n"
         "{\n"
         "    ^deprecation_trigger^return $this->hasOneof(^number^);\n"
         "}\n\n",
@@ -701,11 +701,11 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
         "deprecation_trigger", deprecation_trigger);
   } else if (field->has_presence()) {
     printer->Print(
-        "public function has^camel_name^()\n"
+        "public function has^camel_name^(): bool\n"
         "{\n"
         "    ^deprecation_trigger^return isset($this->^name^);\n"
         "}\n\n"
-        "public function clear^camel_name^()\n"
+        "public function clear^camel_name^(): void\n"
         "{\n"
         "    ^deprecation_trigger^unset($this->^name^);\n"
         "}\n\n",

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -839,15 +839,18 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
       !field->is_repeated() &&
       field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE &&
       IsWrapperType(field)) {
+    const FieldDescriptor* primitiveField = field->message_type()->FindFieldByName("value");
     GenerateWrapperFieldSetterDocComment(printer, field);
     printer->Print(
-        "public function set^camel_name^Unwrapped($var)\n"
+        "public function set^camel_name^Unwrapped(^php_type^^maybe_null^ $var)\n"
         "{\n"
         "    $this->writeWrapperValue(\"^field_name^\", $var);\n"
         "    return $this;"
         "}\n\n",
         "camel_name", UnderscoresToCamelCase(field->name(), true),
-        "field_name", field->name());
+        "field_name", field->name(),
+        "php_type", PhpGetterTypeName(primitiveField, options),
+        "maybe_null", can_return_null ? "|null" : "");
   }
 }
 


### PR DESCRIPTION
Much of the generated PHP code is missing return types, and the type definitions for the expected parameters. This PR adds those types to provide a more pleasant and secure experience for PHP developers.

    // Before
    public function getField()
    {
        return $this->field;
    }

    public function hasField()
    {
        return isset($this->field);
    }

    public function clearField()
    {
        unset($this->field);
    }

    public function setField($var)
    {
        GPBUtil::checkMessage($var, \Google\Protobuf\BoolValue::class);
        $this->field = $var;

        return $this;
    }

    // After
    public function getField(): ?\Google\Protobuf\BoolValue
    {
        return $this->field;
    }

    public function hasField(): bool
    {
        return isset($this->field);
    }

    public function clearField(): void
    {
        unset($this->field);
    }

    public function getFieldUnwrapped(): ?bool
    {
        return $this->readWrapperValue("field");
    }

    public function setField(\Google\Protobuf\BoolValue $var): TestBoolValue
    {
        GPBUtil::checkMessage($var, \Google\Protobuf\BoolValue::class);
        $this->field = $var;

        return $this;
    }