### PR TITLE
BUILD: Set `protoc` binary file mode to 0555 in release archive

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,7 +3,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test", "objc_library", native_cc_proto_library = "cc_proto_library")
 load("@rules_pkg//:pkg.bzl", "pkg_zip")
-load("@rules_pkg//:mappings.bzl", "pkg_files")
+load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
 load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_lite_proto_library", "java_proto_library")
@@ -563,6 +563,7 @@ pkg_files(
 pkg_files(
     name = "protoc_files",
     srcs =  [":protoc"],
+    attributes = pkg_attributes(mode = "0555"),
     visibility = ["//visibility:private"],
     prefix = "bin/",
 )


### PR DESCRIPTION
`bazel build //:protoc` builds the `protoc` binary as `0555`:

```
$ stat bazel-bin/protoc
  File: bazel-bin/protoc
  Size: 9434304   	Blocks: 18432      IO Block: 4096   regular file
Device: 802h/2050d	Inode: 418701      Links: 1
Access: (0555/-r-xr-xr-x)  Uid: ( 1000/    kiwi)   Gid: ( 1000/    kiwi)
Access: 2021-12-28 17:25:49.570581395 -0800
Modify: 2021-12-28 17:25:49.566581359 -0800
Change: 2021-12-28 17:25:49.566581359 -0800
 Birth: -
```

However, `//:protoc_release` packages `protoc` as `0644` (default behavior of `pkg_files`):

```
$ bazel build //:protoc_release
$ unzip bazel-bin/protoc_release.zip -d /tmp/old
$ stat /tmp/old/bin/protoc
  File: /tmp/old/bin/protoc
  Size: 9434304   	Blocks: 18432      IO Block: 4096   regular file
Device: 802h/2050d	Inode: 5539885     Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1000/    kiwi)   Gid: ( 1000/    kiwi)
Access: 1980-01-01 00:00:00.000000000 -0800
Modify: 1980-01-01 00:00:00.000000000 -0800
Change: 2021-12-28 17:26:07.074730225 -0800
 Birth: -
```

This change proposes setting the mode in the release archive to be consistent with the output binary. With this change:

```
$ bazel build //:protoc_release
$ unzip bazel-bin/protoc_release.zip -d /tmp/new
$ stat /tmp/new/bin/protoc
  File: /tmp/new/bin/protoc
  Size: 9434304   	Blocks: 18432      IO Block: 4096   regular file
Device: 802h/2050d	Inode: 5804996     Links: 1
Access: (0555/-r-xr-xr-x)  Uid: ( 1000/    kiwi)   Gid: ( 1000/    kiwi)
Access: 1980-01-01 00:00:00.000000000 -0800
Modify: 1980-01-01 00:00:00.000000000 -0800
Change: 2021-12-28 17:26:57.851164700 -0800
 Birth: -
```

This also makes it consistent with the behavior in the non-Bazel script:

https://github.com/protocolbuffers/protobuf/blob/01e84b129361913e5613464c857734fcfe095367/protoc-artifacts/build-zip.sh#L111