### PR TITLE
Support forward declaration of dependent messages via opt-in option in protoc

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_generator.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_generator.cc
@@ -147,6 +147,8 @@ bool CppGenerator::Generate(const FileDescriptor* file,
                  options[i].second;
         return false;
       }
+    } else if (options[i].first == "non_transitive_pb_h") {
+      file_options.transitive_pb_h = false;
     } else {
       *error = "Unknown generator option: " + options[i].first;
       return false;


### PR DESCRIPTION
Suppose that we have `x.proto` and `y.proto` files. If `x.proto` imports `y.proto`, the generated `x.pb.h` file will include `y.pb.h` file.

In our C++ project protobuf is widely used. It contains hundreds of `.proto` files that actively import each other. Since some of the protobuf messages are huge, each additional dependency results in a further slowdown of the project to compilation.

When project's source file depends on the messages from `x.proto` (and includes `x.pb.h` file), the compiler is forced to transitively parse `y.pb.h`, which in most cases is not necessary.

In fact `x.pb.h` doesn't need to include `y.pb.h` to be usable. Instead of including `y.pb.h`, `x.pb.h` can forward-declare used classes and enums that are defined in `y.pb.h`. It will reduce the cost to parse `y.pb.h`. If a source file needs both `x.pb.h` and `y.pb.h`, it shall now include both of them.

We've measured compile time on Intel Xeon E5-2650 cores clang12 and SSD.

**Build from scratch BEFORE the patch**:
```
real    19m23.164s
user    8m59.026s
sys     5m12.126s
```
**Build from scratch AFTER the patch and codebase fixup**:
```
real    16m0.855s
user    8m29.934s
sys     4m55.299s
```
**Build after changing an essential .proto file BEFORE the patch**:
```
real    15m35.174s
user    7m19.943s
sys     4m27.037s
```
**Build after changing an essential .proto file AFTER the patch**:
```
real    11m45.793s
user    6m58.235s
sys     4m32.752s
```

Though applying this option requires tidying codebase according to include-what-you-use principle, it saves about 25% of the build time which looks like a major improvement to us.
