### PR TITLE
Change sysroot flags

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -113,7 +113,7 @@ cc_toolchain_config(
         "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include"
     ],
     linker_path = "/usr/tools",
-    sysroot = "/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include",
+    sysroot = "/usr/tools/apple_sdks/xcode_13_0/macosx",
     target_cpu = "aarch64",
     target_full_name = "aarch64-apple-macosx11.3",
     toolchain_dir = "/usr/tools/apple_sdks/xcode_13_0/macosx",
@@ -129,7 +129,7 @@ cc_toolchain_config(
         "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include"
     ],
     linker_path = "/usr/tools",
-    sysroot = "/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include",
+    sysroot = "/usr/tools/apple_sdks/xcode_13_0/macosx",
     target_cpu = "x86_64",
     target_full_name = "x86_64-apple-macosx11.3",
     toolchain_dir = "/usr/tools/apple_sdks/xcode_13_0/macosx",

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -109,16 +109,6 @@ def _impl(ctx):
                   ),
               ],
           ),
-          flag_set(
-              actions = all_compile_actions,
-              flag_groups = [
-                  flag_group(
-                      flags = [
-                          "-isysroot" + ctx.attr.sysroot,
-                      ],
-                  ),
-              ],
-         ),
       ],
   )
 


### PR DESCRIPTION
Take away the sysroot flag for the compiler as it isn't necessary, but ensure the sysroot flag is at the top level directory for linker flag.