### PR TITLE
Generated Java code using InternalOneOfEnum should reference AbstractMessageLite instead of AbstractMessage.

### DIFF
--- a/src/google/protobuf/compiler/java/java_message.cc
+++ b/src/google/protobuf/compiler/java/java_message.cc
@@ -433,7 +433,7 @@ void ImmutableMessageGenerator::Generate(io::Printer* printer) {
         // TODO(dweis): Remove EnumLite when we want to break compatibility with
         // 3.x users
         "    implements com.google.protobuf.Internal.EnumLite,\n"
-        "        com.google.protobuf.AbstractMessage.InternalOneOfEnum {\n");
+        "        com.google.protobuf.AbstractMessageLite.InternalOneOfEnum {\n");
     printer->Indent();
     for (int j = 0; j < (oneof)->field_count(); j++) {
       const FieldDescriptor* field = (oneof)->field(j);


### PR DESCRIPTION
Generated Java code using InternalOneOfEnum should reference AbstractMessageLite instead of AbstractMessage.

java_message C++ code has been adjusted in accordance with the java interface AbstractMessageLite.

fixes #7373 