### PR TITLE
Revert "Use repo-relative labels wherever possible (#9187)"

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -266,9 +266,9 @@ def cc_proto_library(
         deps = [],
         cc_libs = [],
         include = None,
-        protoc = Label("//:protoc"),
+        protoc = "@com_google_protobuf//:protoc",
         use_grpc_plugin = False,
-        default_runtime = Label("//:protobuf"),
+        default_runtime = "@com_google_protobuf//:protobuf",
         **kargs):
     """Bazel rule to create a C++ protobuf library from proto source files
 
@@ -386,7 +386,7 @@ internal_gen_well_known_protos_java = rule(
         "_protoc": attr.label(
             executable = True,
             cfg = "exec",
-            default = "//:protoc",
+            default = "@com_google_protobuf//:protoc",
         ),
     },
 )
@@ -493,8 +493,8 @@ def py_proto_library(
         py_libs = [],
         py_extra_srcs = [],
         include = None,
-        default_runtime = Label("//:protobuf_python"),
-        protoc = Label("//:protoc"),
+        default_runtime = "@com_google_protobuf//:protobuf_python",
+        protoc = "@com_google_protobuf//:protoc",
         use_grpc_plugin = False,
         **kargs):
     """Bazel rule to create a Python protobuf library from proto source files

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -30,7 +30,7 @@ def protobuf_deps():
     if not native.existing_rule("zlib"):
         http_archive(
             name = "zlib",
-            build_file = Label("//:third_party/zlib.BUILD"),
+            build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
             sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
             strip_prefix = "zlib-1.2.11",
             urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],


### PR DESCRIPTION
This reverts commit 11de748d66a0b358b01c2ca1a03b6455b33f808b.

Fixes #9688.