### PR TITLE
Fix invalid dependency manifest when using `descriptor_set_out`

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2211,6 +2211,10 @@ bool CommandLineInterface::GenerateDependencyManifestFile(
     }
   }
 
+  if(!descriptor_set_out_name_.empty()) {
+    output_filenames.push_back(descriptor_set_out_name_);
+  }
+
   int fd;
   do {
     fd = open(dependency_out_name_.c_str(),

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -1753,6 +1753,27 @@ TEST_F(CommandLineInterfaceTest, WriteDependencyManifestFileForAbsolutePath) {
                     "$tmpdir/bar.proto.MockCodeGenerator.test_generator: "
                     "$tmpdir/foo.proto\\\n $tmpdir/bar.proto");
 }
+
+TEST_F(CommandLineInterfaceTest, WriteDependencyManifestFileWithDescriptorSetOut) {
+  CreateTempFile("foo.proto",
+                 "syntax = \"proto2\";\n"
+                 "message Foo {}\n");
+  CreateTempFile("bar.proto",
+                 "syntax = \"proto2\";\n"
+                 "import \"foo.proto\";\n"
+                 "message Bar {\n"
+                 "  optional Foo foo = 1;\n"
+                 "}\n");
+
+  Run("protocol_compiler --dependency_out=$tmpdir/manifest "
+      "--descriptor_set_out=bar.pb --proto_path=$tmpdir bar.proto");
+
+  ExpectNoErrors();
+
+  ExpectFileContent("manifest",
+                    "bar.pb: "
+                    "$tmpdir/foo.proto\\\n $tmpdir/bar.proto");
+}
 #endif  // !_WIN32
 
 TEST_F(CommandLineInterfaceTest, TestArgumentFile) {

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -1766,12 +1766,12 @@ TEST_F(CommandLineInterfaceTest, WriteDependencyManifestFileWithDescriptorSetOut
                  "}\n");
 
   Run("protocol_compiler --dependency_out=$tmpdir/manifest "
-      "--descriptor_set_out=bar.pb --proto_path=$tmpdir bar.proto");
+      "--descriptor_set_out=$tmpdir/bar.pb --proto_path=$tmpdir bar.proto");
 
   ExpectNoErrors();
 
   ExpectFileContent("manifest",
-                    "bar.pb: "
+                    "$tmpdir/bar.pb: "
                     "$tmpdir/foo.proto\\\n $tmpdir/bar.proto");
 }
 #endif  // !_WIN32


### PR DESCRIPTION
Currently when using `descriptor_set_out` with `dependency_out` an invalid dependency manifest file is generated.

This is because the code path that generates descriptor sets seems to be entirely separate from the rest of the generators.
This change patches in the `descriptor_set_out` file path into the dependency file when it is used.