### PR TITLE
[C#] Update GetExtension to support getting typed value

### DIFF
--- a/csharp/src/Google.Protobuf.Test.TestProtos/Google.Protobuf.Test.TestProtos.csproj
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/Google.Protobuf.Test.TestProtos.csproj
@@ -6,7 +6,7 @@
     and without the internal visibility from the test project (all of which have caused issues in the past).
   -->
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard1.1;netstandard2.0</TargetFrameworks>
     <LangVersion>3.0</LangVersion>
     <AssemblyOriginatorKeyFile>../../keys/Google.Protobuf.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
@@ -63,7 +63,7 @@ namespace Google.Protobuf
             Assert.AreEqual(message, other);
             Assert.AreEqual(message.CalculateSize(), other.CalculateSize());
         }
-        
+
         [Test]
         public void TryMergeFieldFrom_CodedInputStream()
         {

--- a/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
@@ -62,6 +62,10 @@ namespace Google.Protobuf
             Assert.AreEqual(message, other);
             Assert.AreEqual(message.CalculateSize(), other.CalculateSize());
         }
+        
+        public static readonly Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, object> OptionalStringExtensionBytesHack =
+            new Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, object>(14, codec: null);
+
 
         [Test]
         public void TryMergeFieldFrom_CodedInputStream()
@@ -77,6 +81,9 @@ namespace Google.Protobuf
             // test the legacy overload of TryMergeFieldFrom that takes a CodedInputStream
             Assert.IsTrue(ExtensionSet.TryMergeFieldFrom(ref extensionSet, input));
             Assert.AreEqual("abcd", ExtensionSet.Get(ref extensionSet, OptionalStringExtension));
+
+            var b = ExtensionSet.Get(ref extensionSet, OptionalStringExtensionBytesHack);
+            Assert.AreEqual("abcd", b);
         }
 
         [Test]

--- a/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using Google.Protobuf.TestProtos.Proto2;
 using NUnit.Framework;
 
@@ -81,7 +82,7 @@ namespace Google.Protobuf
         }
 
         [Test]
-        public void GetExtension()
+        public void GetSingle()
         {
             var extensionValue = new TestAllTypes.Types.NestedMessage() { Bb = 42 };
             var untypedExtension = new Extension<TestAllExtensions, object>(OptionalNestedMessageExtension.FieldNumber, codec: null);
@@ -97,6 +98,36 @@ namespace Google.Protobuf
             Assert.IsNotNull(value2);
 
             var valueBytes = ((IMessage)value2).ToByteArray();
+            var parsedValue = TestProtos.Proto2.TestAllTypes.Types.NestedMessage.Parser.ParseFrom(valueBytes);
+            Assert.AreEqual(extensionValue, parsedValue);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => message.GetExtension(wrongTypedExtension));
+
+            var expectedMessage = "The stored extension value has a type of 'Google.Protobuf.TestProtos.Proto2.TestAllTypes+Types+NestedMessage, Google.Protobuf.Test.TestProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604'. " +
+                "This a different from the requested type of 'Google.Protobuf.TestProtos.Proto2.TestAllTypes, Google.Protobuf.Test.TestProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604'.";
+            Assert.AreEqual(expectedMessage, ex.Message);
+        }
+
+        [Test]
+        public void GetRepeated()
+        {
+            var extensionValue = new TestAllTypes.Types.NestedMessage() { Bb = 42 };
+            var untypedExtension = new Extension<TestAllExtensions, IList>(RepeatedNestedMessageExtension.FieldNumber, codec: null);
+            var wrongTypedExtension = new RepeatedExtension<TestAllExtensions, TestAllTypes>(RepeatedNestedMessageExtension.FieldNumber, codec: null);
+
+            var message = new TestAllExtensions();
+
+            var value1 = message.GetExtension(untypedExtension);
+            Assert.IsNull(value1);
+
+            var repeatedField = message.GetOrInitializeExtension<TestAllTypes.Types.NestedMessage>(RepeatedNestedMessageExtension);
+            repeatedField.Add(extensionValue);
+
+            var value2 = message.GetExtension(untypedExtension);
+            Assert.IsNotNull(value2);
+            Assert.AreEqual(1, value2.Count);
+
+            var valueBytes = ((IMessage)value2[0]).ToByteArray();
             var parsedValue = TestProtos.Proto2.TestAllTypes.Types.NestedMessage.Parser.ParseFrom(valueBytes);
             Assert.AreEqual(extensionValue, parsedValue);
 

--- a/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ExtensionSetTest.cs
@@ -1,4 +1,5 @@
-﻿using Google.Protobuf.TestProtos.Proto2;
+﻿using System;
+using Google.Protobuf.TestProtos.Proto2;
 using NUnit.Framework;
 
 using static Google.Protobuf.TestProtos.Proto2.UnittestExtensions;
@@ -63,10 +64,6 @@ namespace Google.Protobuf
             Assert.AreEqual(message.CalculateSize(), other.CalculateSize());
         }
         
-        public static readonly Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, object> OptionalStringExtensionBytesHack =
-            new Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, object>(14, codec: null);
-
-
         [Test]
         public void TryMergeFieldFrom_CodedInputStream()
         {
@@ -81,9 +78,33 @@ namespace Google.Protobuf
             // test the legacy overload of TryMergeFieldFrom that takes a CodedInputStream
             Assert.IsTrue(ExtensionSet.TryMergeFieldFrom(ref extensionSet, input));
             Assert.AreEqual("abcd", ExtensionSet.Get(ref extensionSet, OptionalStringExtension));
+        }
 
-            var b = ExtensionSet.Get(ref extensionSet, OptionalStringExtensionBytesHack);
-            Assert.AreEqual("abcd", b);
+        [Test]
+        public void GetExtension()
+        {
+            var extensionValue = new TestAllTypes.Types.NestedMessage() { Bb = 42 };
+            var untypedExtension = new Extension<TestAllExtensions, object>(OptionalNestedMessageExtension.FieldNumber, codec: null);
+            var wrongTypedExtension = new Extension<TestAllExtensions, TestAllTypes>(OptionalNestedMessageExtension.FieldNumber, codec: null);
+
+            var message = new TestAllExtensions();
+
+            var value1 = message.GetExtension(untypedExtension);
+            Assert.IsNull(value1);
+
+            message.SetExtension(OptionalNestedMessageExtension, extensionValue);
+            var value2 = message.GetExtension(untypedExtension);
+            Assert.IsNotNull(value2);
+
+            var valueBytes = ((IMessage)value2).ToByteArray();
+            var parsedValue = TestProtos.Proto2.TestAllTypes.Types.NestedMessage.Parser.ParseFrom(valueBytes);
+            Assert.AreEqual(extensionValue, parsedValue);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => message.GetExtension(wrongTypedExtension));
+
+            var expectedMessage = "The stored extension value has a type of 'Google.Protobuf.TestProtos.Proto2.TestAllTypes+Types+NestedMessage, Google.Protobuf.Test.TestProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604'. " +
+                "This a different from the requested type of 'Google.Protobuf.TestProtos.Proto2.TestAllTypes, Google.Protobuf.Test.TestProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604'.";
+            Assert.AreEqual(expectedMessage, ex.Message);
         }
 
         [Test]

--- a/csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
+++ b/csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp3.1;net60</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net60</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../keys/Google.Protobuf.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <IsPackable>False</IsPackable>

--- a/csharp/src/Google.Protobuf.Test/RefStructCompatibilityTest.cs
+++ b/csharp/src/Google.Protobuf.Test/RefStructCompatibilityTest.cs
@@ -60,7 +60,7 @@ namespace Google.Protobuf
 
             var currentAssemblyDir = Path.GetDirectoryName(typeof(RefStructCompatibilityTest).GetTypeInfo().Assembly.Location);
             var testProtosProjectDir = Path.GetFullPath(Path.Combine(currentAssemblyDir, "..", "..", "..", "..", "Google.Protobuf.Test.TestProtos"));
-            var testProtosOutputDir = (currentAssemblyDir.Contains("bin/Debug/") || currentAssemblyDir.Contains("bin\\Debug\\")) ? "bin\\Debug\\net45" : "bin\\Release\\net45";
+            var testProtosOutputDir = (currentAssemblyDir.Contains("bin/Debug/") || currentAssemblyDir.Contains("bin\\Debug\\")) ? "bin\\Debug\\net462" : "bin\\Release\\net462";
 
             // If "ref struct" types are used in the generated code, compilation with an old compiler will fail with the following error:
             // "XYZ is obsolete: 'Types with embedded references are not supported in this version of your compiler.'"

--- a/csharp/src/Google.Protobuf/Extension.cs
+++ b/csharp/src/Google.Protobuf/Extension.cs
@@ -77,7 +77,7 @@ namespace Google.Protobuf
             this.codec = codec;
         }
 
-        internal TValue DefaultValue => codec.DefaultValue;
+        internal TValue DefaultValue => codec != null ? codec.DefaultValue : default(TValue);
 
         internal override Type TargetType => typeof(TTarget);
 

--- a/csharp/src/Google.Protobuf/ExtensionSet.cs
+++ b/csharp/src/Google.Protobuf/ExtensionSet.cs
@@ -84,10 +84,18 @@ namespace Google.Protobuf
                 }
                 else
                 {
-                    var storedType = value.GetType().GetTypeInfo().GenericTypeArguments[0];
-                    throw new InvalidOperationException(
-                        "The stored extension value has a type of '" + storedType.AssemblyQualifiedName + "'. " +
-                        "This a different from the requested type of '" + typeof(TValue).AssemblyQualifiedName + "'.");
+                    var valueType = value.GetType().GetTypeInfo();
+                    if (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(ExtensionValue<>))
+                    {
+                        var storedType = valueType.GenericTypeArguments[0];
+                        throw new InvalidOperationException(
+                            "The stored extension value has a type of '" + storedType.AssemblyQualifiedName + "'. " +
+                            "This a different from the requested type of '" + typeof(TValue).AssemblyQualifiedName + "'.");
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("Unexpected extension value type: " + valueType.AssemblyQualifiedName);
+                    }
                 }
             }
             else 

--- a/csharp/src/Google.Protobuf/ExtensionSet.cs
+++ b/csharp/src/Google.Protobuf/ExtensionSet.cs
@@ -63,7 +63,18 @@ namespace Google.Protobuf
             IExtensionValue value;
             if (TryGetValue(ref set, extension, out value))
             {
-                return ((ExtensionValue<TValue>)value).GetValue();
+                if (value is ExtensionValue<TValue> genericValue)
+                {
+                    return genericValue.GetValue();
+                }
+                else if (value.GetValue() is TValue v)
+                {
+                    return v;
+                }
+                else
+                {
+                    throw new Exception("**unknown**");
+                }
             }
             else 
             {

--- a/csharp/src/Google.Protobuf/ExtensionValue.cs
+++ b/csharp/src/Google.Protobuf/ExtensionValue.cs
@@ -44,6 +44,7 @@ namespace Google.Protobuf
         void WriteTo(ref WriteContext ctx);
         int CalculateSize();
         bool IsInitialized();
+        object GetValue();
     }
 
     internal sealed class ExtensionValue<T> : IExtensionValue
@@ -117,6 +118,8 @@ namespace Google.Protobuf
         }
 
         public T GetValue() => field;
+
+        object IExtensionValue.GetValue() => field;
 
         public void SetValue(T value)
         {
@@ -200,6 +203,8 @@ namespace Google.Protobuf
         }
 
         public RepeatedField<T> GetValue() => field;
+
+        object IExtensionValue.GetValue() => field;
 
         public bool IsInitialized()
         {


### PR DESCRIPTION
Fixes https://github.com/protocolbuffers/protobuf/issues/9626

* Improves GetExtension support for unexpected extension values. The error message for getting an extension value with the wrong type is improved.
* Adds GetExtension support for Extensions that get the value typed as a base type.

@jskeet 