### PR TITLE
Temporary Kokoro build for macos-next.

### DIFF
--- a/kokoro/macos-next/README.md
+++ b/kokoro/macos-next/README.md
@@ -1,0 +1,4 @@
+# macOS-next
+
+This builder is temporary for developing and testing builds using the "next"
+macOS version without affecting the ordinary builds.

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -ex
+#
+# Build file to set up and run tests
+
+# NOTE: in order to avoid blocking anyone, this job always succeeds for now.
+exit 0
+
+# Set up artifact output location
+: ${KOKORO_ARTIFACTS_DIR:=/tmp/kokoro_artifacts}
+: ${BUILD_LOGDIR:=$KOKORO_ARTIFACTS_DIR/logs}
+mkdir -p ${BUILD_LOGDIR}
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Update submodules
+git submodule update --init --recursive
+
+# Build in a separate directory
+mkdir -p cmake/build
+cd cmake/build
+
+# Print some basic info
+xcode-select --print-path
+xcodebuild -version
+xcrun --show-sdk-path
+
+# Build everything first
+cmake -G Xcode ../.. \
+  2>&1 | tee ${BUILD_LOGDIR}/00_configure_sponge_log.log
+cmake --build . --config Debug \
+  2>&1 | tee ${BUILD_LOGDIR}/01_build_sponge_log.log
+
+# Run tests
+ctest -C Debug --verbose --quiet \
+  --output-log ${BUILD_LOGDIR}/02_test_sponge_log.log

--- a/kokoro/macos-next/cpp/continuous.cfg
+++ b/kokoro/macos-next/cpp/continuous.cfg
@@ -1,7 +1,7 @@
 # Config file for running tests in Kokoro
 
 # Location of the build script in repository
-build_file: "protobuf/kokoro/macos/cpp/build.sh"
+build_file: "protobuf/kokoro/macos-next/cpp/build.sh"
 timeout_mins: 1440
 
 # Upload logs

--- a/kokoro/macos-next/cpp/continuous.cfg
+++ b/kokoro/macos-next/cpp/continuous.cfg
@@ -1,0 +1,13 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/cpp/build.sh"
+timeout_mins: 1440
+
+# Upload logs
+action: {
+  define_artifacts: {
+    regex: "protobuf/cmake/build/**/*sponge_log.log"
+    regex: "protobuf/cmake/build/**/*sponge_log.xml"
+  }
+}

--- a/kokoro/macos-next/cpp/presubmit.cfg
+++ b/kokoro/macos-next/cpp/presubmit.cfg
@@ -1,7 +1,7 @@
 # Config file for running tests in Kokoro
 
 # Location of the build script in repository
-build_file: "protobuf/kokoro/macos/cpp/build.sh"
+build_file: "protobuf/kokoro/macos-next/cpp/build.sh"
 timeout_mins: 1440
 
 # Upload logs

--- a/kokoro/macos-next/cpp/presubmit.cfg
+++ b/kokoro/macos-next/cpp/presubmit.cfg
@@ -1,0 +1,13 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/cpp/build.sh"
+timeout_mins: 1440
+
+# Upload logs
+action: {
+  define_artifacts: {
+    regex: "protobuf/cmake/build/**/*sponge_log.log"
+    regex: "protobuf/cmake/build/**/*sponge_log.xml"
+  }
+}


### PR DESCRIPTION
This build will be used to troubleshoot building on a newer macOS
image. Once it is stable, this config will replace the "macos" build.
