### PR TITLE
link with correct C runtime on MSVC

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -182,7 +182,11 @@ else (protobuf_BUILD_SHARED_LIBS)
   # making programmatic control difficult.  Prefer the functionality in newer
   # CMake versions when available.
   if(CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
+    if (protobuf_MSVC_STATIC_RUNTIME)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
+    else()
+        set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>DLL)
+    endif()
   else()
     # In case we are building static libraries, link also the runtime library statically
     # so that MSVCR*.DLL is not required at runtime.


### PR DESCRIPTION
when using CMake >= 3.15, we use CMAKE_MSVC_RUNTIME_LIBRARY
to reproduce the /MT vs /MD when protobuf_MSVC_STATIC_RUNTIME
is TRUE or FALSE
MultiThreaded is for /MT
MultiThreadedDebug is for /MTd
MultiThreadedDLL is for /MD
MultiThreadedDebugDLL is for /MDd