### PR TITLE
Support no_package:FILE in the expected prefixes file.

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
@@ -110,6 +110,9 @@ bool ObjectiveCGenerator::GenerateAll(
       //   - Comments start with "#".
       //   - A comment can go on a line after a expected package/prefix pair.
       //     (i.e. - "package=prefix # comment")
+      //   - For files that do NOT have a proto package (not recommended), an
+      //     entry can be made as "no_package:PATH=prefix", where PATH is the
+      //     path for the .proto file.
       //
       // There is no validation that the prefixes are good prefixes, it is
       // assumed that they are when you create the file.

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -352,9 +352,9 @@ bool IsReservedCIdentifier(const std::string& input) {
 }
 
 std::string SanitizeNameForObjC(const std::string& prefix,
-                           const std::string& input,
-                           const std::string& extension,
-                           std::string* out_suffix_added) {
+                                const std::string& input,
+                                const std::string& extension,
+                                std::string* out_suffix_added) {
   static const std::unordered_set<std::string> kReservedWords =
       MakeWordsMap(kReservedWordList, GOOGLE_ARRAYSIZE(kReservedWordList));
   static const std::unordered_set<std::string> kNSObjectMethods =
@@ -1240,6 +1240,11 @@ bool ValidateObjCClassPrefix(
 
   const std::string prefix = file->options().objc_class_prefix();
   const std::string package = file->package();
+  // For files without packages, the can be registered as "no_package:PATH",
+  // allowing the expected prefixes file.
+  static const std::string no_package_prefix("no_package:");
+  const std::string lookup_key =
+      package.empty() ? no_package_prefix + file->name() : package;
 
   // NOTE: src/google/protobuf/compiler/plugin.cc makes use of cerr for some
   // error cases, so it seems to be ok to use as a back door for warnings.
@@ -1247,7 +1252,7 @@ bool ValidateObjCClassPrefix(
   // Check: Error - See if there was an expected prefix for the package and
   // report if it doesn't match (wrong or missing).
   std::map<std::string, std::string>::const_iterator package_match =
-      expected_package_prefixes.find(package);
+      expected_package_prefixes.find(lookup_key);
   if (package_match != expected_package_prefixes.end()) {
     // There was an entry, and...
     if (has_prefix && package_match->second == prefix) {
@@ -1256,8 +1261,11 @@ bool ValidateObjCClassPrefix(
     } else {
       // ...it didn't match!
       *out_error = "error: Expected 'option objc_class_prefix = \"" +
-                   package_match->second + "\";' for package '" + package +
-                   "' in '" + file->name() + "'";
+                   package_match->second + "\";'";
+      if (!package.empty()) {
+        *out_error += " for package '" + package + "'";
+      }
+      *out_error += " in '" + file->name() + "'";
       if (has_prefix) {
         *out_error += "; but found '" + prefix + "' instead";
       }
@@ -1286,35 +1294,12 @@ bool ValidateObjCClassPrefix(
          i != expected_package_prefixes.end(); ++i) {
       if (i->second == prefix) {
         other_package_for_prefix = i->first;
-        break;
+        // Stop on the first real package listing, if it was a no_package file
+        // specific entry, keep looking to try and find a package one.
+        if (!HasPrefixString(other_package_for_prefix, no_package_prefix)) {
+          break;
+        }
       }
-    }
-
-    // Check: Warning - If the file does not have a package, check whether the
-    // prefix was declared is being used by another package or not. This is
-    // a special case for empty packages.
-    if (package.empty()) {
-      // The file does not have a package and ...
-      if (other_package_for_prefix.empty()) {
-        // ... no other package has declared that prefix.
-        std::cerr
-             << "protoc:0: warning: File '" << file->name() << "' has no "
-             << "package. Consider adding a new package to the proto and adding '"
-             << "new.package = " << prefix << "' to the expected prefixes file ("
-             << expected_prefixes_path << ")." << std::endl;
-        std::cerr.flush();
-      } else {
-        // ... another package has declared the same prefix.
-        std::cerr
-             << "protoc:0: warning: File '" << file->name() << "' has no package "
-             << "and package '" << other_package_for_prefix << "' already uses '"
-             << prefix << "' as its prefix. Consider either adding a new package "
-             << "to the proto, or reusing one of the packages already using this "
-             << "prefix in the expected prefixes file ("
-             << expected_prefixes_path << ")." << std::endl;
-        std::cerr.flush();
-      }
-      return true;
     }
 
     // Check: Error - Make sure the prefix wasn't expected for a different
@@ -1323,14 +1308,20 @@ bool ValidateObjCClassPrefix(
     if (!other_package_for_prefix.empty()) {
       *out_error =
           "error: Found 'option objc_class_prefix = \"" + prefix +
-          "\";' in '" + file->name() +
-          "'; that prefix is already used for 'package " +
-          other_package_for_prefix + ";'. It can only be reused by listing " +
-          "it in the expected file (" +
-          expected_prefixes_path + ").";
+          "\";' in '" + file->name() + "'; that prefix is already used for ";
+      if (HasPrefixString(other_package_for_prefix, no_package_prefix)) {
+        *out_error += "file '" +
+          StripPrefixString(other_package_for_prefix, no_package_prefix) +
+          "'.";
+      } else {
+        *out_error += "'package " + other_package_for_prefix + ";'.";
+      }
+      *out_error +=
+        "It can only be reused by adding '" + lookup_key + " = " + prefix +
+        "' to the expected prefixes file (" + expected_prefixes_path + ").";
       return false;  // Only report first usage of the prefix.
     }
-  } // !prefix.empty()
+  } // !prefix.empty() && have_expected_prefix_file
 
   // Check: Warning - Make sure the prefix is is a reasonable value according
   // to Apple's rules (the checks above implicitly whitelist anything that
@@ -1359,17 +1350,18 @@ bool ValidateObjCClassPrefix(
     if (prefixes_must_be_registered) {
       *out_error =
         "error: '" + file->name() + "' has 'option objc_class_prefix = \"" +
-        prefix + "\";', but it is not registered; add it to the expected " +
-        "prefixes file (" + expected_prefixes_path + ") for the package '" +
-        package + "'.";
+        prefix + "\";', but it is not registered. Add '" + lookup_key + " = " +
+        (prefix.empty() ? "\"\"" : prefix) +
+        "' to the expected prefixes file (" + expected_prefixes_path + ").";
       return false;
     }
 
     std::cerr
          << "protoc:0: warning: Found unexpected 'option objc_class_prefix = \""
-         << prefix << "\";' in '" << file->name() << "';"
-         << " consider adding it to the expected prefixes file ("
-         << expected_prefixes_path << ")." << std::endl;
+         << prefix << "\";' in '" << file->name() << "'; consider adding '"
+         << lookup_key << " = " << (prefix.empty() ? "\"\"" : prefix)
+         << "' to the expected prefixes file (" << expected_prefixes_path
+         << ")." << std::endl;
     std::cerr.flush();
   }
 


### PR DESCRIPTION
When a file doesn't have a proto package, allow validation to still be supported
via entries with that consist of 'no_package:FILE'. This allows someone using an
expected prefixes file to also list these exceptional cases, and allows them to
becomes error cases with requiring all prefixes to be registered.