### PR TITLE
Tweak how python/python3 is used.

### DIFF
--- a/objectivec/DevTools/full_mac_build.sh
+++ b/objectivec/DevTools/full_mac_build.sh
@@ -234,8 +234,14 @@ fi
 objectivec/generate_well_known_types.sh --check-only -j "${NUM_MAKE_JOBS}"
 
 header "Checking on the ObjC Runtime Code"
-objectivec/DevTools/pddm_tests.py
-if ! objectivec/DevTools/pddm.py --dry-run objectivec/*.[hm] objectivec/Tests/*.[hm] ; then
+# Some of the kokoro machines don't have python3 yet, so fall back to python if need be.
+if hash python3 >/dev/null 2>&1 ; then
+  LOCAL_PYTHON=python3
+else
+  LOCAL_PYTHON=python
+fi
+"${LOCAL_PYTHON}" objectivec/DevTools/pddm_tests.py
+if ! "${LOCAL_PYTHON}" objectivec/DevTools/pddm.py --dry-run objectivec/*.[hm] objectivec/Tests/*.[hm] ; then
   echo ""
   echo "Update by running:"
   echo "   objectivec/DevTools/pddm.py objectivec/*.[hm] objectivec/Tests/*.[hm]"

--- a/objectivec/DevTools/pddm.py
+++ b/objectivec/DevTools/pddm.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 #
 # Protocol Buffers - Google's data interchange format
 # Copyright 2015 Google Inc.  All rights reserved.

--- a/objectivec/DevTools/pddm_tests.py
+++ b/objectivec/DevTools/pddm_tests.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 #
 # Protocol Buffers - Google's data interchange format
 # Copyright 2015 Google Inc.  All rights reserved.


### PR DESCRIPTION
The kokoro Mac configs seem to be pretty old without python3, tweak how things
are invoked to try and better deal with those configs.