### PR TITLE
Performance fix for DynamicMessage: force GetRaw() to be inlined.

### DIFF
--- a/src/google/protobuf/dynamic_message.cc
+++ b/src/google/protobuf/dynamic_message.cc
@@ -355,7 +355,7 @@ DynamicMessage::DynamicMessage(DynamicMessageFactory::TypeInfo* type_info,
   SharedCtor(lock_factory);
 }
 
-void* DynamicMessage::MutableRaw(int i) {
+inline void* DynamicMessage::MutableRaw(int i) {
   return OffsetToPointer(
       OffsetValue(type_info_->offsets[i], type_info_->type->field(i)->type()));
 }


### PR DESCRIPTION
Fixes: https://github.com/protocolbuffers/protobuf/issues/9014