### PR TITLE
Update the base image from jessie to stretch (for parity with the Java).

### DIFF
--- a/kokoro/linux/dockerfile/test/ruby/Dockerfile
+++ b/kokoro/linux/dockerfile/test/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 # Install dependencies.  We start with the basic ones require to build protoc
 # and the C++ build
@@ -20,10 +20,13 @@ RUN apt-get update && apt-get install -y \
   parallel \
   time \
   wget \
+  # Java dependencies
+  maven \
+  openjdk-8-jdk \
   && apt-get clean
 
 # Install rvm
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys \
+RUN gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys \
     409B6B1796C275462A1703113804BB82D39DC0E3 \
     7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s master
@@ -34,6 +37,8 @@ RUN /bin/bash -l -c "rvm install 2.5.1"
 RUN /bin/bash -l -c "rvm install 2.6.0"
 RUN /bin/bash -l -c "rvm install 2.7.0"
 RUN /bin/bash -l -c "rvm install 3.0.0"
+RUN /bin/bash -l -c "rvm install jruby-9.2.19.0"
+RUN /bin/bash -l -c "rvm install jruby-9.3.0.0"
 
 RUN /bin/bash -l -c "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"


### PR DESCRIPTION
Add Maven and OpenJDK 8 and add JRuby 9.2.x and 9.3.x.

Replace keys.gnupg.net with keyserver.ubuntu.com as the GPG keyserver since the former no longer exists.