### PR TITLE
[Ruby] Fix RepeatedField#last, #first inconsistencies

### DIFF
--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -79,12 +79,25 @@ module Google
 
 
       def first(n=nil)
-        n ? self[0...n] : self[0]
+        if n.nil?
+          return self[0]
+        elsif n < 0
+          raise ArgumentError, "negative array size"
+        else
+          return self[0...n]
+        end
       end
 
 
       def last(n=nil)
-        n ? self[(self.size-n-1)..-1] : self[-1]
+        if n.nil?
+          return self[-1]
+        elsif n < 0
+          raise ArgumentError, "negative array size"
+        else
+          start = [self.size-n, 0].max
+          return self[start..-1]
+        end
       end
 
 

--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -96,7 +96,7 @@ module Google
           raise ArgumentError, "negative array size"
         else
           start = [self.size-n, 0].max
-          return self[start..-1]
+          return self[start...self.size]
         end
       end
 

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -48,6 +48,10 @@ class RepeatedFieldTest < Test::Unit::TestCase
     assert_equal TestMessage2.new(:foo => 1), m.repeated_msg.first
     assert_equal :A, m.repeated_enum.first
 
+    err = assert_raises(ArgumentError) do
+      m.repeated_int32.first(-1)
+    end
+    assert_equal "negative array size", err.message
     assert_equal [], m.repeated_int32.first(0)
     assert_equal [-10], m.repeated_int32.first(1)
     assert_equal [-10, -11], m.repeated_int32.first(2)
@@ -72,6 +76,15 @@ class RepeatedFieldTest < Test::Unit::TestCase
     assert_equal "foo".encode!('ASCII-8BIT'), m.repeated_bytes.last
     assert_equal TestMessage2.new(:foo => 2), m.repeated_msg.last
     assert_equal :B, m.repeated_enum.last
+
+    err = assert_raises(ArgumentError) do
+      m.repeated_int32.last(-1)
+    end
+    assert_equal "negative array size", err.message
+    assert_equal [], m.repeated_int32.last(0)
+    assert_equal [-11], m.repeated_int32.last(1)
+    assert_equal [-10, -11], m.repeated_int32.last(2)
+    assert_equal [-10, -11], m.repeated_int32.last(3)
   end
 
 


### PR DESCRIPTION
`RepeatedField#last(n)` has an off-by-one error resulting in one more element being returned than requested.

While I was at it, I also fixed the following inconsistencies with `Array`:

- `last(n)` where n > size should return all elements; the current implementation wraps around such that e.g. `last(size + 2) == last(2)`
- `last(n)` where n < 0 should raise an `ArgumentError`
