### PR TITLE
Remove libpthread CMake dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,8 +160,6 @@ else()
 endif()
 file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/cmaketest.map)
 
-find_package(Threads REQUIRED)
-
 set(_protobuf_FIND_ZLIB)
 if (protobuf_WITH_ZLIB)
   find_package(ZLIB)


### PR DESCRIPTION
libpthread is not used by the code, yet CMake continued to look for it.

@acozzette , as discussed in https://github.com/protocolbuffers/protobuf/pull/9100#issuecomment-1080533383