### PR TITLE
Specify bits of architectures in toolchain names

### DIFF
--- a/toolchain/toolchains.bazelrc
+++ b/toolchain/toolchains.bazelrc
@@ -1,8 +1,8 @@
 build:cross_config --crosstool_top=//toolchain:clang_suite
 build:cross_config --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 
-build:linux-aarch64 --config=cross_config --cpu=linux-aarch64
-build:linux-ppcle --config=cross_config --cpu=linux-ppcle
-build:linux-s390x --config=cross_config --cpu=linux-s390x
+build:linux-aarch_64 --config=cross_config --cpu=linux-aarch64
+build:linux-ppcle_64 --config=cross_config --cpu=linux-ppcle
+build:linux-s390_64 --config=cross_config --cpu=linux-s390x
 build:linux-x86_32 --config=cross_config --cpu=linux-x86_32
 build:linux-x86_64 --config=cross_config --cpu=linux-x86_64


### PR DESCRIPTION
Changing toolchain names to exactly match the zip files we want to make so that the platform variable can be easily reused for zip file name and bazel toolchain name