### PR TITLE
Cherry-pick fixes for 3.18.1

### DIFF
--- a/kokoro/linux/dockerfile/test/java_stretch/Dockerfile
+++ b/kokoro/linux/dockerfile/test/java_stretch/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
   maven \
   openjdk-8-jdk \
   # Python dependencies
-  python-setuptools \
-  python-pip \
+  python3-setuptools \
+  python3-pip \
   virtualenv \
   && apt-get clean

--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -85,5 +85,5 @@ if [[ "${KOKORO_INSTALL_RVM:-}" == "yes" ]] ; then
   curl -sSL https://rvm.io/mpapis.asc | gpg --import -
   curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
 
-  curl -sSL https://get.rvm.io | bash -s master --ruby
+  curl -sSL https://get.rvm.io | bash -s stable --ruby
 fi

--- a/python/setup.py
+++ b/python/setup.py
@@ -308,4 +308,5 @@ if __name__ == '__main__':
       },
       install_requires=install_requires,
       ext_modules=ext_module_list,
+      python_requires='>=3.5',
   )

--- a/ruby/travis-test.sh
+++ b/ruby/travis-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Exit on any error.
-set -e
+set -ex
 
 test_version() {
   version=$1

--- a/ruby/travis-test.sh
+++ b/ruby/travis-test.sh
@@ -18,7 +18,7 @@ test_version() {
        rake gc_test &&
        cd ../conformance && make test_jruby &&
        cd ../ruby/compatibility_tests/v3.0.0 && ./test.sh"
-  elif [ "$version" == "ruby-2.6.0" -o "$version" == "ruby-2.7.0" -o "$version" == "ruby-3.0.2" ] ; then
+  else
     bash --login -c \
       "rvm install $version && rvm use $version && \
        which ruby && \
@@ -29,19 +29,6 @@ test_version() {
        cd ../conformance && make ${RUBY_CONFORMANCE} &&
        cd ../ruby/compatibility_tests/v3.0.0 &&
        cp -R ../../lib lib && ./test.sh"
-  else
-    # Recent versions of OSX have deprecated OpenSSL, so we have to explicitly
-    # provide a path to the OpenSSL directory installed via Homebrew.
-    bash --login -c \
-      "rvm install $version --with-openssl-dir=`brew --prefix openssl` && \
-       rvm use $version && \
-       which ruby && \
-       git clean -f && \
-       gem install bundler -v 1.17.3 && bundle && \
-       rake test &&
-       rake gc_test &&
-       cd ../conformance && make ${RUBY_CONFORMANCE} &&
-       cd ../ruby/compatibility_tests/v3.0.0 && ./test.sh"
   fi
 }
 

--- a/tests.sh
+++ b/tests.sh
@@ -112,8 +112,8 @@ build_dist_install() {
   virtualenv --no-site-packages venv
   source venv/bin/activate
   pushd python
-  python setup.py clean build sdist
-  pip install dist/protobuf-*.tar.gz
+  python3 setup.py clean build sdist
+  pip3 install dist/protobuf-*.tar.gz
   popd
   deactivate
   rm -rf python/venv

--- a/tests.sh
+++ b/tests.sh
@@ -88,6 +88,18 @@ build_cpp_distcheck() {
 }
 
 build_dist_install() {
+  # Create a symlink pointing to python2 and put it at the beginning of $PATH.
+  # This is necessary because the googletest build system involves a Python
+  # script that is not compatible with Python 3. More recent googletest
+  # versions have fixed this, but they have also removed the autotools build
+  # system support that we rely on. This is a temporary workaround to keep the
+  # googletest build working when the default python binary is Python 3.
+  mkdir tmp || true
+  pushd tmp
+  ln -s /usr/bin/python2 ./python
+  popd
+  PATH=$PWD/tmp:$PATH
+
   # Initialize any submodules.
   git submodule update --init --recursive
   ./autogen.sh


### PR DESCRIPTION
This PR cherry-picks a couple fixes for the 3.18.1 release. The main one is from #8989 and ensures that we explicitly require Python 3 in setup.py. I also made some other small tweaks to get all the tests passing.