### PR TITLE
Allow multiple input files for --dependency_out

### DIFF
--- a/src/google/protobuf/compiler/code_generator.cc
+++ b/src/google/protobuf/compiler/code_generator.cc
@@ -55,6 +55,7 @@ bool CodeGenerator::GenerateAll(const std::vector<const FileDescriptor*>& files,
   bool succeeded = true;
   for (int i = 0; i < files.size(); i++) {
     const FileDescriptor* file = files[i];
+    generator_context->SetCurrentFile(file);
     succeeded = Generate(file, parameter, generator_context, error);
     if (!succeeded && error && error->empty()) {
       *error =
@@ -101,6 +102,10 @@ void GeneratorContext::GetCompilerVersion(Version* version) const {
   version->set_minor(GOOGLE_PROTOBUF_VERSION / 1000 % 1000);
   version->set_patch(GOOGLE_PROTOBUF_VERSION % 1000);
   version->set_suffix(GOOGLE_PROTOBUF_VERSION_SUFFIX);
+}
+
+void GeneratorContext::SetCurrentFile(const FileDescriptor *file) {
+  current_file_ = file;
 }
 
 // Parses a set of comma-delimited name/value pairs.

--- a/src/google/protobuf/compiler/code_generator.h
+++ b/src/google/protobuf/compiler/code_generator.h
@@ -176,6 +176,11 @@ class PROTOC_EXPORT GeneratorContext {
   // this GeneratorContext.
   virtual void GetCompilerVersion(Version* version) const;
 
+  virtual void SetCurrentFile(const FileDescriptor *file);
+
+protected:
+  // The current file that code is being generated for
+  const FileDescriptor* current_file_ = nullptr;
 
  private:
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(GeneratorContext);


### PR DESCRIPTION
Adds functionality that tracks the output files generated for a given descriptor, then uses that information to write a manifest file containing all dependency information. In contrast to the previous implementation, each target in the manifest does not contain a full list of transitive dependencies. Transitivity should be resolved by the build tool parsing the manifest.

Related to #3959
