### PR TITLE
Enable builds for macos-next kokoro.

### DIFF
--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -9,10 +9,16 @@
 : ${BUILD_LOGDIR:=$KOKORO_ARTIFACTS_DIR/logs}
 mkdir -p ${BUILD_LOGDIR}
 
+
 #
 # Change to repo root
 #
-cd $(dirname $0)/../../..
+if [[ -h /tmpfs ]] && [[ ${PWD} == /tmpfs/src ]]; then
+  # Workaround for internal Kokoro bug: b/227401944
+  cd /Volumes/BuildData/tmpfs/src/github/protobuf
+else
+  cd $(dirname $0)/../../..
+fi
 
 #
 # Update submodules

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -1,36 +1,45 @@
-#!/bin/bash -ex
+#!/bin/bash -ex -o pipefail
 #
 # Build file to set up and run tests
 
-# NOTE: in order to avoid blocking anyone, this job always succeeds for now.
-exit 0
-
-# Set up artifact output location
-: ${KOKORO_ARTIFACTS_DIR:=/tmp/kokoro_artifacts}
+#
+# Set up logging output location
+#
+: ${KOKORO_ARTIFACTS_DIR:=/tmp/protobuf_test_logs}
 : ${BUILD_LOGDIR:=$KOKORO_ARTIFACTS_DIR/logs}
 mkdir -p ${BUILD_LOGDIR}
 
+#
 # Change to repo root
+#
 cd $(dirname $0)/../../..
 
+#
 # Update submodules
+#
 git submodule update --init --recursive
 
-# Build in a separate directory
+#
+# Configure and build in a separate directory
+#
 mkdir -p cmake/build
 cd cmake/build
 
-# Print some basic info
-xcode-select --print-path
-xcodebuild -version
-xcrun --show-sdk-path
-
-# Build everything first
 cmake -G Xcode ../.. \
-  2>&1 | tee ${BUILD_LOGDIR}/00_configure_sponge_log.log
-cmake --build . --config Debug \
-  2>&1 | tee ${BUILD_LOGDIR}/01_build_sponge_log.log
+  2>&1 | tee ${BUILD_LOGDIR}/01_configure.log
 
+cp CMakeFiles/CMake*.log ${BUILD_LOGDIR}
+
+cmake --build . --config Debug \
+  2>&1 | tee ${BUILD_LOGDIR}/02_build.log
+
+#
 # Run tests
+#
 ctest -C Debug --verbose --quiet \
-  --output-log ${BUILD_LOGDIR}/02_test_sponge_log.log
+  --output-log ${BUILD_LOGDIR}/03_test.log
+
+#
+# Compress outputs
+#
+gzip ${BUILD_LOGDIR}/*.log

--- a/kokoro/macos-next/cpp/continuous.cfg
+++ b/kokoro/macos-next/cpp/continuous.cfg
@@ -7,7 +7,9 @@ timeout_mins: 1440
 # Upload logs
 action: {
   define_artifacts: {
-    regex: "protobuf/cmake/build/**/*sponge_log.log"
-    regex: "protobuf/cmake/build/**/*sponge_log.xml"
+    regex: "**/*sponge_log.log"
+    regex: "**/*sponge_log.xml"
+    regex: "logs/*.log"
+    regex: "logs/*.log.gz"
   }
 }

--- a/kokoro/macos-next/cpp/presubmit.cfg
+++ b/kokoro/macos-next/cpp/presubmit.cfg
@@ -7,7 +7,9 @@ timeout_mins: 1440
 # Upload logs
 action: {
   define_artifacts: {
-    regex: "protobuf/cmake/build/**/*sponge_log.log"
-    regex: "protobuf/cmake/build/**/*sponge_log.xml"
+    regex: "**/*sponge_log.log"
+    regex: "**/*sponge_log.xml"
+    regex: "logs/*.log"
+    regex: "logs/*.log.gz"
   }
 }


### PR DESCRIPTION
This enables build logic on the "macos-next" flavor of Kokoro tests.

The current runners use Big Sur with Xcode 13.2.1. This build uses cmake to configure and drive the build through Xcode. Tests are run under ctest.

I do plan to make a couple more changes, but they will take some more time and setup, so I'm leaving the "macos" builder alone for now.