### PR TITLE
Small tweaks to C# unit tests

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_bootstrap_unittest.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_bootstrap_unittest.cc
@@ -110,7 +110,8 @@ class MockGeneratorContext : public GeneratorContext {
 class GenerateAndTest {
  public:
   GenerateAndTest() {}
-  void Run(const FileDescriptor* proto_file, std::string file1, std::string file2) {
+  void Run(const FileDescriptor* proto_file, std::string file1,
+           std::string file2) {
     ASSERT_TRUE(proto_file != NULL) << TestSourceDir();
     ASSERT_TRUE(generator_.Generate(proto_file, parameter_,
                                     &context_, &error_));

--- a/src/google/protobuf/compiler/csharp/csharp_generator_unittest.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_generator_unittest.cc
@@ -65,12 +65,12 @@ TEST(CSharpEnumValue, PascalCasedPrefixStripping) {
 
 TEST(DescriptorProtoHelpers, IsDescriptorProto) {
   EXPECT_TRUE(IsDescriptorProto(DescriptorProto::descriptor()->file()));
-  EXPECT_FALSE(IsDescriptorProto(Any::descriptor()->file()));
+  EXPECT_FALSE(IsDescriptorProto(google::protobuf::Any::descriptor()->file()));
 }
 
 TEST(DescriptorProtoHelpers, IsDescriptorOptionMessage) {
   EXPECT_TRUE(IsDescriptorOptionMessage(FileOptions::descriptor()));
-  EXPECT_FALSE(IsDescriptorOptionMessage(Any::descriptor()));
+  EXPECT_FALSE(IsDescriptorOptionMessage(google::protobuf::Any::descriptor()));
   EXPECT_FALSE(IsDescriptorOptionMessage(DescriptorProto::descriptor()));
 }
 


### PR DESCRIPTION
This change includes just a couple small tweaks:
- Keep line lengths under 80 characters
- Fully qualify google::protobuf::Any so that the code still compiles
  internally where we use a different namespace.