### PR TITLE
Make IsDescriptor* helpers lenient about descriptor name

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_generator_unittest.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_generator_unittest.cc
@@ -30,8 +30,10 @@
 
 #include <memory>
 
+#include <google/protobuf/any.pb.h>
 #include <google/protobuf/compiler/command_line_interface.h>
 #include <google/protobuf/compiler/csharp/csharp_helpers.h>
+#include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/io/zero_copy_stream.h>
 #include <google/protobuf/io/printer.h>
 
@@ -61,6 +63,17 @@ TEST(CSharpEnumValue, PascalCasedPrefixStripping) {
   // Identifiers can't start with digits
   EXPECT_EQ("_2Bar", GetEnumValueName("Foo", "FOO_2_BAR"));
   EXPECT_EQ("_2", GetEnumValueName("Foo", "FOO___2"));
+}
+
+TEST(DescriptorProtoHelpers, IsDescriptorProto) {
+  EXPECT_TRUE(IsDescriptorProto(DescriptorProto::descriptor()->file()));
+  EXPECT_FALSE(IsDescriptorProto(Any::descriptor()->file()));
+}
+
+TEST(DescriptorProtoHelpers, IsDescriptorOptionMessage) {
+  EXPECT_TRUE(IsDescriptorOptionMessage(FileOptions::descriptor()));
+  EXPECT_FALSE(IsDescriptorOptionMessage(Any::descriptor()));
+  EXPECT_FALSE(IsDescriptorOptionMessage(DescriptorProto::descriptor()));
 }
 
 }  // namespace

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.h
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.h
@@ -130,7 +130,8 @@ uint GetGroupEndTag(const Descriptor* descriptor);
 // descriptors etc, for use in the runtime. This is the only type which is
 // allowed to use proto2 syntax, and it generates internal classes.
 inline bool IsDescriptorProto(const FileDescriptor* descriptor) {
-  return descriptor->name() == "google/protobuf/descriptor.proto";
+  return descriptor->name() == "google/protobuf/descriptor.proto" ||
+         descriptor->name() == "net/proto2/proto/descriptor.proto";
 }
 
 // Determines whether the given message is an options message within descriptor.proto.
@@ -138,15 +139,15 @@ inline bool IsDescriptorOptionMessage(const Descriptor* descriptor) {
   if (!IsDescriptorProto(descriptor->file())) {
     return false;
   }
-  const std::string name = descriptor->full_name();
-  return name == "google.protobuf.FileOptions" ||
-      name == "google.protobuf.MessageOptions" ||
-      name == "google.protobuf.FieldOptions" ||
-      name == "google.protobuf.OneofOptions" ||
-      name == "google.protobuf.EnumOptions" ||
-      name == "google.protobuf.EnumValueOptions" ||
-      name == "google.protobuf.ServiceOptions" ||
-      name == "google.protobuf.MethodOptions";
+  const std::string name = descriptor->name();
+  return name == "FileOptions" ||
+      name == "MessageOptions" ||
+      name == "FieldOptions" ||
+      name == "OneofOptions" ||
+      name == "EnumOptions" ||
+      name == "EnumValueOptions" ||
+      name == "ServiceOptions" ||
+      name == "MethodOptions";
 }
 
 inline bool IsWrapperType(const FieldDescriptor* descriptor) {


### PR DESCRIPTION
Our internal version of the codebase has a different path and package
name for descriptor.proto, so this change updates IsDescriptorProto()
and IsDescriptorOptionMessage() to be able to handle both the internal
and external descriptor types.