### PR TITLE
chore: [PHP] fix phpdoc for MapField keys

### DIFF
--- a/php/src/Google/Protobuf/Internal/MapField.php
+++ b/php/src/Google/Protobuf/Internal/MapField.php
@@ -131,7 +131,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * This will also be called for: $ele = $arr[$key]
      *
-     * @param int|bool|string $key The key of the element to be fetched.
+     * @param int|string $key The key of the element to be fetched.
      * @return object The stored element at given key.
      * @throws \ErrorException Invalid type for index.
      * @throws \ErrorException Non-existing index.
@@ -148,7 +148,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * This will also be called for: $arr[$key] = $value
      *
-     * @param object $key The key of the element to be fetched.
+     * @param int|string $key The key of the element to be fetched.
      * @param object $value The element to be assigned.
      * @return void
      * @throws \ErrorException Invalid type for key.
@@ -211,7 +211,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * This will also be called for: unset($arr)
      *
-     * @param object $key The key of the element to be removed.
+     * @param int|string $key The key of the element to be removed.
      * @return void
      * @throws \ErrorException Invalid type for key.
      * @todo need to add return type void (require update php version to 7.1)
@@ -228,7 +228,7 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * This will also be called for: isset($arr)
      *
-     * @param object $key The key of the element to be removed.
+     * @param int|string $key The key of the element to be removed.
      * @return bool True if the element at the given key exists.
      * @throws \ErrorException Invalid type for key.
      */


### PR DESCRIPTION
`object` is not a valid offset type. Anything other than `string|int` is not a valid offset type. `bool` may be added, but it's not a true offset because it will be cast to an `int` if used:

```php
$a = [false => '1' , true => '2'];
$a[0] = '3';
$a[1] = '4';
var_dump($a);
// array(2) {
//   [0]=>
//   string(1) "3"
//   [1]=>
//   string(1) "4"
// }
```