### PR TITLE
[Kokoro] Emit XML test logs on macos-next.

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,5 +1,7 @@
 option(protobuf_USE_EXTERNAL_GTEST "Use external Google Test (i.e. not the one in third_party/googletest)" OFF)
 
+option(protobuf_TEST_XML_OUTDIR "Output directory for XML logs from tests." "")
+
 option(protobuf_ABSOLUTE_TEST_PLUGIN_PATH
   "Using absolute test_plugin path in tests" ON)
 mark_as_advanced(protobuf_ABSOLUTE_TEST_PLUGIN_PATH)
@@ -239,6 +241,13 @@ if(MINGW)
 
 endif()
 
+if(protobuf_TEST_XML_OUTDIR)
+  if(NOT "${protobuf_TEST_XML_OUTDIR}" MATCHES "[/\\]$")
+    string(APPEND protobuf_TEST_XML_OUTDIR "/")
+  endif()
+  set(protobuf_GTEST_ARGS "--gtest_output=xml:${protobuf_TEST_XML_OUTDIR}")
+endif()
+
 add_executable(tests ${tests_files})
 if (MSVC)
   target_compile_options(tests PRIVATE
@@ -263,11 +272,17 @@ set(lite_test_files
 add_executable(lite-test ${lite_test_files})
 target_link_libraries(lite-test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
 
+add_test(NAME lite-test
+  COMMAND lite-test ${protobuf_GTEST_ARGS})
+
 set(lite_arena_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/lite_arena_unittest.cc
 )
 add_executable(lite-arena-test ${lite_arena_test_files})
 target_link_libraries(lite-arena-test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
+
+add_test(NAME lite-arena-test
+  COMMAND lite-arena-test ${protobuf_GTEST_ARGS})
 
 add_custom_target(check
   COMMAND tests
@@ -275,5 +290,5 @@ add_custom_target(check
   WORKING_DIRECTORY ${protobuf_SOURCE_DIR})
 
 add_test(NAME check
-  COMMAND tests
+  COMMAND tests ${protobuf_GTEST_ARGS}
   WORKING_DIRECTORY "${protobuf_SOURCE_DIR}")

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,7 +1,5 @@
 option(protobuf_USE_EXTERNAL_GTEST "Use external Google Test (i.e. not the one in third_party/googletest)" OFF)
 
-option(protobuf_TEST_XML_OUTDIR "Output directory for XML logs from tests." "")
-
 option(protobuf_ABSOLUTE_TEST_PLUGIN_PATH
   "Using absolute test_plugin path in tests" ON)
 mark_as_advanced(protobuf_ABSOLUTE_TEST_PLUGIN_PATH)
@@ -150,35 +148,6 @@ set(tests_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenastring_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenaz_sampler_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/descriptor_database_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/descriptor_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/drop_unknown_fields_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/dynamic_message_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/extension_set_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/generated_message_reflection_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/generated_message_tctable_lite_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/inlined_string_field_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_field_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_test.inc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/message_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/message_unittest.inc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/no_field_presence_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/preserve_unknown_enum_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_arena_lite_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_arena_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_lite_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_lite_unittest.inc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/reflection_ops_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/repeated_field_reflection_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/repeated_field_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/text_format_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/unknown_field_set_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_unittest.inc
-)
-
-set(compiler_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/annotation_test_util.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/command_line_interface_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/cpp/bootstrap_unittest.cc
@@ -197,17 +166,33 @@ set(compiler_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/parser_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/python/plugin_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/ruby/ruby_generator_unittest.cc
-)
-
-set(io_test_files
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/descriptor_database_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/descriptor_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/drop_unknown_fields_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/dynamic_message_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/extension_set_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/generated_message_reflection_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/generated_message_tctable_lite_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/inlined_string_field_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/io/coded_stream_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/io/io_win32_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/io/printer_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/io/tokenizer_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/io/zero_copy_stream_unittest.cc
-)
-
-set(stubs_test_files
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_field_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_test.inc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/message_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/message_unittest.inc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/no_field_presence_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/preserve_unknown_enum_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_arena_lite_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_arena_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_lite_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_lite_unittest.inc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/reflection_ops_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/repeated_field_reflection_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/repeated_field_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/bytestream_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/common_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/int128_unittest.cc
@@ -219,9 +204,8 @@ set(stubs_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/strutil_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/template_util_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/time_test.cc
-)
-
-set(util_test_files
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/text_format_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/unknown_field_set_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/delimited_message_util_test.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/field_comparator_test.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/field_mask_util_test.cc
@@ -236,6 +220,8 @@ set(util_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/time_util_test.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/type_resolver_util_test.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/well_known_types_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_unittest.inc
 )
 
 if(protobuf_ABSOLUTE_TEST_PLUGIN_PATH)
@@ -253,21 +239,13 @@ if(MINGW)
 
 endif()
 
-if(protobuf_TEST_XML_OUTDIR)
-  if(NOT "${protobuf_TEST_XML_OUTDIR}" MATCHES "[/\\]$")
-    string(APPEND protobuf_TEST_XML_OUTDIR "/")
-  endif()
-  set(protobuf_GTEST_ARGS "--gtest_output=xml:${protobuf_TEST_XML_OUTDIR}")
-endif()
-
 add_executable(tests ${tests_files})
 if (MSVC)
   target_compile_options(tests PRIVATE
     /wd4146 # unary minus operator applied to unsigned type, result still unsigned
   )
 endif()
-target_link_libraries(tests protobuf-lite-test-common protobuf-test-common libprotobuf GTest::gmock_main)
-add_test(NAME tests COMMAND tests ${protobuf_GTEST_ARGS})
+target_link_libraries(tests protobuf-lite-test-common protobuf-test-common libprotoc libprotobuf GTest::gmock_main)
 
 set(test_plugin_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/mock_code_generator.cc
@@ -275,42 +253,27 @@ set(test_plugin_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/testing/file.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/testing/file.h
 )
+
 add_executable(test_plugin ${test_plugin_files})
 target_link_libraries(test_plugin libprotoc libprotobuf GTest::gmock)
-
-add_executable(compiler_test ${compiler_test_files})
-target_link_libraries(compiler_test protobuf-lite-test-common protobuf-test-common libprotoc libprotobuf-lite libprotobuf GTest::gmock_main)
-add_test(NAME compiler_test
-  COMMAND compiler_test ${protobuf_GTEST_ARGS}
-  WORKING_DIRECTORY "${protobuf_SOURCE_DIR}")
 
 set(lite_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/lite_unittest.cc
 )
-add_executable(lite_test ${lite_test_files})
-target_link_libraries(lite_test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
-add_test(NAME lite_test COMMAND lite_test ${protobuf_GTEST_ARGS})
+add_executable(lite-test ${lite_test_files})
+target_link_libraries(lite-test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
 
 set(lite_arena_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/lite_arena_unittest.cc
 )
-add_executable(lite_arena_test ${lite_arena_test_files})
-target_link_libraries(lite_arena_test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
-add_test(NAME lite_arena_test COMMAND lite_arena_test ${protobuf_GTEST_ARGS})
-
-add_executable(io_test ${io_test_files})
-target_link_libraries(io_test protobuf-lite-test-common protobuf-test-common libprotobuf libprotobuf-lite GTest::gmock_main)
-add_test(NAME io_test COMMAND io_test ${protobuf_GTEST_ARGS})
-
-add_executable(stubs_test ${stubs_test_files})
-target_link_libraries(stubs_test protobuf-lite-test-common protobuf-test-common libprotobuf libprotobuf-lite GTest::gmock_main)
-add_test(NAME stubs_test COMMAND stubs_test ${protobuf_GTEST_ARGS})
-
-add_executable(util_test ${util_test_files})
-target_link_libraries(util_test protobuf-lite-test-common protobuf-test-common libprotobuf libprotobuf-lite GTest::gmock_main)
-add_test(NAME util_test COMMAND util_test ${protobuf_GTEST_ARGS})
+add_executable(lite-arena-test ${lite_arena_test_files})
+target_link_libraries(lite-arena-test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
 
 add_custom_target(check
   COMMAND tests
   DEPENDS tests test_plugin
   WORKING_DIRECTORY ${protobuf_SOURCE_DIR})
+
+add_test(NAME check
+  COMMAND tests
+  WORKING_DIRECTORY "${protobuf_SOURCE_DIR}")

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -150,6 +150,35 @@ set(tests_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenastring_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/arenaz_sampler_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/descriptor_database_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/descriptor_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/drop_unknown_fields_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/dynamic_message_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/extension_set_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/generated_message_reflection_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/generated_message_tctable_lite_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/inlined_string_field_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_field_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_test.inc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/message_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/message_unittest.inc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/no_field_presence_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/preserve_unknown_enum_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_arena_lite_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_arena_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_lite_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_lite_unittest.inc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/reflection_ops_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/repeated_field_reflection_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/repeated_field_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/text_format_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/unknown_field_set_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_unittest.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_unittest.inc
+)
+
+set(compiler_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/annotation_test_util.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/command_line_interface_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/cpp/bootstrap_unittest.cc
@@ -168,33 +197,17 @@ set(tests_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/parser_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/python/plugin_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/ruby/ruby_generator_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/descriptor_database_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/descriptor_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/drop_unknown_fields_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/dynamic_message_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/extension_set_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/generated_message_reflection_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/generated_message_tctable_lite_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/inlined_string_field_unittest.cc
+)
+
+set(io_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/io/coded_stream_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/io/io_win32_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/io/printer_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/io/tokenizer_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/io/zero_copy_stream_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_field_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/map_test.inc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/message_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/message_unittest.inc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/no_field_presence_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/preserve_unknown_enum_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_arena_lite_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_arena_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_lite_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_lite_unittest.inc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/reflection_ops_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/repeated_field_reflection_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/repeated_field_unittest.cc
+)
+
+set(stubs_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/bytestream_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/common_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/int128_unittest.cc
@@ -206,8 +219,9 @@ set(tests_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/strutil_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/template_util_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/time_test.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/text_format_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/unknown_field_set_unittest.cc
+)
+
+set(util_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/delimited_message_util_test.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/field_comparator_test.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/field_mask_util_test.cc
@@ -222,8 +236,6 @@ set(tests_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/time_util_test.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/type_resolver_util_test.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/well_known_types_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_unittest.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_unittest.inc
 )
 
 if(protobuf_ABSOLUTE_TEST_PLUGIN_PATH)
@@ -254,7 +266,8 @@ if (MSVC)
     /wd4146 # unary minus operator applied to unsigned type, result still unsigned
   )
 endif()
-target_link_libraries(tests protobuf-lite-test-common protobuf-test-common libprotoc libprotobuf GTest::gmock_main)
+target_link_libraries(tests protobuf-lite-test-common protobuf-test-common libprotobuf GTest::gmock_main)
+add_test(NAME tests COMMAND tests ${protobuf_GTEST_ARGS})
 
 set(test_plugin_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/mock_code_generator.cc
@@ -262,33 +275,42 @@ set(test_plugin_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/testing/file.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/testing/file.h
 )
-
 add_executable(test_plugin ${test_plugin_files})
 target_link_libraries(test_plugin libprotoc libprotobuf GTest::gmock)
+
+add_executable(compiler_test ${compiler_test_files})
+target_link_libraries(compiler_test protobuf-lite-test-common protobuf-test-common libprotoc libprotobuf-lite libprotobuf GTest::gmock_main)
+add_test(NAME compiler_test
+  COMMAND compiler_test ${protobuf_GTEST_ARGS}
+  WORKING_DIRECTORY "${protobuf_SOURCE_DIR}")
 
 set(lite_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/lite_unittest.cc
 )
-add_executable(lite-test ${lite_test_files})
-target_link_libraries(lite-test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
-
-add_test(NAME lite-test
-  COMMAND lite-test ${protobuf_GTEST_ARGS})
+add_executable(lite_test ${lite_test_files})
+target_link_libraries(lite_test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
+add_test(NAME lite_test COMMAND lite_test ${protobuf_GTEST_ARGS})
 
 set(lite_arena_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/lite_arena_unittest.cc
 )
-add_executable(lite-arena-test ${lite_arena_test_files})
-target_link_libraries(lite-arena-test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
+add_executable(lite_arena_test ${lite_arena_test_files})
+target_link_libraries(lite_arena_test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
+add_test(NAME lite_arena_test COMMAND lite-arena-test ${protobuf_GTEST_ARGS})
 
-add_test(NAME lite-arena-test
-  COMMAND lite-arena-test ${protobuf_GTEST_ARGS})
+add_executable(io_test ${io_test_files})
+target_link_libraries(io_test protobuf-lite-test-common protobuf-test-common libprotobuf libprotobuf-lite GTest::gmock_main)
+add_test(NAME io_test COMMAND io_test ${protobuf_GTEST_ARGS})
+
+add_executable(stubs_test ${stubs_test_files})
+target_link_libraries(stubs_test protobuf-lite-test-common protobuf-test-common libprotobuf libprotobuf-lite GTest::gmock_main)
+add_test(NAME stubs_test COMMAND stubs_test ${protobuf_GTEST_ARGS})
+
+add_executable(util_test ${util_test_files})
+target_link_libraries(util_test protobuf-lite-test-common protobuf-test-common libprotobuf libprotobuf-lite GTest::gmock_main)
+add_test(NAME util_test COMMAND util_test ${protobuf_GTEST_ARGS})
 
 add_custom_target(check
   COMMAND tests
   DEPENDS tests test_plugin
   WORKING_DIRECTORY ${protobuf_SOURCE_DIR})
-
-add_test(NAME check
-  COMMAND tests ${protobuf_GTEST_ARGS}
-  WORKING_DIRECTORY "${protobuf_SOURCE_DIR}")

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -296,7 +296,7 @@ set(lite_arena_test_files
 )
 add_executable(lite_arena_test ${lite_arena_test_files})
 target_link_libraries(lite_arena_test protobuf-lite-test-common libprotobuf-lite GTest::gmock_main)
-add_test(NAME lite_arena_test COMMAND lite-arena-test ${protobuf_GTEST_ARGS})
+add_test(NAME lite_arena_test COMMAND lite_arena_test ${protobuf_GTEST_ARGS})
 
 add_executable(io_test ${io_test_files})
 target_link_libraries(io_test protobuf-lite-test-common protobuf-test-common libprotobuf libprotobuf-lite GTest::gmock_main)

--- a/kokoro/caplog.sh
+++ b/kokoro/caplog.sh
@@ -41,7 +41,7 @@
 #   caplog build/02_build     cmake --build
 #   caplot test/03_test       ctest ${CAPLOG_CTEST_ARGS:-}
 
-if ! [[ -v KOKORO_ARTIFACTS_DIR ]]; then
+if [[ -z ${KOKORO_ARTIFACTS_DIR:-} ]]; then
   function caplog() { shift; "$@"; }
 else
 

--- a/kokoro/caplog.sh
+++ b/kokoro/caplog.sh
@@ -64,6 +64,7 @@ else
 
   # Trap handler: renames logs on script exit so they will be found by Kokoro.
   function _caplog_onexit() {
+    _rc=$?
     set +x
     echo "Collecting logs [${BASH_SOURCE}]"
 
@@ -84,6 +85,7 @@ else
       mv -v "${_src}" "${_stem}/sponge_log.${_ext}"
     done
     rm -rv "${CAPLOG_DIR}"
+    exit ${_rc}
   }
   trap _caplog_onexit EXIT
 

--- a/kokoro/caplog.sh
+++ b/kokoro/caplog.sh
@@ -1,0 +1,82 @@
+# Log capturing for the Kokoro runtime environment.
+#
+# This script should be `source`d from Kokoro build scripts to configure log
+# capturing when running under Kokoro.
+#
+# When not running under Kokoro, no logs will be collected. If you want to run
+# locally and collect logs anyway, set the KOKORO_ARTIFACTS_DIR environment
+# variable to a directory where the logs should go.
+#
+# The job `.cfg` file needs the following stanzas to declare the captured logs
+# as outputs (yes, these are globs, not regexes):
+#
+#   action: {
+#     define_artifacts: {
+#       regex: "**/*sponge_log.log"
+#       regex: "**/*sponge_log.xml"
+#     }
+#   }
+#
+# Use the provided functions below as build/test fixtures, e.g.:
+#
+#   source kokoro/capture_logs.sh
+#   caplog build/step1 <build command>
+#   caplog tests/step2 <test command>
+#
+# If log capturing is enabled, this script will set some variables that can be
+# used if necessary:
+#
+#   CAPLOG_DIR         is used for logs
+#   CAPLOG_CMAKE_ARGS  contains extra cmake args to enable test XML output
+#   CAPLOG_CTEST_ARGS  contains extra ctest args to capture combined test logs
+#
+# For example:
+#
+#   if [[ -v CAPLOG_DIR_BUILD ]]; then
+#     cp extra_diagnostics.log "${CAPLOG_DIR_BUILD}/diagnostics.log"
+#   fi
+#
+#   # Use ${...:-} form under `set -u`:
+#   caplog build/01_configure cmake -G Ninja ${CAPLOG_CMAKE_ARGS:-}
+#   caplog build/02_build     cmake --build
+#   caplot test/03_test       ctest ${CAPLOG_CTEST_ARGS:-}
+
+if ! [[ -v KOKORO_ARTIFACTS_DIR ]]; then
+  function caplog() { shift; "$@"; }
+else
+
+  CAPLOG_DIR="$(mktemp -d)"
+  CAPLOG_CMAKE_ARGS="-Dprotobuf_TEST_XML_OUTDIR=${CAPLOG_DIR}/tests"
+  CAPLOG_CTEST_ARGS="--verbose"
+
+  # Captures the stdout/stderr of a command to a named log file.
+  # Usage: caplog NAME COMMAND [ARGS...]
+  function caplog() {
+    _name="${CAPLOG_DIR}/${1%.log}.log"; shift
+    mkdir -p "${_name%/*}"
+    date
+    if ! time ( "$@" 2>&1 > "${_name}" ) ; then
+      cat "${_name}"
+      return 1
+    fi
+  }
+
+  # Trap handler: renames logs on script exit so they will be found by Kokoro.
+  function _caplog_onexit() {
+    set +x
+    echo "Collecting logs [${BASH_SOURCE}]"
+    find "${CAPLOG_DIR}" -type f \( -name '*.xml' -or -name '*.log' \) \
+      | while read _src; do
+      # Move to artifacts dir, preserving the path relative to CAPLOG_DIR.
+      # The filename changes from foo/bar.log to foo/bar/sponge_log.log.
+      _logfile=${_src/${CAPLOG_DIR}\//}
+      _stem=${KOKORO_ARTIFACTS_DIR}/${_logfile%.*}
+      _ext=${_logfile##*.}
+      mkdir -p ${_stem}
+      mv -v "${_src}" "${_stem}/sponge_log.${_ext}"
+    done
+    rm -rv "${CAPLOG_DIR}"
+  }
+  trap _caplog_onexit EXIT
+
+fi

--- a/kokoro/caplog.sh
+++ b/kokoro/caplog.sh
@@ -55,7 +55,8 @@ else
     _name="${CAPLOG_DIR}/${1%.log}.log"; shift
     mkdir -p "${_name%/*}"
     date
-    if ! time ( "$@" 2>&1 > "${_name}" ) ; then
+    time ( "$@" > "${_name}" 2>&1 )
+    if [[ $? != 0 ]] ; then
       cat "${_name}"
       return 1
     fi

--- a/kokoro/caplog.sh
+++ b/kokoro/caplog.sh
@@ -46,7 +46,7 @@ if [[ -z ${KOKORO_ARTIFACTS_DIR:-} ]]; then
 else
 
   CAPLOG_DIR="$(mktemp -d)"
-  CAPLOG_CMAKE_ARGS="-Dprotobuf_TEST_XML_OUTDIR=${CAPLOG_DIR}/tests"
+  CAPLOG_CMAKE_ARGS="-Dprotobuf_TEST_XML_OUTDIR=${CAPLOG_DIR}/tests/"
   CAPLOG_CTEST_ARGS="--verbose"
 
   # Captures the stdout/stderr of a command to a named log file.

--- a/kokoro/caplog.sh
+++ b/kokoro/caplog.sh
@@ -66,6 +66,13 @@ else
   function _caplog_onexit() {
     set +x
     echo "Collecting logs [${BASH_SOURCE}]"
+
+    find "${CAPLOG_DIR}" -type f -name '*.log' \
+      | while read _textlog; do
+      # Ensure an XML file exists for each .log file.
+      touch ${_textlog%.log}.xml
+    done
+
     find "${CAPLOG_DIR}" -type f \( -name '*.xml' -or -name '*.log' \) \
       | while read _src; do
       # Move to artifacts dir, preserving the path relative to CAPLOG_DIR.

--- a/kokoro/caplog.sh
+++ b/kokoro/caplog.sh
@@ -39,7 +39,7 @@
 #   # Use ${...:-} form under `set -u`:
 #   caplog build/01_configure cmake -G Ninja ${CAPLOG_CMAKE_ARGS:-}
 #   caplog build/02_build     cmake --build
-#   caplot test/03_test       ctest ${CAPLOG_CTEST_ARGS:-}
+#   caplog test/03_test       ctest ${CAPLOG_CTEST_ARGS:-}
 
 if [[ -z ${KOKORO_ARTIFACTS_DIR:-} ]]; then
   function caplog() { shift; "$@"; }

--- a/kokoro/caplog.sh
+++ b/kokoro/caplog.sh
@@ -55,7 +55,7 @@ else
     _name="${CAPLOG_DIR}/${1%.log}.log"; shift
     mkdir -p "${_name%/*}"
     date
-    time ( "$@" > "${_name}" 2>&1 )
+    time ( "$@" 2>&1 | tee "${_name}" )
     if [[ $? != 0 ]] ; then
       cat "${_name}"
       return 1

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -47,7 +47,7 @@ ctest -C Debug --verbose \
 #
 # Rename test XML output
 #
-find ${BUILD_LOGDIR} -name '*.xml' | while read xmllog; do
+find ${KOKORO_ARTIFACTS_DIR} -name '*.xml' | while read xmllog; do
   mkdir -p ${xmllog%.xml}
   mv -v ${xmllog} ${xmllog%.xml}/sponge_log.xml
 done

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -1,55 +1,55 @@
-#!/bin/bash -ex -o pipefail
+#!/bin/bash -eux
 #
 # Build file to set up and run tests
 
-#
-# Set up logging output location
-#
-: ${KOKORO_ARTIFACTS_DIR:=/tmp/protobuf_test_logs}
-: ${BUILD_LOGDIR:=$KOKORO_ARTIFACTS_DIR/logs}
-mkdir -p ${BUILD_LOGDIR}
-: ${TEST_LOGDIR:=$KOKORO_ARTIFACTS_DIR/tests}
-mkdir -p ${TEST_LOGDIR}
+set -o pipefail
 
-#
-# Change to repo root
-#
 if [[ -h /tmpfs ]] && [[ ${PWD} == /tmpfs/src ]]; then
   # Workaround for internal Kokoro bug: b/227401944
-  cd /Volumes/BuildData/tmpfs/src/github/protobuf
-else
-  cd $(dirname $0)/../../..
+  cd /Volumes/BuildData/tmpfs/src
 fi
+
+# These vars can be changed when running manually, e.g.:
+#
+#   % BUILD_CONFIG=RelWithDebInfo path/to/build.sh
+
+# By default, build using Debug config.
+: ${BUILD_CONFIG:=Debug}
+
+# By default, find the sources based on this script path.
+: ${SOURCE_DIR:=$(cd $(dirname $0)/../../..; pwd)}
+
+# By default, put outputs under <git root>/cmake/build.
+: ${BUILD_DIR:=${SOURCE_DIR}/cmake/build}
+
+source ${SOURCE_DIR}/kokoro/caplog.sh
 
 #
 # Update submodules
 #
-git submodule update --init --recursive
+git -C "${SOURCE_DIR}" submodule update --init --recursive
 
 #
 # Configure and build in a separate directory
 #
-mkdir -p cmake/build
-cd cmake/build
+mkdir -p "${BUILD_DIR}"
 
-cmake -G Xcode ../.. -Dprotobuf_TEST_XML_OUTDIR=${TEST_LOGDIR} \
-  2>&1 | tee ${BUILD_LOGDIR}/01_configure.log
+caplog 01_configure \
+  cmake -S "${SOURCE_DIR}" -B "${BUILD_DIR}" ${CAPLOG_CMAKE_ARGS:-}
 
-cp CMakeFiles/CMake*.log ${BUILD_LOGDIR}
+if [[ -v CAPLOG_DIR ]]; then
+  mkdir -p "${CAPLOG_DIR}/CMakeFiles"
+  cp "${BUILD_DIR}"/CMakeFiles/CMake*.log "${CAPLOG_DIR}/CMakeFiles"
+fi
 
-cmake --build . --config Debug \
-  2>&1 | tee ${BUILD_LOGDIR}/02_build.log
+caplog 02_build \
+  cmake --build "${BUILD_DIR}" --config "${BUILD_CONFIG}"
 
 #
 # Run tests
 #
-ctest -C Debug -j4 --verbose \
-  --output-log ${BUILD_LOGDIR}/03_test.log
-
-#
-# Rename test XML output
-#
-find ${TEST_LOGDIR} -name '*.xml' | while read xmllog; do
-  mkdir -p ${xmllog%.xml}
-  mv -v ${xmllog} ${xmllog%.xml}/sponge_log.xml
-done
+(
+  cd "${BUILD_DIR}"
+  caplog 03_combined_testlog \
+    ctest "${BUILD_DIR}" -C "${BUILD_CONFIG}" -j4 ${CAPLOG_CTEST_ARGS:-}
+)

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -43,7 +43,7 @@ cmake --build . --config Debug \
 #
 # Run tests
 #
-ctest -C Debug --verbose \
+ctest -C Debug -j4 --verbose \
   --output-log ${TEST_LOGDIR}/03_test.log
 
 #

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -8,6 +8,8 @@
 : ${KOKORO_ARTIFACTS_DIR:=/tmp/protobuf_test_logs}
 : ${BUILD_LOGDIR:=$KOKORO_ARTIFACTS_DIR/logs}
 mkdir -p ${BUILD_LOGDIR}
+: ${TEST_LOGDIR:=$KOKORO_ARTIFACTS_DIR/tests}
+mkdir -p ${TEST_LOGDIR}
 
 #
 # Change to repo root
@@ -30,7 +32,7 @@ git submodule update --init --recursive
 mkdir -p cmake/build
 cd cmake/build
 
-cmake -G Xcode ../.. -Dprotobuf_TEST_XML_OUTDIR=${KOKORO_ARTIFACTS_DIR} \
+cmake -G Xcode ../.. -Dprotobuf_TEST_XML_OUTDIR=${BUILD_LOGDIR} \
   2>&1 | tee ${BUILD_LOGDIR}/01_configure.log
 
 cp CMakeFiles/CMake*.log ${BUILD_LOGDIR}
@@ -42,12 +44,12 @@ cmake --build . --config Debug \
 # Run tests
 #
 ctest -C Debug --verbose \
-  --output-log ${BUILD_LOGDIR}/03_test.log
+  --output-log ${TEST_LOGDIR}/03_test.log
 
 #
 # Rename test XML output
 #
-find ${KOKORO_ARTIFACTS_DIR} -name '*.xml' | while read xmllog; do
+find ${TEST_LOGDIR} -name '*.xml' | while read xmllog; do
   mkdir -p ${xmllog%.xml}
   mv -v ${xmllog} ${xmllog%.xml}/sponge_log.xml
 done

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -9,7 +9,6 @@
 : ${BUILD_LOGDIR:=$KOKORO_ARTIFACTS_DIR/logs}
 mkdir -p ${BUILD_LOGDIR}
 
-
 #
 # Change to repo root
 #
@@ -31,7 +30,7 @@ git submodule update --init --recursive
 mkdir -p cmake/build
 cd cmake/build
 
-cmake -G Xcode ../.. \
+cmake -G Xcode ../.. -Dprotobuf_TEST_XML_OUTDIR=${BUILD_LOGDIR} \
   2>&1 | tee ${BUILD_LOGDIR}/01_configure.log
 
 cp CMakeFiles/CMake*.log ${BUILD_LOGDIR}
@@ -42,10 +41,12 @@ cmake --build . --config Debug \
 #
 # Run tests
 #
-ctest -C Debug --verbose --quiet \
+ctest -C Debug --verbose \
   --output-log ${BUILD_LOGDIR}/03_test.log
 
 #
-# Compress outputs
+# Rename test XML output
 #
-gzip ${BUILD_LOGDIR}/*.log
+find ${BUILD_LOGDIR} -name '*.xml' | while read xmllog; do
+  mv -v ${xmllog} ${xmllog%/*}/sponge_log_${xmllog##*/}
+done

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -51,5 +51,5 @@ caplog 02_build \
 (
   cd "${BUILD_DIR}"
   caplog 03_combined_testlog \
-    ctest "${BUILD_DIR}" -C "${BUILD_CONFIG}" -j4 ${CAPLOG_CTEST_ARGS:-}
+    ctest -C "${BUILD_CONFIG}" -j4 ${CAPLOG_CTEST_ARGS:-}
 )

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -32,7 +32,7 @@ git submodule update --init --recursive
 mkdir -p cmake/build
 cd cmake/build
 
-cmake -G Xcode ../.. -Dprotobuf_TEST_XML_OUTDIR=${BUILD_LOGDIR} \
+cmake -G Xcode ../.. -Dprotobuf_TEST_XML_OUTDIR=${TEST_LOGDIR} \
   2>&1 | tee ${BUILD_LOGDIR}/01_configure.log
 
 cp CMakeFiles/CMake*.log ${BUILD_LOGDIR}
@@ -44,7 +44,7 @@ cmake --build . --config Debug \
 # Run tests
 #
 ctest -C Debug -j4 --verbose \
-  --output-log ${TEST_LOGDIR}/03_test.log
+  --output-log ${BUILD_LOGDIR}/03_test.log
 
 #
 # Rename test XML output

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -48,5 +48,5 @@ ctest -C Debug --verbose \
 # Rename test XML output
 #
 find ${BUILD_LOGDIR} -name '*.xml' | while read xmllog; do
-  mv -v ${xmllog} ${xmllog%/*}/sponge_log_${xmllog##*/}
+  mv -v ${xmllog} ${xmllog%.xml}_sponge_log.xml
 done

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -30,7 +30,7 @@ git submodule update --init --recursive
 mkdir -p cmake/build
 cd cmake/build
 
-cmake -G Xcode ../.. -Dprotobuf_TEST_XML_OUTDIR=${BUILD_LOGDIR} \
+cmake -G Xcode ../.. -Dprotobuf_TEST_XML_OUTDIR=${KOKORO_ARTIFACTS_DIR} \
   2>&1 | tee ${BUILD_LOGDIR}/01_configure.log
 
 cp CMakeFiles/CMake*.log ${BUILD_LOGDIR}
@@ -48,5 +48,6 @@ ctest -C Debug --verbose \
 # Rename test XML output
 #
 find ${BUILD_LOGDIR} -name '*.xml' | while read xmllog; do
-  mv -v ${xmllog} ${xmllog%.xml}_sponge_log.xml
+  mkdir -p ${xmllog%.xml}
+  mv -v ${xmllog} ${xmllog%.xml}/sponge_log.xml
 done

--- a/kokoro/macos-next/cpp/build.sh
+++ b/kokoro/macos-next/cpp/build.sh
@@ -37,7 +37,7 @@ mkdir -p "${BUILD_DIR}"
 caplog 01_configure \
   cmake -S "${SOURCE_DIR}" -B "${BUILD_DIR}" ${CAPLOG_CMAKE_ARGS:-}
 
-if [[ -v CAPLOG_DIR ]]; then
+if [[ -n ${CAPLOG_DIR:-} ]]; then
   mkdir -p "${CAPLOG_DIR}/CMakeFiles"
   cp "${BUILD_DIR}"/CMakeFiles/CMake*.log "${CAPLOG_DIR}/CMakeFiles"
 fi

--- a/kokoro/macos-next/cpp/continuous.cfg
+++ b/kokoro/macos-next/cpp/continuous.cfg
@@ -9,7 +9,5 @@ action: {
   define_artifacts: {
     regex: "**/*sponge_log.log"
     regex: "**/*sponge_log.xml"
-    regex: "logs/*.log"
-    regex: "logs/*.log.gz"
   }
 }

--- a/kokoro/macos-next/cpp/presubmit.cfg
+++ b/kokoro/macos-next/cpp/presubmit.cfg
@@ -9,7 +9,5 @@ action: {
   define_artifacts: {
     regex: "**/*sponge_log.log"
     regex: "**/*sponge_log.xml"
-    regex: "logs/*.log"
-    regex: "logs/*.log.gz"
   }
 }


### PR DESCRIPTION
This enables googletest XML output on the macos-next builders, and adds logic to collect the results.

The log collection logic is slightly complex, but it should be reusable in other contexts. The idea is to capture stdout/stderr for build steps along with googletest XML reports into a temporary directory, then stage those into paths expected for artifacts.