### PR TITLE
Fix update_version.py script

### DIFF
--- a/update_version.py
+++ b/update_version.py
@@ -111,7 +111,7 @@ def UpdateCMake():
   for cmake_file in cmake_files:
     RewriteTextFile(cmake_file,
       lambda line : re.sub(
-        r'SOVERSION [0-9]+\.[0-9]+(\.[0-9]+)?',
+        r'SOVERSION ([0-9]+)$',
         'SOVERSION %s' % GetSharedObjectVersion()[0],
         line))
 
@@ -365,18 +365,6 @@ def UpdatePhp():
       changelog.appendChild(release)
       changelog.appendChild(document.createTextNode('\n '))
   RewriteXml('php/ext/google/protobuf/package.xml', Callback)
-  RewriteTextFile('php/ext/google/protobuf/protobuf.h',
-    lambda line : re.sub(
-      r'PHP_PROTOBUF_VERSION ".*"$',
-      'PHP_PROTOBUF_VERSION "%s"' % NEW_VERSION,
-      line))
-
-  RewriteTextFile('php/ext/google/protobuf/protobuf.h',
-    lambda line : re.sub(
-      r"^#define PHP_PROTOBUF_VERSION .*$",
-      "#define PHP_PROTOBUF_VERSION \"%s\"" % GetFullVersion(rc_suffix = 'RC'),
-      line))
-
   RewriteTextFile('php/ext/google/protobuf/protobuf.h',
     lambda line : re.sub(
       r"^#define PHP_PROTOBUF_VERSION .*$",


### PR DESCRIPTION
Two small fixes to update_version.py:
- The regex for updating SOVERSION in cmake files was not quite right. I
  fixed it to reflect that the value is a plain integer and not of the
  form x.y.z
- For some reason the code for updating PHP_PROTO_VERSION appeared 3
  times and led to a spurious warning, so I removed the extra calls
  there.