### PR TITLE
Use proper SPDX license identifier

### DIFF
--- a/Protobuf-C++.podspec
+++ b/Protobuf-C++.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version  = '3.19.3'
   s.summary  = 'Protocol Buffers v3 runtime library for C++.'
   s.homepage = 'https://github.com/google/protobuf'
-  s.license  = '3-Clause BSD License'
+  s.license  = 'BSD-3-Clause'
   s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
   s.cocoapods_version = '>= 1.0'
 

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.version  = '3.19.3'
   s.summary  = 'Protocol Buffers v.3 runtime library for Objective-C.'
   s.homepage = 'https://github.com/protocolbuffers/protobuf'
-  s.license  = '3-Clause BSD License'
+  s.license  = 'BSD-3-Clause'
   s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
   s.cocoapods_version = '>= 1.0'
 

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -29,7 +29,7 @@
 
   <licenses>
     <license>
-      <name>3-Clause BSD License</name>
+      <name>BSD-3-Clause</name>
       <url>https://opensource.org/licenses/BSD-3-Clause</url>
     </license>
   </licenses>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -41,7 +41,7 @@
 
   <licenses>
     <license>
-      <name>3-Clause BSD License</name>
+      <name>BSD-3-Clause</name>
       <url>https://opensource.org/licenses/BSD-3-Clause</url>
       <distribution>repo</distribution>
     </license>

--- a/php/ext/google/protobuf/package.xml
+++ b/php/ext/google/protobuf/package.xml
@@ -20,7 +20,7 @@
   <release>stable</release>
   <api>stable</api>
  </stability>
- <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+ <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
  <notes>
  * No new changes in 3.19.3
  </notes>
@@ -73,7 +73,7 @@
    </stability>
    <date>2016-09-23</date>
    <time>16:06:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 First alpha release
    </notes>
@@ -89,7 +89,7 @@ First alpha release
    </stability>
    <date>2017-01-13</date>
    <time>16:06:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 Second alpha release.
    </notes>
@@ -105,7 +105,7 @@ Second alpha release.
    </stability>
    <date>2017-04-28</date>
    <time>16:06:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 GA release.
    </notes>
@@ -121,7 +121,7 @@ GA release.
    </stability>
    <date>2017-05-08</date>
    <time>15:33:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 GA release.
    </notes>
@@ -137,7 +137,7 @@ GA release.
    </stability>
    <date>2017-06-21</date>
    <time>15:33:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 GA release.
    </notes>
@@ -153,7 +153,7 @@ GA release.
    </stability>
    <date>2017-08-16</date>
    <time>15:33:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 GA release.
    </notes>
@@ -169,7 +169,7 @@ GA release.
    </stability>
    <date>2017-09-14</date>
    <time>11:02:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 GA release.
    </notes>
@@ -185,7 +185,7 @@ GA release.
    </stability>
    <date>2017-11-15</date>
    <time>11:02:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 GA release.
    </notes>
@@ -201,7 +201,7 @@ GA release.
    </stability>
    <date>2017-12-06</date>
    <time>11:02:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 GA release.
    </notes>
@@ -217,7 +217,7 @@ GA release.
    </stability>
    <date>2017-12-11</date>
    <time>11:02:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 GA release.
    </notes>
@@ -233,7 +233,7 @@ GA release.
    </stability>
    <date>2018-03-06</date>
    <time>11:02:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 G  A release.
    </notes>
@@ -249,7 +249,7 @@ G  A release.
    </stability>
    <date>2018-06-06</date>
    <time>11:02:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 G  A release.
    </notes>
@@ -265,7 +265,7 @@ G  A release.
    </stability>
    <date>2018-08-03</date>
    <time>11:02:07</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
 G  A release.
    </notes>
@@ -281,7 +281,7 @@ G  A release.
    </stability>
    <date>2019-02-1</date>
    <time>10:22:43</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -295,7 +295,7 @@ G  A release.
    </stability>
    <date>2019-02-22</date>
    <time>11:31:21</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -309,7 +309,7 @@ G  A release.
    </stability>
    <date>2019-02-28</date>
    <time>10:19:15</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -323,7 +323,7 @@ G  A release.
    </stability>
    <date>2019-03-25</date>
    <time>13:23:39</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -337,7 +337,7 @@ G  A release.
    </stability>
    <date>2019-04-23</date>
    <time>16:14:52</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -351,7 +351,7 @@ G  A release.
    </stability>
    <date>2019-05-21</date>
    <time>14:07:13</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -365,7 +365,7 @@ G  A release.
    </stability>
    <date>2019-06-17</date>
    <time>09:34:50</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -379,7 +379,7 @@ G  A release.
    </stability>
    <date>2019-07-10</date>
    <time>16:50:08</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -393,7 +393,7 @@ G  A release.
    </stability>
    <date>2019-08-02</date>
    <time>15:59:08</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -407,7 +407,7 @@ G  A release.
    </stability>
    <date>2019-09-04</date>
    <time>13:24:25</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -421,7 +421,7 @@ G  A release.
    </stability>
    <date>2019-09-05</date>
    <time>10:12:46</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -435,7 +435,7 @@ G  A release.
    </stability>
    <date>2019-09-12</date>
    <time>13:48:02</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -449,7 +449,7 @@ G  A release.
    </stability>
    <date>2019-11-15</date>
    <time>11:44:18</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -463,7 +463,7 @@ G  A release.
    </stability>
    <date>2019-11-21</date>
    <time>10:38:49</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -477,7 +477,7 @@ G  A release.
    </stability>
    <date>2019-11-25</date>
    <time>11:47:41</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -491,7 +491,7 @@ G  A release.
    </stability>
    <date>2019-12-02</date>
    <time>11:09:17</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -505,7 +505,7 @@ G  A release.
    </stability>
    <date>2019-12-10</date>
    <time>11:22:54</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -519,7 +519,7 @@ G  A release.
    </stability>
    <date>2020-01-28</date>
    <time>10:20:43</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -533,7 +533,7 @@ G  A release.
    </stability>
    <date>2020-02-12</date>
    <time>12:46:57</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -547,7 +547,7 @@ G  A release.
    </stability>
    <date>2020-04-30</date>
    <time>14:23:34</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -561,7 +561,7 @@ G  A release.
    </stability>
    <date>2020-05-12</date>
    <time>12:48:03</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -575,7 +575,7 @@ G  A release.
    </stability>
    <date>2020-05-15</date>
    <time>13:26:23</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -589,7 +589,7 @@ G  A release.
    </stability>
    <date>2020-05-20</date>
    <time>10:18:13</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -603,7 +603,7 @@ G  A release.
    </stability>
    <date>2020-05-26</date>
    <time>13:57:10</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -617,7 +617,7 @@ G  A release.
    </stability>
    <date>2020-06-01</date>
    <time>01:09:39</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -631,7 +631,7 @@ G  A release.
    </stability>
    <date>2020-08-05</date>
    <time>11:21:41</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -645,7 +645,7 @@ G  A release.
    </stability>
    <date>2020-08-05</date>
    <time>11:22:52</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -659,7 +659,7 @@ G  A release.
    </stability>
    <date>2020-08-12</date>
    <time>13:46:54</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -673,7 +673,7 @@ G  A release.
    </stability>
    <date>2020-08-14</date>
    <time>14:07:59</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -687,7 +687,7 @@ G  A release.
    </stability>
    <date>2020-10-08</date>
    <time>14:07:59</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>GA release.</notes>
   </release>
   <release>
@@ -701,7 +701,7 @@ G  A release.
    </stability>
    <date>2020-11-05</date>
    <time>13:39:47</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -716,7 +716,7 @@ G  A release.
    </stability>
    <date>2020-11-10</date>
    <time>16:28:41</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -731,7 +731,7 @@ G  A release.
    </stability>
    <date>2020-11-11</date>
    <time>10:35:18</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -746,7 +746,7 @@ G  A release.
    </stability>
    <date>2020-11-12</date>
    <time>14:06:40</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -761,7 +761,7 @@ G  A release.
    </stability>
    <date>2021-02-05</date>
    <time>14:15:36</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -776,7 +776,7 @@ G  A release.
    </stability>
    <date>2021-02-17</date>
    <time>09:10:33</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -791,7 +791,7 @@ G  A release.
    </stability>
    <date>2021-02-18</date>
    <time>10:33:10</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -806,7 +806,7 @@ G  A release.
    </stability>
    <date>2021-02-19</date>
    <time>10:50:04</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -821,7 +821,7 @@ G  A release.
    </stability>
    <date>2021-02-23</date>
    <time>11:35:09</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -836,7 +836,7 @@ G  A release.
    </stability>
    <date>2021-02-24</date>
    <time>16:49:52</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -851,7 +851,7 @@ G  A release.
    </stability>
    <date>2021-03-02</date>
    <time>15:25:02</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -866,7 +866,7 @@ G  A release.
    </stability>
    <date>2021-03-04</date>
    <time>10:45:30</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -881,7 +881,7 @@ G  A release.
    </stability>
    <date>2021-03-10</date>
    <time>10:11:34</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -896,7 +896,7 @@ G  A release.
    </stability>
    <date>2021-04-02</date>
    <time>10:01:42</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -911,7 +911,7 @@ G  A release.
    </stability>
    <date>2021-04-02</date>
    <time>16:11:33</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -926,7 +926,7 @@ G  A release.
    </stability>
    <date>2021-05-03</date>
    <time>16:40:57</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -941,7 +941,7 @@ G  A release.
    </stability>
    <date>2021-05-05</date>
    <time>16:34:02</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -956,7 +956,7 @@ G  A release.
    </stability>
    <date>2021-05-06</date>
    <time>11:08:58</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -971,7 +971,7 @@ G  A release.
    </stability>
    <date>2021-05-07</date>
    <time>15:58:19</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -986,7 +986,7 @@ G  A release.
    </stability>
    <date>2021-05-11</date>
    <time>13:29:14</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1001,7 +1001,7 @@ G  A release.
    </stability>
    <date>2021-05-19</date>
    <time>16:06:12</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
  * Fixed PHP memory leaks and arginfo errors. (#8614)
  * Fixed JSON parser to allow multiple values from the same oneof as long as
@@ -1019,7 +1019,7 @@ G  A release.
    </stability>
    <date>2021-05-25</date>
    <time>19:32:12</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1034,7 +1034,7 @@ G  A release.
    </stability>
    <date>2021-06-04</date>
    <time>21:17:28</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1049,7 +1049,7 @@ G  A release.
    </stability>
    <date>2021-08-18</date>
    <time>15:23:47</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1064,7 +1064,7 @@ G  A release.
    </stability>
    <date>2021-08-27</date>
    <time>14:37:43</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1079,7 +1079,7 @@ G  A release.
    </stability>
    <date>2021-09-13</date>
    <time>11:30:58</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1094,7 +1094,7 @@ G  A release.
    </stability>
    <date>2021-10-04</date>
    <time>13:03:51</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1109,7 +1109,7 @@ G  A release.
    </stability>
    <date>2021-10-15</date>
    <time>13:38:38</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1124,7 +1124,7 @@ G  A release.
    </stability>
    <date>2021-10-18</date>
    <time>15:36:35</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1139,7 +1139,7 @@ G  A release.
    </stability>
    <date>2021-10-19</date>
    <time>11:06:24</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1154,7 +1154,7 @@ G  A release.
    </stability>
    <date>2021-10-28</date>
    <time>20:01:12</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1169,7 +1169,7 @@ G  A release.
    </stability>
    <date>2022-01-05</date>
    <time>17:01:38</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>
@@ -1184,7 +1184,7 @@ G  A release.
    </stability>
    <date>2022-01-11</date>
    <time>00:58:50</time>
-   <license uri="https://opensource.org/licenses/BSD-3-Clause">3-Clause BSD License</license>
+   <license uri="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause</license>
    <notes>
    </notes>
   </release>

--- a/protoc-artifacts/pom.xml
+++ b/protoc-artifacts/pom.xml
@@ -19,7 +19,7 @@
   <url>https://developers.google.com/protocol-buffers/</url>
   <licenses>
     <license>
-      <name>3-Clause BSD License</name>
+      <name>BSD-3-Clause</name>
       <url>https://opensource.org/licenses/BSD-3-Clause</url>
       <distribution>repo</distribution>
     </license>

--- a/python/protobuf_distutils/setup.py
+++ b/python/protobuf_distutils/setup.py
@@ -46,7 +46,7 @@ setup(
     packages=find_packages(),
     maintainer='protobuf@googlegroups.com',
     maintainer_email='protobuf@googlegroups.com',
-    license='3-Clause BSD License',
+    license='BSD-3-Clause',
     classifiers=[
         "Framework :: Setuptools Plugin",
         "Operating System :: OS Independent",

--- a/python/setup.py
+++ b/python/setup.py
@@ -283,7 +283,7 @@ if __name__ == '__main__':
       url='https://developers.google.com/protocol-buffers/',
       maintainer='protobuf@googlegroups.com',
       maintainer_email='protobuf@googlegroups.com',
-      license='3-Clause BSD License',
+      license='BSD-3-Clause',
       classifiers=[
           "Programming Language :: Python",
           "Programming Language :: Python :: 3",

--- a/ruby/pom.xml
+++ b/ruby/pom.xml
@@ -19,7 +19,7 @@
     <url>https://developers.google.com/protocol-buffers/</url>
     <licenses>
       <license>
-        <name>3-Clause BSD License</name>
+        <name>BSD-3-Clause</name>
         <url>https://opensource.org/licenses/BSD-3-Clause</url>
         <distribution>repo</distribution>
       </license>


### PR DESCRIPTION
The previously used term "3-Clause BSD License" is not properly
standarized. A common standard is SPDX, therefore "3-Clause BSD License"
is substituted with "BSD-3-Clause" which is a SPDX identifier.

`grep -rl "3-Clause BSD License" | xargs -n1 sed -i "s/3-Clause BSD
License/BSD-3-Clause/g"`