### PR TITLE
[JAVA]supporting nanos and second in timestamp merge

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -1558,11 +1558,19 @@ public class JsonFormat {
     }
 
     private void mergeTimestamp(JsonElement json, Message.Builder builder)
-        throws InvalidProtocolBufferException {
-      try {
-        Timestamp value = Timestamps.parse(json.getAsString());
-        builder.mergeFrom(value.toByteString());
-      } catch (ParseException | UnsupportedOperationException e) {
+            throws InvalidProtocolBufferException {
+        try {
+          Timestamp value = Timestamps.parse(json.getAsString());
+          Timestamp value;
+          if (json.isJsonObject()) {
+            long seconds = json.getAsJsonObject().get("seconds").getAsLong();
+            int nanos = json.getAsJsonObject().get("nanos").getAsInt();
+            value = Timestamp.newBuilder().setSeconds(seconds).setNanos(nanos).build();
+          } else {
+            value = Timestamps.parse(json.getAsString());
+          }
+          builder.mergeFrom(value.toByteString());
+        } catch (ParseException | UnsupportedOperationException e) {
         throw new InvalidProtocolBufferException("Failed to parse timestamp: " + json);
       }
     }

--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -822,18 +822,11 @@ public class JsonFormatTest {
   }
 
   @Test
-  public void testTimestampMergeError() throws Exception {
-    final String incorrectTimestampString = "{\"seconds\":1800,\"nanos\":0}";
-    try {
-      TestTimestamp.Builder builder = TestTimestamp.newBuilder();
-      mergeFromJson(String.format("{\"timestamp_value\": %s}", incorrectTimestampString), builder);
-      assertWithMessage("expected exception").fail();
-    } catch (InvalidProtocolBufferException e) {
-      // Exception expected.
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo("Failed to parse timestamp: " + incorrectTimestampString);
-    }
+  public void testTimestampMerge() throws Exception {
+    final String timestampString = "{\"seconds\":1800,\"nanos\":0}";
+    TestTimestamp.Builder builder = TestTimestamp.newBuilder();
+    mergeFromJson(String.format("{\"timestamp_value\": %s}", incorrectTimestampString), builder);
+    assertThat(String.valueOf(builder.getTimestampValue()).trim()).isEqualTo("seconds: 1800");
   }
 
   @Test


### PR DESCRIPTION
This Commit adds in the ablity of mergeTimestamp method to parse the timestamp formate of type "{"seconds":1800,"nanos":0}" as if now only this format was supported "1970-01-01T00:00:00Z".