### PR TITLE
Add k8 toolchain

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -14,6 +14,7 @@ TOOLCHAINS = {
     "linux-x86_64": "cc-compiler-linux-x86_64",
     "win32": "cc-compiler-windows-x86_32",
     "win64": "cc-compiler-windows-x86_64",
+    "k8": "cc-compiler-k8",
 }
 
 cc_toolchain_suite(
@@ -38,6 +39,14 @@ cc_toolchain_suite(
     )
     for cpu, toolchain in TOOLCHAINS.items()
 ]
+
+cc_toolchain_config(
+    name = "k8-config",
+    linker_path = "/usr/bin/ld",
+    sysroot = "/opt/manylinux/2014/x86_64",
+    target_cpu = "x86_64",
+    target_full_name = "x86_64-linux-gnu",
+)
 
 cc_toolchain_config(
     name = "linux-aarch_64-config",

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -157,6 +157,21 @@ def _impl(ctx):
       ],
   )
 
+  features = [linker_flags, compiler_flags, sysroot_flags]
+
+  if "mingw" in ctx.attr.target_full_name:
+      features.append(
+          feature(
+              name = "targets_windows",
+              enabled = True,
+              #implies = ["copy_dynamic_libraries_to_binary"],
+          )
+      )
+  else:
+      features.append(
+          feature(name = "supports_pic", enabled = True)
+      )
+
   return cc_common.create_cc_toolchain_config_info(
       abi_libc_version = ctx.attr.abi_version,
       abi_version = ctx.attr.abi_version,
@@ -169,7 +184,7 @@ def _impl(ctx):
           "/usr/local/include",
           "/usr/local/lib/clang",
       ],
-      features = [linker_flags, compiler_flags, sysroot_flags],
+      features = features,
       host_system_name = "local",
       target_cpu = ctx.attr.target_cpu,
       target_libc = ctx.attr.target_cpu,

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -168,7 +168,10 @@ def _impl(ctx):
       )
   else:
       features.append(
-          feature(name = "supports_pic", enabled = True)
+          feature(
+              name = "supports_pic",
+              enabled = True
+          )
       )
 
   return cc_common.create_cc_toolchain_config_info(

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -164,7 +164,6 @@ def _impl(ctx):
           feature(
               name = "targets_windows",
               enabled = True,
-              #implies = ["copy_dynamic_libraries_to_binary"],
           )
       )
   else:


### PR DESCRIPTION
Add a toolchain for k8 that is the same as x86-64 to prevent some compiler errors.
Add a feature to support dynamic toolchains for linux/macos.