### PR TITLE
Implement `respond_to?` in RubyMessage

### DIFF
--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyDescriptor.java
@@ -209,6 +209,8 @@ public class RubyDescriptor extends RubyObject {
         klass.include(new IRubyObject[] {messageExts});
         klass.instance_variable_set(runtime.newString(Utils.DESCRIPTOR_INSTANCE_VAR), this);
         klass.defineAnnotatedMethods(RubyMessage.class);
+        // Workaround for https://github.com/jruby/jruby/issues/7154
+        klass.searchMethod("respond_to?").setIsBuiltin(false);
         return klass;
     }
 

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
@@ -334,7 +334,7 @@ public class RubyMessage extends RubyObject {
             }
         }
         boolean includePrivate = false;
-        if ( args.length == 2 ) {
+        if (args.length == 2) {
             includePrivate = context.runtime.getTrue().equals(args[1]);
         }
         return metaClass.respondsToMethod(methodName, includePrivate) ? context.runtime.getTrue() : context.runtime.getFalse();

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
@@ -280,6 +280,11 @@ public class RubyMessage extends RubyObject {
         }
         if (methodName.startsWith(CLEAR_PREFIX)) {
             String strippedMethodName = methodName.substring(6);
+            oneofDescriptor = rubyDescriptor.lookupOneof(context, context.runtime.newSymbol(strippedMethodName));
+            if (!oneofDescriptor.isNil()) {
+                return context.runtime.getTrue();
+            }
+
             if (descriptor.findFieldByName(strippedMethodName) != null) {
                 return context.runtime.getTrue();
             }
@@ -409,9 +414,12 @@ public class RubyMessage extends RubyObject {
             if (methodName.startsWith(CLEAR_PREFIX)) {
                 methodName = methodName.substring(6);
                 oneofDescriptor = rubyDescriptor.lookupOneof(context, runtime.newSymbol(methodName));
-
                 if (!oneofDescriptor.isNil()) {
                     fieldDescriptor = oneofCases.get(((RubyOneofDescriptor) oneofDescriptor).getDescriptor());
+                    if (fieldDescriptor == null) {
+                        // Clearing an already cleared oneof; return here to avoid NoMethodError.
+                        return context.nil;
+                    }
                 }
 
                 if (fieldDescriptor == null) {

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -67,7 +67,7 @@ module BasicTest
       msg = TestMessage.new
       msg.repeated_int32 = ::Google::Protobuf::RepeatedField.new(:int32, [1, 2, 3])
 
-      # https://github.com/jruby/jruby/issues/6818 was fix in JRuby 9.3.0.0
+      # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
       match = RUBY_PLATFORM == "java" &&
         JRUBY_VERSION.match(/^(\d+)\.(\d+)\.\d+\.\d+$/)
       unless match and (match[1].to_i < 9 or match[2].to_i < 3)

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -691,5 +691,51 @@ module BasicTest
       m2 = proto_module::TestMessage.decode(proto_module::TestMessage.encode(m))
       assert_equal m2, m
     end
+
+    def test_map_fields_respond_to? # regression test for issue 9202
+      msg = proto_module::MapMessage.new
+      assert msg.respond_to?(:map_string_int32=)
+      msg.map_string_int32 = Google::Protobuf::Map.new(:string, :int32)
+      assert msg.respond_to?(:map_string_int32)
+      assert_equal( Google::Protobuf::Map.new(:string, :int32), msg.map_string_int32 )
+      assert msg.respond_to?(:clear_map_string_int32)
+      msg.clear_map_string_int32
+
+      assert !msg.respond_to?(:has_map_string_int32?)
+      assert_raise NoMethodError do
+        msg.has_map_string_int32?
+      end
+      assert !msg.respond_to?(:map_string_int32_as_value)
+      assert_raise NoMethodError do
+        msg.map_string_int32_as_value
+      end
+      assert !msg.respond_to?(:map_string_int32_as_value=)
+      assert_raise NoMethodError do
+        msg.map_string_int32_as_value = :boom
+      end
+    end
+  end
+
+  def test_oneof_fields_respond_to? # regression test for issue 9202
+    msg = proto_module::OneofMessage.new
+    # `has_` prefix + "?" suffix actions should only work for oneofs fields.
+    assert msg.has_my_oneof?
+    assert msg.respond_to? :has_my_oneof?
+    assert !msg.respond_to?( :has_a? )
+    assert_raise NoMethodError do
+      msg.has_a?
+    end
+    assert !msg.respond_to?( :has_b? )
+    assert_raise NoMethodError do
+      msg.has_b?
+    end
+    assert !msg.respond_to?( :has_c? )
+    assert_raise NoMethodError do
+      msg.has_c?
+    end
+    assert !msg.respond_to?( :has_d? )
+    assert_raise NoMethodError do
+      msg.has_d?
+    end
   end
 end

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -68,9 +68,7 @@ module BasicTest
       msg.repeated_int32 = ::Google::Protobuf::RepeatedField.new(:int32, [1, 2, 3])
 
       # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
-      match = RUBY_PLATFORM == "java" &&
-        JRUBY_VERSION.match(/^(\d+)\.(\d+)\.\d+\.\d+$/)
-      unless match and (match[1].to_i < 9 or match[2].to_i < 3)
+      if cruby_or_jruby_9_3_or_higher?
         GC.start(full_mark: true, immediate_sweep: true)
       end
       TestMessage.encode(msg)
@@ -104,7 +102,7 @@ module BasicTest
 
       begin
         encoded = msgclass.encode(m)
-      rescue java.lang.NullPointerException => e
+      rescue java.lang.NullPointerException
         flunk "NPE rescued"
       end
       decoded = msgclass.decode(encoded)
@@ -178,7 +176,7 @@ module BasicTest
       m = TestSingularFields.new
 
       m.singular_int32 = -42
-      assert_equal -42, m.singular_int32
+      assert_equal( -42, m.singular_int32 )
       m.clear_singular_int32
       assert_equal 0, m.singular_int32
 

--- a/ruby/tests/basic_proto2.rb
+++ b/ruby/tests/basic_proto2.rb
@@ -142,7 +142,7 @@ module BasicTestProto2
       m = TestMessageDefaults.new
 
       m.optional_int32 = -42
-      assert_equal -42, m.optional_int32
+      assert_equal( -42, m.optional_int32 )
       assert m.has_optional_int32?
       m.clear_optional_int32
       assert_equal 1, m.optional_int32

--- a/ruby/tests/basic_proto2.rb
+++ b/ruby/tests/basic_proto2.rb
@@ -255,5 +255,20 @@ module BasicTestProto2
       assert_equal "tests/basic_test_proto2.proto", file_descriptor.name
       assert_equal :proto2, file_descriptor.syntax
     end
+
+    def test_oneof_fields_respond_to? # regression test for issue 9202
+      msg = proto_module::OneofMessage.new(a: "foo")
+      # `has_` prefix + "?" suffix actions should only work for oneofs fields.
+      assert msg.respond_to? :has_my_oneof?
+      assert msg.has_my_oneof?
+      assert msg.respond_to? :has_a?
+      assert msg.has_a?
+      assert msg.respond_to? :has_b?
+      assert !msg.has_b?
+      assert msg.respond_to? :has_c?
+      assert !msg.has_c?
+      assert msg.respond_to? :has_d?
+      assert !msg.has_d?
+    end
   end
 end

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1898,25 +1898,9 @@ module CommonTests
     assert msg.respond_to? :d=
     msg.d = :Default
 
-    # `has_` prefix + "?" suffix actions should only work for oneofs fields.
-    assert msg.has_my_oneof?
+    # `has_` prefix + "?" suffix actions work for oneofs fields.
     assert msg.respond_to? :has_my_oneof?
-    assert !msg.respond_to?( :has_a? )
-    assert_raise NoMethodError do
-      msg.has_a?
-    end
-    assert !msg.respond_to?( :has_b? )
-    assert_raise NoMethodError do
-      msg.has_b?
-    end
-    assert !msg.respond_to?( :has_c? )
-    assert_raise NoMethodError do
-      msg.has_c?
-    end
-    assert !msg.respond_to?( :has_d? )
-    assert_raise NoMethodError do
-      msg.has_d?
-    end
+    assert msg.has_my_oneof?
 
     # `_as_value` suffix actions should only work for wrapped fields.
     assert !msg.respond_to?( :my_oneof_as_value )
@@ -1981,29 +1965,6 @@ module CommonTests
     end
     assert msg.respond_to? :d_const
     assert_equal 0, msg.d_const
-  end
-
-  def test_map_fields_respond_to? # regression test for issue 9202
-    msg = proto_module::MapMessage.new
-    assert msg.respond_to?(:map_string_int32=)
-    msg.map_string_int32 = Google::Protobuf::Map.new(:string, :int32)
-    assert msg.respond_to?(:map_string_int32)
-    assert_equal( Google::Protobuf::Map.new(:string, :int32), msg.map_string_int32 )
-    assert msg.respond_to?(:clear_map_string_int32)
-    msg.clear_map_string_int32
-
-    assert !msg.respond_to?(:has_map_string_int32?)
-    assert_raise NoMethodError do
-      msg.has_map_string_int32?
-    end
-    assert !msg.respond_to?(:map_string_int32_as_value)
-    assert_raise NoMethodError do
-      msg.map_string_int32_as_value
-    end
-    assert !msg.respond_to?(:map_string_int32_as_value=)
-    assert_raise NoMethodError do
-      msg.map_string_int32_as_value = :boom
-    end
   end
 
   def test_wrapped_fields_respond_to? # regression test for issue 9202

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1893,9 +1893,10 @@ module CommonTests
 
     # `=` suffix actions should work on elements of a oneof but not the oneof itself.
     assert !msg.respond_to?( :my_oneof= )
-    assert_raise NoMethodError do
+    error = assert_raise RuntimeError do
       msg.my_oneof = nil
     end
+    assert_equal "Oneof accessors are read-only.", error.message
     assert msg.respond_to? :a=
     msg.a = "foo"
     assert msg.respond_to? :b=

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1085,8 +1085,6 @@ module CommonTests
   end
 
   def test_json
-    # # TODO: Fix JSON in JRuby version.
-    # return if RUBY_PLATFORM == "java"
     m = proto_module::TestMessage.new(:optional_int32 => 1234,
                                       :optional_int64 => -0x1_0000_0000,
                                       :optional_uint32 => 0x8000_0000,

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1791,7 +1791,7 @@ module CommonTests
     # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
     match = RUBY_PLATFORM == "java" &&
       JRUBY_VERSION.match(/^(\d+)\.(\d+)\.\d+\.\d+$/)
-    match && (match[1].to_i < 9 or match[2].to_i < 3)
+    match && (match[1].to_i > 9 || (match[1].to_i == 9 && match[2].to_i >= 3))
   end
 
   def test_object_gc

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1085,8 +1085,8 @@ module CommonTests
   end
 
   def test_json
-    # TODO: Fix JSON in JRuby version.
-    return if RUBY_PLATFORM == "java"
+    # # TODO: Fix JSON in JRuby version.
+    # return if RUBY_PLATFORM == "java"
     m = proto_module::TestMessage.new(:optional_int32 => 1234,
                                       :optional_int64 => -0x1_0000_0000,
                                       :optional_uint32 => 0x8000_0000,
@@ -1787,27 +1787,34 @@ module CommonTests
     assert_nil h[m2]
   end
 
+  def cruby_or_jruby_9_3_or_higher?
+    # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
+    match = RUBY_PLATFORM == "java" &&
+      JRUBY_VERSION.match(/^(\d+)\.(\d+)\.\d+\.\d+$/)
+    match && (match[1].to_i < 9 or match[2].to_i < 3)
+  end
+
   def test_object_gc
     m = proto_module::TestMessage.new(optional_msg: proto_module::TestMessage2.new)
     m.optional_msg
-    # TODO: Remove the platform check once https://github.com/jruby/jruby/issues/6818 is released in JRuby 9.3.0.0
-    GC.start(full_mark: true, immediate_sweep: true) unless RUBY_PLATFORM == "java"
+    # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
+    GC.start(full_mark: true, immediate_sweep: true) if cruby_or_jruby_9_3_or_higher?
     m.optional_msg.inspect
   end
 
   def test_object_gc_freeze
     m = proto_module::TestMessage.new
     m.repeated_float.freeze
-    # TODO: Remove the platform check once https://github.com/jruby/jruby/issues/6818 is released in JRuby 9.3.0.0
-    GC.start(full_mark: true) unless RUBY_PLATFORM == "java"
+    # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
+    GC.start(full_mark: true) if cruby_or_jruby_9_3_or_higher?
 
     # Make sure we remember that the object is frozen.
     # The wrapper object contains this information, so we need to ensure that
     # the previous GC did not collect it.
     assert m.repeated_float.frozen?
 
-    # TODO: Remove the platform check once https://github.com/jruby/jruby/issues/6818 is released in JRuby 9.3.0.0
-    GC.start(full_mark: true, immediate_sweep: true) unless RUBY_PLATFORM == "java"
+    # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
+    GC.start(full_mark: true, immediate_sweep: true) if cruby_or_jruby_9_3_or_higher?
     assert m.repeated_float.frozen?
   end
 

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1858,7 +1858,7 @@ module CommonTests
   def test_oneof_fields_respond_to? # regression test for issue 9202
     msg = proto_module::OneofMessage.new
 
-    # names of the elements of a oneof and the oneof itself should be valid actions.
+    # names of the elements of a oneof and the oneof itself are valid actions.
     assert msg.respond_to? :my_oneof
     assert_nil msg.my_oneof
     assert msg.respond_to? :a
@@ -1870,11 +1870,11 @@ module CommonTests
     assert msg.respond_to? :d
     assert_equal :Default, msg.d
 
-    # `clear` prefix actions should elements of a oneof but not the oneof itself.
-    assert !msg.respond_to?( :clear_my_oneof )
-    assert_raise NoMethodError do
-      msg.clear_my_oneof
-    end
+    # `clear` prefix actions work on elements of a oneof and the oneof itself.
+    assert msg.respond_to? :clear_my_oneof
+    msg.clear_my_oneof
+    # Repeatedly clearing a oneof used to cause a NoMethodError under JRuby
+    msg.clear_my_oneof
     assert msg.respond_to? :clear_a
     msg.clear_a
     assert msg.respond_to? :clear_b
@@ -1884,7 +1884,7 @@ module CommonTests
     assert msg.respond_to? :clear_d
     msg.clear_d
 
-    # `=` suffix actions should elements of a oneof but not the oneof itself.
+    # `=` suffix actions should work on elements of a oneof but not the oneof itself.
     assert !msg.respond_to?( :my_oneof= )
     assert_raise NoMethodError do
       msg.my_oneof = nil

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -796,7 +796,7 @@ module CommonTests
     m.repeated_string += %w[two three]
     assert_equal %w[one two three], m.repeated_string
 
-    m.repeated_string.push *['four', 'five']
+    m.repeated_string.push( *['four', 'five'] )
     assert_equal %w[one two three four five], m.repeated_string
 
     m.repeated_string.push 'six', 'seven'
@@ -1286,6 +1286,7 @@ module CommonTests
     m2 = proto_module::Wrapper.decode(m.to_proto)
     run_asserts.call(m2)
     m3 = proto_module::Wrapper.decode_json(m.to_json)
+    run_asserts.call(m3)
   end
 
   def test_wrapper_getters
@@ -1536,8 +1537,6 @@ module CommonTests
       assert_nil m.bytes
       assert_nil m.bytes_as_value
     }
-
-    m = proto_module::Wrapper.new
 
     m2 = proto_module::Wrapper.new(
       double: Google::Protobuf::DoubleValue.new(value: 2.0),

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -36,13 +36,13 @@ class RepeatedFieldTest < Test::Unit::TestCase
     end
 
     fill_test_msg(m)
-    assert_equal( -10, m.repeated_int32.first )
-    assert_equal( -1_000_000, m.repeated_int64.first )
+    assert_equal -10, m.repeated_int32.first
+    assert_equal -1_000_000, m.repeated_int64.first
     assert_equal 10, m.repeated_uint32.first
     assert_equal 1_000_000, m.repeated_uint64.first
     assert_equal true, m.repeated_bool.first
-    assert_equal( -1.01,  m.repeated_float.first.round(2) )
-    assert_equal( -1.0000000000001, m.repeated_double.first )
+    assert_equal -1.01,  m.repeated_float.first.round(2)
+    assert_equal -1.0000000000001, m.repeated_double.first
     assert_equal 'foo', m.repeated_string.first
     assert_equal "bar".encode!('ASCII-8BIT'), m.repeated_bytes.first
     assert_equal TestMessage2.new(:foo => 1), m.repeated_msg.first
@@ -61,13 +61,13 @@ class RepeatedFieldTest < Test::Unit::TestCase
       assert_nil m.send(field_name).first
     end
     fill_test_msg(m)
-    assert_equal( -11, m.repeated_int32.last )
-    assert_equal( -1_000_001, m.repeated_int64.last )
+    assert_equal -11, m.repeated_int32.last
+    assert_equal -1_000_001, m.repeated_int64.last
     assert_equal 11, m.repeated_uint32.last
     assert_equal 1_000_001, m.repeated_uint64.last
     assert_equal false, m.repeated_bool.last
-    assert_equal( -1.02, m.repeated_float.last.round(2) )
-    assert_equal( -1.0000000000002, m.repeated_double.last )
+    assert_equal -1.02, m.repeated_float.last.round(2)
+    assert_equal -1.0000000000002, m.repeated_double.last
     assert_equal 'bar', m.repeated_string.last
     assert_equal "foo".encode!('ASCII-8BIT'), m.repeated_bytes.last
     assert_equal TestMessage2.new(:foo => 2), m.repeated_msg.last
@@ -82,20 +82,20 @@ class RepeatedFieldTest < Test::Unit::TestCase
     end
     fill_test_msg(m)
 
-    assert_equal( -11, m.repeated_int32.pop )
-    assert_equal( -10, m.repeated_int32.pop )
-    assert_equal( -1_000_001, m.repeated_int64.pop )
-    assert_equal( -1_000_000, m.repeated_int64.pop )
+    assert_equal -11, m.repeated_int32.pop
+    assert_equal -10, m.repeated_int32.pop
+    assert_equal -1_000_001, m.repeated_int64.pop
+    assert_equal -1_000_000, m.repeated_int64.pop
     assert_equal 11, m.repeated_uint32.pop
     assert_equal 10, m.repeated_uint32.pop
     assert_equal 1_000_001, m.repeated_uint64.pop
     assert_equal 1_000_000, m.repeated_uint64.pop
     assert_equal false, m.repeated_bool.pop
     assert_equal true, m.repeated_bool.pop
-    assert_equal( -1.02,  m.repeated_float.pop.round(2) )
-    assert_equal( -1.01,  m.repeated_float.pop.round(2) )
-    assert_equal( -1.0000000000002, m.repeated_double.pop )
-    assert_equal( -1.0000000000001, m.repeated_double.pop )
+    assert_equal -1.02,  m.repeated_float.pop.round(2)
+    assert_equal -1.01,  m.repeated_float.pop.round(2)
+    assert_equal -1.0000000000002, m.repeated_double.pop
+    assert_equal -1.0000000000001, m.repeated_double.pop
     assert_equal 'bar', m.repeated_string.pop
     assert_equal 'foo', m.repeated_string.pop
     assert_equal "foo".encode!('ASCII-8BIT'), m.repeated_bytes.pop
@@ -487,7 +487,7 @@ class RepeatedFieldTest < Test::Unit::TestCase
   def test_shuffle!
     m = TestMessage.new
     m.repeated_string += %w(foo bar baz)
-    # orig_repeated_string = m.repeated_string.clone
+    orig_repeated_string = m.repeated_string.clone
     result = m.repeated_string.shuffle!
     assert_equal m.repeated_string, result
     # NOTE: sometimes it doesn't change the order...

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -36,13 +36,13 @@ class RepeatedFieldTest < Test::Unit::TestCase
     end
 
     fill_test_msg(m)
-    assert_equal -10, m.repeated_int32.first
-    assert_equal -1_000_000, m.repeated_int64.first
+    assert_equal( -10, m.repeated_int32.first )
+    assert_equal( -1_000_000, m.repeated_int64.first )
     assert_equal 10, m.repeated_uint32.first
     assert_equal 1_000_000, m.repeated_uint64.first
     assert_equal true, m.repeated_bool.first
-    assert_equal -1.01,  m.repeated_float.first.round(2)
-    assert_equal -1.0000000000001, m.repeated_double.first
+    assert_equal( -1.01,  m.repeated_float.first.round(2) )
+    assert_equal( -1.0000000000001, m.repeated_double.first )
     assert_equal 'foo', m.repeated_string.first
     assert_equal "bar".encode!('ASCII-8BIT'), m.repeated_bytes.first
     assert_equal TestMessage2.new(:foo => 1), m.repeated_msg.first
@@ -61,13 +61,13 @@ class RepeatedFieldTest < Test::Unit::TestCase
       assert_nil m.send(field_name).first
     end
     fill_test_msg(m)
-    assert_equal -11, m.repeated_int32.last
-    assert_equal -1_000_001, m.repeated_int64.last
+    assert_equal( -11, m.repeated_int32.last )
+    assert_equal( -1_000_001, m.repeated_int64.last )
     assert_equal 11, m.repeated_uint32.last
     assert_equal 1_000_001, m.repeated_uint64.last
     assert_equal false, m.repeated_bool.last
-    assert_equal -1.02, m.repeated_float.last.round(2)
-    assert_equal -1.0000000000002, m.repeated_double.last
+    assert_equal( -1.02, m.repeated_float.last.round(2) )
+    assert_equal( -1.0000000000002, m.repeated_double.last )
     assert_equal 'bar', m.repeated_string.last
     assert_equal "foo".encode!('ASCII-8BIT'), m.repeated_bytes.last
     assert_equal TestMessage2.new(:foo => 2), m.repeated_msg.last
@@ -82,20 +82,20 @@ class RepeatedFieldTest < Test::Unit::TestCase
     end
     fill_test_msg(m)
 
-    assert_equal -11, m.repeated_int32.pop
-    assert_equal -10, m.repeated_int32.pop
-    assert_equal -1_000_001, m.repeated_int64.pop
-    assert_equal -1_000_000, m.repeated_int64.pop
+    assert_equal( -11, m.repeated_int32.pop )
+    assert_equal( -10, m.repeated_int32.pop )
+    assert_equal( -1_000_001, m.repeated_int64.pop )
+    assert_equal( -1_000_000, m.repeated_int64.pop )
     assert_equal 11, m.repeated_uint32.pop
     assert_equal 10, m.repeated_uint32.pop
     assert_equal 1_000_001, m.repeated_uint64.pop
     assert_equal 1_000_000, m.repeated_uint64.pop
     assert_equal false, m.repeated_bool.pop
     assert_equal true, m.repeated_bool.pop
-    assert_equal -1.02,  m.repeated_float.pop.round(2)
-    assert_equal -1.01,  m.repeated_float.pop.round(2)
-    assert_equal -1.0000000000002, m.repeated_double.pop
-    assert_equal -1.0000000000001, m.repeated_double.pop
+    assert_equal( -1.02,  m.repeated_float.pop.round(2) )
+    assert_equal( -1.01,  m.repeated_float.pop.round(2) )
+    assert_equal( -1.0000000000002, m.repeated_double.pop )
+    assert_equal( -1.0000000000001, m.repeated_double.pop )
     assert_equal 'bar', m.repeated_string.pop
     assert_equal 'foo', m.repeated_string.pop
     assert_equal "foo".encode!('ASCII-8BIT'), m.repeated_bytes.pop
@@ -487,7 +487,7 @@ class RepeatedFieldTest < Test::Unit::TestCase
   def test_shuffle!
     m = TestMessage.new
     m.repeated_string += %w(foo bar baz)
-    orig_repeated_string = m.repeated_string.clone
+    # orig_repeated_string = m.repeated_string.clone
     result = m.repeated_string.shuffle!
     assert_equal m.repeated_string, result
     # NOTE: sometimes it doesn't change the order...


### PR DESCRIPTION
All synthetic method names implemented by `method_missing` return true. Add regression tests.

* Fix null pointer exceptions and class cast exceptions in `method_missing` exposed by new unit tests.
* Fix bug where multiple calls to `clear_` on a oneof field would throw an exception.
* Align behavior with CRuby implementation by throwing a `RuntimeError` rather than a `NoMethodError` when attempting to assign to a oneof.

Code cleanup: remove test code that was skipping several unit tests only on JRuby.

Fixes issue https://github.com/protocolbuffers/protobuf/issues/9202.