### PR TITLE
Toolchain cleanups

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -41,95 +41,70 @@ cc_toolchain_suite(
 
 cc_toolchain_config(
     name = "linux-aarch_64-config",
-    bit_flag = "-m64",
-    cpp_flag = "-lstdc++",
     sysroot = "/opt/manylinux/2014/aarch64",
     linker_path = "/usr/bin/ld",
     target_cpu = "aarch64",
     target_full_name = "aarch64-linux-gnu",
-    toolchain_name = "linux_aarch_64",
 )
 
 cc_toolchain_config(
     name = "linux-ppcle_64-config",
-    bit_flag = "-m64",
-    cpp_flag = "-lstdc++",
     linker_path = "/usr/bin/ld",
     sysroot = "/opt/manylinux/2014/ppc64le",
     target_cpu = "ppc64",
     target_full_name = "powerpc64le-linux-gnu",
-    toolchain_name = "linux_ppcle_64",
 )
 
 cc_toolchain_config(
     name = "linux-s390_64-config",
-    bit_flag = "-m64",
-    cpp_flag = "-lstdc++",
     linker_path = "/usr/bin/ld",
     sysroot = "/opt/manylinux/2014/s390x",
     target_cpu = "systemz",
     target_full_name = "s390x-linux-gnu",
-    toolchain_name = "linux_s390_64",
 )
 
 cc_toolchain_config(
     name = "linux-x86_32-config",
-    bit_flag = "-m32",
-    cpp_flag = "-lstdc++",
     linker_path = "/usr/bin/ld",
     sysroot = "/opt/manylinux/2014/i686",
     target_cpu = "x86_32",
     target_full_name = "i386-linux-gnu",
-    toolchain_name = "linux_x86_32",
 )
 
 cc_toolchain_config(
     name = "linux-x86_64-config",
-    bit_flag = "-m64",
-    cpp_flag = "-lstdc++",
     linker_path = "/usr/bin/ld",
     sysroot = "/opt/manylinux/2014/x86_64",
     target_cpu = "x86_64",
     target_full_name = "x86_64-linux-gnu",
-    toolchain_name = "linux_x86_64",
 )
 
 cc_toolchain_config(
     name = "osx-aarch_64-config",
-    bit_flag = "-m64",
-    cpp_flag = "-lc++",
     extra_compiler_flags = [
         "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include/c++/v1",
         "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include"
     ],
-    extra_include = "/usr/include",
     linker_path = "/usr/tools",
     sysroot = "/usr/tools/apple_sdks/xcode_13_0/macosx",
     target_cpu = "aarch64",
     target_full_name = "aarch64-apple-macosx11.3",
-    toolchain_name = "osx_aarch_64",
 )
 
 cc_toolchain_config(
     name = "osx-x86_64-config",
-    bit_flag = "-m64",
-    cpp_flag = "-lc++",
     extra_compiler_flags = [
         "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include/c++/v1",
         "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include"
     ],
-    extra_include = "/usr/include",
     linker_path = "/usr/tools",
     sysroot = "/usr/tools/apple_sdks/xcode_13_0/macosx",
     target_cpu = "x86_64",
     target_full_name = "x86_64-apple-macosx11.3",
-    toolchain_name = "osx_x86_64",
 )
 
 cc_toolchain_config(
     name = "win32-config",
-    bit_flag = "-m32",
-    cpp_flag = "-lstdc++",
     extra_compiler_flags = [
         "-isystem/usr/lib/gcc/i686-w64-mingw32/8.3-posix/include/c++",
         "-isystem/usr/lib/gcc/i686-w64-mingw32/8.3-posix/include/c++/i686-w64-mingw32",
@@ -144,13 +119,10 @@ cc_toolchain_config(
     sysroot = "/usr/i686-w64-mingw32",
     target_cpu = "x86_32",
     target_full_name = "i686-w64-mingw32",
-    toolchain_name = "i686-w64-mingw32",
 )
 
 cc_toolchain_config(
     name = "win64-config",
-    bit_flag = "-m64",
-    cpp_flag = "-lstdc++",
     extra_compiler_flags = [
         "-isystem/usr/lib/gcc/x86_64-w64-mingw32/8.3-posix/include/c++/",
         "-isystem/usr/lib/gcc/x86_64-w64-mingw32/8.3-posix/include/c++/x86_64-w64-mingw32",
@@ -163,5 +135,4 @@ cc_toolchain_config(
     sysroot = "/usr/x86_64-w64-mingw32",
     target_cpu = "x86_64",
     target_full_name = "x86_64-w64-mingw32",
-    toolchain_name = "x86_64-w64-mingw32",
 )

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -28,7 +28,7 @@ all_compile_actions = [
 ]
 
 def _impl(ctx):
-  if 'mingw' in ctx.attr.target_full_name:
+  if "mingw" in ctx.attr.target_full_name:
       artifact_name_patterns = [
           artifact_name_pattern(
               category_name = "executable",
@@ -96,7 +96,7 @@ def _impl(ctx):
                   flag_group(
                       flags = [
                           "-B" + ctx.attr.linker_path,
-                          ctx.attr.cpp_flag,
+                          "-lstdc++",
                           "--target=" + ctx.attr.target_full_name,
                       ] + ctx.attr.extra_linker_flags,
                   ),
@@ -105,7 +105,7 @@ def _impl(ctx):
       ],
   )
 
-  if 'osx' in ctx.attr.target_full_name:
+  if "osx" in ctx.attr.target_full_name:
     sysroot_action_set = all_link_actions
   else:
     sysroot_action_set = all_link_actions + all_compile_actions
@@ -129,6 +129,10 @@ def _impl(ctx):
       ],
   )
 
+  if ctx.attr.target_cpu == "x86_32":
+    bit_flag = "-m32"
+  else:
+    bit_flag = "-m64"
   compiler_flags = feature(
       name = "default_compile_flags",
       enabled = True,
@@ -138,7 +142,7 @@ def _impl(ctx):
               flag_groups = [
                   flag_group(
                       flags = [
-                          ctx.attr.bit_flag,
+                          bit_flag,
                           "-Wall",
                           "-no-canonical-prefixes",
                           "--target=" + ctx.attr.target_full_name,
@@ -170,7 +174,7 @@ def _impl(ctx):
       target_cpu = ctx.attr.target_cpu,
       target_libc = ctx.attr.target_cpu,
       target_system_name = ctx.attr.target_full_name,
-      toolchain_identifier = ctx.attr.toolchain_name,
+      toolchain_identifier = ctx.attr.target_full_name,
       tool_paths = tool_paths,
   )
 
@@ -178,8 +182,6 @@ cc_toolchain_config = rule(
     implementation = _impl,
     attrs = {
         "abi_version": attr.string(default = "local"),
-        "bit_flag": attr.string(mandatory = True, values = ["-m32", "-m64"]),
-        "cpp_flag": attr.string(mandatory = True),
         "extra_compiler_flags": attr.string_list(),
         "extra_include": attr.string(mandatory = False),
         "extra_linker_flags": attr.string_list(),
@@ -187,7 +189,6 @@ cc_toolchain_config = rule(
         "sysroot": attr.string(mandatory = False),
         "target_cpu": attr.string(mandatory = True, values = ["aarch64", "ppc64", "systemz", "x86_32", "x86_64"]),
         "target_full_name": attr.string(mandatory = True),
-        "toolchain_name": attr.string(mandatory = True),
     },
     provides = [CcToolchainConfigInfo],
 )


### PR DESCRIPTION
Make a variety of cleanups to the bazel toolchain including:
- Remove `cpp_flag` variable and instead always use `-lstdc++` 
- Remove `bit_flag` variable and instead set it based on CPU
- Remove `toolchain_name` variable and instead use `target_full_name` as a unique identifier
- Remove osx `extra_includes` since `/usr/include` should be included by default
- Change all single quotes to double quotes to be consistent
