### PR TITLE
[C#] added new csharp options for protoc

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_generator.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_generator.cc
@@ -80,11 +80,21 @@ bool Generator::Generate(const FileDescriptor* file,
       cli_options.internal_access = true;
     } else if (options[i].first == "serializable") {
       cli_options.serializable = true;
+    } else if (options[i].first == "custom_base_class") {
+      cli_options.custom_base_class = options[i].second;
+    } else if (options[i].first == "keep_original_file_name") {
+      cli_options.keep_original_file_name = true;
+    } else if (options[i].first == "keep_original_field_name") {
+      cli_options.keep_original_field_name = true;
+    } else if (options[i].first == "disable_nested_types_container") {
+      cli_options.disable_nested_types_container = true;
     } else {
       *error = "Unknown generator option: " + options[i].first;
       return false;
     }
   }
+
+  HelperSetGeneratorOptions(&cli_options);
 
   std::string filename_error = "";
   std::string filename = GetOutputFile(file,

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.h
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.h
@@ -53,6 +53,8 @@ namespace csharp {
 struct Options;
 class FieldGeneratorBase;
 
+void HelperSetGeneratorOptions(const Options*);
+
 // TODO: start using this enum.
 enum CSharpType {
   CSHARPTYPE_INT32 = 1,

--- a/src/google/protobuf/compiler/csharp/csharp_message.h
+++ b/src/google/protobuf/compiler/csharp/csharp_message.h
@@ -78,6 +78,7 @@ class MessageGenerator : public SourceGeneratorBase {
 
   void AddDeprecatedFlag(io::Printer* printer);
   void AddSerializableAttribute(io::Printer* printer);
+  void AddCustomBaseClass(io::Printer* printer);
 
   std::string class_name();
   std::string full_class_name();

--- a/src/google/protobuf/compiler/csharp/csharp_options.h
+++ b/src/google/protobuf/compiler/csharp/csharp_options.h
@@ -45,7 +45,11 @@ struct Options {
       base_namespace(""),
       base_namespace_specified(false),
       internal_access(false),
-      serializable(false) {
+      serializable(false),
+      custom_base_class(""),
+      keep_original_file_name(false), 
+      keep_original_field_name(false), 
+      disable_nested_types_container(false) {
   }
   // Extension of the generated file. Defaults to ".cs"
   std::string file_extension;
@@ -71,6 +75,22 @@ struct Options {
   // Whether the generated classes should have a global::System.Serializable attribute added
   // Defaults to false
   bool serializable;
+  // Custom base class to use for generated classes. Defaults to "".
+  // If specified, the base class must be a public class in the current namespace.
+  // There is a special support for generic classes, which can be specified by "MyBaseClass<>",
+  // "<>" is a placeholder, which will be replaced by the current message class name.
+  // For example, for a message named "MyMessage", if "MyBaseClass<>" is specified, 
+  // the base class will be "MyBaseClass<MyMessage>".
+  std::string custom_base_class;
+  // Whether to keep the original file name. Defaults to false.
+  // If true, the CamelCase name transformation is skipped, and the original file name of proto file is preserved
+  bool keep_original_file_name;
+  // Whether to keep the original field name. Defaults to false.
+  // If true, the CamelCase name transformation is skipped, and the original field name defined in proto file is preserved
+  bool keep_original_field_name;
+  // Whether to generate a nested `Types` container class for sub messages.
+  // If true, the nested `Types` container class will not be generated. Be ware, name collision may occurs.
+  bool disable_nested_types_container;
 };
 
 }  // namespace csharp


### PR DESCRIPTION
## `custom_base_class`
Custom base class to use for generated classes. Defaults to `""`.

If specified, the base class must be a public class in the current namespace.

There is a special support for generic classes, which can be specified by `"MyBaseClass<>"`, `"<>"` is a placeholder, which will be replaced by the current message class name.

For example, for a message named `"MyMessage"`, if `"MyBaseClass<>"` is specified, the base class will be `"MyBaseClass<MyMessage>"`.

## `keep_original_file_name`
Whether to keep the original file name. Defaults to `false`.
If `true`, the CamelCase name transformation is skiped, and the original file name of proto file is preserved

## `keep_original_field_name`
Whether to keep the original field name. Defaults to `false`.
If `true`, the CamelCase name transformation is skiped, and the original field name defined in proto file is preserved

## `disable_nested_types_container`
Whether to generate a nested `Types` container class for sub messages.
If true, the nested `Types` container class will not be generated. Be ware, name collision may occurs.
