### PR TITLE
Standardize on Array copyOf

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/BooleanArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/BooleanArrayList.java
@@ -197,10 +197,7 @@ final class BooleanArrayList extends AbstractProtobufList<Boolean>
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      boolean[] newArray = new boolean[length];
-
-      System.arraycopy(array, 0, newArray, 0, size);
-      array = newArray;
+      array = Arrays.copyOf(array, length);
     }
 
     array[size++] = element;
@@ -219,14 +216,10 @@ final class BooleanArrayList extends AbstractProtobufList<Boolean>
     } else {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      boolean[] newArray = new boolean[length];
-
-      // Copy the first part directly
-      System.arraycopy(array, 0, newArray, 0, index);
+      array = Arrays.copyOf(array, length);
 
       // Copy the rest shifted over by one to make room
-      System.arraycopy(array, index, newArray, index + 1, size - index);
-      array = newArray;
+      System.arraycopy(array, index, array, index + 1, size - index);
     }
 
     array[index] = element;

--- a/java/core/src/main/java/com/google/protobuf/DoubleArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/DoubleArrayList.java
@@ -197,10 +197,7 @@ final class DoubleArrayList extends AbstractProtobufList<Double>
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      double[] newArray = new double[length];
-
-      System.arraycopy(array, 0, newArray, 0, size);
-      array = newArray;
+      array = Arrays.copyOf(array, length);
     }
 
     array[size++] = element;
@@ -219,14 +216,10 @@ final class DoubleArrayList extends AbstractProtobufList<Double>
     } else {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      double[] newArray = new double[length];
-
-      // Copy the first part directly
-      System.arraycopy(array, 0, newArray, 0, index);
+      array = Arrays.copyOf(array, length);
 
       // Copy the rest shifted over by one to make room
-      System.arraycopy(array, index, newArray, index + 1, size - index);
-      array = newArray;
+      System.arraycopy(array, index, array, index + 1, size - index);
     }
 
     array[index] = element;

--- a/java/core/src/main/java/com/google/protobuf/FloatArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/FloatArrayList.java
@@ -196,10 +196,7 @@ final class FloatArrayList extends AbstractProtobufList<Float>
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      float[] newArray = new float[length];
-
-      System.arraycopy(array, 0, newArray, 0, size);
-      array = newArray;
+      array = Arrays.copyOf(array, length);
     }
 
     array[size++] = element;
@@ -218,14 +215,10 @@ final class FloatArrayList extends AbstractProtobufList<Float>
     } else {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      float[] newArray = new float[length];
-
-      // Copy the first part directly
-      System.arraycopy(array, 0, newArray, 0, index);
+      array = Arrays.copyOf(array, length);
 
       // Copy the rest shifted over by one to make room
-      System.arraycopy(array, index, newArray, index + 1, size - index);
-      array = newArray;
+      System.arraycopy(array, index, array, index + 1, size - index);
     }
 
     array[index] = element;

--- a/java/core/src/main/java/com/google/protobuf/IntArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/IntArrayList.java
@@ -196,10 +196,7 @@ final class IntArrayList extends AbstractProtobufList<Integer>
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      int[] newArray = new int[length];
-
-      System.arraycopy(array, 0, newArray, 0, size);
-      array = newArray;
+      array = Arrays.copyOf(array, length);
     }
 
     array[size++] = element;
@@ -218,14 +215,10 @@ final class IntArrayList extends AbstractProtobufList<Integer>
     } else {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      int[] newArray = new int[length];
-
-      // Copy the first part directly
-      System.arraycopy(array, 0, newArray, 0, index);
+      array = Arrays.copyOf(array, length);
 
       // Copy the rest shifted over by one to make room
-      System.arraycopy(array, index, newArray, index + 1, size - index);
-      array = newArray;
+      System.arraycopy(array, index, array, index + 1, size - index);
     }
 
     array[index] = element;

--- a/java/core/src/main/java/com/google/protobuf/LongArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/LongArrayList.java
@@ -196,10 +196,7 @@ final class LongArrayList extends AbstractProtobufList<Long>
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      long[] newArray = new long[length];
-
-      System.arraycopy(array, 0, newArray, 0, size);
-      array = newArray;
+      array = Arrays.copyOf(array, length);
     }
 
     array[size++] = element;
@@ -218,14 +215,10 @@ final class LongArrayList extends AbstractProtobufList<Long>
     } else {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      long[] newArray = new long[length];
-
-      // Copy the first part directly
-      System.arraycopy(array, 0, newArray, 0, index);
+      array = Arrays.copyOf(array, length);
 
       // Copy the rest shifted over by one to make room
-      System.arraycopy(array, index, newArray, index + 1, size - index);
-      array = newArray;
+      System.arraycopy(array, index, array, index + 1, size - index);
     }
 
     array[index] = element;

--- a/java/core/src/main/java/com/google/protobuf/ProtobufArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/ProtobufArrayList.java
@@ -80,9 +80,7 @@ final class ProtobufArrayList<E> extends AbstractProtobufList<E> implements Rand
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      E[] newArray = Arrays.copyOf(array, length);
-
-      array = newArray;
+      array = Arrays.copyOf(array, length);
     }
 
     array[size++] = element;


### PR DESCRIPTION
Code already uses instances of copyOf, make it the standard.

https://docs.oracle.com/javase/7/docs/api/java/util/Arrays.html