### PR TITLE
Suppress warning for intentional circular require

### DIFF
--- a/ruby/lib/google/protobuf/descriptor_dsl.rb
+++ b/ruby/lib/google/protobuf/descriptor_dsl.rb
@@ -2,7 +2,14 @@
 #
 # Code that implements the DSL for defining proto messages.
 
-require 'google/protobuf/descriptor_pb'
+# Suppress warning: loading in progress, circular require considered harmful.
+# This circular require is intentional to avoid missing dependency.
+begin
+  old_verbose, $VERBOSE = $VERBOSE, nil
+  require 'google/protobuf/descriptor_pb'
+ensure
+  $VERBOSE = old_verbose
+end
 
 module Google
   module Protobuf


### PR DESCRIPTION
If ruby was started in verbose mode, it prints this warning:

```
$ ruby -w -r google/protobuf -e ''
<internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85: warning: <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85: warning: loading in progress, circular require considered harmful - /usr/local/bundle/gems/google-protobuf-3.19.4/lib/google/protobuf.rb
        from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:149:in  `require'
        from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in  `rescue in require'
        from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in  `require'
        from /usr/local/bundle/gems/google-protobuf-3.19.4/lib/google/protobuf.rb:57:in  `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in  `require'
        from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in  `require'
        from /usr/local/bundle/gems/google-protobuf-3.19.4/lib/google/protobuf/descriptor_dsl.rb:5:in  `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in  `require'
        from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in  `require'
        from /usr/local/bundle/gems/google-protobuf-3.19.4/lib/google/protobuf/descriptor_pb.rb:4:in  `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in  `require'
        from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in  `require'
```

The circular require is:
```
protobuf.rb -> protobuf/descriptor_dsl.rb -> protobuf/descriptor_pb.rb -> protobuf.rb
```

It is very annoying that many ruby test framework (e.g. minitest) runs in ruby verbose mode by default and thus prints this message every time the test runs.

As far as I can see, this circular require is actually needed. It guarantees that if user requires any one of the three files, all three files will be loaded. Since we intentionally need this circular require, it's best to just suppress the warning here, rather than having the user dealing with figure out how to suppress this one warning with other warnings untouched.