### PR TITLE
[cleanup] Msvc warnings

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -28,7 +28,6 @@ ZLIB_DEPS = ["@zlib//:zlib"]
 ################################################################################
 
 MSVC_COPTS = [
-    "/wd4018",  # -Wno-sign-compare
     "/wd4065",  # switch statement contains 'default' but no 'case' labels
     "/wd4146",  # unary minus operator applied to unsigned type, result still unsigned
     "/wd4244",  # 'conversion' conversion from 'type1' to 'type2', possible loss of data

--- a/BUILD
+++ b/BUILD
@@ -29,7 +29,6 @@ ZLIB_DEPS = ["@zlib//:zlib"]
 
 MSVC_COPTS = [
     "/wd4065",  # switch statement contains 'default' but no 'case' labels
-    "/wd4146",  # unary minus operator applied to unsigned type, result still unsigned
     "/wd4244",  # 'conversion' conversion from 'type1' to 'type2', possible loss of data
     "/wd4251",  # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
     "/wd4267",  # 'var' : conversion from 'size_t' to 'type', possible loss of data

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -211,7 +211,6 @@ if (MSVC)
   # MSVC warning suppressions
   add_definitions(
     /wd4065 # switch statement contains 'default' but no 'case' labels
-    /wd4146 # unary minus operator applied to unsigned type, result still unsigned
     /wd4244 # 'conversion' conversion from 'type1' to 'type2', possible loss of data
     /wd4251 # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
     /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -210,7 +210,6 @@ if (MSVC)
   add_definitions(/utf-8)
   # MSVC warning suppressions
   add_definitions(
-    /wd4018 # 'expression' : signed/unsigned mismatch
     /wd4065 # switch statement contains 'default' but no 'case' labels
     /wd4146 # unary minus operator applied to unsigned type, result still unsigned
     /wd4244 # 'conversion' conversion from 'type1' to 'type2', possible loss of data

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -320,8 +320,6 @@ The following warnings have been disabled while building the protobuf libraries
 and compiler.  You may have to disable some of them in your own project as
 well, or live with them.
 
-* C4018 - 'expression' : signed/unsigned mismatch
-* C4146 - unary minus operator applied to unsigned type, result still unsigned
 * C4244 - Conversion from 'type1' to 'type2', possible loss of data.
 * C4251 - 'identifier' : class 'type' needs to have dll-interface to be used by
   clients of class 'type2'

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -222,6 +222,11 @@ if(MINGW)
 endif()
 
 add_executable(tests ${tests_files} ${common_test_files} ${tests_proto_files} ${lite_test_proto_files})
+if (MSVC)
+  target_compile_options(tests PRIVATE
+    /wd4146 # unary minus operator applied to unsigned type, result still unsigned
+  )
+endif()
 target_link_libraries(tests libprotoc libprotobuf gmock_main)
 
 set(test_plugin_files

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -1007,7 +1007,7 @@ class TableArena {
     }
 
     for (int i = kSmallSizes.size(); --i >= 0;) {
-      if (to_relocate->space_left() >= 1 + kSmallSizes[i]) {
+      if (to_relocate->space_left() >= 1U + kSmallSizes[i]) {
         to_relocate->PrependTo(small_size_blocks_[i]);
         return;
       }

--- a/src/google/protobuf/io/io_win32_unittest.cc
+++ b/src/google/protobuf/io/io_win32_unittest.cc
@@ -164,8 +164,8 @@ void IoWin32Test::SetUp() {
   test_tmpdir.clear();
   wtest_tmpdir.clear();
   DWORD size = ::GetCurrentDirectoryW(MAX_PATH, working_directory);
-  EXPECT_GT(size, 0);
-  EXPECT_LT(size, MAX_PATH);
+  EXPECT_GT(size, 0U);
+  EXPECT_LT(size, static_cast<DWORD>(MAX_PATH));
 
   string tmp;
   bool ok = false;
@@ -581,7 +581,7 @@ TEST_F(IoWin32Test, ExpandWildcardsFailsIfNoFileMatchesTest) {
 TEST_F(IoWin32Test, AsWindowsPathTest) {
   DWORD size = GetCurrentDirectoryW(0, nullptr);
   std::unique_ptr<wchar_t[]> cwd_str(new wchar_t[size]);
-  EXPECT_GT(GetCurrentDirectoryW(size, cwd_str.get()), 0);
+  EXPECT_GT(GetCurrentDirectoryW(size, cwd_str.get()), 0U);
   wstring cwd = wstring(L"\\\\?\\") + cwd_str.get();
 
   ASSERT_EQ(testonly_utf8_to_winpath("relative_mkdirtest"),

--- a/src/google/protobuf/stubs/int128.cc
+++ b/src/google/protobuf/stubs/int128.cc
@@ -173,12 +173,13 @@ std::ostream& operator<<(std::ostream& o, const uint128& b) {
 
   // Add the requisite padding.
   std::streamsize width = o.width(0);
-  if (width > rep.size()) {
+  auto repSize = static_cast<std::streamsize>(rep.size());
+  if (width > repSize) {
     if ((flags & std::ios::adjustfield) == std::ios::left) {
-      rep.append(width - rep.size(), o.fill());
+      rep.append(width - repSize, o.fill());
     } else {
       rep.insert(static_cast<std::string::size_type>(0),
-                 width - rep.size(), o.fill());
+                 width - repSize, o.fill());
     }
   }
 


### PR DESCRIPTION
Removes the need for disabling two warnings. Context: Our org considers it best practice to always enable
 4018;4146;4244;4267;4996. The last 3 relate to type conversions and deprecation - they'll require some more effort to root out.

First, by fixing the offending code for
/wd4018 # 'expression' : signed/unsigned mismatch

And second by moving this warning down to the place it is needed (tests)
/wd4146 # unary minus operator applied to unsigned type, result still unsigned