### PR TITLE
Fix cl deprecation warning

### DIFF
--- a/editors/protobuf-mode.el
+++ b/editors/protobuf-mode.el
@@ -68,7 +68,7 @@
 (eval-when-compile
   (and (= emacs-major-version 24)
        (>= emacs-minor-version 4)
-       (require 'cl))
+       (require 'cl-lib))
   (require 'cc-langs)
   (require 'cc-fonts))
 


### PR DESCRIPTION
The `cl` package has been deprecated in emacs 27, this PR make this warning go away.