### PR TITLE
Add the `withoutHtmlEscaping` option to `JsonFormat` printer

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -115,7 +115,8 @@ public class JsonFormat {
         /* preservingProtoFieldNames */ false,
         /* omittingInsignificantWhitespace */ false,
         /* printingEnumsAsInts */ false,
-        /* sortingMapKeys */ false);
+        /* sortingMapKeys */ false,
+        /* disablingHtmlEscaping */ false);
   }
 
   /**
@@ -138,6 +139,7 @@ public class JsonFormat {
     private final boolean omittingInsignificantWhitespace;
     private final boolean printingEnumsAsInts;
     private final boolean sortingMapKeys;
+    private final boolean disablingHtmlEscaping;
 
     private Printer(
         com.google.protobuf.TypeRegistry registry,
@@ -147,7 +149,8 @@ public class JsonFormat {
         boolean preservingProtoFieldNames,
         boolean omittingInsignificantWhitespace,
         boolean printingEnumsAsInts,
-        boolean sortingMapKeys) {
+        boolean sortingMapKeys,
+        boolean disablingHtmlEscaping) {
       this.registry = registry;
       this.oldRegistry = oldRegistry;
       this.alwaysOutputDefaultValueFields = alwaysOutputDefaultValueFields;
@@ -156,6 +159,7 @@ public class JsonFormat {
       this.omittingInsignificantWhitespace = omittingInsignificantWhitespace;
       this.printingEnumsAsInts = printingEnumsAsInts;
       this.sortingMapKeys = sortingMapKeys;
+      this.disablingHtmlEscaping = disablingHtmlEscaping;
     }
 
     /**
@@ -177,7 +181,8 @@ public class JsonFormat {
           preservingProtoFieldNames,
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
-          sortingMapKeys);
+          sortingMapKeys,
+          disablingHtmlEscaping);
     }
 
     /**
@@ -199,7 +204,8 @@ public class JsonFormat {
           preservingProtoFieldNames,
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
-          sortingMapKeys);
+          sortingMapKeys,
+          disablingHtmlEscaping);
     }
 
     /**
@@ -218,7 +224,8 @@ public class JsonFormat {
           preservingProtoFieldNames,
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
-          sortingMapKeys);
+          sortingMapKeys,
+          disablingHtmlEscaping);
     }
 
     /**
@@ -235,7 +242,8 @@ public class JsonFormat {
           preservingProtoFieldNames,
           omittingInsignificantWhitespace,
           true,
-          sortingMapKeys);
+          sortingMapKeys,
+          disablingHtmlEscaping);
     }
 
     private void checkUnsetPrintingEnumsAsInts() {
@@ -265,7 +273,8 @@ public class JsonFormat {
           preservingProtoFieldNames,
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
-          sortingMapKeys);
+          sortingMapKeys,
+          disablingHtmlEscaping);
     }
 
     private void checkUnsetIncludingDefaultValueFields() {
@@ -290,7 +299,8 @@ public class JsonFormat {
           true,
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
-          sortingMapKeys);
+          sortingMapKeys,
+          disablingHtmlEscaping);
     }
 
 
@@ -319,7 +329,8 @@ public class JsonFormat {
           preservingProtoFieldNames,
           true,
           printingEnumsAsInts,
-          sortingMapKeys);
+          sortingMapKeys,
+          disablingHtmlEscaping);
     }
 
     /**
@@ -342,6 +353,27 @@ public class JsonFormat {
           preservingProtoFieldNames,
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
+          true,
+          disablingHtmlEscaping);
+    }
+
+    /**
+     * Create a new {@link Printer} that will disable HTML escaping in the JSON output.
+     *
+     * <p>The new printer has its underlying {@link Gson#htmlSafe()} returning false.
+     *
+     * <p>This new Printer clones all other configurations from the current {@link Printer}.
+     */
+    public Printer disablingHtmlEscaping() {
+      return new Printer(
+          registry,
+          oldRegistry,
+          alwaysOutputDefaultValueFields,
+          includingDefaultValueFields,
+          preservingProtoFieldNames,
+          omittingInsignificantWhitespace,
+          printingEnumsAsInts,
+          sortingMapKeys,
           true);
     }
 
@@ -364,7 +396,8 @@ public class JsonFormat {
               output,
               omittingInsignificantWhitespace,
               printingEnumsAsInts,
-              sortingMapKeys)
+              sortingMapKeys,
+              disablingHtmlEscaping)
           .print(message);
     }
 
@@ -723,6 +756,8 @@ public class JsonFormat {
 
     private static class GsonHolder {
       private static final Gson DEFAULT_GSON = new GsonBuilder().create();
+      private static final Gson DEFAULT_NO_HTML_ESCAPING_GSON =
+          DEFAULT_GSON.newBuilder().disableHtmlEscaping().create();
     }
 
     PrinterImpl(
@@ -734,7 +769,8 @@ public class JsonFormat {
         Appendable jsonOutput,
         boolean omittingInsignificantWhitespace,
         boolean printingEnumsAsInts,
-        boolean sortingMapKeys) {
+        boolean sortingMapKeys,
+        boolean disablingHtmlEscaping) {
       this.registry = registry;
       this.oldRegistry = oldRegistry;
       this.alwaysOutputDefaultValueFields = alwaysOutputDefaultValueFields;
@@ -742,7 +778,10 @@ public class JsonFormat {
       this.preservingProtoFieldNames = preservingProtoFieldNames;
       this.printingEnumsAsInts = printingEnumsAsInts;
       this.sortingMapKeys = sortingMapKeys;
-      this.gson = GsonHolder.DEFAULT_GSON;
+      this.gson =
+          disablingHtmlEscaping
+              ? GsonHolder.DEFAULT_NO_HTML_ESCAPING_GSON
+              : GsonHolder.DEFAULT_GSON;
       // json format related properties, determined by printerType
       if (omittingInsignificantWhitespace) {
         this.generator = new CompactTextGenerator(jsonOutput);

--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -116,7 +116,7 @@ public class JsonFormat {
         /* omittingInsignificantWhitespace */ false,
         /* printingEnumsAsInts */ false,
         /* sortingMapKeys */ false,
-        /* disablingHtmlEscaping */ false);
+        /* withoutHtmlEscaping */ false);
   }
 
   /**
@@ -139,7 +139,7 @@ public class JsonFormat {
     private final boolean omittingInsignificantWhitespace;
     private final boolean printingEnumsAsInts;
     private final boolean sortingMapKeys;
-    private final boolean disablingHtmlEscaping;
+    private final boolean withoutHtmlEscaping;
 
     private Printer(
         com.google.protobuf.TypeRegistry registry,
@@ -150,7 +150,7 @@ public class JsonFormat {
         boolean omittingInsignificantWhitespace,
         boolean printingEnumsAsInts,
         boolean sortingMapKeys,
-        boolean disablingHtmlEscaping) {
+        boolean withoutHtmlEscaping) {
       this.registry = registry;
       this.oldRegistry = oldRegistry;
       this.alwaysOutputDefaultValueFields = alwaysOutputDefaultValueFields;
@@ -159,7 +159,7 @@ public class JsonFormat {
       this.omittingInsignificantWhitespace = omittingInsignificantWhitespace;
       this.printingEnumsAsInts = printingEnumsAsInts;
       this.sortingMapKeys = sortingMapKeys;
-      this.disablingHtmlEscaping = disablingHtmlEscaping;
+      this.withoutHtmlEscaping = withoutHtmlEscaping;
     }
 
     /**
@@ -182,7 +182,7 @@ public class JsonFormat {
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
           sortingMapKeys,
-          disablingHtmlEscaping);
+          withoutHtmlEscaping);
     }
 
     /**
@@ -205,7 +205,7 @@ public class JsonFormat {
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
           sortingMapKeys,
-          disablingHtmlEscaping);
+          withoutHtmlEscaping);
     }
 
     /**
@@ -225,7 +225,7 @@ public class JsonFormat {
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
           sortingMapKeys,
-          disablingHtmlEscaping);
+          withoutHtmlEscaping);
     }
 
     /**
@@ -243,7 +243,7 @@ public class JsonFormat {
           omittingInsignificantWhitespace,
           true,
           sortingMapKeys,
-          disablingHtmlEscaping);
+          withoutHtmlEscaping);
     }
 
     private void checkUnsetPrintingEnumsAsInts() {
@@ -274,7 +274,7 @@ public class JsonFormat {
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
           sortingMapKeys,
-          disablingHtmlEscaping);
+          withoutHtmlEscaping);
     }
 
     private void checkUnsetIncludingDefaultValueFields() {
@@ -300,7 +300,7 @@ public class JsonFormat {
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
           sortingMapKeys,
-          disablingHtmlEscaping);
+          withoutHtmlEscaping);
     }
 
 
@@ -330,7 +330,7 @@ public class JsonFormat {
           true,
           printingEnumsAsInts,
           sortingMapKeys,
-          disablingHtmlEscaping);
+          withoutHtmlEscaping);
     }
 
     /**
@@ -354,7 +354,7 @@ public class JsonFormat {
           omittingInsignificantWhitespace,
           printingEnumsAsInts,
           true,
-          disablingHtmlEscaping);
+          withoutHtmlEscaping);
     }
 
     /**
@@ -364,7 +364,7 @@ public class JsonFormat {
      *
      * <p>This new Printer clones all other configurations from the current {@link Printer}.
      */
-    public Printer disablingHtmlEscaping() {
+    public Printer withoutHtmlEscaping() {
       return new Printer(
           registry,
           oldRegistry,
@@ -397,7 +397,7 @@ public class JsonFormat {
               omittingInsignificantWhitespace,
               printingEnumsAsInts,
               sortingMapKeys,
-              disablingHtmlEscaping)
+              withoutHtmlEscaping)
           .print(message);
     }
 
@@ -756,7 +756,7 @@ public class JsonFormat {
 
     private static class GsonHolder {
       private static final Gson DEFAULT_GSON = new GsonBuilder().create();
-      private static final Gson DEFAULT_NO_HTML_ESCAPING_GSON =
+      private static final Gson NO_HTML_ESCAPING_GSON =
           DEFAULT_GSON.newBuilder().disableHtmlEscaping().create();
     }
 
@@ -770,7 +770,7 @@ public class JsonFormat {
         boolean omittingInsignificantWhitespace,
         boolean printingEnumsAsInts,
         boolean sortingMapKeys,
-        boolean disablingHtmlEscaping) {
+        boolean withoutHtmlEscaping) {
       this.registry = registry;
       this.oldRegistry = oldRegistry;
       this.alwaysOutputDefaultValueFields = alwaysOutputDefaultValueFields;
@@ -779,8 +779,8 @@ public class JsonFormat {
       this.printingEnumsAsInts = printingEnumsAsInts;
       this.sortingMapKeys = sortingMapKeys;
       this.gson =
-          disablingHtmlEscaping
-              ? GsonHolder.DEFAULT_NO_HTML_ESCAPING_GSON
+          withoutHtmlEscaping
+              ? GsonHolder.NO_HTML_ESCAPING_GSON
               : GsonHolder.DEFAULT_GSON;
       // json format related properties, determined by printerType
       if (omittingInsignificantWhitespace) {

--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -192,7 +192,7 @@ public class JsonFormatTest {
     return JsonFormat.printer().sortingMapKeys().print(message);
   }
   private String toUnescapedJsonString(Message message) throws IOException {
-    return JsonFormat.printer().disablingHtmlEscaping().print(message);
+    return JsonFormat.printer().withoutHtmlEscaping().print(message);
   }
 
   private void mergeFromJson(String json, Message.Builder builder) throws IOException {

--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -191,6 +191,9 @@ public class JsonFormatTest {
   private String toSortedJsonString(Message message) throws IOException {
     return JsonFormat.printer().sortingMapKeys().print(message);
   }
+  private String toUnescapedJsonString(Message message) throws IOException {
+    return JsonFormat.printer().disablingHtmlEscaping().print(message);
+  }
 
   private void mergeFromJson(String json, Message.Builder builder) throws IOException {
     JsonFormat.parser().merge(json, builder);
@@ -1503,6 +1506,17 @@ public class JsonFormatTest {
 
     TestAllTypes.Builder builder = TestAllTypes.newBuilder();
     JsonFormat.parser().merge(toJsonString(message), builder);
+    assertThat(builder.getOptionalString()).isEqualTo(message.getOptionalString());
+  }
+
+  @Test
+  public void testUnescapedStringValue() throws Exception {
+    TestAllTypes message = TestAllTypes.newBuilder().setOptionalString("=</script>").build();
+    assertThat(toUnescapedJsonString(message))
+        .isEqualTo("{\n  \"optionalString\": \"=</script>\"\n}");
+
+    TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+    JsonFormat.parser().merge(toUnescapedJsonString(message), builder);
     assertThat(builder.getOptionalString()).isEqualTo(message.getOptionalString());
   }
 


### PR DESCRIPTION
Related: #7273 (closed but not fixed / discussed).

Since 3.7.0, `JsonFormat.printer()` would only use the default `Gson` instance, which would escape characters like `=`. Not all use cases of `JsonFormat.printer()` is related to HTML. An option to not escape these characters would be great.