### PR TITLE
Fix checking Windows platform with preprocessor

### DIFF
--- a/src/google/protobuf/io/zero_copy_stream_unittest.cc
+++ b/src/google/protobuf/io/zero_copy_stream_unittest.cc
@@ -49,7 +49,7 @@
 #include <chrono>
 #include <thread>
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
 #endif
@@ -764,7 +764,7 @@ TEST_F(IoTest, FileIo) {
   }
 }
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 // This tests the FileInputStream with a non blocking file. It opens a pipe in
 // non blocking mode, then starts reading it. The writing thread starts writing
 // 100ms after that.


### PR DESCRIPTION
Check _WIN32 instead of _MSC_VER because the later one is for MSVC only.
This fixes building with mingw-w64 toolchain which uses GCC or Clang.