### PR TITLE
Fix off-by-one in RepeatedMessage#last

### DIFF
--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -84,7 +84,7 @@ module Google
 
 
       def last(n=nil)
-        n ? self[(self.size-n-1)..-1] : self[-1]
+        n ? self[(self.size-n)..-1] : self[-1]
       end
 
 

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -71,6 +71,7 @@ class RepeatedFieldTest < Test::Unit::TestCase
     assert_equal "foo".encode!('ASCII-8BIT'), m.repeated_bytes.last
     assert_equal TestMessage2.new(:foo => 2), m.repeated_msg.last
     assert_equal :B, m.repeated_enum.last
+    assert_equal [-1.0000000000002], m.repeated_double.last(1)
   end
 
 


### PR DESCRIPTION
It was returning one item too many because of the extra `-1`