### PR TITLE
Lower minimum CMake version to 3.5

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake required
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.5)
 
 if(protobuf_VERBOSE)
   message(STATUS "Protocol Buffers Configuring...")


### PR DESCRIPTION
We tried increasing it to 3.10, but that turned out to be too high since
gRPC still supports 3.5.1.