### PR TITLE
Add jsr305 to protobuf-util deps.

### DIFF
--- a/java/util/pom.xml
+++ b/java/util/pom.xml
@@ -33,6 +33,11 @@
       <version>1.3</version>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
This prepares for a change (internal CL 399474184, to be mirrored out to GitHub) to add a few such annotations in FieldMaskUtil and JsonFormat.

(Technically, this PR is probably not "necessary" because protobuf-util already depends transitively on jsr305. But it's better hygiene to depend on it directly, and the direct dependency could protect against problems if protobuf-util drops some of its other deps -- or if those deps drop their own deps on jsr305.)