### PR TITLE
Avoid installing anything from Homebrew in test runs

### DIFF
--- a/kokoro/macos/objectivec_cocoapods_integration/build.sh
+++ b/kokoro/macos/objectivec_cocoapods_integration/build.sh
@@ -6,7 +6,6 @@
 cd $(dirname $0)/../../..
 
 # Prepare worker environment to run tests
-KOKORO_INSTALL_COCOAPODS=yes
 source kokoro/macos/prepare_build_macos_rc
 
 ./tests.sh objectivec_cocoapods_integration

--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -20,58 +20,6 @@ export CC=gcc
 export CXX=g++
 
 ##
-# Brew: update, then upgrade the installed tools to current version and install
-# some needed ones not in the Kokoro base image. This ensure current versions
-# of CMake, autotools, etc.
-
-# But first...
-#
-# The transitive deps of the installed tools need protobuf, but Kokoro manually
-# installed it outside of brew so it needs to be removed so brew can install the
-# tools (and a newer version of protobuf). g/kokoro-users/7FRvQMUdN40 about why
-# it is a manual install vs. a brew install in the first place.
-sudo rm -rf \
-    /usr/local/include/google/protobuf \
-    /usr/local/bin/protoc
-# Likewise, updating python can have issues because of some existing binaries.
-sudo rm -rf \
-    /usr/local/bin/2to3* \
-    /usr/local/bin/idle3* \
-    /usr/local/bin/pip3 \
-    /usr/local/bin/pydoc3* \
-    /usr/local/bin/python3* \
-    /usr/local/bin/pyvenv*
-
-git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
-git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
-
-# This is needed to fix a conflict between the ilmbase and imath packages,
-# which seem to conflict with each other by both trying to install
-# libImath.dylib.
-brew unlink ilmbase
-
-brew update
-brew upgrade
-
-##
-# Install Ruby
-
-if [[ "${KOKORO_INSTALL_RUBY:-}" == "yes" ]] ; then
-  brew install ruby
-fi
-
-##
-# Install Cocoapods
-
-if [[ "${KOKORO_INSTALL_COCOAPODS:-}" == "yes" ]] ; then
-  # The existing cocoapods was installed via gem, but that doesn't work well
-  # with the overlap in deps with things managed by brew (errors around ruby
-  # versions, etc.); so remove it and install in via brew instead.
-  gem uninstall -a "$(gem list | grep cocoapods | cut -d ' ' -f 1)"
-  brew install cocoapods
-fi
-
-##
 # Install Tox
 
 if [[ "${KOKORO_INSTALL_TOX:-}" == "yes" ]] ; then

--- a/kokoro/macos/ruby23/build.sh
+++ b/kokoro/macos/ruby23/build.sh
@@ -6,7 +6,6 @@
 cd $(dirname $0)/../../..
 
 # Prepare worker environment to run tests
-KOKORO_INSTALL_RUBY=yes
 KOKORO_INSTALL_RVM=yes
 source kokoro/macos/prepare_build_macos_rc
 

--- a/kokoro/macos/ruby24/build.sh
+++ b/kokoro/macos/ruby24/build.sh
@@ -6,7 +6,6 @@
 cd $(dirname $0)/../../..
 
 # Prepare worker environment to run tests
-KOKORO_INSTALL_RUBY=yes
 KOKORO_INSTALL_RVM=yes
 source kokoro/macos/prepare_build_macos_rc
 

--- a/kokoro/macos/ruby25/build.sh
+++ b/kokoro/macos/ruby25/build.sh
@@ -6,7 +6,6 @@
 cd $(dirname $0)/../../..
 
 # Prepare worker environment to run tests
-KOKORO_INSTALL_RUBY=yes
 KOKORO_INSTALL_RVM=yes
 source kokoro/macos/prepare_build_macos_rc
 

--- a/kokoro/macos/ruby26/build.sh
+++ b/kokoro/macos/ruby26/build.sh
@@ -6,7 +6,6 @@
 cd $(dirname $0)/../../..
 
 # Prepare worker environment to run tests
-KOKORO_INSTALL_RUBY=yes
 KOKORO_INSTALL_RVM=yes
 source kokoro/macos/prepare_build_macos_rc
 

--- a/kokoro/macos/ruby27/build.sh
+++ b/kokoro/macos/ruby27/build.sh
@@ -6,7 +6,6 @@
 cd $(dirname $0)/../../..
 
 # Prepare worker environment to run tests
-KOKORO_INSTALL_RUBY=yes
 KOKORO_INSTALL_RVM=yes
 source kokoro/macos/prepare_build_macos_rc
 

--- a/kokoro/macos/ruby30/build.sh
+++ b/kokoro/macos/ruby30/build.sh
@@ -6,7 +6,6 @@
 cd $(dirname $0)/../../..
 
 # Prepare worker environment to run tests
-KOKORO_INSTALL_RUBY=yes
 KOKORO_INSTALL_RVM=yes
 source kokoro/macos/prepare_build_macos_rc
 


### PR DESCRIPTION
Installing and upgrading Homebrew packages is taking quite a lot of time
(around 20-30 minutes) for each run. This commit removes all Homebrew
usage from the test runs. Homebrew may have been necessary at some point
in the past, but now it appears that everything works without it. The
preinstalled build tools seem to be sufficient for building protoc, and
Ruby is something we already get from rvm.