### PR TITLE
[editors/emacs] Fix protobuf-mode definition

### DIFF
--- a/editors/protobuf-mode.el
+++ b/editors/protobuf-mode.el
@@ -193,7 +193,7 @@
 ;;;###autoload (add-to-list 'auto-mode-alist '("\\.proto\\'" . protobuf-mode))
 
 ;;;###autoload
-(define-derived-mode protobuf-mode prog-mode "Protobuf"
+(define-derived-mode protobuf-mode prog-mode "Protocol-Buffers"
   "Major mode for editing Protocol Buffers description language.
 
 The hook `c-mode-common-hook' is run with no argument at mode
@@ -201,26 +201,17 @@ initialization, then `protobuf-mode-hook'.
 
 Key bindings:
 \\{protobuf-mode-map}"
-  (interactive)
-  (kill-all-local-variables)
-  (set-syntax-table protobuf-mode-syntax-table)
-  (setq major-mode 'protobuf-mode
-        mode-name "Protocol-Buffers"
-        local-abbrev-table protobuf-mode-abbrev-table
-        abbrev-mode t)
-  (use-local-map protobuf-mode-map)
+  :after-hook (c-update-modeline)
+  (setq abbrev-mode t)
   (c-initialize-cc-mode t)
-  (if (fboundp 'c-make-emacs-variables-local)
-      (c-make-emacs-variables-local))
   (c-init-language-vars protobuf-mode)
   (c-common-init 'protobuf-mode)
   (easy-menu-add protobuf-menu)
-  (c-run-mode-hooks 'c-mode-common-hook 'protobuf-mode-hook)
-  (c-update-modeline)
   (setq imenu-generic-expression
 	    '(("Message" "^[[:space:]]*message[[:space:]]+\\([[:alnum:]]+\\)" 1)
           ("Enum" "^[[:space:]]*enum[[:space:]]+\\([[:alnum:]]+\\)" 1)
-          ("Service" "^[[:space:]]*service[[:space:]]+\\([[:alnum:]]+\\)" 1))))
+          ("Service" "^[[:space:]]*service[[:space:]]+\\([[:alnum:]]+\\)" 1)))
+  (c-run-mode-hooks 'c-mode-common-hook))
 
 (provide 'protobuf-mode)
 


### PR DESCRIPTION
Fix a few issues with the Emacs mode definition.

First, in 1ab7789f3 (2021-10-13, Emacs: Protobuf mode should be derived from
prog-mode) we made `protobuf-mode` a derived mode of `prog-mode` using the
`define-derived-mode` macro ([doc](https://www.gnu.org/software/emacs/manual/html_node/elisp/Derived-Modes.html)). However, the definition body was not updated
accordingly. So in this commit, we:

- Remove the superfluous `(interactive)` form;
- Remove the unnecessary call of `kill-all-local-variables`, which is already
  handled by `define-derived-mode` and could cause a few issues, for example,
  it prevents `prog-mode-hook` from being run;
- Remove forms that set `major-mode` and `mode-name`, which are automatically
  set to the first and third arguments respectively;
- Remove forms that set key map, syntax table, and abbrev table, which are
  already handled automatically;
- Do not run `protobuf-mode-hook` explicitly in the body. It is already arranged
  to be run after the body.

Second, the call to `c-make-emacs-variables-local` is removed. It is called
inside `c-init-language-vars` already. Calling it again should do no harm now,
but to be future-proof it might be better to just remove it.

Finally, we move the `c-update-modeline` form to the :after-hook argument to
ensure it is run at the very end, so that the mode line will reflect all user
customizations done in various mode hooks. Similarly, we run
`c-mode-common-hook` also at the very end to leave a place for user
customizations (for example, set `imenu-generic-expression` in
`c-mode-common-hook`).

Re: https://github.com/protocolbuffers/protobuf/issues/7316
Re: https://github.com/protocolbuffers/protobuf/pull/9076

Cc @xuhdev.

Thanks!