### PR TITLE
Changes to build aarch64 under manylinux.

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -44,15 +44,16 @@ cc_toolchain_config(
     bit_flag = "-m64",
     cpp_flag = "-lstdc++",
     extra_compiler_flags = [
-        "-I/usr/aarch64-linux-gnu/include/c++/8/aarch64-linux-gnu/",
-        "-I/usr/aarch64-linux-gnu/include/c++/8"
+        "-I/opt/manylinux/2014/aarch64/usr/include/c++/10/aarch64-redhat-linux",
+        "-I/opt/manylinux/2014/aarch64/usr/include/c++/10"
     ],
-    extra_include = "/usr/include",
+    sysroot = "/opt/manylinux/2014/aarch64",
     linker_path = "/usr/bin/ld",
     target_cpu = "aarch64",
     target_full_name = "aarch64-linux-gnu",
-    toolchain_dir = "/usr/aarch64-linux-gnu/include",
     toolchain_name = "linux_aarch_64",
+    # Don't really need this, setting it because it's required.
+    toolchain_dir = "/opt/manylinux/2014/aarch64/usr/include",
 )
 
 cc_toolchain_config(

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -108,7 +108,7 @@ def _impl(ctx):
       enabled = (ctx.attr.sysroot != ""),
       flag_sets = [
           flag_set(
-              actions = all_link_actions,
+              actions = all_link_actions + all_compile_actions,
               flag_groups = [
                   flag_group(
                       flags = [


### PR DESCRIPTION
This will take advantage of a Docker image that contains a manylinux_aarch64 sysroot, to create binaries that are compatble with old Linux distros.

If the approach is working out, we can add this for all our other architectures too.