### PR TITLE
Express JRuby's dependency on Java through a Maven submodule

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -268,6 +268,7 @@
     <module>util</module>
     <module>kotlin</module>
     <module>kotlin-lite</module>
+    <module>../ruby</module>
   </modules>
 
 </project>

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -68,11 +68,15 @@ end
 
 if RUBY_PLATFORM == "java"
   task :clean => :require_mvn do
-    system("mvn --batch-mode clean")
+    Dir.chdir('../java') do
+      system("mvn --batch-mode clean")
+    end
   end
 
   task :compile => :require_mvn do
-    system("mvn --batch-mode package")
+    Dir.chdir('../java') do
+      system("mvn --batch-mode package -pl core,../ruby -Dmaven.test.skip=true")
+    end
   end
 
   task :require_mvn do
@@ -105,7 +109,7 @@ else
     repo_root = File.realdirpath File.join(Dir.pwd, '..')
     RakeCompilerDock.sh <<-"EOT", platform: 'jruby', rubyvm: :jruby, mountdir: repo_root, workdir: repo_root
       sudo apt-get install maven -y && \
-      cd java && mvn install -Dmaven.test.skip=true && cd ../ruby && \
+      cd ruby && \
       bundle && \
       IN_DOCKER=true rake compile gem
     EOT

--- a/ruby/pom.xml
+++ b/ruby/pom.xml
@@ -2,15 +2,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>com.google</groupId>
-      <artifactId>google</artifactId>
-      <version>1</version>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-parent</artifactId>
+      <version>3.18.1</version>
+      <relativePath>../java</relativePath>
     </parent>
 
-    <groupId>com.google.protobuf.jruby</groupId>
     <artifactId>protobuf-jruby</artifactId>
     <version>3.18.1</version>
-    <name>Protocol Buffer JRuby native extension</name>
+    <name>Protocol Buffers [JRuby native extension]</name>
     <description>
       Protocol Buffers are a way of encoding structured data in an efficient yet
       extensible format.


### PR DESCRIPTION
An alternative approach to #9071 that makes JRuby a submodule of the protobuf-parent artifact.