### PR TITLE
Remove references to HAVE_PTHREAD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,7 +26,6 @@ ZLIB_DEPS = ["@zlib//:zlib"]
 ################################################################################
 
 MSVC_COPTS = [
-    "/DHAVE_PTHREAD",
     "/wd4018",  # -Wno-sign-compare
     "/wd4065",  # switch statement contains 'default' but no 'case' labels
     "/wd4146",  # unary minus operator applied to unsigned type, result still unsigned
@@ -46,7 +45,6 @@ MSVC_COPTS = [
 COPTS = select({
     ":msvc": MSVC_COPTS,
     "//conditions:default": [
-        "-DHAVE_PTHREAD",
         "-DHAVE_ZLIB",
         "-Wmissing-field-initializers",
         "-Woverloaded-virtual",

--- a/Protobuf-C++.podspec
+++ b/Protobuf-C++.podspec
@@ -35,9 +35,6 @@ Pod::Spec.new do |s|
     # Do not let src/google/protobuf/stubs/time.h override system API
     'USE_HEADERMAP' => 'NO',
     'ALWAYS_SEARCH_USER_PATHS' => 'NO',
-
-    # Configure tool is not being used for Xcode. When building, assume pthread is supported.
-    'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "HAVE_PTHREAD=1"',
   }
 
 end

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -127,9 +127,6 @@ if (protobuf_DISABLE_RTTI)
 endif()
 
 find_package(Threads REQUIRED)
-if (CMAKE_USE_PTHREADS_INIT)
-  add_definitions(-DHAVE_PTHREAD)
-endif (CMAKE_USE_PTHREADS_INIT)
 
 set(_protobuf_FIND_ZLIB)
 if (protobuf_WITH_ZLIB)

--- a/cmake/protobuf-module.cmake.in
+++ b/cmake/protobuf-module.cmake.in
@@ -110,16 +110,6 @@ function(_protobuf_find_libraries name filename)
   endif()
 endfunction()
 
-# Internal function: find threads library
-function(_protobuf_find_threads)
-    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-    find_package(Threads)
-    if(Threads_FOUND)
-        list(APPEND PROTOBUF_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-        set(PROTOBUF_LIBRARIES "${PROTOBUF_LIBRARIES}" PARENT_SCOPE)
-    endif()
-endfunction()
-
 #
 # Main.
 #
@@ -138,10 +128,6 @@ _protobuf_find_libraries(Protobuf_LITE protobuf-lite)
 
 # The Protobuf Protoc Library
 _protobuf_find_libraries(Protobuf_PROTOC protoc)
-
-if(UNIX)
-  _protobuf_find_threads()
-endif()
 
 # Set the include directory
 get_target_property(Protobuf_INCLUDE_DIRS protobuf::libprotobuf

--- a/protobuf-lite.pc.in
+++ b/protobuf-lite.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: Protocol Buffers
 Description: Google's Data Interchange Format
 Version: @VERSION@
-Libs: -L${libdir} -lprotobuf-lite @PTHREAD_LIBS@
-Cflags: -I${includedir} @PTHREAD_CFLAGS@
+Libs: -L${libdir} -lprotobuf-lite
+Cflags: -I${includedir}
 Conflicts: protobuf

--- a/protobuf.pc.in
+++ b/protobuf.pc.in
@@ -6,8 +6,8 @@ includedir=@includedir@
 Name: Protocol Buffers
 Description: Google's Data Interchange Format
 Version: @VERSION@
-Libs: -L${libdir} -lprotobuf @PTHREAD_LIBS@
+Libs: -L${libdir} -lprotobuf
 Libs.private: @LIBS@
 
-Cflags: -I${includedir} @PTHREAD_CFLAGS@
+Cflags: -I${includedir}
 Conflicts: protobuf-lite

--- a/src/google/protobuf/stubs/common.cc
+++ b/src/google/protobuf/stubs/common.cc
@@ -44,10 +44,6 @@
 #endif
 #include <windows.h>
 #define snprintf _snprintf    // see comment in strutil.cc
-#elif defined(HAVE_PTHREAD)
-#include <pthread.h>
-#else
-#error "No suitable threading library available."
 #endif
 #if defined(__ANDROID__)
 #include <android/log.h>


### PR DESCRIPTION
This is based on @haberman's changes in #8257. Now that we're using
std::mutex we no longer need to check whether pthreads are available, so
this commit removes references to HAVE_PTHREAD. I left the autotools
build alone, though, since we are likely to drop support for it soon
anyway.