### PR TITLE
cmake: Use linker version scripts

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake required
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.10)
 
 if(protobuf_VERBOSE)
   message(STATUS "Protocol Buffers Configuring...")
@@ -127,6 +127,30 @@ if (protobuf_DISABLE_RTTI)
   add_definitions(-DGOOGLE_PROTOBUF_NO_RTTI=1)
 endif()
 
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmaketest.map
+"{
+  global:
+    main;
+  local:
+    *;
+};")
+# CheckLinkerFlag module available in CMake >=3.18.
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.18)
+  include(CheckLinkerFlag)
+  check_linker_flag(CXX -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/cmaketest.map protobuf_HAVE_LD_VERSION_SCRIPT)
+else()
+  include(CheckCXXSourceCompiles)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/cmaketest.map)
+  check_cxx_source_compiles("
+    int main() {
+      return 0;
+    }
+  " protobuf_HAVE_LD_VERSION_SCRIPT)
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+endif()
+file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/cmaketest.map)
+
 find_package(Threads REQUIRED)
 
 set(_protobuf_FIND_ZLIB)
@@ -182,7 +206,7 @@ else (protobuf_BUILD_SHARED_LIBS)
   # Prior to CMake 3.15, the MSVC runtime library was pushed into the same flags
   # making programmatic control difficult.  Prefer the functionality in newer
   # CMake versions when available.
-  if(CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.15)
     if (protobuf_MSVC_STATIC_RUNTIME)
         set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
     else()

--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -93,6 +93,11 @@ endif()
 
 add_library(libprotobuf-lite ${protobuf_SHARED_OR_STATIC}
   ${libprotobuf_lite_files} ${libprotobuf_lite_includes} ${libprotobuf_lite_rc_files})
+if(protobuf_HAVE_LD_VERSION_SCRIPT)
+  target_link_options(libprotobuf-lite PRIVATE -Wl,--version-script=${protobuf_source_dir}/src/libprotobuf-lite.map)
+  set_target_properties(libprotobuf-lite PROPERTIES
+    LINK_DEPENDS ${protobuf_source_dir}/src/libprotobuf-lite.map)
+endif()
 target_link_libraries(libprotobuf-lite ${CMAKE_THREAD_LIBS_INIT})
 if(protobuf_LINK_LIBATOMIC)
   target_link_libraries(libprotobuf-lite atomic)

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -107,6 +107,11 @@ endif()
 
 add_library(libprotobuf ${protobuf_SHARED_OR_STATIC}
   ${libprotobuf_lite_files} ${libprotobuf_files} ${libprotobuf_includes} ${libprotobuf_rc_files})
+if(protobuf_HAVE_LD_VERSION_SCRIPT)
+  target_link_options(libprotobuf PRIVATE -Wl,--version-script=${protobuf_source_dir}/src/libprotobuf.map)
+  set_target_properties(libprotobuf PROPERTIES
+    LINK_DEPENDS ${protobuf_source_dir}/src/libprotobuf.map)
+endif()
 target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT})
 if(protobuf_WITH_ZLIB)
   target_link_libraries(libprotobuf ${ZLIB_LIBRARIES})

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -131,6 +131,11 @@ endif()
 
 add_library(libprotoc ${protobuf_SHARED_OR_STATIC}
   ${libprotoc_files} ${libprotoc_headers} ${libprotoc_rc_files})
+if(protobuf_HAVE_LD_VERSION_SCRIPT)
+  target_link_options(libprotoc PRIVATE -Wl,--version-script=${protobuf_source_dir}/src/libprotoc.map)
+  set_target_properties(libprotoc PROPERTIES
+    LINK_DEPENDS ${protobuf_source_dir}/src/libprotoc.map)
+endif()
 target_link_libraries(libprotoc libprotobuf)
 if(MSVC AND protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotoc


### PR DESCRIPTION
Autotools build system already uses linker version scripts since
commit 13d165de9e737cec750a2ab3d1ef68bb3f276c48.

Fixes: #6113