### PR TITLE
Must build project before running benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,7 +87,17 @@ To run all the benchmark dataset:
 
 ### Java:
 
+First build the Java binary in the usual way with Maven:
+
 ```
+$ cd java
+$ mvn install
+```
+
+Assuing that completes successfully,
+
+```
+$ cd ../benchmarks
 $ make java
 ```
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -94,7 +94,7 @@ $ cd java
 $ mvn install
 ```
 
-Assuing that completes successfully,
+Assuming that completes successfully,
 
 ```
 $ cd ../benchmarks


### PR DESCRIPTION
That is, it does not test the version downloaded from Maven central.

@acozzette 