### PR TITLE
Emacs: Protobuf mode should be derived from prog-mode

### DIFF
--- a/editors/protobuf-mode.el
+++ b/editors/protobuf-mode.el
@@ -193,7 +193,7 @@
 ;;;###autoload (add-to-list 'auto-mode-alist '("\\.proto\\'" . protobuf-mode))
 
 ;;;###autoload
-(defun protobuf-mode ()
+(define-derived-mode protobuf-mode prog-mode "Protobuf"
   "Major mode for editing Protocol Buffers description language.
 
 The hook `c-mode-common-hook' is run with no argument at mode


### PR DESCRIPTION
Prog mode is a basic major mode for buffers containing programming
language source code:
https://www.gnu.org/software/emacs/manual/html_node/elisp/Basic-Major-Modes.html

A lot of programming mode setup is based on whether the major mode is
derived from `prog-mode`.