### PR TITLE
Fix building packaged PHP extension

### DIFF
--- a/.github/workflows/php-ext.yml
+++ b/.github/workflows/php-ext.yml
@@ -1,0 +1,43 @@
+name: PHP extension
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build-php:
+    name: Build PHP extension
+    runs-on: ubuntu-latest
+    container: ${{ matrix.php-image }}
+    strategy:
+      matrix:
+        php-image:
+          - php:7.4-cli
+          - php:8.1-cli
+    steps:
+      - name: Install git
+        run: |
+          apt-get update -q
+          apt-get install -qy --no-install-recommends git
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Prepare source code
+        run: |
+          rm -rf "$GITHUB_WORKSPACE/php/ext/google/protobuf/third_party"
+          cp -r "$GITHUB_WORKSPACE/third_party" "$GITHUB_WORKSPACE/php/ext/google/protobuf"
+          cp "$GITHUB_WORKSPACE/LICENSE" "$GITHUB_WORKSPACE/php/ext/google/protobuf"
+      - name: Create package
+        run: |
+          cd /tmp
+          rm -rf protobuf-*.tgz
+          pecl package "$GITHUB_WORKSPACE/php/ext/google/protobuf/package.xml"
+      - name: Compile extension
+        run: |
+          cd /tmp
+          MAKE="make -j$(nproc)" pecl install protobuf-*.tgz
+      - name: Enable extension
+        run: docker-php-ext-enable protobuf
+      - name: Inspect extension
+        run: php --ri protobuf

--- a/php/ext/google/protobuf/config.m4
+++ b/php/ext/google/protobuf/config.m4
@@ -6,5 +6,6 @@ if test "$PHP_PROTOBUF" != "no"; then
     protobuf,
     arena.c array.c convert.c def.c map.c message.c names.c php-upb.c protobuf.c third_party/utf8_range/naive.c third_party/utf8_range/range2-neon.c third_party/utf8_range/range2-sse.c,
     $ext_shared, , -std=gnu99)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/utf8_range)
 
 fi


### PR DESCRIPTION
We've recently had a couple of issues that prevented the PHP extension from being installed with pecl (see #9654 and #9724).

So, what about adding a GitHub Action that checks if the PHP extension can be built successfully?

In this PR I first add that test (which will fail), then I'll add the required changes to make it pass

Fix #9724