### PR TITLE
Fix broken max macro on Windows

### DIFF
--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -37,9 +37,6 @@
 #include <limits>
 #include <type_traits>
 #include <utility>
-#ifdef max
-#undef max  // Visual Studio defines this macro
-#endif
 #if defined(_MSC_VER) && !defined(_LIBCPP_STD_VER) && !_HAS_EXCEPTIONS
 // Work around bugs in MSVC <typeinfo> header when _HAS_EXCEPTIONS=0.
 #include <exception>

--- a/src/google/protobuf/stubs/stl_util.h
+++ b/src/google/protobuf/stubs/stl_util.h
@@ -37,6 +37,8 @@
 
 #include <algorithm>
 
+#include <google/protobuf/port_def.inc>
+
 namespace google {
 namespace protobuf {
 
@@ -81,5 +83,7 @@ inline char* string_as_array(std::string* str) {
 
 }  // namespace protobuf
 }  // namespace google
+
+#include <google/protobuf/port_undef.inc>
 
 #endif  // GOOGLE_PROTOBUF_STUBS_STL_UTIL_H__


### PR DESCRIPTION
Hi there,

I found that if I include the auto generated XX.pb.h in my code then the "max" macro defined by Windows will be broken.

And this is caused by a direct undef in `src/google/protobuf/arena.h`
```cpp
#ifdef max
#undef max  // Visual Studio defines this macro
#endif
```

I think this should be done by using `port_def.inc` and `port_undef.inc` pairs so I removed this undef and add a protect on `src/google/protobuf/stubs/stl_util.h`.

Thank you