### PR TITLE
Fix PHP 8.1 compatibility

### DIFF
--- a/php/src/Google/Protobuf/Internal/MapField.php
+++ b/php/src/Google/Protobuf/Internal/MapField.php
@@ -134,6 +134,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
      * @throws \ErrorException Invalid type for index.
      * @throws \ErrorException Non-existing index.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->container[$key];
@@ -151,6 +152,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
      * @throws \ErrorException Invalid type for value.
      * @throws \ErrorException Non-existing key.
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->checkKey($this->key_type, $key);
@@ -209,6 +211,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
      * @return void
      * @throws \ErrorException Invalid type for key.
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         $this->checkKey($this->key_type, $key);
@@ -224,6 +227,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
      * @return bool True if the element at the given key exists.
      * @throws \ErrorException Invalid type for key.
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         $this->checkKey($this->key_type, $key);
@@ -233,6 +237,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * @ignore
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new MapFieldIter($this->container, $this->key_type);
@@ -245,6 +250,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @return integer The number of stored elements.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->container);

--- a/php/src/Google/Protobuf/Internal/MapFieldIter.php
+++ b/php/src/Google/Protobuf/Internal/MapFieldIter.php
@@ -68,6 +68,7 @@ class MapFieldIter implements \Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->container);
@@ -78,6 +79,7 @@ class MapFieldIter implements \Iterator
      *
      * @return object The element at the current position.
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->container);
@@ -88,6 +90,7 @@ class MapFieldIter implements \Iterator
      *
      * @return object The current key.
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         $key = key($this->container);
@@ -117,6 +120,7 @@ class MapFieldIter implements \Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         return next($this->container);
@@ -127,6 +131,7 @@ class MapFieldIter implements \Iterator
      *
      * @return bool True if there are more elements to iterate.
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return key($this->container) !== null;

--- a/php/src/Google/Protobuf/Internal/RepeatedField.php
+++ b/php/src/Google/Protobuf/Internal/RepeatedField.php
@@ -121,6 +121,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      * @throws \ErrorException Invalid type for index.
      * @throws \ErrorException Non-existing index.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset];
@@ -138,6 +139,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      * @throws \ErrorException Non-existing index.
      * @throws \ErrorException Incorrect type of the element.
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         switch ($this->type) {
@@ -209,6 +211,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      * @throws \ErrorException The element to be removed is not at the end of the
      * RepeatedField.
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $count = count($this->container);
@@ -230,6 +233,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      * @return bool True if the element at the given offset exists.
      * @throws \ErrorException Invalid type for index.
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -238,6 +242,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * @ignore
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new RepeatedFieldIter($this->container);
@@ -250,6 +255,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @return integer The number of stored elements.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->container);

--- a/php/src/Google/Protobuf/Internal/RepeatedFieldIter.php
+++ b/php/src/Google/Protobuf/Internal/RepeatedFieldIter.php
@@ -71,6 +71,7 @@ class RepeatedFieldIter implements \Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
@@ -81,6 +82,7 @@ class RepeatedFieldIter implements \Iterator
      *
      * @return object The element at the current position.
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->container[$this->position];
@@ -91,6 +93,7 @@ class RepeatedFieldIter implements \Iterator
      *
      * @return integer The current position.
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
@@ -101,6 +104,7 @@ class RepeatedFieldIter implements \Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->position;
@@ -111,6 +115,7 @@ class RepeatedFieldIter implements \Iterator
      *
      * @return bool True if there are more elements to iterate.
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->container[$this->position]);


### PR DESCRIPTION
Fix Deprecated such as:
```
Deprecated: Return type of Google\Protobuf\Internal\RepeatedFieldIter::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in
```