### PR TITLE
[ObjC] Rename `proto_package_to_prefix_mappings_path` to `package_to_prefix_mappings_path`.

### DIFF
--- a/objectivec/README.md
+++ b/objectivec/README.md
@@ -133,7 +133,7 @@ This options allow you to provide a custom prefix for all the symbols generated
 from a proto file (classes (from message), enums, the Root for extension
 support).
 
-If not set, the generation options `prefix_to_proto_package_mappings_path` and
+If not set, the generation options `package_to_prefix_mappings_path` and
 `use_package_as_prefix` (documented below) controls what is used instead. Since
 Objective C uses a global namespace for all of its classes, there can be collisions.
 `use_package_as_prefix=yes` should avoid collisions since proto package are used to
@@ -182,8 +182,8 @@ supported keys are:
     having to add the runtime directory to the header search path since the
     generate `#import` will be more complete.
 
-  * `prefix_to_proto_package_mappings_path`: The `value` used for
-    this key is a path to a file containing a list of prefixes and proto packages.
+  * `package_to_prefix_mappings_path`: The `value` used for this key is a 
+    path to a file containing a list of proto packages and prefixes.
     The generator will use this to locate which ObjC class prefix to use when
     generating sources _unless_ the `objc_class_prefix` file option is set.
     This option can be useful if multiple apps consume a common set of

--- a/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
@@ -190,7 +190,7 @@ bool ObjectiveCGenerator::GenerateAll(
       // header search path since the generate #import will be more complete.
       generation_options.runtime_import_prefix =
           StripSuffixString(options[i].second, "/");
-    } else if (options[i].first == "prefix_to_proto_package_mappings_path") {
+    } else if (options[i].first == "package_to_prefix_mappings_path") {
       // Path to use for when loading the objc class prefix mappings to use.
       // The `objc_class_prefix` file option is always honored first if one is present.
       // This option also has precedent over the use_package_as_prefix option.
@@ -204,7 +204,7 @@ bool ObjectiveCGenerator::GenerateAll(
       //     entry can be made as "no_package:PATH=prefix", where PATH is the
       //     path for the .proto file.
       //
-      SetPrefixToProtoPackageMappingsPath(options[i].second);
+      SetPackageToPrefixMappingsPath(options[i].second);
     } else if (options[i].first == "use_package_as_prefix") {
       // Controls how the symbols should be prefixed to avoid symbols
       // collisions. The objc_class_prefix file option is always honored, this

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -112,10 +112,10 @@ class PrefixModeStorage {
  public:
   PrefixModeStorage();
 
-  const std::string prefix_to_proto_package_mappings_path() const { return prefix_to_proto_package_mappings_path_; }
-  void set_prefix_to_proto_package_mappings_path(const std::string& path) {
-    prefix_to_proto_package_mappings_path_ = path;
-    prefix_to_proto_package_map_.clear();
+  const std::string package_to_prefix_mappings_path() const { return package_to_prefix_mappings_path_; }
+  void set_package_to_prefix_mappings_path(const std::string& path) {
+    package_to_prefix_mappings_path_ = path;
+    package_to_prefix_map_.clear();
   }
 
   std::string prefix_from_proto_package_mappings(const FileDescriptor* file);
@@ -137,8 +137,8 @@ class PrefixModeStorage {
 
  private:
   bool use_package_name_;
-  std::map<std::string, std::string> prefix_to_proto_package_map_;
-  std::string prefix_to_proto_package_mappings_path_;
+  std::map<std::string, std::string> package_to_prefix_map_;
+  std::string package_to_prefix_mappings_path_;
   std::string exception_path_;
   std::string forced_prefix_;
   std::unordered_set<std::string> exceptions_;
@@ -168,20 +168,20 @@ std::string PrefixModeStorage::prefix_from_proto_package_mappings(const FileDesc
     return "";
   }
 
-  if (prefix_to_proto_package_map_.empty() && !prefix_to_proto_package_mappings_path_.empty()) {
+  if (package_to_prefix_map_.empty() && !package_to_prefix_mappings_path_.empty()) {
     std::string error_str;
     // Re use the same collector as we use for expected_prefixes_path since the file
     // format is the same.
-    PackageToPrefixesCollector collector("Package to prefixes", &prefix_to_proto_package_map_);
-    if (!ParseSimpleFile(prefix_to_proto_package_mappings_path_, &collector, &error_str)) {
+    PackageToPrefixesCollector collector("Package to prefixes", &package_to_prefix_map_);
+    if (!ParseSimpleFile(package_to_prefix_mappings_path_, &collector, &error_str)) {
       if (error_str.empty()) {
         error_str = std::string("protoc:0: warning: Failed to parse")
            + std::string(" prefix to proto package mappings file: ")
-           + prefix_to_proto_package_mappings_path_;
+           + package_to_prefix_mappings_path_;
       }
       std::cerr << error_str << std::endl;
       std::cerr.flush();
-      prefix_to_proto_package_map_.clear();      
+      package_to_prefix_map_.clear();
     }
   }
 
@@ -192,9 +192,9 @@ std::string PrefixModeStorage::prefix_from_proto_package_mappings(const FileDesc
   const std::string lookup_key = package.empty() ? no_package_prefix + file->name() : package;
 
   std::map<std::string, std::string>::const_iterator prefix_lookup =
-      prefix_to_proto_package_map_.find(lookup_key);
+      package_to_prefix_map_.find(lookup_key);
 
-  if (prefix_lookup != prefix_to_proto_package_map_.end()) {
+  if (prefix_lookup != package_to_prefix_map_.end()) {
     return prefix_lookup->second;
   }  
 
@@ -230,12 +230,12 @@ PrefixModeStorage g_prefix_mode;
 
 }  // namespace
 
-std::string GetPrefixToProtoPackageMappingsPath() {
-  return g_prefix_mode.prefix_to_proto_package_mappings_path();
+std::string GetPackageToPrefixMappingsPath() {
+  return g_prefix_mode.package_to_prefix_mappings_path();
 }
 
-void SetPrefixToProtoPackageMappingsPath(const std::string& file_path) {
-  g_prefix_mode.set_prefix_to_proto_package_mappings_path(file_path);
+void SetPackageToPrefixMappingsPath(const std::string& file_path) {
+  g_prefix_mode.set_package_to_prefix_mappings_path(file_path);
 }
 
 bool UseProtoPackageAsDefaultPrefix() {

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
@@ -48,8 +48,8 @@ namespace compiler {
 namespace objectivec {
 
 // Get/Set the path to a file to load for objc class prefix lookups.
-std::string PROTOC_EXPORT GetPrefixToProtoPackageMappingsPath();
-void PROTOC_EXPORT SetPrefixToProtoPackageMappingsPath(
+std::string PROTOC_EXPORT GetPackageToPrefixMappingsPath();
+void PROTOC_EXPORT SetPackageToPrefixMappingsPath(
     const std::string& file_path);
 // Get/Set if the proto package should be used to make the default prefix for
 // symbols. This will then impact most of the type naming apis below. It is done


### PR DESCRIPTION
The file format is actually the reverse of the initial option so we now rename the option to match the file format to avoid confusion.