### PR TITLE
Make protoc executable names consistent

### DIFF
--- a/protobuf_release.bzl
+++ b/protobuf_release.bzl
@@ -20,6 +20,8 @@ def _package_naming_impl(ctx):
     cpu = "s390_64"
   elif cpu == "aarch64":
     cpu = "aarch_64"
+  elif cpu == "ppc64":
+    cpu = "ppcle_64"
 
   # use the system name to determine the os and then create platform names
   if "apple" in system_name:


### PR DESCRIPTION
Rename ppc64 cpu to ppcle_64 to match current release.