### PR TITLE
for ios shared library export api visibility

### DIFF
--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -103,12 +103,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
 	target_link_libraries(libprotobuf-lite log)
 endif()
 target_include_directories(libprotobuf-lite PUBLIC ${protobuf_source_dir}/src)
-if(MSVC AND protobuf_BUILD_SHARED_LIBS)
-  target_compile_definitions(libprotobuf-lite
-    PUBLIC  PROTOBUF_USE_DLLS
-    PRIVATE LIBPROTOBUF_EXPORTS)
-endif()
-if(${CMAKE_SYSTEM_NAME} STREQUAL "iOS" AND protobuf_BUILD_SHARED_LIBS)
+if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf-lite
     PUBLIC  PROTOBUF_USE_DLLS
     PRIVATE LIBPROTOBUF_EXPORTS)

--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -108,6 +108,11 @@ if(MSVC AND protobuf_BUILD_SHARED_LIBS)
     PUBLIC  PROTOBUF_USE_DLLS
     PRIVATE LIBPROTOBUF_EXPORTS)
 endif()
+if(${CMAKE_SYSTEM_NAME} STREQUAL "iOS" AND protobuf_BUILD_SHARED_LIBS)
+  target_compile_definitions(libprotobuf-lite
+    PUBLIC  PROTOBUF_USE_DLLS
+    PRIVATE LIBPROTOBUF_EXPORTS)
+endif()
 set_target_properties(libprotobuf-lite PROPERTIES
     VERSION ${protobuf_VERSION}
     OUTPUT_NAME ${LIB_PREFIX}protobuf-lite

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -118,12 +118,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
 	target_link_libraries(libprotobuf log)
 endif()
 target_include_directories(libprotobuf PUBLIC ${protobuf_source_dir}/src)
-if(MSVC AND protobuf_BUILD_SHARED_LIBS)
-  target_compile_definitions(libprotobuf
-    PUBLIC  PROTOBUF_USE_DLLS
-    PRIVATE LIBPROTOBUF_EXPORTS)
-endif()
-if(${CMAKE_SYSTEM_NAME} STREQUAL "iOS" AND protobuf_BUILD_SHARED_LIBS)
+if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf
     PUBLIC  PROTOBUF_USE_DLLS
     PRIVATE LIBPROTOBUF_EXPORTS)

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -123,6 +123,11 @@ if(MSVC AND protobuf_BUILD_SHARED_LIBS)
     PUBLIC  PROTOBUF_USE_DLLS
     PRIVATE LIBPROTOBUF_EXPORTS)
 endif()
+if(${CMAKE_SYSTEM_NAME} STREQUAL "iOS" AND protobuf_BUILD_SHARED_LIBS)
+  target_compile_definitions(libprotobuf
+    PUBLIC  PROTOBUF_USE_DLLS
+    PRIVATE LIBPROTOBUF_EXPORTS)
+endif()
 set_target_properties(libprotobuf PROPERTIES
     VERSION ${protobuf_VERSION}
     OUTPUT_NAME ${LIB_PREFIX}protobuf


### PR DESCRIPTION
If ios client need link protobuf against shared library (dylib) , the attribute visibility("default") must be set  to make protobuf symbols are accessible to clients. as the macro are defined in \google\protobuf\port_def.inc line 422.
so when compile protobuf for ios shared library , we need define PROTOBUF_USE_DLLS and LIBPROTOBUF_EXPORTS to make
 visibility("default") take effect.

I write an example. https://github.com/appledragon/TestPBIosSharedLibrary
libprotobuf-lite-fail.dylib is generated without attribute visibility("default") from 3.19.0 official code.
libprotobuf-lite.dylib is generated with  visibility("default") .

when I link protobuf as ios shared library, this is the result.
https://github.com/appledragon/TestPBIosSharedLibrary/runs/4017222652?check_suite_focus=true

the failed case show all the protobuf export symbol can not be accessed by client.


