### PR TITLE
Helper method on Any to allow an any to be unpacked more easily

### DIFF
--- a/csharp/src/Google.Protobuf/WellKnownTypes/AnyPartial.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/AnyPartial.cs
@@ -121,6 +121,26 @@ namespace Google.Protobuf.WellKnownTypes
         }
 
         /// <summary>
+        /// Attempts to unpack the content of this Any message into one of the message types
+        /// in the given type registry, based on the type URL.
+        /// </summary>
+        /// <param name="registry">The type registry to consult for messages.</param>
+        /// <returns>The unpacked message, or <c>null</c> if no matching message was found.</returns>
+        public IMessage Unpack(TypeRegistry registry)
+        {
+            string typeName = GetTypeName(TypeUrl);
+            MessageDescriptor descriptor = registry.Find(typeName);
+            if (descriptor == null)
+            {
+                return null;
+            }
+
+            var message = descriptor.Parser.CreateTemplate();
+            message.MergeFrom(Value);
+            return message;
+        }
+
+        /// <summary>
         /// Packs the specified message into an Any message using a type URL prefix of "type.googleapis.com".
         /// </summary>
         /// <param name="message">The message to pack.</param>


### PR DESCRIPTION
We already have the TypeRegistry abstraction for JSON parsing, so it lends itself well to this.

Note that this is much more useful than it would have been before C# gained pattern matching support: it's easy to imagine a switch statement/expression using pattern matching with the result of this, with cases for a set of known message types, for example.