### PR TITLE
Revert "Standardize on Array copyOf"

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/BooleanArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/BooleanArrayList.java
@@ -197,7 +197,10 @@ final class BooleanArrayList extends AbstractProtobufList<Boolean>
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      boolean[] newArray = new boolean[length];
+
+      System.arraycopy(array, 0, newArray, 0, size);
+      array = newArray;
     }
 
     array[size++] = element;
@@ -216,10 +219,14 @@ final class BooleanArrayList extends AbstractProtobufList<Boolean>
     } else {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      boolean[] newArray = new boolean[length];
+
+      // Copy the first part directly
+      System.arraycopy(array, 0, newArray, 0, index);
 
       // Copy the rest shifted over by one to make room
-      System.arraycopy(array, index, array, index + 1, size - index);
+      System.arraycopy(array, index, newArray, index + 1, size - index);
+      array = newArray;
     }
 
     array[index] = element;

--- a/java/core/src/main/java/com/google/protobuf/DoubleArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/DoubleArrayList.java
@@ -197,7 +197,10 @@ final class DoubleArrayList extends AbstractProtobufList<Double>
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      double[] newArray = new double[length];
+
+      System.arraycopy(array, 0, newArray, 0, size);
+      array = newArray;
     }
 
     array[size++] = element;
@@ -216,10 +219,14 @@ final class DoubleArrayList extends AbstractProtobufList<Double>
     } else {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      double[] newArray = new double[length];
+
+      // Copy the first part directly
+      System.arraycopy(array, 0, newArray, 0, index);
 
       // Copy the rest shifted over by one to make room
-      System.arraycopy(array, index, array, index + 1, size - index);
+      System.arraycopy(array, index, newArray, index + 1, size - index);
+      array = newArray;
     }
 
     array[index] = element;

--- a/java/core/src/main/java/com/google/protobuf/FloatArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/FloatArrayList.java
@@ -196,7 +196,10 @@ final class FloatArrayList extends AbstractProtobufList<Float>
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      float[] newArray = new float[length];
+
+      System.arraycopy(array, 0, newArray, 0, size);
+      array = newArray;
     }
 
     array[size++] = element;
@@ -215,10 +218,14 @@ final class FloatArrayList extends AbstractProtobufList<Float>
     } else {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      float[] newArray = new float[length];
+
+      // Copy the first part directly
+      System.arraycopy(array, 0, newArray, 0, index);
 
       // Copy the rest shifted over by one to make room
-      System.arraycopy(array, index, array, index + 1, size - index);
+      System.arraycopy(array, index, newArray, index + 1, size - index);
+      array = newArray;
     }
 
     array[index] = element;

--- a/java/core/src/main/java/com/google/protobuf/IntArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/IntArrayList.java
@@ -196,7 +196,10 @@ final class IntArrayList extends AbstractProtobufList<Integer>
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      int[] newArray = new int[length];
+
+      System.arraycopy(array, 0, newArray, 0, size);
+      array = newArray;
     }
 
     array[size++] = element;
@@ -215,10 +218,14 @@ final class IntArrayList extends AbstractProtobufList<Integer>
     } else {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      int[] newArray = new int[length];
+
+      // Copy the first part directly
+      System.arraycopy(array, 0, newArray, 0, index);
 
       // Copy the rest shifted over by one to make room
-      System.arraycopy(array, index, array, index + 1, size - index);
+      System.arraycopy(array, index, newArray, index + 1, size - index);
+      array = newArray;
     }
 
     array[index] = element;

--- a/java/core/src/main/java/com/google/protobuf/LongArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/LongArrayList.java
@@ -196,7 +196,10 @@ final class LongArrayList extends AbstractProtobufList<Long>
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      long[] newArray = new long[length];
+
+      System.arraycopy(array, 0, newArray, 0, size);
+      array = newArray;
     }
 
     array[size++] = element;
@@ -215,10 +218,14 @@ final class LongArrayList extends AbstractProtobufList<Long>
     } else {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      long[] newArray = new long[length];
+
+      // Copy the first part directly
+      System.arraycopy(array, 0, newArray, 0, index);
 
       // Copy the rest shifted over by one to make room
-      System.arraycopy(array, index, array, index + 1, size - index);
+      System.arraycopy(array, index, newArray, index + 1, size - index);
+      array = newArray;
     }
 
     array[index] = element;

--- a/java/core/src/main/java/com/google/protobuf/ProtobufArrayList.java
+++ b/java/core/src/main/java/com/google/protobuf/ProtobufArrayList.java
@@ -80,7 +80,9 @@ final class ProtobufArrayList<E> extends AbstractProtobufList<E> implements Rand
     if (size == array.length) {
       // Resize to 1.5x the size
       int length = ((size * 3) / 2) + 1;
-      array = Arrays.copyOf(array, length);
+      E[] newArray = Arrays.copyOf(array, length);
+
+      array = newArray;
     }
 
     array[size++] = element;


### PR DESCRIPTION
This reverts commit 935d099ad9f6692e727406764bb3226d935e899d from PR #9162.

While the original commit was a nice simplification, I learned from
another Googler that there is unfortunately a performance cost to this
(or at least there was last time this change was attempted). Even if it
turns out to be fast on modern Java runtimes, we still care about the
performance on old Android devices.