### PR TITLE
Fix failing FieldMask.Merge for well-known wrapper field types

### DIFF
--- a/csharp/src/Google.Protobuf/FieldMaskTree.cs
+++ b/csharp/src/Google.Protobuf/FieldMaskTree.cs
@@ -333,15 +333,24 @@ namespace Google.Protobuf
                         {
                             if (sourceField != null)
                             {
-                                var sourceByteString = ((IMessage)sourceField).ToByteString();
-                                var destinationValue = (IMessage)field.Accessor.GetValue(destination);
-                                if (destinationValue != null)
+                                // Well-known wrapper types are represented as nullable primitive types, so we do not "merge" them.
+                                // Instead, any non-null value just overwrites the previous value directly.
+                                if (field.MessageType.IsWrapperType)
                                 {
-                                    destinationValue.MergeFrom(sourceByteString);
+                                    field.Accessor.SetValue(destination, sourceField);
                                 }
                                 else
                                 {
-                                    field.Accessor.SetValue(destination, field.MessageType.Parser.ParseFrom(sourceByteString));
+                                    var sourceByteString = ((IMessage)sourceField).ToByteString();
+                                    var destinationValue = (IMessage)field.Accessor.GetValue(destination);
+                                    if (destinationValue != null)
+                                    {
+                                        destinationValue.MergeFrom(sourceByteString);
+                                    }
+                                    else
+                                    {
+                                        field.Accessor.SetValue(destination, field.MessageType.Parser.ParseFrom(sourceByteString));
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Closes #9283.