### PR TITLE
Add prefix_to_proto_package_mappings_path ObjC option.

### DIFF
--- a/objectivec/README.md
+++ b/objectivec/README.md
@@ -133,12 +133,12 @@ This options allow you to provide a custom prefix for all the symbols generated
 from a proto file (classes (from message), enums, the Root for extension
 support).
 
-If not set, the generation option `use_package_as_prefix` (documented below)
-controls what is used instead. Since Objective C uses a global namespace for all
-of its classes, there can be collisions. `use_package_as_prefix=yes` should
-avoid collisions since proto package are used to scope/name things in other
-languages, but this option can be used to get shorter names instead. Convention
-is to base the explicit prefix on the proto package.
+If not set, the generation options `prefix_to_proto_package_mappings_path` and
+`use_package_as_prefix` (documented below) controls what is used instead. Since
+Objective C uses a global namespace for all of its classes, there can be collisions.
+`use_package_as_prefix=yes` should avoid collisions since proto package are used to
+scope/name things in other languages, but this option can be used to get shorter
+names instead. Convention is to base the explicit prefix on the proto package.
 
 Objective C Generator `protoc` Options
 --------------------------------------
@@ -181,6 +181,24 @@ supported keys are:
     When integrating ObjC protos into a build system, this can be used to avoid
     having to add the runtime directory to the header search path since the
     generate `#import` will be more complete.
+
+  * `prefix_to_proto_package_mappings_path`: The `value` used for
+    this key is a path to a file containing a list of prefixes and proto packages.
+    The generator will use this to locate which ObjC class prefix to use when
+    generating sources _unless_ the `objc_class_prefix` file option is set.
+    This option can be useful if multiple apps consume a common set of
+    proto files but wish to use a different prefix for the generated sources
+    between them. This option takes precedent over the `use_package_as_prefix`
+    option.
+
+    The format of the file is:
+      * An entry is a line of "package=prefix".
+      * Comments start with `#`.
+      * A comment can go on a line after a expected package/prefix pair.
+        (i.e. - "package=prefix # comment")
+      * For files that do NOT have a proto package (not recommended), an
+        entry can be made as "no_package:PATH=prefix", where PATH is the
+      path for the .proto file.
 
   * `use_package_as_prefix` and `proto_package_prefix_exceptions_path`: The
     `value` for `use_package_as_prefix` can be `yes` or `no`, and indicates

--- a/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
@@ -190,6 +190,21 @@ bool ObjectiveCGenerator::GenerateAll(
       // header search path since the generate #import will be more complete.
       generation_options.runtime_import_prefix =
           StripSuffixString(options[i].second, "/");
+    } else if (options[i].first == "prefix_to_proto_package_mappings_path") {
+      // Path to use for when loading the objc class prefix mappings to use.
+      // The `objc_class_prefix` file option is always honored first if one is present.
+      // This option also has precedent over the use_package_as_prefix option.
+      //
+      // The format of the file is:
+      //   - An entry is a line of "package=prefix".
+      //   - Comments start with "#".
+      //   - A comment can go on a line after a expected package/prefix pair.
+      //     (i.e. - "package=prefix # comment")
+      //   - For files that do NOT have a proto package (not recommended), an
+      //     entry can be made as "no_package:PATH=prefix", where PATH is the
+      //     path for the .proto file.
+      //
+      SetPrefixToProtoPackageMappingsPath(options[i].second);
     } else if (options[i].first == "use_package_as_prefix") {
       // Controls how the symbols should be prefixed to avoid symbols
       // collisions. The objc_class_prefix file option is always honored, this

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
@@ -47,6 +47,10 @@ namespace protobuf {
 namespace compiler {
 namespace objectivec {
 
+// Get/Set the path to a file to load for objc class prefix lookups.
+std::string PROTOC_EXPORT GetPrefixToProtoPackageMappingsPath();
+void PROTOC_EXPORT SetPrefixToProtoPackageMappingsPath(
+    const std::string& file_path);
 // Get/Set if the proto package should be used to make the default prefix for
 // symbols. This will then impact most of the type naming apis below. It is done
 // as a global to not break any other generator reusing the methods since they


### PR DESCRIPTION
Hey @thomasvl in the [previous PR](https://github.com/protocolbuffers/protobuf/pull/9476) we introduced the `default_objc_class_prefix` objc_opt.

However, upon using it it had a major flaw. We have protos that we generate this prefix for for namespacing and it is not always the same. Upon using this, we realized that objc class prefix passed was also used when generating code for dependencies which was causing compilation issues. In other words, it was applied globally. This might be OK if anyone decides to use the same prefix for all protos so maybe we can keep that option as well?

I figured anyone can generate a map with the same prefix across all proto files if they desire to do so.

This is basically a different solution to https://github.com/protocolbuffers/protobuf/issues/9469