### PR TITLE
fix: use E_USER_ERROR for trigger_error calls

### DIFF
--- a/php/src/Google/Protobuf/Internal/DescriptorPool.php
+++ b/php/src/Google/Protobuf/Internal/DescriptorPool.php
@@ -159,7 +159,7 @@ class DescriptorPool
                     if (is_null($subdesc)) {
                         trigger_error(
                             'proto not added: ' . $proto
-                            . " for " . $desc->getFullName(), E_ERROR);
+                            . " for " . $desc->getFullName(), E_USER_ERROR);
                     }
                     $field->setMessageType($subdesc);
                     break;

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -423,7 +423,7 @@ class Message
                 }
                 break;
             case GPBType::GROUP:
-                trigger_error("Not implemented.", E_ERROR);
+                trigger_error("Not implemented.", E_USER_ERROR);
                 break;
             case GPBType::MESSAGE:
                 if ($field->isMap()) {


### PR DESCRIPTION
According to [the manual for trigger_error](https://www.php.net/manual/en/function.trigger-error.php) only constants from the E_USER family can be used. Without this, a cryptic error is presented.