### PR TITLE
Ensure that release archives contain everything needed for Bazel

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1424,8 +1424,10 @@ EXTRA_DIST = $(@DIST_LANG@_EXTRA_DIST)   \
   examples/list_people.py                \
   examples/list_people_test.go           \
   examples/pubspec.yaml                  \
+  maven_install.json                     \
   protobuf.bzl                           \
   protobuf_deps.bzl                      \
+  protobuf_version.bzl                   \
   third_party/zlib.BUILD                 \
   util/python/BUILD                      \
   internal.bzl

--- a/kokoro/linux/bazel/build.sh
+++ b/kokoro/linux/bazel/build.sh
@@ -35,5 +35,13 @@ bazel test -k --copt=-Werror --host_copt=-Werror \
   @com_google_protobuf//:cc_proto_blacklist_test
 trap - EXIT
 
-cd examples
+pushd examples
 bazel build //...
+popd
+
+# Verify that we can build successfully from generated tar files.
+./autogen.sh && ./configure && make -j$(nproc) dist
+DIST=`ls *.tar.gz`
+tar -xf $DIST
+cd ${DIST//.tar.gz}
+bazel build //:protobuf //:protobuf_java


### PR DESCRIPTION
This change adds some files to EXTRA_DIST in Makefile.am so that our
published tar and zip files will have everything needed for Bazel
builds. I also added a basic test for this so that next time we should
find out sooner if we're missing any important files.

fixes #9129