### PR TITLE
Pin multibuild scripts to get manylinux1 wheels back

### DIFF
--- a/kokoro/release/python/linux/build_artifacts.sh
+++ b/kokoro/release/python/linux/build_artifacts.sh
@@ -54,17 +54,20 @@ build_artifact_version() {
   sudo rm -rf $REPO_DIR
 }
 
-build_x86_64_artifact_version() {
+build_x86_64_manylinux1_artifact_version() {
   # Explicitly request building manylinux1 wheels, which is no longer the default.
   # https://github.com/protocolbuffers/protobuf/issues/9180
   MB_ML_VER=1
-
-  # TODO(jtatermusch): currently when crosscompiling, "auditwheel repair" will be disabled
-  # since auditwheel doesn't work for crosscomiled wheels.
   build_artifact_version $@
 }
 
-build_crosscompiled_aarch64_artifact_version() {
+build_x86_64_manylinux2010_artifact_version() {
+  # Explicitly request building manylinux2010 wheels
+  MB_ML_VER=2010
+  build_artifact_version $@
+}
+
+build_crosscompiled_aarch64_manylinux2014_artifact_version() {
   # crosscompilation is only supported with the dockcross manylinux2014 image
   DOCKER_IMAGE=dockcross/manylinux2014-aarch64:20210706-65bf2dd
   MB_ML_VER=2014
@@ -75,13 +78,13 @@ build_crosscompiled_aarch64_artifact_version() {
   build_artifact_version $@
 }
 
-build_x86_64_artifact_version 3.6
-build_x86_64_artifact_version 3.7
-build_x86_64_artifact_version 3.8
-build_x86_64_artifact_version 3.9
-build_x86_64_artifact_version 3.10
+build_x86_64_manylinux1_artifact_version 3.6
+build_x86_64_manylinux1_artifact_version 3.7
+build_x86_64_manylinux1_artifact_version 3.8
+build_x86_64_manylinux1_artifact_version 3.9
+build_x86_64_manylinux2010_artifact_version 3.10
 
-build_crosscompiled_aarch64_artifact_version 3.7
-build_crosscompiled_aarch64_artifact_version 3.8
-build_crosscompiled_aarch64_artifact_version 3.9
-build_crosscompiled_aarch64_artifact_version 3.10
+build_crosscompiled_aarch64_manylinux2014_artifact_version 3.7
+build_crosscompiled_aarch64_manylinux2014_artifact_version 3.8
+build_crosscompiled_aarch64_manylinux2014_artifact_version 3.9
+build_crosscompiled_aarch64_manylinux2014_artifact_version 3.10

--- a/kokoro/release/python/linux/build_artifacts.sh
+++ b/kokoro/release/python/linux/build_artifacts.sh
@@ -25,7 +25,13 @@ rm -rf multibuild/
 mkdir artifacts
 export ARTIFACT_DIR=$(pwd)/artifacts
 
+# Pin multibuild script to a version just before the default
+# manylinux image has switched from manylinux1 to manylinux2014.
+# Also, pinning version avoid potentially unwanted future changes from
+# silently creeping in.
+# See https://github.com/protocolbuffers/protobuf/issues/9180
 git clone https://github.com/matthew-brett/multibuild.git
+(cd multibuild; git checkout 13a01725b0f0aa551ab34aa2311cdc1c77be4337)
 cp kokoro/release/python/linux/config.sh config.sh
 
 build_artifact_version() {

--- a/kokoro/release/python/macos/build_artifacts.sh
+++ b/kokoro/release/python/macos/build_artifacts.sh
@@ -25,7 +25,14 @@ rm -rf multibuild/
 mkdir artifacts
 export ARTIFACT_DIR=$(pwd)/artifacts
 
-git clone https://github.com/matthew-brett/multibuild.git
+git clone https://github.com/matthew-brett/
+# Pin multibuild scripts at a known commit to avoid potentially unwanted future changes from
+# silently creeping in (see https://github.com/protocolbuffers/protobuf/issues/9180).
+# IMPORTANT: always pin multibuild at the same commit for:
+# - linux/build_artifacts.sh
+# - linux/build_artifacts.sh
+# - windows/build_artifacts.bat
+(cd multibuild; git checkout b89bb903e94308be79abefa4f436bf123ebb1313)
 cp kokoro/release/python/macos/config.sh config.sh
 
 OLD_PATH=$PATH

--- a/kokoro/release/python/macos/build_artifacts.sh
+++ b/kokoro/release/python/macos/build_artifacts.sh
@@ -25,7 +25,7 @@ rm -rf multibuild/
 mkdir artifacts
 export ARTIFACT_DIR=$(pwd)/artifacts
 
-git clone https://github.com/matthew-brett/
+git clone https://github.com/matthew-brett/multibuild.git
 # Pin multibuild scripts at a known commit to avoid potentially unwanted future changes from
 # silently creeping in (see https://github.com/protocolbuffers/protobuf/issues/9180).
 # IMPORTANT: always pin multibuild at the same commit for:

--- a/kokoro/release/python/windows/build_artifacts.bat
+++ b/kokoro/release/python/windows/build_artifacts.bat
@@ -14,6 +14,15 @@ set OLD_PATH=C:\Program Files (x86)\MSBuild\14.0\bin\;%PATH%
 
 REM Fetch multibuild
 git clone https://github.com/matthew-brett/multibuild.git
+REM Pin multibuild scripts at a known commit to avoid potentially unwanted future changes from
+REM silently creeping in (see https://github.com/protocolbuffers/protobuf/issues/9180).
+REM IMPORTANT: always pin multibuild at the same commit for:
+REM - linux/build_artifacts.sh
+REM - linux/build_artifacts.sh
+REM - windows/build_artifacts.bat
+cd multibuild
+git checkout b89bb903e94308be79abefa4f436bf123ebb1313
+cd ..
 
 REM Install zlib
 mkdir zlib


### PR DESCRIPTION
Hotfix for https://github.com/protocolbuffers/protobuf/issues/9180.

See https://github.com/protocolbuffers/protobuf/issues/9180#issuecomment-966946662 for more context.