### PR TITLE
Speed up Java UTF-8 validation tests

### DIFF
--- a/java/core/src/test/java/com/google/protobuf/DecodeUtf8Test.java
+++ b/java/core/src/test/java/com/google/protobuf/DecodeUtf8Test.java
@@ -55,29 +55,24 @@ public class DecodeUtf8Test extends TestCase {
   }
 
   public void testThreeBytes() throws Exception {
-    // Travis' OOM killer doesn't like this test
-    if (System.getenv("TRAVIS") == null) {
-      int count = 0;
-      int valid = 0;
-      for (int i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
-        for (int j = Byte.MIN_VALUE; j <= Byte.MAX_VALUE; j++) {
-          for (int k = Byte.MIN_VALUE; k <= Byte.MAX_VALUE; k++) {
-            byte[] bytes = new byte[]{(byte) i, (byte) j, (byte) k};
-            ByteString bs = ByteString.copyFrom(bytes);
-            if (!bs.isValidUtf8()) {
-              assertInvalid(bytes);
-            } else {
-              valid++;
-            }
-            count++;
-            if (count % 1000000L == 0) {
-              logger.info("Processed " + (count / 1000000L) + " million characters");
-            }
+    int count = 0;
+    int valid = 0;
+    for (int i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
+      for (int j = Byte.MIN_VALUE; j <= Byte.MAX_VALUE; j++) {
+        for (int k = Byte.MIN_VALUE; k <= Byte.MAX_VALUE; k++) {
+          byte[] bytes = new byte[]{(byte) i, (byte) j, (byte) k};
+          ByteString bs = ByteString.copyFrom(bytes);
+          if (bs.isValidUtf8()) {
+            valid++;
+          }
+          count++;
+          if (count % 1000000L == 0) {
+            logger.info("Processed " + (count / 1000000L) + " million characters");
           }
         }
       }
-      assertEquals(IsValidUtf8TestUtil.EXPECTED_THREE_BYTE_ROUNDTRIPPABLE_COUNT, valid);
     }
+    assertEquals(IsValidUtf8TestUtil.EXPECTED_THREE_BYTE_ROUNDTRIPPABLE_COUNT, valid);
   }
 
   /**

--- a/java/core/src/test/java/com/google/protobuf/IsValidUtf8Test.java
+++ b/java/core/src/test/java/com/google/protobuf/IsValidUtf8Test.java
@@ -74,12 +74,8 @@ public class IsValidUtf8Test {
   /** Tests that round tripping of all three byte permutations work. */
   @Test
   public void testIsValidUtf8_3Bytes() {
-    // Travis' OOM killer doesn't like this test
-    if (System.getenv("TRAVIS") == null) {
-      testBytes(LITERAL_FACTORY, 3, EXPECTED_THREE_BYTE_ROUNDTRIPPABLE_COUNT);
-      testBytes(HEAP_NIO_FACTORY, 3, EXPECTED_THREE_BYTE_ROUNDTRIPPABLE_COUNT);
-      testBytes(DIRECT_NIO_FACTORY, 3, EXPECTED_THREE_BYTE_ROUNDTRIPPABLE_COUNT);
-    }
+    // This test is slow, so we test just one factory instead of all three.
+    testBytes(DIRECT_NIO_FACTORY, 3, EXPECTED_THREE_BYTE_ROUNDTRIPPABLE_COUNT);
   }
 
   /**


### PR DESCRIPTION
These are by far our slowest tests, so this commit makes some changes to
speed them up. The reason they're slow is that they exhaustively iterate
over all 2**24 possible 3-byte sequences.
- In DecodeUtf8Test, I changed the test to just count the number of
  valid sequences instead of asserting on the outcome of each one. This
  way, the number of loop iterations is the same but each iteration is
  much faster. If we introduce a bug, it should still be pretty likely
  to make the test fail.
- In IsValidUtf8Test, I kept the same basic test structure but updated
  the test to exercise just one ByteStringFactory instead of all three.
  DIRECT_NIO_FACTORY sounded like the most subtle one, so I chose that
  one to test.

This makes "bazel test --nocache_test_results //java/core:tests" take 2
minutes instead of 6. The time for "mvn test" is down to about 7
minutes. I didn't time it at the baseline but I think it was upwards of
10 minutes.

I suspect we could make the Maven test run comparable to Bazel if we
could configure Maven to parallelize its test cases, but I'm not sure
how to do this.