### PR TITLE
Removing toolchain_dir variable

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -48,8 +48,6 @@ cc_toolchain_config(
     target_cpu = "aarch64",
     target_full_name = "aarch64-linux-gnu",
     toolchain_name = "linux_aarch_64",
-    # Don't really need this, setting it because it's required.
-    toolchain_dir = "/opt/manylinux/2014/aarch64",
 )
 
 cc_toolchain_config(
@@ -60,7 +58,6 @@ cc_toolchain_config(
     sysroot = "/opt/manylinux/2014/ppc64le",
     target_cpu = "ppc64",
     target_full_name = "powerpc64le-linux-gnu",
-    toolchain_dir = "/opt/manylinux/2014/ppc64le",
     toolchain_name = "linux_ppcle_64",
 )
 
@@ -72,7 +69,6 @@ cc_toolchain_config(
     sysroot = "/opt/manylinux/2014/s390x",
     target_cpu = "systemz",
     target_full_name = "s390x-linux-gnu",
-    toolchain_dir = "/opt/manylinux/2014/s390x",
     toolchain_name = "linux_s390_64",
 )
 
@@ -84,7 +80,6 @@ cc_toolchain_config(
     sysroot = "/opt/manylinux/2014/i686",
     target_cpu = "x86_32",
     target_full_name = "i386-linux-gnu",
-    toolchain_dir = "/opt/manylinux/2014/i686",
     toolchain_name = "linux_x86_32",
 )
 
@@ -96,7 +91,6 @@ cc_toolchain_config(
     sysroot = "/opt/manylinux/2014/x86_64",
     target_cpu = "x86_64",
     target_full_name = "x86_64-linux-gnu",
-    toolchain_dir = "/opt/manylinux/2014/x86_64",
     toolchain_name = "linux_x86_64",
 )
 
@@ -113,7 +107,6 @@ cc_toolchain_config(
     sysroot = "/usr/tools/apple_sdks/xcode_13_0/macosx",
     target_cpu = "aarch64",
     target_full_name = "aarch64-apple-macosx11.3",
-    toolchain_dir = "/usr/tools/apple_sdks/xcode_13_0/macosx",
     toolchain_name = "osx_aarch_64",
 )
 
@@ -130,7 +123,6 @@ cc_toolchain_config(
     sysroot = "/usr/tools/apple_sdks/xcode_13_0/macosx",
     target_cpu = "x86_64",
     target_full_name = "x86_64-apple-macosx11.3",
-    toolchain_dir = "/usr/tools/apple_sdks/xcode_13_0/macosx",
     toolchain_name = "osx_x86_64",
 )
 
@@ -143,15 +135,15 @@ cc_toolchain_config(
         "-isystem/usr/lib/gcc/i686-w64-mingw32/8.3-posix/include/c++/i686-w64-mingw32",
         "-fsjlj-exceptions",
     ],
-    extra_include = "/usr/lib/gcc/i686-w64-mingw32/8.3-posix/include",
+    extra_include = "/usr/lib/gcc/i686-w64-mingw32",
     extra_linker_flags = [
         "-L/usr/lib/gcc/i686-w64-mingw32/8.3-posix",
         "-pthread",
     ],
     linker_path = "/usr/bin/ld",
+    sysroot = "/usr/i686-w64-mingw32",
     target_cpu = "x86_32",
     target_full_name = "i686-w64-mingw32",
-    toolchain_dir = "/usr/i686-w64-mingw32/include",
     toolchain_name = "i686-w64-mingw32",
 )
 
@@ -168,8 +160,8 @@ cc_toolchain_config(
         "-L/usr/lib/gcc/x86_64-w64-mingw32/8.3-posix",
     ],
     linker_path = "/usr/bin/ld",
+    sysroot = "/usr/x86_64-w64-mingw32",
     target_cpu = "x86_64",
     target_full_name = "x86_64-w64-mingw32",
-    toolchain_dir = "/usr/x86_64-w64-mingw32/include",
     toolchain_name = "x86_64-w64-mingw32",
 )

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -145,7 +145,7 @@ def _impl(ctx):
                           "-fvisibility=hidden",
                       ] + ctx.attr.extra_compiler_flags + [
                           "-isystem",
-                          ctx.attr.toolchain_dir,
+                          ctx.attr.sysroot,
                       ],
                   ),
               ],
@@ -160,7 +160,7 @@ def _impl(ctx):
       ctx = ctx,
       compiler = "clang",
       cxx_builtin_include_directories = [
-          ctx.attr.toolchain_dir,
+          ctx.attr.sysroot,
           ctx.attr.extra_include,
           "/usr/local/include",
           "/usr/local/lib/clang",
@@ -187,7 +187,6 @@ cc_toolchain_config = rule(
         "sysroot": attr.string(mandatory = False),
         "target_cpu": attr.string(mandatory = True, values = ["aarch64", "ppc64", "systemz", "x86_32", "x86_64"]),
         "target_full_name": attr.string(mandatory = True),
-        "toolchain_dir": attr.string(mandatory = True),
         "toolchain_name": attr.string(mandatory = True),
     },
     provides = [CcToolchainConfigInfo],


### PR DESCRIPTION
Removing the toolchain_dir variable and replacing usages of it to directly using the sysroot. This change required setting a sysroot for windows. 

Unfortunately, I wasn't able to remove the windows additional compiler flags because gcc defaults to using the non-posix libraries. In the future, we could look into how to change the gcc settings to automatically use the posix directory.