### PR TITLE
Python: fix usages of deprecated assertRaisesRegexp

### DIFF
--- a/python/google/protobuf/internal/descriptor_database_test.py
+++ b/python/google/protobuf/internal/descriptor_database_test.py
@@ -100,7 +100,7 @@ class DescriptorDatabaseTest(unittest.TestCase):
     self.assertEqual(file_desc_proto2, db.FindFileContainingSymbol(
         'protobuf_unittest.TestAllTypes.none_field'))
 
-    with self.assertRaisesRegexp(KeyError, r'\'protobuf_unittest\.NoneMessage\''):
+    with self.assertRaisesRegex(KeyError, r'\'protobuf_unittest\.NoneMessage\''):
       db.FindFileContainingSymbol('protobuf_unittest.NoneMessage')
 
   def testConflictRegister(self):

--- a/python/google/protobuf/internal/descriptor_pool_test.py
+++ b/python/google/protobuf/internal/descriptor_pool_test.py
@@ -648,10 +648,10 @@ class SecondaryDescriptorFromDescriptorDB(DescriptorPoolTestBase,
     enum_value.number = 0
     self.db.Add(file_proto)
 
-    self.assertRaisesRegexp(KeyError, 'SubMessage',
+    self.assertRaisesRegex(KeyError, 'SubMessage',
                             self.pool.FindMessageTypeByName,
                             'collector.ErrorMessage')
-    self.assertRaisesRegexp(KeyError, 'SubMessage',
+    self.assertRaisesRegex(KeyError, 'SubMessage',
                             self.pool.FindFileByName, 'error_file')
     with self.assertRaises(KeyError) as exc:
       self.pool.FindFileByName('none_file')

--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -100,7 +100,7 @@ class JsonFormatBase(unittest.TestCase):
 
   def CheckError(self, text, error_message):
     message = json_format_proto3_pb2.TestMessage()
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         error_message,
         json_format.Parse, text, message)
@@ -813,7 +813,7 @@ class JsonFormatTest(JsonFormatBase):
     json_format.Parse('{"messageValue": {}}', parsed_message)
     self.assertTrue(parsed_message.HasField('message_value'))
     # Null is not allowed to be used as an element in repeated field.
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'Failed to parse repeatedInt32Value field: '
         'null is not allowed to be used as an element in a repeated field.',
@@ -901,7 +901,7 @@ class JsonFormatTest(JsonFormatBase):
     json_format.Parse(text, message)
     # Proto2 does not accept unknown enums.
     message = unittest_pb2.TestAllTypes()
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'Failed to parse optionalNestedEnum field: Invalid enum value 12345 '
         'for enum type protobuf_unittest.TestAllTypes.NestedEnum.',
@@ -1015,28 +1015,28 @@ class JsonFormatTest(JsonFormatBase):
   def testInvalidMap(self):
     message = json_format_proto3_pb2.TestMap()
     text = '{"int32Map": {"null": 2, "2": 3}}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'Failed to parse int32Map field: invalid literal',
         json_format.Parse, text, message)
     text = '{"int32Map": {1: 2, "2": 3}}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         (r'Failed to load JSON: Expecting property name'
          r'( enclosed in double quotes)?: line 1'),
         json_format.Parse, text, message)
     text = '{"boolMap": {"null": 1}}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'Failed to parse boolMap field: Expected "true" or "false", not null.',
         json_format.Parse, text, message)
     text = r'{"stringMap": {"a": 3, "\u0061": 2}}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'Failed to load JSON: duplicate key a',
         json_format.Parse, text, message)
     text = r'{"stringMap": 0}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'Failed to parse stringMap field: Map field string_map must be '
         'in a dict which is 0.',
@@ -1045,31 +1045,31 @@ class JsonFormatTest(JsonFormatBase):
   def testInvalidTimestamp(self):
     message = json_format_proto3_pb2.TestTimestamp()
     text = '{"value": "10000-01-01T00:00:00.00Z"}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'Failed to parse value field: '
         'time data \'10000-01-01T00:00:00\' does not match'
         ' format \'%Y-%m-%dT%H:%M:%S\'.',
         json_format.Parse, text, message)
     text = '{"value": "1970-01-01T00:00:00.0123456789012Z"}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'nanos 0123456789012 more than 9 fractional digits.',
         json_format.Parse, text, message)
     text = '{"value": "1972-01-01T01:00:00.01+08"}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         (r'Invalid timezone offset value: \+08.'),
         json_format.Parse, text, message)
     # Time smaller than minimum time.
     text = '{"value": "0000-01-01T00:00:00Z"}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'Failed to parse value field: year (0 )?is out of range.',
         json_format.Parse, text, message)
     # Time bigger than maximum time.
     message.value.seconds = 253402300800
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         OverflowError,
         'date value out of range',
         json_format.MessageToJson, message)
@@ -1086,7 +1086,7 @@ class JsonFormatTest(JsonFormatBase):
   def testInvalidOneof(self):
     message = json_format_proto3_pb2.TestOneof()
     text = '{"oneofInt32Value": 1, "oneofStringValue": "2"}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'Message type "proto3.TestOneof"'
         ' should not have multiple "oneof_value" oneof fields.',
@@ -1095,7 +1095,7 @@ class JsonFormatTest(JsonFormatBase):
   def testInvalidListValue(self):
     message = json_format_proto3_pb2.TestListValue()
     text = '{"value": 1234}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         r'Failed to parse value field: ListValue must be in \[\] which is 1234',
         json_format.Parse, text, message)
@@ -1103,7 +1103,7 @@ class JsonFormatTest(JsonFormatBase):
   def testInvalidStruct(self):
     message = json_format_proto3_pb2.TestStruct()
     text = '{"value": 1234}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         'Failed to parse value field: Struct must be in a dict which is 1234',
         json_format.Parse, text, message)
@@ -1111,7 +1111,7 @@ class JsonFormatTest(JsonFormatBase):
   def testTimestampInvalidStringValue(self):
     message = json_format_proto3_pb2.TestTimestamp()
     text = '{"value": {"foo": 123}}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         r"Timestamp JSON value not a string: {u?'foo': 123}", json_format.Parse,
         text, message)
@@ -1119,7 +1119,7 @@ class JsonFormatTest(JsonFormatBase):
   def testDurationInvalidStringValue(self):
     message = json_format_proto3_pb2.TestDuration()
     text = '{"value": {"foo": 123}}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         r"Duration JSON value not a string: {u?'foo': 123}", json_format.Parse,
         text, message)
@@ -1127,7 +1127,7 @@ class JsonFormatTest(JsonFormatBase):
   def testFieldMaskInvalidStringValue(self):
     message = json_format_proto3_pb2.TestFieldMask()
     text = '{"value": {"foo": 123}}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         r"FieldMask JSON value not a string: {u?'foo': 123}", json_format.Parse,
         text, message)
@@ -1135,17 +1135,17 @@ class JsonFormatTest(JsonFormatBase):
   def testInvalidAny(self):
     message = any_pb2.Any()
     text = '{"@type": "type.googleapis.com/google.protobuf.Int32Value"}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         KeyError,
         'value',
         json_format.Parse, text, message)
     text = '{"value": 1234}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         '@type is missing when parsing any message.',
         json_format.Parse, text, message)
     text = '{"@type": "type.googleapis.com/MessageNotExist", "value": 1234}'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         TypeError,
         'Can not find message descriptor by type_url: '
         'type.googleapis.com/MessageNotExist.',
@@ -1233,7 +1233,7 @@ class JsonFormatTest(JsonFormatBase):
       def __repr__(self):
         return 'v'
     message = json_format_proto3_pb2.TestValue()
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         json_format.ParseError,
         r"Value v has unexpected type <class '.*\.UnknownClass'>.",
         json_format.ParseDict,

--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -2033,7 +2033,7 @@ class Proto3Test(unittest.TestCase):
 
   def testMergeFromBadType(self):
     msg = map_unittest_pb2.TestMap()
-    with self.assertRaisesRegexp(
+    with self.assertRaisesRegex(
         TypeError,
         r'Parameter to MergeFrom\(\) must be instance of same class: expected '
         r'.+TestMap got int\.'):
@@ -2041,7 +2041,7 @@ class Proto3Test(unittest.TestCase):
 
   def testCopyFromBadType(self):
     msg = map_unittest_pb2.TestMap()
-    with self.assertRaisesRegexp(
+    with self.assertRaisesRegex(
         TypeError,
         r'Parameter to [A-Za-z]*From\(\) must be instance of same class: '
         r'expected .+TestMap got int\.'):

--- a/python/google/protobuf/internal/reflection_test.py
+++ b/python/google/protobuf/internal/reflection_test.py
@@ -427,7 +427,7 @@ class ReflectionTest(unittest.TestCase):
       pb.optional_uint64 = '2'
 
     # The exact error should propagate with a poorly written custom integer.
-    with self.assertRaisesRegexp(RuntimeError, 'my_error'):
+    with self.assertRaisesRegex(RuntimeError, 'my_error'):
       pb.optional_uint64 = test_util.NonStandardInteger(5, 'my_error')
 
   def assetIntegerBoundsChecking(self, integer_fn, message_module):

--- a/python/google/protobuf/internal/well_known_types_test.py
+++ b/python/google/protobuf/internal/well_known_types_test.py
@@ -295,82 +295,82 @@ class TimeUtilTest(TimeUtilTestBase):
 
   def testInvalidTimestamp(self):
     message = timestamp_pb2.Timestamp()
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'Failed to parse timestamp: missing valid timezone offset.',
         message.FromJsonString,
         '')
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'Failed to parse timestamp: invalid trailing data '
         '1970-01-01T00:00:01Ztrail.',
         message.FromJsonString,
         '1970-01-01T00:00:01Ztrail')
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'time data \'10000-01-01T00:00:00\' does not match'
         ' format \'%Y-%m-%dT%H:%M:%S\'',
         message.FromJsonString, '10000-01-01T00:00:00.00Z')
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'nanos 0123456789012 more than 9 fractional digits.',
         message.FromJsonString,
         '1970-01-01T00:00:00.0123456789012Z')
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         (r'Invalid timezone offset value: \+08.'),
         message.FromJsonString,
         '1972-01-01T01:00:00.01+08',)
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'year (0 )?is out of range',
         message.FromJsonString,
         '0000-01-01T00:00:00Z')
     message.seconds = 253402300800
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         OverflowError,
         'date value out of range',
         message.ToJsonString)
 
   def testInvalidDuration(self):
     message = duration_pb2.Duration()
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'Duration must end with letter "s": 1.',
         message.FromJsonString, '1')
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'Couldn\'t parse duration: 1...2s.',
         message.FromJsonString, '1...2s')
     text = '-315576000001.000000000s'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         r'Duration is not valid\: Seconds -315576000001 must be in range'
         r' \[-315576000000\, 315576000000\].',
         message.FromJsonString, text)
     text = '315576000001.000000000s'
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         r'Duration is not valid\: Seconds 315576000001 must be in range'
         r' \[-315576000000\, 315576000000\].',
         message.FromJsonString, text)
     message.seconds = -315576000001
     message.nanos = 0
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         r'Duration is not valid\: Seconds -315576000001 must be in range'
         r' \[-315576000000\, 315576000000\].',
         message.ToJsonString)
     message.seconds = 0
     message.nanos = 999999999 + 1
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         r'Duration is not valid\: Nanos 1000000000 must be in range'
         r' \[-999999999\, 999999999\].',
         message.ToJsonString)
     message.seconds = -1
     message.nanos = 1
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         r'Duration is not valid\: Sign mismatch.',
         message.ToJsonString)
@@ -695,7 +695,7 @@ class FieldMaskTest(unittest.TestCase):
                      well_known_types._SnakeCaseToCamelCase('foo3_bar'))
 
     # No uppercase letter is allowed.
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'Fail to print FieldMask to Json string: Path name Foo must '
         'not contain uppercase letters.',
@@ -705,19 +705,19 @@ class FieldMaskTest(unittest.TestCase):
     #   1. "_" cannot be followed by another "_".
     #   2. "_" cannot be followed by a digit.
     #   3. "_" cannot appear as the last character.
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'Fail to print FieldMask to Json string: The character after a '
         '"_" must be a lowercase letter in path name foo__bar.',
         well_known_types._SnakeCaseToCamelCase,
         'foo__bar')
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'Fail to print FieldMask to Json string: The character after a '
         '"_" must be a lowercase letter in path name foo_3bar.',
         well_known_types._SnakeCaseToCamelCase,
         'foo_3bar')
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'Fail to print FieldMask to Json string: Trailing "_" in path '
         'name foo_bar_.',
@@ -731,7 +731,7 @@ class FieldMaskTest(unittest.TestCase):
                      well_known_types._CamelCaseToSnakeCase('FooBar'))
     self.assertEqual('foo3_bar',
                      well_known_types._CamelCaseToSnakeCase('foo3Bar'))
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'Fail to parse FieldMask: Path name foo_bar must not contain "_"s.',
         well_known_types._CamelCaseToSnakeCase,


### PR DESCRIPTION
assertRaisesRegexp has been deprecated in favor of the slightly
different spelling assertRaisesRegex. Let's fix this just to clean up a
bunch of deprecation warnings in the tests.