### PR TITLE
Add micro Registered Extension Number

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -308,4 +308,8 @@ with info about your project (name and website) so we can add an entry for you.
 1. Protoc-gen-fieldmask
    * Website: https://github.com/yeqown/protoc-gen-fieldmask
    * Extension: 1142
+
+1. Protoc-gen-go-micro
+   * Website: https://github.com/unistack-org/protoc-gen-go-micro
+   * Extension: 1144
  


### PR DESCRIPTION
unistack-org/micro (microservices framework) uses protoc-gen-go-micro generator that has extension support for additional framework related options.

It is currently not using any registered extension number, so i want to stabilise this and i think that this is a good thing.
