### PR TITLE
No error throwing for unknown OS

### DIFF
--- a/protobuf_release.bzl
+++ b/protobuf_release.bzl
@@ -32,7 +32,7 @@ def _package_naming_impl(ctx):
     else:
       values["platform"] = "win32"
   else:
-    fail("Unrecognized platform")
+    values["platform"] = "unknown"
 
   return PackageVariablesInfo(values = values)
 


### PR DESCRIPTION
Remove error throwing if we can't tell what OS we are trying to run for and just name the artifact something with "unknown". This is mainly to fix the case without a --config where the cpu defaults to local and the script can't tell what OS we are using. 