### PR TITLE
Fixing windows builds

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -43,7 +43,7 @@ cc_toolchain_config(
     name = "linux-aarch_64-config",
     bit_flag = "-m64",
     cpp_flag = "-lstdc++",
-    include_flag = [
+    extra_compiler_flags = [
         "-I/usr/aarch64-linux-gnu/include/c++/8/aarch64-linux-gnu/",
         "-I/usr/aarch64-linux-gnu/include/c++/8"
     ],
@@ -58,7 +58,7 @@ cc_toolchain_config(
     name = "linux-ppcle_64-config",
     bit_flag = "-m64",
     cpp_flag = "-lstdc++",
-    include_flag = [
+    extra_compiler_flags = [
         "-I/usr/powerpc64le-linux-gnu/include/c++/8/powerpc64le-linux-gnu/",
         "-I/usr/powerpc64le-linux-gnu/include/c++/8/"
     ],
@@ -73,7 +73,7 @@ cc_toolchain_config(
     name = "linux-s390_64-config",
     bit_flag = "-m64",
     cpp_flag = "-lstdc++",
-    include_flag = [
+    extra_compiler_flags = [
         "-I/usr/s390x-linux-gnu/include/c++/8/s390x-linux-gnu/",
         "-I/usr/s390x-linux-gnu/include/c++/8/"
     ],
@@ -110,7 +110,7 @@ cc_toolchain_config(
     name = "osx-aarch_64-config",
     bit_flag = "-m64",
     cpp_flag = "-lc++",
-    include_flag = [
+    extra_compiler_flags = [
         "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include/c++/v1",
         "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include"
     ],
@@ -126,7 +126,7 @@ cc_toolchain_config(
     name = "osx-x86_64-config",
     bit_flag = "-m64",
     cpp_flag = "-lc++",
-    include_flag = [
+    extra_compiler_flags = [
         "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include/c++/v1",
         "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include"
     ],
@@ -142,12 +142,16 @@ cc_toolchain_config(
     name = "win32-config",
     bit_flag = "-m32",
     cpp_flag = "-lstdc++",
-    extra_include = "/usr/lib/gcc/i686-w64-mingw32/10-posix/include",
-    extra_linker_flag = "-L/usr/lib/gcc/i686-w64-mingw32/10-posix",
-    include_flag = [
-        "-I/usr/lib/gcc/i686-w64-mingw32/10-posix/include/c++",
-        "-I/usr/lib/gcc/i686-w64-mingw32/10-posix/include/c++/i686-w64-mingw32",
-        "-I/usr/i686-w64-mingw32/include"
+    extra_compiler_flags = [
+        "-I/usr/lib/gcc/i686-w64-mingw32/8.3-posix/include/c++",
+        "-I/usr/lib/gcc/i686-w64-mingw32/8.3-posix/include/c++/i686-w64-mingw32",
+        "-I/usr/i686-w64-mingw32/include",
+        "-fsjlj-exceptions",
+    ],
+    extra_include = "/usr/lib/gcc/i686-w64-mingw32/8.3-posix/include",
+    extra_linker_flags = [
+        "-L/usr/lib/gcc/i686-w64-mingw32/8.3-posix",
+        "-pthread",
     ],
     linker_path = "/usr/bin/ld",
     target_cpu = "x86_32",
@@ -160,12 +164,14 @@ cc_toolchain_config(
     name = "win64-config",
     bit_flag = "-m64",
     cpp_flag = "-lstdc++",
-    extra_include = "/usr/lib/gcc/x86_64-w64-mingw32/10-posix/include",
-    extra_linker_flag = "-L/usr/lib/gcc/x86_64-w64-mingw32/10-posix",
-    include_flag = [
-        "-I/usr/lib/gcc/x86_64-w64-mingw32/10-posix/include/c++/",
-        "-I/usr/lib/gcc/x86_64-w64-mingw32/10-posix/include/c++/x86_64-w64-mingw32",
+    extra_compiler_flags = [
+        "-I/usr/lib/gcc/x86_64-w64-mingw32/8.3-posix/include/c++/",
+        "-I/usr/lib/gcc/x86_64-w64-mingw32/8.3-posix/include/c++/x86_64-w64-mingw32",
         "-I/usr/x86_64-w64-mingw32/include"
+    ],
+    extra_include = "/usr/lib/gcc/x86_64-w64-mingw32/8.3-posix/include",
+    extra_linker_flags = [
+        "-L/usr/lib/gcc/x86_64-w64-mingw32/8.3-posix",
     ],
     linker_path = "/usr/bin/ld",
     target_cpu = "x86_64",

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -1,6 +1,7 @@
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load(
     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "artifact_name_pattern",
     "feature",
     "flag_group",
     "flag_set",
@@ -27,6 +28,14 @@ all_compile_actions = [
 ]
 
 def _impl(ctx):
+  artifact_name_patterns = [
+      artifact_name_pattern(
+          category_name = "executable",
+          prefix = "",
+          extension = ".exe",
+      ),
+  ]
+
   tool_paths = [
       tool_path(
           name = "gcc",
@@ -86,8 +95,7 @@ def _impl(ctx):
                           "-B" + ctx.attr.linker_path,
                           ctx.attr.cpp_flag,
                           "--target=" + ctx.attr.target_full_name,
-                          ctx.attr.extra_linker_flag,
-                      ],
+                      ] + ctx.attr.extra_linker_flags,
                   ),
               ],
           ),
@@ -129,7 +137,7 @@ def _impl(ctx):
                           "-isystem",
                           ctx.attr.toolchain_dir,
                           "-fvisibility=hidden",
-                      ] + ctx.attr.include_flag,
+                      ] + ctx.attr.extra_compiler_flags,
                   ),
               ],
           ),
@@ -139,6 +147,7 @@ def _impl(ctx):
   return cc_common.create_cc_toolchain_config_info(
       abi_libc_version = ctx.attr.abi_version,
       abi_version = ctx.attr.abi_version,
+      artifact_name_patterns = artifact_name_patterns,
       ctx = ctx,
       compiler = "clang",
       cxx_builtin_include_directories = [
@@ -163,9 +172,9 @@ cc_toolchain_config = rule(
         "abi_version": attr.string(default = "local"),
         "bit_flag": attr.string(mandatory = True, values = ["-m32", "-m64"]),
         "cpp_flag": attr.string(mandatory = True),
+        "extra_compiler_flags": attr.string_list(),
         "extra_include": attr.string(mandatory = False),
-        "extra_linker_flag": attr.string(mandatory = False),
-        "include_flag": attr.string_list(),
+        "extra_linker_flags": attr.string_list(),
         "linker_path": attr.string(mandatory = True),
         "sysroot": attr.string(mandatory = False),
         "target_cpu": attr.string(mandatory = True, values = ["aarch64", "ppc64", "systemz", "x86_32", "x86_64"]),


### PR DESCRIPTION
Fix windows builds by:
- Creating an artifact pattern to match protoc even with an .exe extension
- Changing version of mingw libraries 
- Adding a compiler flag to use fsjlj exceptions to match mingw library exceptions for win32
- Use -pthread for win32 