### PR TITLE
Remove unused `HasTopLevelEnums` function

### DIFF
--- a/src/google/protobuf/compiler/python/generator.cc
+++ b/src/google/protobuf/compiler/python/generator.cc
@@ -90,12 +90,6 @@ std::string ModuleAlias(const std::string& filename) {
 // in proto2/public/reflection.py.
 const char kDescriptorKey[] = "DESCRIPTOR";
 
-
-// Does the file have top-level enums?
-inline bool HasTopLevelEnums(const FileDescriptor* file) {
-  return file->enum_type_count() > 0;
-}
-
 // file output by this generator.
 void PrintTopBoilerplate(io::Printer* printer, const FileDescriptor* file,
                          bool descriptor_proto) {


### PR DESCRIPTION
This will address the following compiler warning:

```
src/google/protobuf/compiler/python/python_generator.cc:95:13: warning: unused function 'HasTopLevelEnums' [-Wunused-function]
```