### PR TITLE
Revert "Add an option to preserve proto names in JsonFormatter"

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonFormatterTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonFormatterTest.cs
@@ -663,13 +663,6 @@ namespace Google.Protobuf
         }
 
         [Test]
-        public void WriteValue_Message_PreserveNames()
-        {
-            var value = new TestAllTypes { SingleInt32 = 100, SingleInt64 = 3210987654321L };
-            AssertWriteValue(value, "{ 'single_int32': 100, 'single_int64': '3210987654321' }", JsonFormatter.Settings.Default.WithPreserveProtoFieldNames(true));
-        }
-
-        [Test]
         public void WriteValue_List()
         {
             var value = new RepeatedField<int> { 1, 2, 3 };
@@ -683,10 +676,10 @@ namespace Google.Protobuf
             AssertWriteValue(value, "{ 'FieldName13': 0 }");
         }
 
-        private static void AssertWriteValue(object value, string expectedJson, JsonFormatter.Settings settings = null)
+        private static void AssertWriteValue(object value, string expectedJson)
         {
             var writer = new StringWriter();
-            new JsonFormatter(settings ?? JsonFormatter.Settings.Default).WriteValue(writer, value);
+            JsonFormatter.Default.WriteValue(writer, value);
             string actual = writer.ToString();
             AssertJson(expectedJson, actual);
         }

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -233,14 +233,7 @@ namespace Google.Protobuf
                     writer.Write(PropertySeparator);
                 }
 
-                if (settings.PreserveProtoFieldNames)
-                {
-                    WriteString(writer, accessor.Descriptor.Name);
-                }
-                else
-                {
-                    WriteString(writer, accessor.Descriptor.JsonName);
-                }
+                WriteString(writer, accessor.Descriptor.JsonName);
                 writer.Write(NameValueSeparator);
                 WriteValue(writer, value);
 
@@ -823,11 +816,6 @@ namespace Google.Protobuf
             /// </summary>
             public bool FormatEnumsAsIntegers { get; }
 
-            /// <summary>
-            /// Whether to use the original proto field names as defined in the .proto file. Defaults to false.
-            /// </summary>
-            public bool PreserveProtoFieldNames { get; }
-
 
             /// <summary>
             /// Creates a new <see cref="Settings"/> object with the specified formatting of default values
@@ -844,7 +832,7 @@ namespace Google.Protobuf
             /// </summary>
             /// <param name="formatDefaultValues"><c>true</c> if default values (0, empty strings etc) should be formatted; <c>false</c> otherwise.</param>
             /// <param name="typeRegistry">The <see cref="TypeRegistry"/> to use when formatting <see cref="Any"/> messages.</param>
-            public Settings(bool formatDefaultValues, TypeRegistry typeRegistry) : this(formatDefaultValues, typeRegistry, false, false)
+            public Settings(bool formatDefaultValues, TypeRegistry typeRegistry) : this(formatDefaultValues, typeRegistry, false)
             {
             }
 
@@ -854,41 +842,32 @@ namespace Google.Protobuf
             /// <param name="formatDefaultValues"><c>true</c> if default values (0, empty strings etc) should be formatted; <c>false</c> otherwise.</param>
             /// <param name="typeRegistry">The <see cref="TypeRegistry"/> to use when formatting <see cref="Any"/> messages. TypeRegistry.Empty will be used if it is null.</param>
             /// <param name="formatEnumsAsIntegers"><c>true</c> to format the enums as integers; <c>false</c> to format enums as enum names.</param>
-            /// <param name="preserveProtoFieldNames"><c>true</c> to preserve proto field names; <c>false</c> to convert them to lowerCamelCase.</param>
             private Settings(bool formatDefaultValues,
                             TypeRegistry typeRegistry,
-                            bool formatEnumsAsIntegers,
-                            bool preserveProtoFieldNames)
+                            bool formatEnumsAsIntegers)
             {
                 FormatDefaultValues = formatDefaultValues;
                 TypeRegistry = typeRegistry ?? TypeRegistry.Empty;
                 FormatEnumsAsIntegers = formatEnumsAsIntegers;
-                PreserveProtoFieldNames = preserveProtoFieldNames;
             }
 
             /// <summary>
             /// Creates a new <see cref="Settings"/> object with the specified formatting of default values and the current settings.
             /// </summary>
             /// <param name="formatDefaultValues"><c>true</c> if default values (0, empty strings etc) should be formatted; <c>false</c> otherwise.</param>
-            public Settings WithFormatDefaultValues(bool formatDefaultValues) => new Settings(formatDefaultValues, TypeRegistry, FormatEnumsAsIntegers, PreserveProtoFieldNames);
+            public Settings WithFormatDefaultValues(bool formatDefaultValues) => new Settings(formatDefaultValues, TypeRegistry, FormatEnumsAsIntegers);
 
             /// <summary>
             /// Creates a new <see cref="Settings"/> object with the specified type registry and the current settings.
             /// </summary>
             /// <param name="typeRegistry">The <see cref="TypeRegistry"/> to use when formatting <see cref="Any"/> messages.</param>
-            public Settings WithTypeRegistry(TypeRegistry typeRegistry) => new Settings(FormatDefaultValues, typeRegistry, FormatEnumsAsIntegers, PreserveProtoFieldNames);
+            public Settings WithTypeRegistry(TypeRegistry typeRegistry) => new Settings(FormatDefaultValues, typeRegistry, FormatEnumsAsIntegers);
 
             /// <summary>
             /// Creates a new <see cref="Settings"/> object with the specified enums formatting option and the current settings.
             /// </summary>
             /// <param name="formatEnumsAsIntegers"><c>true</c> to format the enums as integers; <c>false</c> to format enums as enum names.</param>
-            public Settings WithFormatEnumsAsIntegers(bool formatEnumsAsIntegers) => new Settings(FormatDefaultValues, TypeRegistry, formatEnumsAsIntegers, PreserveProtoFieldNames);
-
-            /// <summary>
-            /// Creates a new <see cref="Settings"/> object with the specified field name formatting option and the current settings.
-            /// </summary>
-            /// <param name="preserveProtoFieldNames"><c>true</c> to preserve proto field names; <c>false</c> to convert them to lowerCamelCase.</param>
-            public Settings WithPreserveProtoFieldNames(bool preserveProtoFieldNames) => new Settings(FormatDefaultValues, TypeRegistry, FormatEnumsAsIntegers, preserveProtoFieldNames);
+            public Settings WithFormatEnumsAsIntegers(bool formatEnumsAsIntegers) => new Settings(FormatDefaultValues, TypeRegistry, formatEnumsAsIntegers);
         }
 
         // Effectively a cache of mapping from enum values to the original name as specified in the proto file,


### PR DESCRIPTION
Reverts protocolbuffers/protobuf#6307

- there is a large white-space only diff that obscures the real changes, which is really bad for maintenance. Let's reintroduce the PR without the whitespace changes so that the correct diff is shown in github UI.
- there's been some other concerns with the PR (see comment thread on https://github.com/protocolbuffers/protobuf/pull/6307).

We'll be happy to accept the PR again once the concerns from the review are addressed and once the diff looks fine.

@ObsidianMinor 