### PR TITLE
Update Mac test runs to download RVM directly from GitHub

### DIFF
--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -33,5 +33,8 @@ if [[ "${KOKORO_INSTALL_RVM:-}" == "yes" ]] ; then
   curl -sSL https://rvm.io/mpapis.asc | gpg --import -
   curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
 
-  curl -sSL https://get.rvm.io | bash -s stable --ruby
+  # Old OpenSSL versions cannot handle the SSL certificate used by
+  # https://get.rvm.io, so as a workaround we download RVM directly from
+  # GitHub. See this issue for details: https://github.com/rvm/rvm/issues/5133
+  curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s stable --ruby
 fi


### PR DESCRIPTION
Our Mac test runs recently started failing to download RVM. The issue
appears to be a combination of an SSL certificate expiring and old
OpenSSL versions having a bug preventing them from validating the
replacement certificate: https://github.com/rvm/rvm/issues/5133

This commit works around the problem by downloading RVM from GitHub as
suggested in one of the comments on the issue above.