### PR TITLE
[C#] fix parse failure for extensions with large field numbers

### DIFF
--- a/csharp/compatibility_tests/v3.0.0/src/Google.Protobuf.Test/CodedInputStreamTest.cs
+++ b/csharp/compatibility_tests/v3.0.0/src/Google.Protobuf.Test/CodedInputStreamTest.cs
@@ -416,6 +416,25 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void MaximumFieldNumber()
+        {
+            MemoryStream ms = new MemoryStream();
+            CodedOutputStream output = new CodedOutputStream(ms);
+
+            int fieldNumber = 0x1FFFFFFF;
+            uint tag = WireFormat.MakeTag(fieldNumber, WireFormat.WireType.LengthDelimited);
+            output.WriteRawVarint32(tag);
+            output.WriteString("field 1");
+            output.Flush();
+            ms.Position = 0;
+
+            CodedInputStream input = new CodedInputStream(ms);
+
+            Assert.AreEqual(tag, input.ReadTag());
+            Assert.AreEqual(fieldNumber, WireFormat.GetTagFieldNumber(tag));
+        }
+
+        [Test]
         public void Tag0Throws()
         {
             var input = new CodedInputStream(new byte[] { 0 });

--- a/csharp/compatibility_tests/v3.0.0/src/Google.Protobuf.Test/CodedInputStreamTest.cs
+++ b/csharp/compatibility_tests/v3.0.0/src/Google.Protobuf.Test/CodedInputStreamTest.cs
@@ -416,25 +416,6 @@ namespace Google.Protobuf
         }
 
         [Test]
-        public void MaximumFieldNumber()
-        {
-            MemoryStream ms = new MemoryStream();
-            CodedOutputStream output = new CodedOutputStream(ms);
-
-            int fieldNumber = 0x1FFFFFFF;
-            uint tag = WireFormat.MakeTag(fieldNumber, WireFormat.WireType.LengthDelimited);
-            output.WriteRawVarint32(tag);
-            output.WriteString("field 1");
-            output.Flush();
-            ms.Position = 0;
-
-            CodedInputStream input = new CodedInputStream(ms);
-
-            Assert.AreEqual(tag, input.ReadTag());
-            Assert.AreEqual(fieldNumber, WireFormat.GetTagFieldNumber(tag));
-        }
-
-        [Test]
         public void Tag0Throws()
         {
             var input = new CodedInputStream(new byte[] { 0 });

--- a/csharp/src/Google.Protobuf.Test/CodedInputStreamTest.cs
+++ b/csharp/src/Google.Protobuf.Test/CodedInputStreamTest.cs
@@ -717,6 +717,25 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void MaximumFieldNumber()
+        {
+            MemoryStream ms = new MemoryStream();
+            CodedOutputStream output = new CodedOutputStream(ms);
+
+            int fieldNumber = 0x1FFFFFFF;
+            uint tag = WireFormat.MakeTag(fieldNumber, WireFormat.WireType.LengthDelimited);
+            output.WriteRawVarint32(tag);
+            output.WriteString("field 1");
+            output.Flush();
+            ms.Position = 0;
+
+            CodedInputStream input = new CodedInputStream(ms);
+
+            Assert.AreEqual(tag, input.ReadTag());
+            Assert.AreEqual(fieldNumber, WireFormat.GetTagFieldNumber(tag));
+        }
+
+        [Test]
         public void Tag0Throws()
         {
             var input = new CodedInputStream(new byte[] { 0 });

--- a/csharp/src/Google.Protobuf/WireFormat.cs
+++ b/csharp/src/Google.Protobuf/WireFormat.cs
@@ -90,7 +90,7 @@ namespace Google.Protobuf
         /// </summary>
         public static int GetTagFieldNumber(uint tag)
         {
-            return (int) tag >> TagTypeBits;
+            return (int) (tag >> TagTypeBits);
         }
 
         /// <summary>


### PR DESCRIPTION
Currently, it is failing to parse messages with an extension whose field number is large (> 0x10000000), e.g. https://github.com/google/mediapipe/blob/e6c19885c6d3c6f410c730952aeed2852790d306/mediapipe/calculators/tensor/tensors_to_detections_calculator.proto#L25) because the tag value is cast to `int` before shifting right.
