### PR TITLE
[C++] Fix Windows CRT false alarm memory leak report

### DIFF
--- a/src/google/protobuf/message_lite.cc
+++ b/src/google/protobuf/message_lite.cc
@@ -38,6 +38,9 @@
 #include <climits>
 #include <cstdint>
 #include <string>
+# ifdef _MSC_VER
+#  include <crtdbg.h>
+# endif  // _MSC_VER
 
 #include <google/protobuf/stubs/logging.h>
 #include <google/protobuf/stubs/common.h>
@@ -569,8 +572,6 @@ class MemoryIsNotDeallocated
 
  private:
   int old_crtdbg_flag_;
-
-  GTEST_DISALLOW_COPY_AND_ASSIGN_(MemoryIsNotDeallocated);
 };
 #endif  // _MSC_VER
 


### PR DESCRIPTION
We are hitting this issue when we use windows CRT to detect memory leak in our test application which is linked to ProtoBuf library. The windows CRT memory leak detector reports the "ShutdownData" object allocated in line 594 is a memory leak. We know this object is designed to be not released, however windows CRT will treat it as a memory leak since the object is never released. And there is no way to differentiate this false alarm from real memory leaks. We have also found similar issue in Google Test and committed patch there. Here we want to use the same way to patch protobuf source code to suppress the false alarm from CRT. Please kindly review and approve. Thanks!