### PR TITLE
Add WhichOneof util in cpp to get the set oneof field descriptor

### DIFF
--- a/src/google/protobuf/util/oneof_util.cc
+++ b/src/google/protobuf/util/oneof_util.cc
@@ -1,0 +1,58 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <google/protobuf/util/oneof_util.h>
+
+// Must go after other includes.
+#include <google/protobuf/port_def.inc>
+
+namespace google {
+namespace protobuf {
+namespace util {
+
+const FieldDescriptor* WhichOneof(const Message& message,
+                                  const std::string& oneof_name) {
+  const Descriptor* descriptor = message.GetDescriptor();
+  if (descriptor == nullptr) return nullptr;  // Internal error.
+
+  const OneofDescriptor* oneof_descriptor =
+      descriptor->FindOneofByName(oneof_name);
+  if (oneof_descriptor == nullptr) return nullptr;  // No found with oneof_name.
+
+  const Reflection* reflection = message.GetReflection();
+  if (reflection == nullptr) return nullptr;  // Internal error.
+
+  // Return nullptr if no oneof set.
+  return reflection->GetOneofFieldDescriptor(message, oneof_descriptor);
+}
+
+}  // namespace util
+}  // namespace protobuf
+}  // namespace google

--- a/src/google/protobuf/util/oneof_util.h
+++ b/src/google/protobuf/util/oneof_util.h
@@ -1,0 +1,56 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Defines utilities for the Oneof fields.
+
+#ifndef GOOGLE_PROTOBUF_UTIL_ONEOF_UTIL_H_
+#define GOOGLE_PROTOBUF_UTIL_ONEOF_UTIL_H_
+
+#include <string>
+
+#include <google/protobuf/descriptor.h>  // FieldDescriptor
+#include <google/protobuf/message.h>     // Message
+
+#include <google/protobuf/port_def.inc>
+
+namespace google {
+namespace protobuf {
+namespace util {
+
+const FieldDescriptor* WhichOneof(const Message& message,
+                                  const std::string& oneof_name);
+
+}  // namespace util
+}  // namespace protobuf
+}  // namespace google
+
+#include <google/protobuf/port_undef.inc>
+
+#endif // GOOGLE_PROTOBUF_UTIL_ONEOF_UTIL_H_

--- a/src/google/protobuf/util/oneof_util_test.cc
+++ b/src/google/protobuf/util/oneof_util_test.cc
@@ -1,0 +1,92 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+#include <string>
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/testing/googletest.h>
+#include <google/protobuf/util/oneof_util_test.pb.h>
+#include <google/protobuf/util/oneof_util.h>
+#include <gtest/gtest.h>
+
+namespace google {
+namespace protobuf {
+namespace util {
+namespace {
+
+TEST(OneofUtilTest, WhichOneof) {
+  // test_msg_1 field set in FullMsg
+  {
+    FullMsg msg;
+    *(msg.mutable_test_msg_1()->mutable_name()) = "msg1_initialized";
+    const FieldDescriptor* fd = WhichOneof(msg, "test_type");
+    EXPECT_NE(fd, nullptr);
+    EXPECT_EQ(fd->name(), "test_msg_1")
+  }
+  // test_msg_2 field set in FullMsg
+  {
+    FullMsg msg;
+    *(msg.mutable_test_msg_2()->mutable_name()) = "msg2_initialized";
+    const FieldDescriptor* fd = WhichOneof(msg, "test_type");
+    EXPECT_NE(fd, nullptr);
+    EXPECT_EQ(fd->name(), "test_msg_2")
+  }
+  // No field set in FullMsg
+  {
+    FullMsg msg;
+    const FieldDescriptor* fd = WhichOneof(msg, "test_type");
+    EXPECT_EQ(fd, nullptr);
+  }
+  // No wrong oneof name passed to WhichOneof (the oneof exists)
+  {
+    FullMsg msg;
+    *(msg.mutable_test_msg_1()->mutable_name()) = "msg1_initialized";
+    const FieldDescriptor* fd = WhichOneof(msg, "extra_test_type");
+    EXPECT_EQ(fd, nullptr);
+  }
+  // No wrong oneof name passed to WhichOneof (the oneof does not exist)
+  {
+    FullMsg msg;
+    *(msg.mutable_test_msg_1()->mutable_name()) = "msg1_initialized";
+    const FieldDescriptor* fd = WhichOneof(msg, "none_exist_type");
+    EXPECT_EQ(fd, nullptr);
+  }
+  // No oneof exist in BaseMsg
+  {
+    BaseMsg1 msg;
+    const FieldDescriptor* fd = WhichOneof(msg, "any_type");
+    EXPECT_EQ(fd, nullptr);
+  }
+
+}  // namespace
+}  // namespace util
+}  // namespace protobuf
+}  // namespace google

--- a/src/google/protobuf/util/oneof_util_test.proto
+++ b/src/google/protobuf/util/oneof_util_test.proto
@@ -1,0 +1,55 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Author: guanchenglichina@qq.com (Guancheng Li)
+
+syntax = "proto2";
+
+package protobuf_unittest;
+
+message BaseMsg1 {
+  optional string name = 1;
+}
+
+message BaseMsg2 {
+  optional string name = 1;
+}
+
+message FullMsg {
+  oneof test_type {
+    BaseMsg1 test_msg_1 = 1;
+    BaseMsg2 test_msg_2 = 2;
+  }
+
+  oneof extra_test_type {
+    BaseMsg1 test_msg_3 = 1;
+    BaseMsg2 test_msg_4 = 2;
+  }
+}


### PR DESCRIPTION
**Description**
Address this issue: https://github.com/protocolbuffers/protobuf/issues/9502

In python, there is an API (WhichOneOf) to get the initialized field name: https://github.com/protocolbuffers/protobuf/blob/master/python/google/protobuf/message.py#L295

This function is very useful for us, but it does not implement in CPP.
The API in python implemented in the file `message.py`, I've read the message related code in CPP,
and get a conclusion that this function may not proper to put in the following paths:
```
src/google/protobuf/message.h
src/google/protobuf/message_lite.h
src/google/protobuf/descriptor.h
```

The current way may be a better choice for a "helper function".