### PR TITLE
chore: gitignore ephemeral files that clangd uses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,7 @@ _build/
 
 # BenchmarkDotNet
 BenchmarkDotNet.Artifacts/
+
+# Clangd uses these common ephemeral files
+.cache
+compile_commands.json


### PR DESCRIPTION
This PR tells git to ignore ephemeral files that are created when
developers use clangd.

clangd needs a `compile_commands.json` file at the root of the repo (or
in a `build/` directory) to tell it how to compile each file. CMake can
generate this file with something like the following:

```console
$ cmake -Scmake -B.build \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -Dprotobuf_BUILD_TESTS=OFF
$ ln -sf .build/compile_commands.json .
```

Then clangd will compile and index files into the `.cache` directory.