### PR TITLE
Fix build error with MinGW

### DIFF
--- a/src/google/protobuf/io/zero_copy_stream_impl.cc
+++ b/src/google/protobuf/io/zero_copy_stream_impl.cc
@@ -104,7 +104,7 @@ FileInputStream::CopyingFileInputStream::CopyingFileInputStream(
       is_closed_(false),
       errno_(0),
       previous_seek_failed_(false) {
-#ifndef _MSC_VER
+#ifndef _WIN32
   int flags = fcntl(file_, F_GETFL);
   flags &= ~O_NONBLOCK;
   fcntl(file_, F_SETFL, flags);


### PR DESCRIPTION
Fixes:
  * zero_copy_stream_impl.cc uses F_GETFL when build with MinGW,
    which isn't defined under Windows.