### PR TITLE
Add Google Gnostic Registered Extension Number

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -308,4 +308,8 @@ with info about your project (name and website) so we can add an entry for you.
 1. Protoc-gen-fieldmask
    * Website: https://github.com/yeqown/protoc-gen-fieldmask
    * Extension: 1142
- 
+
+1. Google Gnostic
+   * Website: https://github.com/google/gnostic
+   * Extension: 1143
+


### PR DESCRIPTION
google/gnostic's protoc-gen-openapi generator has extension support for additional openapi options.

It is [currently using `1042`](https://github.com/google/gnostic/blob/master/openapiv3/annotations.proto) which is registered with grpc-gateway's protoc-gen-openapiv2 extension which probably isn't a good thing.

See [here](https://github.com/google/gnostic/blob/master/cmd/protoc-gen-openapi/examples/tests/openapiv3annotations/message.proto) for an example of the extenstion in action.