### PR TITLE
Fix Ruby release build by pinning rake-compiler-dock version

### DIFF
--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   else
     s.files     += Dir.glob('ext/**/*')
     s.extensions= ["ext/google/protobuf_c/extconf.rb"]
-    s.add_development_dependency "rake-compiler-dock", ">= 1.1.0", "< 2.0"
+    s.add_development_dependency "rake-compiler-dock", "= 1.1.0"
   end
   s.test_files  = ["tests/basic.rb",
                   "tests/stress.rb",


### PR DESCRIPTION
Our Ruby release build broke at some point in the past day or so, and I
strongly suspect it is due to a new version (1.2.0) of
rake-compiler-dock. This commit pins the version to 1.1.0 as a temporary
fix.