### PR TITLE
[CMake] Allow custom plugin options e.g. to generate mocks

### DIFF
--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -39,11 +39,18 @@ function(protobuf_generate)
   endif()
 
   if(protobuf_generate_EXPORT_MACRO AND protobuf_generate_LANGUAGE STREQUAL cpp)
-    set(_dll_export_decl "dllexport_decl=${protobuf_generate_EXPORT_MACRO}:")
-  else()
-    set(_plugin_options "${protobuf_generate_PLUGIN_OPTIONS}:")
+    set(_dll_export_decl "dllexport_decl=${protobuf_generate_EXPORT_MACRO}")
   endif()
-  
+
+  foreach(_option ${_dll_export_decl} ${protobuf_generate_PLUGIN_OPTIONS})
+    # append comma - not using CMake lists and string replacement as users
+    # might have semicolons in options
+    if(_plugin_options)
+      set( _plugin_options "${_plugin_options},")
+    endif()
+    set(_plugin_options "${_plugin_options}${_option}")
+  endforeach()
+
   if(protobuf_generate_PLUGIN)
       set(_plugin "--plugin=${protobuf_generate_PLUGIN}")
   endif()
@@ -131,16 +138,16 @@ function(protobuf_generate)
 
     set(_comment "Running ${protobuf_generate_LANGUAGE} protocol buffer compiler on ${_proto}")
     if(protobuf_generate_PROTOC_OPTIONS)
-      set(_comment "${_comment}, Custom protoc options: ${protobuf_generate_PROTOC_OPTIONS}")
+      set(_comment "${_comment}, protoc-options: ${protobuf_generate_PROTOC_OPTIONS}")
     endif()
-    if(protobuf_generate_PLUGIN_OPTIONS)
-      set(_comment "${_comment}, Custom plugin options: ${protobuf_generate_PLUGIN_OPTIONS}")
+    if(_plugin_options)
+      set(_comment "${_comment}, plugin-options: ${_plugin_options}")
     endif()
 
     add_custom_command(
       OUTPUT ${_generated_srcs}
-      COMMAND  protobuf::protoc
-      ARGS ${protobuf_generate_PROTOC_OPTIONS} --${protobuf_generate_LANGUAGE}_out ${_plugin_options}${_dll_export_decl}${protobuf_generate_PROTOC_OUT_DIR} ${_plugin} ${_protobuf_include_path} ${_abs_file}
+      COMMAND protobuf::protoc
+      ARGS ${protobuf_generate_PROTOC_OPTIONS} --${protobuf_generate_LANGUAGE}_out ${_plugin_options}:${protobuf_generate_PROTOC_OUT_DIR} ${_plugin} ${_protobuf_include_path} ${_abs_file}
       DEPENDS ${_abs_file} protobuf::protoc
       COMMENT ${_comment}
       VERBATIM )


### PR DESCRIPTION
This would allow setting options for plugins, e.g. to generate mocks.
Example:
```
protobuf_generate(
      TARGET
      myTarget
      LANGUAGE
      grpc
      PROTOC_OUT_DIR
      ${CMAKE_BINARY_DIR}
      GENERATE_EXTENSIONS
      .grpc.pb.h
      .grpc.pb.cc
      PLUGIN
      protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
      PLUGIN_OPTIONS
      generate_mock_code=true
      IMPORT_DIRS
      ${PROTO_IMPORT_DIRS})
```