### PR TITLE
Update location of llvm-ar in bazel toolchain

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -47,7 +47,7 @@ def _impl(ctx):
       ),
       tool_path(
           name = "ar",
-          path = "/usr/bin/llvm-ar",
+          path = "/usr/local/bin/llvm-ar",
       ),
       tool_path(
           name = "compat-ld",


### PR DESCRIPTION
Change the location of the llvm-ar tool to match the new docker container.