### PR TITLE
Change toolchain artifact name patterns

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -28,13 +28,16 @@ all_compile_actions = [
 ]
 
 def _impl(ctx):
-  artifact_name_patterns = [
-      artifact_name_pattern(
-          category_name = "executable",
-          prefix = "",
-          extension = ".exe",
-      ),
-  ]
+  if 'mingw' in ctx.attr.target_full_name:
+      artifact_name_patterns = [
+          artifact_name_pattern(
+              category_name = "executable",
+              prefix = "",
+              extension = ".exe",
+          ),
+      ]
+  else:
+      artifact_name_patterns = []
 
   tool_paths = [
       tool_path(


### PR DESCRIPTION
Only windows executable artifacts should have the ".exe" extension, other OSes should not.