### PR TITLE
cmake: Set correct sonames for libprotobuf-lite.so and libprotoc.so (#8635)

### DIFF
--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -108,6 +108,7 @@ if(protobuf_BUILD_SHARED_LIBS)
 endif()
 set_target_properties(libprotobuf-lite PROPERTIES
     VERSION ${protobuf_VERSION}
+    SOVERSION 30
     OUTPUT_NAME ${LIB_PREFIX}protobuf-lite
     DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
 add_library(protobuf::libprotobuf-lite ALIAS libprotobuf-lite)

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -125,7 +125,6 @@ if(protobuf_BUILD_SHARED_LIBS)
 endif()
 set_target_properties(libprotobuf PROPERTIES
     VERSION ${protobuf_VERSION}
-    # Use only the first SO version component for compatibility with Makefile emitted SONAME.
     SOVERSION 30
     OUTPUT_NAME ${LIB_PREFIX}protobuf
     DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -140,6 +140,7 @@ endif()
 set_target_properties(libprotoc PROPERTIES
     COMPILE_DEFINITIONS LIBPROTOC_EXPORTS
     VERSION ${protobuf_VERSION}
+    SOVERSION 30
     OUTPUT_NAME ${LIB_PREFIX}protoc
     DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
 add_library(protobuf::libprotoc ALIAS libprotoc)

--- a/update_version.py
+++ b/update_version.py
@@ -103,11 +103,17 @@ def RewriteTextFile(filename, line_rewriter):
 
 
 def UpdateCMake():
-  RewriteTextFile('cmake/libprotobuf.cmake',
-    lambda line : re.sub(
-      r'SOVERSION [0-9]+\.[0-9]+(\.[0-9]+)?',
-      'SOVERSION %s' % GetSharedObjectVersion()[0],
-      line))
+  cmake_files = (
+    'cmake/libprotobuf.cmake',
+    'cmake/libprotobuf-lite.cmake',
+    'cmake/libprotoc.cmake'
+  )
+  for cmake_file in cmake_files:
+    RewriteTextFile(cmake_file,
+      lambda line : re.sub(
+        r'SOVERSION [0-9]+\.[0-9]+(\.[0-9]+)?',
+        'SOVERSION %s' % GetSharedObjectVersion()[0],
+        line))
 
 
 def UpdateConfigure():


### PR DESCRIPTION
Soname was set for libprotobuf.so in commit a9cf69a0ed7766f56976e48a0c96300e94433511,
but similar changes for libprotobuf-lite.so and libprotoc.so were missed.

Fixes: #8635