### PR TITLE
[JAVA]supporting nanos and second in timestamp merge

### DIFF
--- a/java/util/pom.xml
+++ b/java/util/pom.xml
@@ -51,6 +51,23 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-protobuf</artifactId>
+      <version>1.10.2</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java-util</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>

--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -398,6 +398,7 @@ public class JsonFormat {
         com.google.protobuf.TypeRegistry.getEmptyTypeRegistry(),
         TypeRegistry.getEmptyTypeRegistry(),
         false,
+        false,
         Parser.DEFAULT_RECURSION_LIMIT);
   }
 
@@ -408,6 +409,7 @@ public class JsonFormat {
     private final com.google.protobuf.TypeRegistry registry;
     private final TypeRegistry oldRegistry;
     private final boolean ignoringUnknownFields;
+    private final boolean lenient;
     private final int recursionLimit;
 
     // The default parsing recursion limit is aligned with the proto binary parser.
@@ -417,10 +419,12 @@ public class JsonFormat {
         com.google.protobuf.TypeRegistry registry,
         TypeRegistry oldRegistry,
         boolean ignoreUnknownFields,
+        boolean lenient,
         int recursionLimit) {
       this.registry = registry;
       this.oldRegistry = oldRegistry;
       this.ignoringUnknownFields = ignoreUnknownFields;
+      this.lenient = lenient;
       this.recursionLimit = recursionLimit;
     }
 
@@ -438,6 +442,7 @@ public class JsonFormat {
       return new Parser(
           com.google.protobuf.TypeRegistry.getEmptyTypeRegistry(),
           oldRegistry,
+          lenient,
           ignoringUnknownFields,
           recursionLimit);
     }
@@ -453,7 +458,7 @@ public class JsonFormat {
           || this.registry != com.google.protobuf.TypeRegistry.getEmptyTypeRegistry()) {
         throw new IllegalArgumentException("Only one registry is allowed.");
       }
-      return new Parser(registry, oldRegistry, ignoringUnknownFields, recursionLimit);
+      return new Parser(registry, oldRegistry, ignoringUnknownFields, lenient, recursionLimit);
     }
 
     /**
@@ -461,7 +466,15 @@ public class JsonFormat {
      * encountered. The new Parser clones all other configurations from this Parser.
      */
     public Parser ignoringUnknownFields() {
-      return new Parser(this.registry, oldRegistry, true, recursionLimit);
+      return new Parser(this.registry, oldRegistry, true, lenient, recursionLimit);
+    }
+
+    /**
+     * Creates a new {@link Parser} configured to handle lenient parsing e.g. Timestamp represented as seconds and nanos instead of String format.
+     * The new Parser clones all other configurations from this Parser.
+     */
+    public Parser lenient() {
+      return new Parser(this.registry, oldRegistry, ignoringUnknownFields, true, recursionLimit);
     }
 
     /**
@@ -473,7 +486,7 @@ public class JsonFormat {
     public void merge(String json, Message.Builder builder) throws InvalidProtocolBufferException {
       // TODO(xiaofeng): Investigate the allocation overhead and optimize for
       // mobile.
-      new ParserImpl(registry, oldRegistry, ignoringUnknownFields, recursionLimit)
+      new ParserImpl(registry, oldRegistry, ignoringUnknownFields, lenient, recursionLimit)
           .merge(json, builder);
     }
 
@@ -487,13 +500,13 @@ public class JsonFormat {
     public void merge(Reader json, Message.Builder builder) throws IOException {
       // TODO(xiaofeng): Investigate the allocation overhead and optimize for
       // mobile.
-      new ParserImpl(registry, oldRegistry, ignoringUnknownFields, recursionLimit)
+      new ParserImpl(registry, oldRegistry, ignoringUnknownFields, lenient, recursionLimit)
           .merge(json, builder);
     }
 
     // For testing only.
     Parser usingRecursionLimit(int recursionLimit) {
-      return new Parser(registry, oldRegistry, ignoringUnknownFields, recursionLimit);
+      return new Parser(registry, oldRegistry, ignoringUnknownFields, lenient, recursionLimit);
     }
   }
 
@@ -1298,6 +1311,7 @@ public class JsonFormat {
     private final com.google.protobuf.TypeRegistry registry;
     private final TypeRegistry oldRegistry;
     private final boolean ignoringUnknownFields;
+    private final boolean lenient;
     private final int recursionLimit;
     private int currentDepth;
 
@@ -1305,10 +1319,12 @@ public class JsonFormat {
         com.google.protobuf.TypeRegistry registry,
         TypeRegistry oldRegistry,
         boolean ignoreUnknownFields,
+        boolean lenient,
         int recursionLimit) {
       this.registry = registry;
       this.oldRegistry = oldRegistry;
       this.ignoringUnknownFields = ignoreUnknownFields;
+      this.lenient = lenient;
       this.recursionLimit = recursionLimit;
       this.currentDepth = 0;
     }
@@ -1560,7 +1576,14 @@ public class JsonFormat {
     private void mergeTimestamp(JsonElement json, Message.Builder builder)
         throws InvalidProtocolBufferException {
       try {
-        Timestamp value = Timestamps.parse(json.getAsString());
+        Timestamp value;
+        if (lenient && json.isJsonObject()) {
+          long seconds = json.getAsJsonObject().get("seconds").getAsLong();
+          int nanos = json.getAsJsonObject().get("nanos").getAsInt();
+          value = Timestamp.newBuilder().setSeconds(seconds).setNanos(nanos).build();
+        } else {
+          value = Timestamps.parse(json.getAsString());
+        }
         builder.mergeFrom(value.toByteString());
       } catch (ParseException | UnsupportedOperationException e) {
         throw new InvalidProtocolBufferException("Failed to parse timestamp: " + json);


### PR DESCRIPTION
Add lenient toggle so that those with any existing behavior today reliant on strict only would not break
Add test case for seconds/nanos
Add test case demonstrating full Proto -> Avro -> Json -> Proto trip. 
Note no existing Test cases altered ensuring no change in behavior for any existing cases.