### PR TITLE
Escape GetObject macro inside protoc-generated code

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -779,6 +779,8 @@
 #undef GetClassName
 #pragma push_macro("GetMessage")
 #undef GetMessage
+#pragma push_macro("GetObject")
+#undef GetObject
 #pragma push_macro("IGNORE")
 #undef IGNORE
 #pragma push_macro("IN")

--- a/src/google/protobuf/port_undef.inc
+++ b/src/google/protobuf/port_undef.inc
@@ -114,6 +114,7 @@
 #pragma pop_macro("ERROR_NOT_FOUND")
 #pragma pop_macro("GetClassName")
 #pragma pop_macro("GetMessage")
+#pragma pop_macro("GetObject")
 #pragma pop_macro("IGNORE")
 #pragma pop_macro("IN")
 #pragma pop_macro("INPUT_KEYBOARD")


### PR DESCRIPTION
GetObject macro is defined in wingdi.h (included transitively in windows.h):

`#ifdef UNICODE
#define GetObject  GetObjectW
#else
#define GetObject  GetObjectA
#endif`

This can cause unexpected problems when compiling "GetObject" contains proto for windows.

Also "GetObject" looks like common method name for grpc. [Here](https://github.com/grpc/grpc/pull/29311) I want to wrap grpc-generated code with port_def/port_undef

