### PR TITLE
Support protobuf_MSVC_STATIC_RUNTIME when using CMake(3.15+)

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -182,7 +182,9 @@ else (protobuf_BUILD_SHARED_LIBS)
   # making programmatic control difficult.  Prefer the functionality in newer
   # CMake versions when available.
   if(CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
+    if (protobuf_MSVC_STATIC_RUNTIME)
+      set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
+    endif (protobuf_MSVC_STATIC_RUNTIME)
   else()
     # In case we are building static libraries, link also the runtime library statically
     # so that MSVCR*.DLL is not required at runtime.


### PR DESCRIPTION
When using `MSVC_RUNTIME_LIBRARY` to select the runtime library, developers need to have the opportunity to choose whether to use static runtime library through option `protobuf_MSVC_STATIC_RUNTIME`