### PR TITLE
Implement unambiguous comparisons for RepeatedPtrIterator in C++20

### DIFF
--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -1617,6 +1617,8 @@ class RepeatedPtrIterator {
   using iterator = RepeatedPtrIterator<Element>;
   using iterator_category = std::random_access_iterator_tag;
   using value_type = typename std::remove_const<Element>::type;
+  using const_iterator = RepeatedPtrIterator<const value_type>;
+  using nonconst_iterator = RepeatedPtrIterator<value_type>;
   using difference_type = std::ptrdiff_t;
   using pointer = Element*;
   using reference = Element&;
@@ -1652,14 +1654,20 @@ class RepeatedPtrIterator {
   iterator operator--(int) { return iterator(it_--); }
 
   // equality_comparable
-  bool operator==(const iterator& x) const { return it_ == x.it_; }
-  bool operator!=(const iterator& x) const { return it_ != x.it_; }
+  bool operator==(const nonconst_iterator& x) const { return it_ == x.it_; }
+  bool operator==(const const_iterator& x) const { return it_ == x.it_; }
+  bool operator!=(const nonconst_iterator& x) const { return it_ != x.it_; }
+  bool operator!=(const const_iterator& x) const { return it_ != x.it_; }
 
   // less_than_comparable
-  bool operator<(const iterator& x) const { return it_ < x.it_; }
-  bool operator<=(const iterator& x) const { return it_ <= x.it_; }
-  bool operator>(const iterator& x) const { return it_ > x.it_; }
-  bool operator>=(const iterator& x) const { return it_ >= x.it_; }
+  bool operator<(const nonconst_iterator& x) const { return it_ < x.it_; }
+  bool operator<(const const_iterator& x) const { return it_ < x.it_; }
+  bool operator<=(const nonconst_iterator& x) const { return it_ <= x.it_; }
+  bool operator<=(const const_iterator& x) const { return it_ <= x.it_; }
+  bool operator>(const nonconst_iterator& x) const { return it_ > x.it_; }
+  bool operator>(const const_iterator& x) const { return it_ > x.it_; }
+  bool operator>=(const nonconst_iterator& x) const { return it_ >= x.it_; }
+  bool operator>=(const const_iterator& x) const { return it_ >= x.it_; }
 
   // addable, subtractable
   iterator& operator+=(difference_type d) {


### PR DESCRIPTION
In C++20, code that compares `RepeatedPtrIterator<Foo>` and `RepeatedPtrIterator<const Foo>` can be ambiguous because the reversed operator is equally viable (`[-Wambiguous-reversed-operator]`). If we define viable operators for both combinations of constness there is always a best match when comparing const and non-const iterators.

Without this either warnings will be omitted or compilation failures will occur when using this header in C++20. Notably this causes the `//:protobuf_test` target to no longer fail under `--cxxopt='-std=c++20'`.