### PR TITLE
Add osx aarch_64 to protoc-artifacts

### DIFF
--- a/protoc-artifacts/README.md
+++ b/protoc-artifacts/README.md
@@ -128,6 +128,8 @@ target directory layout:
       + osx
         + x86_64
           protoc.exe
+        + aarch_64
+          protoc.exe
         + x86_32
           protoc.exe
       + windows

--- a/protoc-artifacts/build-protoc.sh
+++ b/protoc-artifacts/build-protoc.sh
@@ -17,6 +17,7 @@
 #   linux  windows x86_64   Requires: x86_64-w64-mingw32-gcc
 #   macos  osx     x86_32
 #   macos  osx     x86_64
+#   macos  osx     aarch_64
 #   mingw  windows x86_32
 #   mingw  windows x86_64
 #
@@ -125,6 +126,8 @@ checkArch ()
       assertEq $format "i386" $LINENO
     elif [[ "$ARCH" == x86_64 ]]; then
       assertEq $format "x86_64" $LINENO
+    elif [[ "$ARCH" == aarch_64 ]]; then
+      assertEq $format "arm64" $LINENO
     else
       fail "Unsupported arch: $ARCH"
     fi
@@ -251,6 +254,10 @@ elif [[ "$(uname)" == Darwin* ]]; then
   CXXFLAGS="$CXXFLAGS -mmacosx-version-min=10.7"
   if [[ "$ARCH" == x86_64 ]]; then
     CXXFLAGS="$CXXFLAGS -m64"
+  elif [[ "$ARCH" == aarch_64 ]]; then
+    CONFIGURE_ARGS="$CONFIGURE_ARGS --host=aarch64-apple-darwin"
+    CXXFLAGS="$CXXFLAGS -m64 -arch arm64"
+    LDFLAGS="$LDFLAGS -arch arm64"
   elif [[ "$ARCH" == x86_32 ]]; then
     CXXFLAGS="$CXXFLAGS -m32"
   else

--- a/protoc-artifacts/pom.xml
+++ b/protoc-artifacts/pom.xml
@@ -71,11 +71,7 @@
                   <type>exe</type>
                 </artifact>
                 <artifact>
-                  <!-- Reuse a compatible osx-x86_64 version until binary
-                       support for osx-aarch_64 is added. TODO: use
-                       <file>${basedir}/target/osx/aarch_64/protoc.exe</file>
-                       -->
-                  <file>${basedir}/target/osx/x86_64/protoc.exe</file>
+                  <file>${basedir}/target/osx/aarch_64/protoc.exe</file>
                   <classifier>osx-aarch_64</classifier>
                   <type>exe</type>
                 </artifact>


### PR DESCRIPTION
This is my attempt to add a real osx aarch_64 (aka M1, Apple Silicon) artifact. I can run locally on a recent x86_64 mac which is one of the environments specified in the protoc-artifacts/README.md.

It was not super clear how the build automation runs this or moves stuff around. I see the linux CI jobs in kokoro seem to call the build-protoc.sh, but the mac job seems to build it without this script. Per build-zip.sh it should already pick up the artifact, but is currently skipped since it does not exist. It also looks like it should appear on the github release artifacts. I assume in this PR (possibly incorrectly) that the artifact will get to the "right" place, so I updated the pom.xml, but I can hold back on that if you advise. I don't feel comfortable (and the README discourages) making kokoro modifications, so I'm not going to touch that stuff. And building out the CI to assert that these new artifacts in fact work on this new macs is more of a maintainer task.

There seems to be a few issues tracking this and if its accepted, I'll link to those.

Signed-off-by: James Yuzawa <jtyuzawa@gmail.com>