### PR TITLE
[C++] Fix missing #ifdef for undefined identifiers

### DIFF
--- a/src/google/protobuf/inlined_string_field.h
+++ b/src/google/protobuf/inlined_string_field.h
@@ -347,7 +347,7 @@ inline void InlinedStringField::Swap(
     InlinedStringField* from, const std::string* /*default_value*/,
     Arena* arena, bool donated, bool from_donated, uint32_t* donating_states,
     uint32_t* from_donating_states, uint32_t mask) {
-#if GOOGLE_PROTOBUF_INTERNAL_DONATE_STEAL_INLINE
+#ifdef GOOGLE_PROTOBUF_INTERNAL_DONATE_STEAL_INLINE
   // If one is donated and the other is not, undonate the donated one.
   if (donated && !from_donated) {
     MutableSlow(arena, donated, donating_states, mask);

--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -617,7 +617,7 @@
 #ifdef PROTOBUF_PRAGMA_INIT_SEG
 #error PROTOBUF_PRAGMA_INIT_SEG was previously defined
 #endif
-#if _MSC_VER
+#ifdef _MSC_VER
 #define PROTOBUF_PRAGMA_INIT_SEG __pragma(init_seg(lib))
 #else
 #define PROTOBUF_PRAGMA_INIT_SEG
@@ -784,7 +784,7 @@
 #endif
 
 // Silence some MSVC warnings in all our code.
-#if _MSC_VER
+#ifdef _MSC_VER
 #pragma warning(push)
 // For non-trivial unions
 #pragma warning(disable : 4582)

--- a/src/google/protobuf/port_undef.inc
+++ b/src/google/protobuf/port_undef.inc
@@ -140,6 +140,6 @@
 #endif
 
 // Pop the warning(push) from port_def.inc
-#if _MSC_VER
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif


### PR DESCRIPTION
When compiling under LLVM/Clang 11.0 this will error out with "not defined, evaluates to 0" error. 

This can be worked around with `CGO_CFLAGS=-Wno-undef-prefix`, however for consistency with the rest of the identifiers it would be nice to have this fix. 


Also fixes https://github.com/protocolbuffers/protobuf/issues/8538 

