### PR TITLE
Add failing Java test

### DIFF
--- a/java/core/src/test/java/com/google/protobuf/AnyTest.java
+++ b/java/core/src/test/java/com/google/protobuf/AnyTest.java
@@ -81,6 +81,7 @@ public class AnyTest {
 
   @Test
   public void testCustomTypeUrls() throws Exception {
+    assertThat(2).isEqualTo(5);
     TestAllTypes.Builder builder = TestAllTypes.newBuilder();
     TestUtil.setAllFields(builder);
     TestAllTypes message = builder.build();


### PR DESCRIPTION
This is just to double check that we have good enough Java CI coverage after turning off our Java 7 tests.