### PR TITLE
Ruby: rename max_recursion_depth to recursion_limit

### DIFF
--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -959,7 +959,7 @@ static VALUE Message_index_set(VALUE _self, VALUE field_name, VALUE value) {
  * format) under the interpretration given by this message class's definition
  * and returns a message object with the corresponding field values.
  * @param options [Hash] options for the decoder
- *  max_recursion_depth: set to maximum decoding depth for message (default is 64)
+ *  recursion_limit: set to maximum decoding depth for message (default is 64)
  */
 static VALUE Message_decode(int argc, VALUE* argv, VALUE klass) {
   VALUE data = argv[0];
@@ -975,7 +975,7 @@ static VALUE Message_decode(int argc, VALUE* argv, VALUE klass) {
       rb_raise(rb_eArgError, "Expected hash arguments.");
     }
 
-    VALUE depth = rb_hash_lookup(hash_args, ID2SYM(rb_intern("max_recursion_depth")));
+    VALUE depth = rb_hash_lookup(hash_args, ID2SYM(rb_intern("recursion_limit")));
 
     if (depth != Qnil && TYPE(depth) == T_FIXNUM) {
       options |= UPB_DECODE_MAXDEPTH(FIX2INT(depth));
@@ -1070,7 +1070,7 @@ static VALUE Message_decode_json(int argc, VALUE* argv, VALUE klass) {
  * Encodes the given message object to its serialized form in protocol buffers
  * wire format.
  * @param options [Hash] options for the encoder
- *  max_recursion_depth: set to maximum encoding depth for message (default is 64)
+ *  recursion_limit: set to maximum encoding depth for message (default is 64)
  */
 static VALUE Message_encode(int argc, VALUE* argv, VALUE klass) {
   Message* msg = ruby_to_Message(argv[0]);
@@ -1091,7 +1091,7 @@ static VALUE Message_encode(int argc, VALUE* argv, VALUE klass) {
     if (TYPE(hash_args) != T_HASH) {
       rb_raise(rb_eArgError, "Expected hash arguments.");
     }
-    VALUE depth = rb_hash_lookup(hash_args, ID2SYM(rb_intern("max_recursion_depth")));
+    VALUE depth = rb_hash_lookup(hash_args, ID2SYM(rb_intern("recursion_limit")));
 
     if (depth != Qnil && TYPE(depth) == T_FIXNUM) {
       options |= UPB_DECODE_MAXDEPTH(FIX2INT(depth));

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
@@ -389,7 +389,7 @@ public class RubyMap extends RubyObject {
         return newMap;
     }
 
-    protected List<DynamicMessage> build(ThreadContext context, RubyDescriptor descriptor, int depth, int maxRecursionDepth) {
+    protected List<DynamicMessage> build(ThreadContext context, RubyDescriptor descriptor, int depth, int recursionLimit) {
         List<DynamicMessage> list = new ArrayList<DynamicMessage>();
         RubyClass rubyClass = (RubyClass) descriptor.msgclass(context);
         FieldDescriptor keyField = descriptor.getField("key");
@@ -398,7 +398,7 @@ public class RubyMap extends RubyObject {
             RubyMessage mapMessage = (RubyMessage) rubyClass.newInstance(context, Block.NULL_BLOCK);
             mapMessage.setField(context, keyField, key);
             mapMessage.setField(context, valueField, table.get(key));
-            list.add(mapMessage.build(context, depth + 1, maxRecursionDepth));
+            list.add(mapMessage.build(context, depth + 1, recursionLimit));
         }
         return list;
     }

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1245,7 +1245,7 @@ module CommonTests
     struct = struct_from_ruby(JSON.parse(json))
     assert_equal json, struct.to_json
 
-    assert_raise(RuntimeError, "Maximum recursion depth exceeded during encoding") do
+    assert_raise(RuntimeError, "Recursion limit exceeded during encoding") do
       struct = Google::Protobuf::Struct.new
       struct.fields["foobar"] = Google::Protobuf::Value.new(struct_value: struct)
       Google::Protobuf::Struct.encode(struct)

--- a/ruby/tests/encode_decode_test.rb
+++ b/ruby/tests/encode_decode_test.rb
@@ -119,10 +119,10 @@ class EncodeDecodeTest < Test::Unit::TestCase
     assert_match msg.to_json, msg_out.to_json
 
     assert_raise Google::Protobuf::ParseError do
-      A::B::C::TestMessage.decode(msg_encoded, { max_recursion_depth: 4 })
+      A::B::C::TestMessage.decode(msg_encoded, { recursion_limit: 4 })
     end
 
-    msg_out = A::B::C::TestMessage.decode(msg_encoded, { max_recursion_depth: 5 })
+    msg_out = A::B::C::TestMessage.decode(msg_encoded, { recursion_limit: 5 })
     assert_match msg.to_json, msg_out.to_json
   end
 
@@ -144,10 +144,10 @@ class EncodeDecodeTest < Test::Unit::TestCase
     assert_match msg.to_json, msg_out.to_json
 
     assert_raise RuntimeError do
-      A::B::C::TestMessage.encode(msg, { max_recursion_depth: 5 })
+      A::B::C::TestMessage.encode(msg, { recursion_limit: 5 })
     end
 
-    msg_encoded = A::B::C::TestMessage.encode(msg, { max_recursion_depth: 6 })
+    msg_encoded = A::B::C::TestMessage.encode(msg, { recursion_limit: 6 })
     msg_out = A::B::C::TestMessage.decode(msg_encoded)
     assert_match msg.to_json, msg_out.to_json
   end


### PR DESCRIPTION
This will help keep the terminology consistent with the other language
implementations.