### PR TITLE
Add python 3.10

### DIFF
--- a/kokoro/linux/dockerfile/test/python310/Dockerfile
+++ b/kokoro/linux/dockerfile/test/python310/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.10-buster
+
+# Install dependencies.  We start with the basic ones require to build protoc
+# and the C++ build
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  bzip2 \
+  ccache \
+  curl \
+  gcc \
+  git \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libtool \
+  make \
+  parallel \
+  time \
+  wget \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Python libraries.
+RUN python -m pip install --no-cache-dir --upgrade \
+  pip \
+  setuptools \
+  tox \
+  wheel

--- a/kokoro/linux/python310/build.sh
+++ b/kokoro/linux/python310/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# This is the top-level script we give to Kokoro as the entry point for
+# running the "pull request" project:
+#
+# This script selects a specific Dockerfile (for building a Docker image) and
+# a script to run inside that image.  Then we delegate to the general
+# build_and_run_docker.sh script.
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+export DOCKERHUB_ORGANIZATION=protobuftesting
+export DOCKERFILE_DIR=kokoro/linux/dockerfile/test/python310
+export DOCKER_RUN_SCRIPT=kokoro/linux/pull_request_in_docker.sh
+export OUTPUT_DIR=testoutput
+export TEST_SET="python310"
+./kokoro/linux/build_and_run_docker.sh

--- a/kokoro/linux/python310/continuous.cfg
+++ b/kokoro/linux/python310/continuous.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/python310/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/linux/python310/presubmit.cfg
+++ b/kokoro/linux/python310/presubmit.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/python310/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/linux/python310_cpp/build.sh
+++ b/kokoro/linux/python310_cpp/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# This is the top-level script we give to Kokoro as the entry point for
+# running the "pull request" project:
+#
+# This script selects a specific Dockerfile (for building a Docker image) and
+# a script to run inside that image.  Then we delegate to the general
+# build_and_run_docker.sh script.
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+export DOCKERHUB_ORGANIZATION=protobuftesting
+export DOCKERFILE_DIR=kokoro/linux/dockerfile/test/python310
+export DOCKER_RUN_SCRIPT=kokoro/linux/pull_request_in_docker.sh
+export OUTPUT_DIR=testoutput
+export TEST_SET="python310_cpp"
+./kokoro/linux/build_and_run_docker.sh

--- a/kokoro/linux/python310_cpp/continuous.cfg
+++ b/kokoro/linux/python310_cpp/continuous.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/python310_cpp/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/linux/python310_cpp/presubmit.cfg
+++ b/kokoro/linux/python310_cpp/presubmit.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/python310_cpp/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/release/python/linux/build_artifacts.sh
+++ b/kokoro/release/python/linux/build_artifacts.sh
@@ -61,7 +61,9 @@ build_artifact_version 3.6
 build_artifact_version 3.7
 build_artifact_version 3.8
 build_artifact_version 3.9
+build_artifact_version 3.10
 
 build_crosscompiled_aarch64_artifact_version 3.7
 build_crosscompiled_aarch64_artifact_version 3.8
 build_crosscompiled_aarch64_artifact_version 3.9
+build_crosscompiled_aarch64_artifact_version 3.10

--- a/kokoro/release/python/macos/build_artifacts.sh
+++ b/kokoro/release/python/macos/build_artifacts.sh
@@ -55,3 +55,4 @@ build_artifact_version 3.6
 build_artifact_version 3.7
 build_artifact_version 3.8
 build_artifact_version 3.9
+build_artifact_version 3.10

--- a/kokoro/release/python/windows/build_artifacts.bat
+++ b/kokoro/release/python/windows/build_artifacts.bat
@@ -74,6 +74,16 @@ SET PYTHON_VERSION=3.9
 SET PYTHON_ARCH=64
 CALL build_single_artifact.bat || goto :error
 
+SET PYTHON=C:\python310_32bit
+SET PYTHON_VERSION=3.10
+SET PYTHON_ARCH=32
+CALL build_single_artifact.bat || goto :error
+
+SET PYTHON=C:\python310
+SET PYTHON_VERSION=3.10
+SET PYTHON_ARCH=64
+CALL build_single_artifact.bat || goto :error
+
 goto :EOF
 
 :error

--- a/kokoro/release/python/windows/build_single_artifact.bat
+++ b/kokoro/release/python/windows/build_single_artifact.bat
@@ -24,6 +24,12 @@ if %PYTHON%==C:\python39_32bit set vcplatform=Win32
 if %PYTHON%==C:\python39 set generator=Visual Studio 14 Win64
 if %PYTHON%==C:\python39 set vcplatform=x64
 
+if %PYTHON%==C:\python310_32bit set generator=Visual Studio 14
+if %PYTHON%==C:\python310_32bit set vcplatform=Win32
+
+if %PYTHON%==C:\python310 set generator=Visual Studio 14 Win64
+if %PYTHON%==C:\python310 set vcplatform=x64
+
 REM Prepend newly installed Python to the PATH of this build (this cannot be
 REM done from inside the powershell script as it would require to restart
 REM the parent CMD process).

--- a/kokoro/release/python/windows/install_python_interpreters.ps1
+++ b/kokoro/release/python/windows/install_python_interpreters.ps1
@@ -95,3 +95,20 @@ $Python39x64Config = @{
     PythonInstallerHash = "b61a33dc28f13b561452f3089c87eb63"
 }
 Install-Python @Python39x64Config
+
+# Python 3.10
+$Python39x86Config = @{
+    PythonVersion = "3.10.0"
+    PythonInstaller = "python-3.10.0"
+    PythonInstallPath = "C:\python310_32bit"
+    PythonInstallerHash = "6de353f2f7422aa030d4ccc788ffa75e"
+}
+Install-Python @Python310x86Config
+
+$Python39x64Config = @{
+    PythonVersion = "3.10.0"
+    PythonInstaller = "python-3.10.0-amd64"
+    PythonInstallPath = "C:\python39"
+    PythonInstallerHash = "39135519b044757f0a3b09d63612b0da"
+}
+Install-Python @Python310x64Config

--- a/python/setup.py
+++ b/python/setup.py
@@ -292,6 +292,9 @@ if __name__ == '__main__':
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         ],
       namespace_packages=['google'],
       packages=find_packages(

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37,38,39}-{cpp,python}
+    py{35,36,37,38,39,310}-{cpp,python}
 
 [testenv]
 usedevelop=true
@@ -14,7 +14,7 @@ setenv =
 commands =
     python setup.py -q build_py
     python: python setup.py -q build
-    py{35,36,37,38,39}-cpp: python setup.py -q build --cpp_implementation --warnings_as_errors --compile_static_extension
+    py{35,36,37,38,39,310}-cpp: python setup.py -q build --cpp_implementation --warnings_as_errors --compile_static_extension
     python: python setup.py -q test -q
     cpp: python setup.py -q test -q --cpp_implementation
     python: python setup.py -q test_conformance

--- a/tests.sh
+++ b/tests.sh
@@ -356,6 +356,10 @@ build_python39() {
   build_python_version py39-python
 }
 
+build_python310() {
+  build_python_version py310-python
+}
+
 build_python_cpp() {
   internal_build_cpp
   export LD_LIBRARY_PATH=../src/.libs # for Linux
@@ -407,6 +411,11 @@ build_python38_cpp() {
 build_python39_cpp() {
   build_python_cpp_version py39-cpp
 }
+
+build_python310_cpp() {
+  build_python_cpp_version py39-cpp
+}
+
 
 build_ruby23() {
   internal_build_cpp  # For conformance tests.


### PR DESCRIPTION
The Python 3.10 release is scheduled for next Monday, 2021-10-04. https://www.python.org/dev/peps/pep-0619/

Because 3.10 is still technically a release candidate, the image `python:3.10-buster` does not yet exist, but should soon.

Intended to be reviewed together with Kokoro config change in internal changelist 399739838.