### PR TITLE
Proof of concept for accessing semi-raw extension values

### DIFF
--- a/csharp/src/Google.Protobuf/ExtensionSet.cs
+++ b/csharp/src/Google.Protobuf/ExtensionSet.cs
@@ -55,6 +55,21 @@ namespace Google.Protobuf
             return set.ValuesByNumber.TryGetValue(extension.FieldNumber, out value);
         }
 
+        // TODO: Documentation, and coming up with a better name. (And tests!)
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TTarget"></typeparam>
+        /// <param name="set"></param>
+        /// <param name="fieldNumber"></param>
+        /// <returns></returns>
+        public static object GetRawValue<TTarget>(ref ExtensionSet<TTarget> set, int fieldNumber) where TTarget : IExtendableMessage<TTarget>
+        {
+            set.ValuesByNumber.TryGetValue(fieldNumber, out var value);
+            return value?.GetValue();
+        }
+
         /// <summary>
         /// Gets the value of the specified extension
         /// </summary>

--- a/csharp/src/Google.Protobuf/ExtensionValue.cs
+++ b/csharp/src/Google.Protobuf/ExtensionValue.cs
@@ -44,6 +44,7 @@ namespace Google.Protobuf
         void WriteTo(ref WriteContext ctx);
         int CalculateSize();
         bool IsInitialized();
+        object GetValue();
     }
 
     internal sealed class ExtensionValue<T> : IExtensionValue
@@ -116,6 +117,7 @@ namespace Google.Protobuf
             }
         }
 
+        object IExtensionValue.GetValue() => GetValue();
         public T GetValue() => field;
 
         public void SetValue(T value)
@@ -199,6 +201,7 @@ namespace Google.Protobuf
             field.WriteTo(ref ctx, codec);
         }
 
+        object IExtensionValue.GetValue() => GetValue();
         public RepeatedField<T> GetValue() => field;
 
         public bool IsInitialized()

--- a/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
@@ -9052,8 +9052,13 @@ namespace Google.Protobuf.Reflection {
         }
       }
     }
-    #endif
+#endif
 
+    // Note: we'd generate this for every extendable message. See https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/csharp/csharp_message.cc#L272
+    // The name is definitely up for discussion.
+    public object GetExtensionValue(int fieldNumber) {
+      return pb::ExtensionSet.GetRawValue(ref _extensions, fieldNumber);
+    }
     public TValue GetExtension<TValue>(pb::Extension<MethodOptions, TValue> extension) {
       return pb::ExtensionSet.Get(ref _extensions, extension);
     }


### PR DESCRIPTION
The extension still needs to be registered in the extension
registry, but you don't need to know the exact type of the value in
order to access is.

This is a prototype for #9626.