### PR TITLE
Fixes NullReferenceException when accessing FieldDescriptor.IsPacked

### DIFF
--- a/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
@@ -239,7 +239,8 @@ namespace Google.Protobuf.Reflection
                 }
                 else
                 {
-                    return !Proto.Options.HasPacked || Proto.Options.Packed;
+                    // Packed by default with proto3
+                    return Proto.Options == null || !Proto.Options.HasPacked || Proto.Options.Packed;
                 }
             }
         }


### PR DESCRIPTION
Hey,

While developing a small service [grpc-curl](https://github.com/xoofx/grpc-curl), I found a small bug in `FieldDescriptor.IsPacked` that was throwing a `NullReferenceException` that I had to workaround here:

https://github.com/xoofx/grpc-curl/blob/f7bbe35af79713f278150b96ce51817807a06581/src/DynamicGrpc/DynamicMessageSerializer.cs#L434-L455

So this PR is a small bug fix. Though, I haven't found a test to update about it, not sure if we have any?