### PR TITLE
Add test scope to kotlin-test for protobuf-kotlin-lite

### DIFF
--- a/java/kotlin-lite/pom.xml
+++ b/java/kotlin-lite/pom.xml
@@ -59,6 +59,7 @@
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-test</artifactId>
       <version>${kotlin.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
I believe this is all that is needed to fix #9517 (this also matches the declaration for `protobuf-kotlin`: https://github.com/protocolbuffers/protobuf/blob/b0bf163c78d6839fad43146e7d2f85c59a4e5b6d/java/kotlin/pom.xml#L61)