### PR TITLE
JS: Fixed `ReferenceError: window is not defined` 

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -3634,7 +3634,14 @@ void Generator::GenerateFile(const GeneratorOptions& options,
       // - self: defined inside Web Workers (WorkerGlobalScope)
       // - Function('return this')(): this will work on most platforms, but it may be blocked by things like CSP.
       //   Function('') is almost the same as eval('')
-      printer->Print("var global = (function() { return this || window || global || self || Function('return this')(); }).call(null);\n\n");
+      printer->Print(
+          "var global = (function() {\n"
+          "  if (this) { return this; }\n"
+          "  if (typeof window !== 'undefined') { return window; }\n"
+          "  if (typeof global !== 'undefined') { return global; }\n"
+          "  if (typeof self !== 'undefined') { return self; }\n"
+          "  return Function('return this')();\n"
+          "}.call(null));\n\n");
     }
 
     for (int i = 0; i < file->dependency_count(); i++) {


### PR DESCRIPTION
PR https://github.com/protocolbuffers/protobuf/pull/8864 introduced a bug (https://github.com/protocolbuffers/protobuf/issues/9152) in generated JS code where it would error getting the global object saying that `window` is undefined.

I've missed this scenario in my original PR so this PR is here to make the functionality more robust.
This PR fixes this issue by explicitly checking if window is defined.
