### PR TITLE
deps: update to 3.19.0

### DIFF
--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.google.protobuf</groupId>
   <artifactId>protobuf-bom</artifactId>
-  <version>3.18.1</version>
+  <version>3.19.0</version>
   <packaging>pom</packaging>
 
   <name>Protocol Buffers [BOM]</name>


### PR DESCRIPTION
@acozzette I'm confused. Per Maven Central protobuf-bom 3.19.0 was released but I don't see it in the repo? What's going on? 