### PR TITLE
Fix protobuf_MSVC_STATIC_RUNTIME flag for cmake 3.15.0+

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -177,27 +177,29 @@ if (protobuf_BUILD_SHARED_LIBS)
   set(protobuf_SHARED_OR_STATIC "SHARED")
 else (protobuf_BUILD_SHARED_LIBS)
   set(protobuf_SHARED_OR_STATIC "STATIC")
-  # The CMAKE_<LANG>_FLAGS(_<BUILD_TYPE>)? is meant to be user controlled.
-  # Prior to CMake 3.15, the MSVC runtime library was pushed into the same flags
-  # making programmatic control difficult.  Prefer the functionality in newer
-  # CMake versions when available.
-  if(CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
-  else()
-    # In case we are building static libraries, link also the runtime library statically
-    # so that MSVCR*.DLL is not required at runtime.
-    # https://msdn.microsoft.com/en-us/library/2kzt1wy3.aspx
-    # This is achieved by replacing msvc option /MD with /MT and /MDd with /MTd
-    # http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F
-    if (MSVC AND protobuf_MSVC_STATIC_RUNTIME)
-      foreach(flag_var
-          CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-          CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-        if(${flag_var} MATCHES "/MD")
-          string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-        endif(${flag_var} MATCHES "/MD")
-      endforeach(flag_var)
-    endif (MSVC AND protobuf_MSVC_STATIC_RUNTIME)
+  if(protobuf_MSVC_STATIC_RUNTIME)
+    # The CMAKE_<LANG>_FLAGS(_<BUILD_TYPE>)? is meant to be user controlled.
+    # Prior to CMake 3.15, the MSVC runtime library was pushed into the same flags
+    # making programmatic control difficult.  Prefer the functionality in newer
+    # CMake versions when available.
+    if(CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)
+      set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
+    else()
+      # In case we are building static libraries, link also the runtime library statically
+      # so that MSVCR*.DLL is not required at runtime.
+      # https://msdn.microsoft.com/en-us/library/2kzt1wy3.aspx
+      # This is achieved by replacing msvc option /MD with /MT and /MDd with /MTd
+      # http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F
+      if (MSVC)
+        foreach(flag_var
+            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+            CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+          if(${flag_var} MATCHES "/MD")
+            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+          endif(${flag_var} MATCHES "/MD")
+        endforeach(flag_var)
+      endif (MSVC)
+    endif()
   endif()
 endif (protobuf_BUILD_SHARED_LIBS)
 


### PR DESCRIPTION
Fix for the following config:
- MSVC
- cmake 3.15.0+
- static protobuf
- dynamic runtime (`protobuf_MSVC_STATIC_RUNTIME=OFF`)

Previous behavior:
Ignore `protobuf_MSVC_STATIC_RUNTIME` value and set runtime to static.

New behavior:
Set static runtime if and only if `protobuf_MSVC_STATIC_RUNTIME=ON`.

(it's the fixed version of #9312 )