### PR TITLE
Allow pre-compiled binaries for ruby 3.1.0

### DIFF
--- a/kokoro/linux/dockerfile/test/ruby/Dockerfile
+++ b/kokoro/linux/dockerfile/test/ruby/Dockerfile
@@ -35,6 +35,7 @@ RUN /bin/bash -l -c "rvm install 2.5.1"
 RUN /bin/bash -l -c "rvm install 2.6.0"
 RUN /bin/bash -l -c "rvm install 2.7.0"
 RUN /bin/bash -l -c "rvm install 3.0.0"
+RUN /bin/bash -l -c "rvm install 3.1.0"
 RUN /bin/bash -l -c "rvm install jruby-9.2.20.1"
 RUN /bin/bash -l -c "rvm install jruby-9.3.3.0"
 

--- a/kokoro/linux/dockerfile/test/ruby/Dockerfile
+++ b/kokoro/linux/dockerfile/test/ruby/Dockerfile
@@ -31,6 +31,7 @@ RUN gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys \
     7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s master
 
+RUN /bin/bash -l -c "rvm get head"
 RUN /bin/bash -l -c "rvm install 2.5.1"
 RUN /bin/bash -l -c "rvm install 2.6.0"
 RUN /bin/bash -l -c "rvm install 2.7.0"

--- a/kokoro/linux/dockerfile/test/ruby/Dockerfile
+++ b/kokoro/linux/dockerfile/test/ruby/Dockerfile
@@ -31,7 +31,6 @@ RUN gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys \
     7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s master
 
-RUN /bin/bash -l -c "rvm get head"
 RUN /bin/bash -l -c "rvm install 2.5.1"
 RUN /bin/bash -l -c "rvm install 2.6.0"
 RUN /bin/bash -l -c "rvm install 2.7.0"

--- a/kokoro/linux/ruby31/build.sh
+++ b/kokoro/linux/ruby31/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# This is the top-level script we give to Kokoro as the entry point for
+# running the "pull request" project:
+#
+# This script selects a specific Dockerfile (for building a Docker image) and
+# a script to run inside that image.  Then we delegate to the general
+# build_and_run_docker.sh script.
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+export DOCKERHUB_ORGANIZATION=protobuftesting
+export DOCKERFILE_DIR=kokoro/linux/dockerfile/test/ruby
+export DOCKER_RUN_SCRIPT=kokoro/linux/pull_request_in_docker.sh
+export OUTPUT_DIR=testoutput
+export TEST_SET="ruby31"
+./kokoro/linux/build_and_run_docker.sh

--- a/kokoro/linux/ruby31/continuous.cfg
+++ b/kokoro/linux/ruby31/continuous.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/ruby31/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/linux/ruby31/presubmit.cfg
+++ b/kokoro/linux/ruby31/presubmit.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/ruby31/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -36,5 +36,5 @@ if [[ "${KOKORO_INSTALL_RVM:-}" == "yes" ]] ; then
   # Old OpenSSL versions cannot handle the SSL certificate used by
   # https://get.rvm.io, so as a workaround we download RVM directly from
   # GitHub. See this issue for details: https://github.com/rvm/rvm/issues/5133
-  curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s stable --ruby
+  curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s master --ruby
 fi

--- a/kokoro/macos/ruby31/build.sh
+++ b/kokoro/macos/ruby31/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+KOKORO_INSTALL_RVM=yes
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh ruby31

--- a/kokoro/macos/ruby31/continuous.cfg
+++ b/kokoro/macos/ruby31/continuous.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/ruby31/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/ruby31/presubmit.cfg
+++ b/kokoro/macos/ruby31/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/ruby31/build.sh"
+timeout_mins: 1440

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -76,7 +76,7 @@ patch "$CROSS_RUBY31" << EOF
      '--enable-static',
      '--disable-shared',
      '--disable-install-doc',
-+    '--with-coroutine=context',
++    '--with-coroutine=ucontext',
      '--without-gmp',
      '--with-ext=',
      'LDFLAGS=-pipe',

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -71,12 +71,12 @@ cp $CROSS_RUBY CROSS_RUBY31
 
 patch "$CROSS_RUBY31" << EOF
 --- cross-ruby.rake	2022-03-04 11:49:52.000000000 +0000
-+++ patched	2022-03-04 11:50:29.000000000 +0000
++++ patched	2022-03-04 11:58:22.000000000 +0000
 @@ -114,6 +114,7 @@
      '--enable-static',
      '--disable-shared',
      '--disable-install-doc',
-+    '--with-coroutine=universal',
++    '--with-coroutine=context',
      '--without-gmp',
      '--with-ext=',
      'LDFLAGS=-pipe',

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -67,7 +67,7 @@ patch "$CROSS_RUBY" << EOF
  end
 EOF
 
-cp $CROSS_RUBY CROSS_RUBY31
+cp $CROSS_RUBY $CROSS_RUBY31
 
 patch "$CROSS_RUBY31" << EOF
 --- cross-ruby.rake	2022-03-04 11:49:52.000000000 +0000

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -58,7 +58,7 @@ set +x # rvm commands are very verbose
 rvm use 2.7.0
 set -x
 ruby --version | grep 'ruby 2.7.0'
-for v in 3.0.0 2.7.0 ; do
+for v in 3.1.0 3.0.0 2.7.0 ; do
   ccache -c
   rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin MAKE="$MAKE"
   rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=aarch64-darwin MAKE="$MAKE"

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -5,7 +5,6 @@ set -ex
 set +ex  # rvm script is very verbose and exits with errorcode
 source $HOME/.rvm/scripts/rvm
 set -e  # rvm commands are very verbose
-rvm get head
 time rvm install 2.5.0
 rvm use 2.5.0
 gem install rake-compiler --no-document

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -5,6 +5,7 @@ set -ex
 set +ex  # rvm script is very verbose and exits with errorcode
 source $HOME/.rvm/scripts/rvm
 set -e  # rvm commands are very verbose
+rvm get head
 time rvm install 2.5.0
 rvm use 2.5.0
 gem install rake-compiler --no-document

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -33,6 +33,8 @@ set -ex
 rm -rf ~/.rake-compiler
 
 CROSS_RUBY=$(mktemp tmpfile.XXXXXXXX)
+CROSS_RUBY31=$(mktemp tmpfile.XXXXXXXX)
+
 
 curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/72184e51779b6a3b9b8580b036a052fdc3181ced/tasks/bin/cross-ruby.rake > "$CROSS_RUBY"
 
@@ -65,6 +67,21 @@ patch "$CROSS_RUBY" << EOF
  end
 EOF
 
+cp $CROSS_RUBY CROSS_RUBY31
+
+patch "$CROSS_RUBY31" << EOF
+--- cross-ruby.rake	2022-03-04 11:49:52.000000000 +0000
++++ patched	2022-03-04 11:50:29.000000000 +0000
+@@ -114,6 +114,7 @@
+     '--enable-static',
+     '--disable-shared',
+     '--disable-install-doc',
++    '--with-coroutine=universal',
+     '--without-gmp',
+     '--with-ext=',
+     'LDFLAGS=-pipe',
+EOF
+
 MAKE="make -j8"
 
 set +x # rvm commands are very verbose
@@ -73,8 +90,8 @@ set -x
 ruby --version | grep 'ruby 3.1.0'
 for v in 3.1.0 ; do
   ccache -c
-  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin MAKE="$MAKE"
-  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=aarch64-darwin MAKE="$MAKE"
+  rake -f "$CROSS_RUBY31" cross-ruby VERSION="$v" HOST=x86_64-darwin MAKE="$MAKE"
+  rake -f "$CROSS_RUBY31" cross-ruby VERSION="$v" HOST=aarch64-darwin MAKE="$MAKE"
 done
 
 set +x # rvm commands are very verbose

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -3,6 +3,15 @@
 set -ex
 
 set +ex  # rvm script is very verbose and exits with errorcode
+
+curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
+
+# Old OpenSSL versions cannot handle the SSL certificate used by
+# https://get.rvm.io, so as a workaround we download RVM directly from
+# GitHub. See this issue for details: https://github.com/rvm/rvm/issues/5133
+curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s master --ruby
+
 source $HOME/.rvm/scripts/rvm
 set -e  # rvm commands are very verbose
 time rvm install 2.5.0

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -9,6 +9,10 @@ time rvm install 2.5.0
 rvm use 2.5.0
 gem install rake-compiler --no-document
 gem install bundler --no-document
+time rvm install 3.1.0
+rvm use 3.1.0
+gem install rake-compiler --no-document
+gem install bundler --no-document
 time rvm install 2.7.0
 rvm use 2.7.0 --default
 gem install rake-compiler --no-document

--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -55,10 +55,20 @@ EOF
 MAKE="make -j8"
 
 set +x # rvm commands are very verbose
+rvm use 3.1.0
+set -x
+ruby --version | grep 'ruby 3.1.0'
+for v in 3.1.0 ; do
+  ccache -c
+  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin MAKE="$MAKE"
+  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=aarch64-darwin MAKE="$MAKE"
+done
+
+set +x # rvm commands are very verbose
 rvm use 2.7.0
 set -x
 ruby --version | grep 'ruby 2.7.0'
-for v in 3.1.0 3.0.0 2.7.0 ; do
+for v in 3.0.0 2.7.0 ; do
   ccache -c
   rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin MAKE="$MAKE"
   rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=aarch64-darwin MAKE="$MAKE"

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
-
+group :development do
+  gem 'rake-compiler-dock', git: 'https://github.com/rake-compiler/rake-compiler-dock.git'
+end
 gemspec

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
-group :development do
-  gem 'rake-compiler-dock', git: 'https://github.com/rake-compiler/rake-compiler-dock.git'
-end
+
 gemspec

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -125,11 +125,11 @@ else
     ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux', 'x64-mingw-ucrt'].each do |plat|
       # x64-mingw-ucrt only supports 3.1+ whereas 'x64-mingw32' only supports up to 3.0
       versions = if plat == 'x64-mingw-ucrt'
-        '3.1.1'
+        '3.1.0'
       elsif plat == 'x64-mingw32'
         '3.0.0:2.7.0:2.6.0:2.5.0'
       else
-        '3.1.1:3.0.0:2.7.0:2.6.0:2.5.0'
+        '3.1.0:3.0.0:2.7.0:2.6.0:2.5.0'
       end
       RakeCompilerDock.sh <<-"EOT", platform: plat
         bundle && \
@@ -141,7 +141,7 @@ else
   if RUBY_PLATFORM =~ /darwin/
     task 'gem:native' do
       system "rake genproto"
-      system "rake cross native gem RUBY_CC_VERSION=3.1.1:3.0.0:2.7.0:2.6.0:2.5.1"
+      system "rake cross native gem RUBY_CC_VERSION=3.1.0:3.0.0:2.7.0:2.6.0:2.5.1"
     end
   else
     task 'gem:native' => [:genproto, 'gem:windows', 'gem:java']

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -122,18 +122,11 @@ else
   task 'gem:windows' do
     sh "rm Gemfile.lock"
     require 'rake_compiler_dock'
-    ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux', 'x64-mingw-ucrt'].each do |plat|
+    ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux'].each do |plat|
       # x64-mingw-ucrt only supports 3.1+ whereas 'x64-mingw32' only supports up to 3.0
-      versions = if plat == 'x64-mingw-ucrt'
-        '3.1.0'
-      elsif plat == 'x64-mingw32'
-        '3.0.0:2.7.0:2.6.0:2.5.0'
-      else
-        '3.1.0:3.0.0:2.7.0:2.6.0:2.5.0'
-      end
       RakeCompilerDock.sh <<-"EOT", platform: plat
         bundle && \
-        IN_DOCKER=true rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem RUBY_CC_VERSION=#{versions}
+        IN_DOCKER=true rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem RUBY_CC_VERSION=3.1.0:3.0.0:2.7.0:2.6.0:2.5.0
       EOT
     end
   end

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -123,6 +123,7 @@ else
     sh "rm Gemfile.lock"
     require 'rake_compiler_dock'
     ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux', 'x64-mingw-ucrt'].each do |plat|
+      # x64-mingw-ucrt only supports 3.1+ whereas 'x64-mingw32' only supports up to 3.0
       versions = if plat == 'x64-mingw-ucrt'
         '3.1.1'
       elsif plat == 'x64-mingw32'

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -122,10 +122,17 @@ else
   task 'gem:windows' do
     sh "rm Gemfile.lock"
     require 'rake_compiler_dock'
-    ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux'].each do |plat|
+    ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux', 'x64-mingw-ucrt'].each do |plat|
+      versions = if plat == 'x64-mingw-ucrt'
+        '3.1.1'
+      elsif plat == 'x64-mingw32'
+        '3.0.0:2.7.0:2.6.0:2.5.0'
+      else
+        '3.1.1:3.0.0:2.7.0:2.6.0:2.5.0'
+      end
       RakeCompilerDock.sh <<-"EOT", platform: plat
         bundle && \
-        IN_DOCKER=true rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem RUBY_CC_VERSION=3.0.0:2.7.0:2.6.0:2.5.0
+        IN_DOCKER=true rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem RUBY_CC_VERSION=#{versions}
       EOT
     end
   end
@@ -133,7 +140,7 @@ else
   if RUBY_PLATFORM =~ /darwin/
     task 'gem:native' do
       system "rake genproto"
-      system "rake cross native gem RUBY_CC_VERSION=3.0.0:2.7.0:2.6.0:2.5.1"
+      system "rake cross native gem RUBY_CC_VERSION=3.1.1:3.0.0:2.7.0:2.6.0:2.5.1"
     end
   else
     task 'gem:native' => [:genproto, 'gem:windows', 'gem:java']

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -123,7 +123,6 @@ else
     sh "rm Gemfile.lock"
     require 'rake_compiler_dock'
     ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux'].each do |plat|
-      # x64-mingw-ucrt only supports 3.1+ whereas 'x64-mingw32' only supports up to 3.0
       RakeCompilerDock.sh <<-"EOT", platform: plat
         bundle && \
         IN_DOCKER=true rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem RUBY_CC_VERSION=3.1.0:3.0.0:2.7.0:2.6.0:2.5.0

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   else
     s.files     += Dir.glob('ext/**/*')
     s.extensions= ["ext/google/protobuf_c/extconf.rb"]
-    s.add_development_dependency "rake-compiler-dock", "= 1.2.0"
   end
   s.test_files  = ["tests/basic.rb",
                   "tests/stress.rb",

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   else
     s.files     += Dir.glob('ext/**/*')
     s.extensions= ["ext/google/protobuf_c/extconf.rb"]
-  end
+    s.add_development_dependency "rake-compiler-dock", "= 1.2.1"  end
   s.test_files  = ["tests/basic.rb",
                   "tests/stress.rb",
                   "tests/generated_code_test.rb"]

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |s|
   else
     s.files     += Dir.glob('ext/**/*')
     s.extensions= ["ext/google/protobuf_c/extconf.rb"]
-    s.add_development_dependency "rake-compiler-dock", "= 1.1.0"
+    s.add_development_dependency "rake-compiler-dock", "= 1.2.0"
   end
   s.test_files  = ["tests/basic.rb",
                   "tests/stress.rb",
                   "tests/generated_code_test.rb"]
   s.required_ruby_version = '>= 2.3'
-  s.add_development_dependency "rake-compiler", "~> 1.1.0"
+  s.add_development_dependency "rake-compiler", "~> 1.2.0"
   s.add_development_dependency "test-unit", '~> 3.0', '>= 3.0.9'
 end

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
                   "tests/stress.rb",
                   "tests/generated_code_test.rb"]
   s.required_ruby_version = '>= 2.3'
-  s.add_development_dependency "rake-compiler", "~> 1.2.0"
+  s.add_development_dependency "rake-compiler", "~> 1.1.0"
   s.add_development_dependency "test-unit", '~> 3.0', '>= 3.0.9'
 end

--- a/tests.sh
+++ b/tests.sh
@@ -597,6 +597,7 @@ Usage: $0 { cpp |
             ruby26 |
             ruby27 |
             ruby30 |
+            ruby31 |
             jruby92 |
             jruby93 |
             ruby_all |

--- a/tests.sh
+++ b/tests.sh
@@ -422,6 +422,10 @@ build_ruby30() {
   internal_build_cpp  # For conformance tests.
   cd ruby && bash travis-test.sh ruby-3.0.2 && cd ..
 }
+build_ruby31() {
+  internal_build_cpp  # For conformance tests.
+  cd ruby && bash travis-test.sh ruby-3.1.0 && cd ..
+}
 
 build_jruby92() {
   internal_build_cpp                # For conformance tests.


### PR DESCRIPTION
## Why?

Fixes #9364

## What are the changes? 

I added 3.1.1 as a RUBY_CC_VERSION. I had to upgrade rake-compiler-dock to 1.2.0 as this is the only version of this gem that supports compilation for ruby 3.1+

Furthermore, I had to add a bit of logic (and a new platform this compiles to) as since RubyInstaller 3.1 x64 Windows is not `x64-mingw32` but rather `x64-mingw-ucrt` as explained [here](https://rubyinstaller.org/2021/12/31/rubyinstaller-3.1.0-1-released.html) 

Also `x64-mingw-ucrt` only supports 3.1+ whereas `x64-mingw32` only supports anything up to 3.0 so a little if statement is needed.