### PR TITLE
Factor out common test libraries in the cmake build.

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -127,6 +127,9 @@ set(common_lite_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/test_util_lite.cc
 )
 
+add_library(protobuf-lite-test-common ${protobuf_SHARED_OR_STATIC}
+  ${common_lite_test_files} ${lite_test_proto_files})
+
 set(common_test_files
   ${common_lite_test_files}
   ${protobuf_SOURCE_DIR}/src/google/protobuf/map_test_util.inc
@@ -136,6 +139,9 @@ set(common_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/testing/file.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/testing/googletest.cc
 )
+
+add_library(protobuf-test-common ${protobuf_SHARED_OR_STATIC}
+  ${common_test_files} ${tests_proto_files})
 
 set(tests_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/any_test.cc
@@ -233,13 +239,13 @@ if(MINGW)
 
 endif()
 
-add_executable(tests ${tests_files} ${common_test_files} ${tests_proto_files} ${lite_test_proto_files})
+add_executable(tests ${tests_files})
 if (MSVC)
   target_compile_options(tests PRIVATE
     /wd4146 # unary minus operator applied to unsigned type, result still unsigned
   )
 endif()
-target_link_libraries(tests libprotoc libprotobuf GTest::gmock_main)
+target_link_libraries(tests protobuf-lite-test-common protobuf-test-common libprotoc libprotobuf GTest::gmock_main)
 
 set(test_plugin_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/mock_code_generator.cc
@@ -254,14 +260,14 @@ target_link_libraries(test_plugin libprotoc libprotobuf GTest::gmock)
 set(lite_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/lite_unittest.cc
 )
-add_executable(lite-test ${lite_test_files} ${common_lite_test_files} ${lite_test_proto_files})
-target_link_libraries(lite-test libprotobuf-lite GTest::gmock_main)
+add_executable(lite-test ${lite_test_files})
+target_link_libraries(lite-test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
 
 set(lite_arena_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/lite_arena_unittest.cc
 )
-add_executable(lite-arena-test ${lite_arena_test_files} ${common_lite_test_files} ${lite_test_proto_files})
-target_link_libraries(lite-arena-test libprotobuf-lite GTest::gmock_main)
+add_executable(lite-arena-test ${lite_arena_test_files})
+target_link_libraries(lite-arena-test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
 
 add_custom_target(check
   COMMAND tests


### PR DESCRIPTION
This change adds separate libraries for common test utilities and test proto definitions, which are shared by different test targets.

Without this change, cmake fails when generating Xcode files with the error:

```
CMake Error in CMakeLists.txt:
  The custom command generating

    .../protobuf/src/google/protobuf/unittest_lite.pb.cc

  is attached to multiple targets:

    tests
    lite-test
    lite-arena-test

  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".
```