### PR TITLE
Disable [[clang::musttail]] attribute on Windows x86

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -229,11 +229,13 @@
 #ifdef PROTOBUF_TAILCALL
 #error PROTOBUF_TAILCALL was previously defined
 #endif
-#if __has_cpp_attribute(clang::musttail) && \
-  !defined(__arm__) && !defined(_ARCH_PPC) && !defined(__wasm__)
+#if __has_cpp_attribute(clang::musttail) &&                         \
+  !defined(__arm__) && !defined(_ARCH_PPC) && !defined(__wasm__) && \
+  !(defined(_MSC_VER) && defined(_M_IX86))
 #  ifndef PROTO2_OPENSOURCE
 // Compilation fails on ARM32: b/195943306
 // Compilation fails on powerpc64le: b/187985113
+// Compilation fails on X86 Windows: https://github.com/llvm/llvm-project/issues/53271
 #  endif
 #define PROTOBUF_MUSTTAIL [[clang::musttail]]
 #define PROTOBUF_TAILCALL true


### PR DESCRIPTION
This fixes #9421 