### PR TITLE
[MIN-2347] (early draft, testing the current state) Implementing Enum schema evolution

### DIFF
--- a/conformance/binary_json_conformance_suite.h
+++ b/conformance/binary_json_conformance_suite.h
@@ -53,6 +53,7 @@ class BinaryAndJsonConformanceSuite : public ConformanceTestSuite {
   void RunJsonTestsForStruct();
   void RunJsonTestsForValue();
   void RunJsonTestsForAny();
+  void RunJsonTestsForUnknownEnumStringValues();
   void RunValidJsonTest(const std::string& test_name, ConformanceLevel level,
                         const std::string& input_json,
                         const std::string& equivalent_text_format);
@@ -60,10 +61,16 @@ class BinaryAndJsonConformanceSuite : public ConformanceTestSuite {
       const std::string& test_name, ConformanceLevel level,
       const protobuf_test_messages::proto3::TestAllTypesProto3& input,
       const std::string& equivalent_text_format);
+  // Runs in proto3 only.
   void RunValidJsonIgnoreUnknownTest(const std::string& test_name,
                                      ConformanceLevel level,
                                      const std::string& input_json,
                                      const std::string& equivalent_text_format);
+  void RunValidJsonIgnoreUnknownTestWithProtoVersion(const std::string& test_name,
+                                     ConformanceLevel level,
+                                     const std::string& input_json,
+                                     const std::string& equivalent_text_format,
+                                     bool is_proto3);
   void RunValidProtobufTest(const std::string& test_name,
                             ConformanceLevel level,
                             const std::string& input_protobuf,
@@ -97,9 +104,15 @@ class BinaryAndJsonConformanceSuite : public ConformanceTestSuite {
                                      const std::string& input_json,
                                      const Validator& validator,
                                      bool is_proto3);
+  // Runs in proto3 only.
   void ExpectParseFailureForJson(const std::string& test_name,
                                  ConformanceLevel level,
                                  const std::string& input_json);
+  void ExpectParseFailureForJsonWithProtoVersion(const std::string& test_name,
+                                 ConformanceLevel level,
+                                 const std::string& input_json,
+                                 bool is_proto3);
+  // Runs for both proto2 and proto3.
   void ExpectSerializeFailureForJson(const std::string& test_name,
                                      ConformanceLevel level,
                                      const std::string& text_format);

--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -907,6 +907,17 @@ class JsonFormatTest(JsonFormatBase):
         'for enum type protobuf_unittest.TestAllTypes.NestedEnum.',
         json_format.Parse, '{"optionalNestedEnum": 12345}', message)
 
+  def testAntonProto3(self):
+    message = json_format_proto3_pb2.TestMessage()
+    text = '{"enumValue": "BAZ"}'
+    json_format.Parse(text, message, ignore_unknown_fields=True)
+
+  def testAntonProto2(self):
+    message = json_format_pb2.TestNumbers()
+    text = '{"a": "BAZ"}'
+    json_format.Parse(text, message, ignore_unknown_fields=True)
+    self.assertFalse(message.HasField("a"))
+
   def testBytes(self):
     message = json_format_proto3_pb2.TestMessage()
     # Test url base64


### PR DESCRIPTION
# (not ready yet, I'll review with my teammates internally first)

# Motivation

Some clients (python, swift, c#) will raise an exception during parsing of JSON messages if unknown enum value is encountered. In those clients it's not possible to ignore unknown enum values, which blocks us from adding new enum values in a backward compatible way. Java and C++ will ignore unknown enum values if `ignoreUnknownFields` is set.

# Prior related discussion

Related issues/PR in the official repo:
* ISSUE https://github.com/protocolbuffers/protobuf/issues/7392
  * Asks the protobuf team for the specification in this situation.
  * dupe https://github.com/protocolbuffers/protobuf/issues/8244
* ISSUE https://github.com/protocolbuffers/protobuf/issues/3012
  * original Java issue, fixed now
  * PR https://github.com/protocolbuffers/protobuf/pull/4825
    * original fix for Java
* PR https://github.com/protocolbuffers/protobuf/pull/7974
  * c# fix attempt

Related PRs in other implementations
  * PR https://github.com/timostamm/protobuf-ts/pull/170
    * fix for the typescript library
  * PR https://github.com/streem/pbandk/pull/100
    * fix for Kotlin implementation
  * ISSUE https://github.com/apple/swift-protobuf/issues/972
    * swift issue
    * PR https://github.com/apple/swift-protobuf/pull/896
      * attempt to fix for Swift-> lesson learned: map is a thing

# Changes

High level:
  * Align all implementations on handling of unknown enum values in parsing when `ignoreUnknownFields` is set.
  * The proposal is to follow what C++ and Java implementations are doing today -> if enum values are serialized as string, ignore unknown values.

Scope:
  * only JSON format
  * only when `ignoreUnknownFields` is set
  * only enum values that are serialized as strings (as opposed to integers)
  * both proto2 and proto3
 
I'll maintain 3 commits in this PR (or split to 3 PRs if the team prefers to review it that way):

* Add conformance tests that define the specification on how to parse unknown enum string value
* Add python unit tests that match the above conformance tests
* Fix python implementation so that all tests pass

# Tested

Steps:
- https://jwangee.github.io/blog/2017/12/08/protobuf1.html
- To build java for conformance tests I followed [these instructions](https://github.com/noom/protobuf/blob/master/tests.sh#L242)
- To run cpp conformance tests, I run `cd conformance && make test_cpp`
- To run python conformance tests, I followed `python/README.md` and run `python setup.py test_conformance` 