### PR TITLE
Add bazel rules to do Kotlin mvn exports

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -13,6 +13,8 @@ filegroup(
     name = "release",
     srcs = [
         "//java/core:release", # contains lite.
+        "//java/kotlin:release",
+        "//java/kotlin-lite:release",
         "//java/util:release",
     ]
 )

--- a/java/kotlin-lite/BUILD
+++ b/java/kotlin-lite/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_java//java:defs.bzl", "java_lite_proto_library")
+load("@rules_jvm_external//:kt_defs.bzl", "kt_jvm_export")
+load("//:protobuf_version.bzl", "PROTOBUF_VERSION")
 load("//:protobuf.bzl", "internal_gen_kt_protos")
 
 java_lite_proto_library(
@@ -11,6 +13,47 @@ kt_jvm_library(
     name = "lite_extensions",
     srcs = ["src/main/kotlin/com/google/protobuf/ExtendableMessageLiteExtensions.kt"],
     deps = ["//java/lite"],
+)
+
+kt_jvm_library(
+    name = "well_known_protos_kotlin_lite",
+    srcs = [
+        "//:gen_well_known_protos_kotlinlite",
+    ],
+    deps = [
+        "//java/lite",
+        "//java/kotlin:only_for_use_in_proto_generated_code_its_generator_and_tests",
+        "//java/kotlin:shared_runtime",
+    ],
+)
+
+kt_jvm_export(
+    name = "kotlin-lite_mvn",
+    maven_coordinates = "com.google.protobuf:protobuf-kotlin-lite:%s" % PROTOBUF_VERSION,
+    pom_template = "//java/kotlin-lite:pom_template.xml",
+    resources = ["//:well_known_protos"],
+    runtime_deps = [
+        ":lite_extensions",
+        ":well_known_protos_kotlin_lite",
+        "//java/kotlin:bytestring_lib",
+        "//java/kotlin:only_for_use_in_proto_generated_code_its_generator_and_tests",
+        "//java/kotlin:shared_runtime",
+    ],
+    deploy_env = [
+        "@com_github_jetbrains_kotlin//:kotlin-stdlib",
+        "//java/lite",
+    ],
+)
+
+filegroup(
+    name = "release",
+    srcs = [
+        ":kotlin-lite_mvn-docs",
+        ":kotlin-lite_mvn-maven-source",
+        ":kotlin-lite_mvn-pom",
+        ":kotlin-lite_mvn-project",
+    ],
+    visibility = ["//java:__pkg__"],
 )
 
 test_suite(

--- a/java/kotlin/BUILD
+++ b/java/kotlin/BUILD
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_jvm_external//:kt_defs.bzl", "kt_jvm_export")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//:protobuf_version.bzl", "PROTOBUF_VERSION")
 load("//:protobuf.bzl", "internal_gen_kt_protos")
@@ -45,6 +46,35 @@ kt_jvm_library(
       "src/main/kotlin/com/google/protobuf/ExtendableMessageExtensions.kt",
     ],
     deps = ["//java/core"],
+)
+
+kt_jvm_library(
+    name = "kotlin",
+    runtime_deps = [
+      ":bytestring_lib",
+      ":full_extensions",
+      ":only_for_use_in_proto_generated_code_its_generator_and_tests",
+      ":shared_runtime",
+      ":well_known_protos_kotlin",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+kt_jvm_export(
+    name = "kotlin_mvn",
+    maven_coordinates = "com.google.protobuf:protobuf-kotlin:%s" % PROTOBUF_VERSION,
+    resources = ["//:well_known_protos"],
+    runtime_deps = [
+      ":bytestring_lib",
+      ":full_extensions",
+      ":only_for_use_in_proto_generated_code_its_generator_and_tests",
+      ":shared_runtime",
+      ":well_known_protos_kotlin",
+    ],
+    deploy_env = [
+        "@com_github_jetbrains_kotlin//:kotlin-stdlib",
+        "//java/core",
+    ],
 )
 
 test_suite(

--- a/java/kotlin/BUILD
+++ b/java/kotlin/BUILD
@@ -37,6 +37,7 @@ kt_jvm_library(
     name = "bytestring_lib",
     srcs = ["src/main/kotlin/com/google/protobuf/ByteStrings.kt"],
     deps = ["//java/lite"],
+    visibility = ["//java:__subpackages__"],
 )
 
 kt_jvm_library(
@@ -48,21 +49,10 @@ kt_jvm_library(
     deps = ["//java/core"],
 )
 
-kt_jvm_library(
-    name = "kotlin",
-    runtime_deps = [
-      ":bytestring_lib",
-      ":full_extensions",
-      ":only_for_use_in_proto_generated_code_its_generator_and_tests",
-      ":shared_runtime",
-      ":well_known_protos_kotlin",
-    ],
-    visibility = ["//visibility:public"],
-)
-
 kt_jvm_export(
     name = "kotlin_mvn",
     maven_coordinates = "com.google.protobuf:protobuf-kotlin:%s" % PROTOBUF_VERSION,
+    pom_template = "//java/kotlin:pom_template.xml",
     resources = ["//:well_known_protos"],
     runtime_deps = [
       ":bytestring_lib",
@@ -75,6 +65,17 @@ kt_jvm_export(
         "@com_github_jetbrains_kotlin//:kotlin-stdlib",
         "//java/core",
     ],
+)
+
+filegroup(
+    name = "release",
+    srcs = [
+        ":kotlin_mvn-docs",
+        ":kotlin_mvn-maven-source",
+        ":kotlin_mvn-pom",
+        ":kotlin_mvn-project",
+    ],
+    visibility = ["//java:__pkg__"],
 )
 
 test_suite(

--- a/java/util/BUILD
+++ b/java/util/BUILD
@@ -27,6 +27,7 @@ java_export(
     pom_template = "pom_template.xml",
     visibility = ["//java:__pkg__"],
     runtime_deps = [":util"],
+    deploy_env = ["//java/core"],
 )
 
 filegroup(

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -70,9 +70,9 @@ def protobuf_deps():
     if not native.existing_rule("rules_jvm_external"):
         http_archive(
             name = "rules_jvm_external",
-            sha256 = "f36441aa876c4f6427bfb2d1f2d723b48e9d930b62662bf723ddfb8fc80f0140",
-            strip_prefix = "rules_jvm_external-4.1",
-            urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/4.1.zip"],
+            sha256 = "744bd7436f63af7e9872948773b8b106016dc164acb3960b4963f86754532ee7",
+            strip_prefix = "rules_jvm_external-906875b0d5eaaf61a8ca2c9c3835bde6f435d011",
+            urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/906875b0d5eaaf61a8ca2c9c3835bde6f435d011.zip"],
         )
 
     if not native.existing_rule("rules_pkg"):


### PR DESCRIPTION
Use kt_jvm_export to make bazel rules that create maven jars. Update the util rule to not copy over all of the java core runtime.

I tested this by comparing the jars that it creates with the jars that the maven command creates, and the output is consistent.