### PR TITLE
Creates a protoc release zip

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,11 +2,13 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test", "objc_library", native_cc_proto_library = "cc_proto_library")
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
+load("@rules_pkg//:mappings.bzl", "pkg_files")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
 load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_lite_proto_library", "java_proto_library")
 load(":cc_proto_blacklist_test.bzl", "cc_proto_blacklist_test")
-
+load(":protobuf_release.bzl", "package_naming")
 licenses(["notice"])
 
 exports_files(["LICENSE"])
@@ -516,6 +518,69 @@ cc_binary(
     linkopts = LINK_OPTS,
     visibility = ["//visibility:public"],
     deps = [":protoc_lib"],
+)
+
+
+################################################################################
+# Generates protoc release artifacts.
+################################################################################
+
+genrule(
+    name = "protoc_readme",
+    visibility = ["//visibility:private"],
+    cmd = """
+echo "Protocol Buffers - Google's data interchange format
+Copyright 2008 Google Inc.
+https://developers.google.com/protocol-buffers/
+This package contains a precompiled binary version of the protocol buffer
+compiler (protoc). This binary is intended for users who want to use Protocol
+Buffers in languages other than C++ but do not want to compile protoc
+themselves. To install, simply place this binary somewhere in your PATH.
+If you intend to use the included well known types then don't forget to
+copy the contents of the 'include' directory somewhere as well, for example
+into '/usr/local/include/'.
+Please refer to our official github site for more installation instructions:
+  https://github.com/protocolbuffers/protobuf" > $@
+    """,
+    outs = ["readme.txt"],
+)
+
+pkg_files(
+    name = "wkt_protos_files",
+    srcs =  [value[0] for value in WELL_KNOWN_PROTO_MAP.values() if not value[0].endswith("plugin.proto")],
+    visibility = ["//visibility:private"],
+    prefix = "include/google/protobuf",
+)
+
+pkg_files(
+    name = "compiler_plugin_protos_files",
+    srcs =  ["src/google/protobuf/compiler/plugin.proto"],
+    visibility = ["//visibility:private"],
+    prefix = "include/google/protobuf/compiler",
+)
+
+pkg_files(
+    name = "protoc_files",
+    srcs =  [":protoc"],
+    visibility = ["//visibility:private"],
+    prefix = "bin/",
+)
+
+package_naming(
+    name = "protoc_pkg_naming",
+    product_name = "protoc",
+)
+
+pkg_zip(
+    name = "protoc_release",
+    package_file_name = "{product_name}-{version}-{cpu}.zip",
+    package_variables = ":protoc_pkg_naming",
+    srcs = [
+        ":protoc_files",
+        ":wkt_protos_files",
+        ":compiler_plugin_protos_files",
+        "readme.txt",
+    ],
 )
 
 ################################################################################

--- a/BUILD
+++ b/BUILD
@@ -545,6 +545,7 @@ Please refer to our official github site for more installation instructions:
     outs = ["readme.txt"],
 )
 
+# plugin.proto is excluded from this list because it belongs in a nested folder (protobuf/compiler/plugin.proto)
 pkg_files(
     name = "wkt_protos_files",
     srcs =  [value[0] for value in WELL_KNOWN_PROTO_MAP.values() if not value[0].endswith("plugin.proto")],
@@ -568,12 +569,11 @@ pkg_files(
 
 package_naming(
     name = "protoc_pkg_naming",
-    product_name = "protoc",
 )
 
 pkg_zip(
     name = "protoc_release",
-    package_file_name = "{product_name}-{version}-{cpu}.zip",
+    package_file_name = "protoc-{version}-{cpu}.zip",
     package_variables = ":protoc_pkg_naming",
     srcs = [
         ":protoc_files",

--- a/Makefile.am
+++ b/Makefile.am
@@ -1429,6 +1429,7 @@ EXTRA_DIST = $(@DIST_LANG@_EXTRA_DIST)              \
   maven_install.json                                \
   protobuf.bzl                                      \
   protobuf_deps.bzl                                 \
+  protobuf_release.bzl                              \
   protobuf_version.bzl                              \
   third_party/zlib.BUILD                            \
   util/python/BUILD                                 \

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,3 +56,6 @@ pinned_maven_install()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -73,3 +73,13 @@ def protobuf_deps():
             strip_prefix = "rules_jvm_external-4.1",
             urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/4.1.zip"],
         )
+    
+    if not native.existing_rule("rules_pkg"):
+        http_archive(
+            name = "rules_pkg",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
+                "https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
+            ],
+            sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
+        )

--- a/protobuf_release.bzl
+++ b/protobuf_release.bzl
@@ -8,7 +8,6 @@ load(":protobuf_version.bzl", "PROTOBUF_VERSION")
 
 def _package_naming_impl(ctx):
   values = {}
-  values["product_name"] = ctx.attr.product_name
   values["version"] = PROTOBUF_VERSION
 
   # infer from the current cpp toolchain.
@@ -21,12 +20,6 @@ def _package_naming_impl(ctx):
 package_naming = rule(
   implementation = _package_naming_impl,
     attrs = {
-      "product_name": attr.string(
-          doc = "Placeholder for our final product name.",
-      ),
-      "version": attr.string(
-          doc = "Placeholder for our release version.",
-      ),
       "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],

--- a/protobuf_release.bzl
+++ b/protobuf_release.bzl
@@ -13,7 +13,7 @@ def _package_naming_impl(ctx):
 
   # infer from the current cpp toolchain.
   toolchain = find_cpp_toolchain(ctx)
-  values["cpu"] = toolchain.cpu.replace("darwin", "osx")
+  values["cpu"] = toolchain.cpu
   
   return PackageVariablesInfo(values = values)
 

--- a/protobuf_release.bzl
+++ b/protobuf_release.bzl
@@ -1,0 +1,34 @@
+"""
+Generates package naming variables for use with rules_pkg.
+"""
+
+load("@rules_pkg//:providers.bzl", "PackageVariablesInfo")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load(":protobuf_version.bzl", "PROTOBUF_VERSION")
+
+def _package_naming_impl(ctx):
+  values = {}
+  values["product_name"] = ctx.attr.product_name
+  values["version"] = PROTOBUF_VERSION
+
+  # infer from the current cpp toolchain.
+  toolchain = find_cpp_toolchain(ctx)
+  values["cpu"] = toolchain.cpu.replace("darwin", "osx")
+  
+  return PackageVariablesInfo(values = values)
+
+
+package_naming = rule(
+  implementation = _package_naming_impl,
+    attrs = {
+      "product_name": attr.string(
+          doc = "Placeholder for our final product name.",
+      ),
+      "version": attr.string(
+          doc = "Placeholder for our release version.",
+      ),
+      "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+    },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
+)

--- a/protobuf_release.bzl
+++ b/protobuf_release.bzl
@@ -20,6 +20,7 @@ def _package_naming_impl(ctx):
 package_naming = rule(
   implementation = _package_naming_impl,
     attrs = {
+      # Necessary data dependency for find_cpp_toolchain.
       "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -4,7 +4,6 @@ load(
     "feature",
     "flag_group",
     "flag_set",
-    "tool",
     "tool_path",
 )
 


### PR DESCRIPTION
Mimics what we're doing manually today but powered by Bazel.

Example output:

```
bazel build //:protoc_release
...
 bazel-bin/protoc-3.19.1-osx_x86_64.zip
```