### PR TITLE
Use matching soname when building with CMake as Makefile

### DIFF
--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -125,6 +125,8 @@ if(MSVC AND protobuf_BUILD_SHARED_LIBS)
 endif()
 set_target_properties(libprotobuf PROPERTIES
     VERSION ${protobuf_VERSION}
+    # Use only the first SO version component for compatibility with Makefile emitted SONAME.
+    SOVERSION 30
     OUTPUT_NAME ${LIB_PREFIX}protobuf
     DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
 add_library(protobuf::libprotobuf ALIAS libprotobuf)

--- a/update_version.py
+++ b/update_version.py
@@ -61,6 +61,19 @@ def GetFullVersion(rc_suffix = '-rc-'):
     return '%s%s%s' % (NEW_VERSION, rc_suffix, RC_VERSION)
 
 
+def GetSharedObjectVersion():
+  protobuf_version_offset = 11
+  expected_major_version = 3
+  if NEW_VERSION_INFO[0] != expected_major_version:
+    print("""[ERROR] Major protobuf version has changed. Please update
+update_version.py to readjust the protobuf_version_offset and
+expected_major_version such that the PROTOBUF_VERSION in src/Makefile.am is
+always increasing.
+    """)
+    exit(1)
+  return [NEW_VERSION_INFO[1] + protobuf_version_offset, NEW_VERSION_INFO[2], 0]
+
+
 def RewriteXml(filename, rewriter, add_xml_prefix=True):
   document = minidom.parse(filename)
   rewriter(document)
@@ -87,6 +100,14 @@ def RewriteTextFile(filename, line_rewriter):
   f = open(filename, 'w')
   f.write(''.join(updated_lines))
   f.close()
+
+
+def UpdateCMake():
+  RewriteTextFile('cmake/libprotobuf.cmake',
+    lambda line : re.sub(
+      r'SOVERSION [0-9]+\.[0-9]+(\.[0-9]+)?',
+      'SOVERSION %s' % GetSharedObjectVersion()[0],
+      line))
 
 
 def UpdateConfigure():
@@ -270,22 +291,10 @@ def UpdateJavaScript():
 
 
 def UpdateMakefile():
-  protobuf_version_offset = 11
-  expected_major_version = 3
-  if NEW_VERSION_INFO[0] != expected_major_version:
-    print("""[ERROR] Major protobuf version has changed. Please update
-update_version.py to readjust the protobuf_version_offset and
-expected_major_version such that the PROTOBUF_VERSION in src/Makefile.am is
-always increasing.
-    """)
-    exit(1)
-
-  protobuf_version_info = '%d:%d:0' % (
-    NEW_VERSION_INFO[1] + protobuf_version_offset, NEW_VERSION_INFO[2])
   RewriteTextFile('src/Makefile.am',
     lambda line : re.sub(
       r'^PROTOBUF_VERSION = .*$',
-      'PROTOBUF_VERSION = %s' % protobuf_version_info,
+      'PROTOBUF_VERSION = %s' % ":".join(map(str,GetSharedObjectVersion())),
       line))
 
 
@@ -397,6 +406,7 @@ def UpdateBazel():
      line))
 
 
+UpdateCMake()
 UpdateConfigure()
 UpdateCsharp()
 UpdateCpp()


### PR DESCRIPTION
This updates the CMake support to additionally symlink the soversion value
to the generated shared library when so generated. This aligns the
generated soversion with that traditionally used by the Makefile build
workflow and provides cross-compatibility irrespective of build approach
used.

The primary version of the non-symlink library retains the actual
(non-SO) project version for clarity and compatibility with
installations built using prior versions of CMake support. An example of
the net resulting symlink structures is shown below, where the most
important aspect is that the symlink matching the embedded SONAME is
present (libprotobuf.so.30 in the example case).

Makefile:

    libprotobuf.so -> libprotobuf.so.30.0.0
    libprotobuf.so.30 -> libprotobuf.so.30.0.0
    libprotobuf.so.30.0.0

CMake:

    libprotobuf.so -> libprotobuf.so.30
    libprotobuf.so.30 -> libprotobuf.so.3.19.0.0
    libprotobuf.so.3.19.0.0

Fixes: #8635