### PR TITLE
Change sysroot flags

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -102,13 +102,18 @@ def _impl(ctx):
       ],
   )
 
+  if 'osx' in ctx.attr.target_full_name:
+    sysroot_action_set = all_link_actions
+  else:
+    sysroot_action_set = all_link_actions + all_compile_actions
+
   sysroot_flags = feature(
       name = "sysroot_flags",
       #Only enable this if a sysroot was specified
       enabled = (ctx.attr.sysroot != ""),
       flag_sets = [
           flag_set(
-              actions = all_link_actions + all_compile_actions,
+              actions = sysroot_action_set,
               flag_groups = [
                   flag_group(
                       flags = [


### PR DESCRIPTION
Only put sysroot flags on linker actions for the osx case.