### PR TITLE
Add -fvisibility=hidden and -fvisibility-inlines-hidden flags to cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ endif()
 if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif()
+# Honor visibility properties for all target types.
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
 
 # Project
 project(protobuf C CXX)
@@ -40,6 +44,11 @@ else()
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
+
+# For -fvisibility=hidden and -fvisibility-inlines-hidden
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
 # The Intel compiler isn't able to deal with noinline member functions of
 # template classes defined in headers.  As such it spams the output with

--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -629,7 +629,7 @@ class PROTOBUF_EXPORT PROTOBUF_ALIGNAS(8) Arena final {
   }
 
   template <typename T, typename... Args>
-  PROTOBUF_ALWAYS_INLINE static T* CreateMaybeMessage(Arena* arena,
+  PROTOBUF_NOINLINE PROTOBUF_EXPORT_TEMPLATE_DECLARE static T* CreateMaybeMessage(Arena* arena,
                                                       Args&&... args) {
     return DoCreateMaybeMessage<T>(arena, is_arena_constructable<T>(),
                                    std::forward<Args>(args)...);

--- a/src/google/protobuf/compiler/cpp/file.cc
+++ b/src/google/protobuf/compiler/cpp/file.cc
@@ -973,7 +973,7 @@ class FileGenerator::ForwardDeclarations {
                          const Options& options) const {
     for (const auto& pair : classes_) {
       format(
-          "template<> $dllexport_decl $"
+          "template<> PROTOBUF_EXPORT_TEMPLATE_DECLARE "
           "$1$* Arena::CreateMaybeMessage<$1$>(Arena*);\n",
           QualifiedClassName(pair.second, options));
     }

--- a/src/google/protobuf/compiler/cpp/message.cc
+++ b/src/google/protobuf/compiler/cpp/message.cc
@@ -2803,7 +2803,7 @@ void MessageGenerator::GenerateSourceInProto2Namespace(io::Printer* printer) {
   Formatter format(printer, variables_);
   format(
       "template<> "
-      "PROTOBUF_NOINLINE $classtype$*\n"
+      "PROTOBUF_NOINLINE PROTOBUF_EXPORT_TEMPLATE_DECLARE $classtype$*\n"
       "Arena::CreateMaybeMessage< $classtype$ >(Arena* arena) {\n"
       "  return Arena::CreateMessageInternal< $classtype$ >(arena);\n"
       "}\n");

--- a/src/google/protobuf/generated_message_tctable_impl.h
+++ b/src/google/protobuf/generated_message_tctable_impl.h
@@ -253,6 +253,7 @@ template <size_t align>
 #endif
 void AlignFail(uintptr_t address) {
   GOOGLE_LOG(FATAL) << "Unaligned (" << align << ") access at " << address;
+  while(1);
 }
 
 extern template void AlignFail<4>(uintptr_t);

--- a/src/google/protobuf/map_field_test.cc
+++ b/src/google/protobuf/map_field_test.cc
@@ -232,9 +232,7 @@ TEST_P(MapFieldBasePrimitiveTest, EnforceNoArena) {
   EXPECT_EQ(map_field->GetArenaForInternalRepeatedField(), nullptr);
 }
 
-namespace {
 enum State { CLEAN, MAP_DIRTY, REPEATED_DIRTY };
-}  // anonymous namespace
 
 class MapFieldStateTest
     : public testing::TestWithParam<std::tuple<State, bool>> {

--- a/src/google/protobuf/metadata_lite.h
+++ b/src/google/protobuf/metadata_lite.h
@@ -60,7 +60,7 @@ namespace internal {
 // It uses bit 0 == 0 to indicate an arena pointer and bit 0 == 1 to indicate a
 // UFS+Arena-container pointer. Besides it uses bit 1 == 0 to indicate arena
 // allocation and bit 1 == 1 to indicate heap allocation.
-class InternalMetadata {
+class PROTOBUF_EXPORT InternalMetadata {
  public:
   constexpr InternalMetadata() : ptr_(0) {}
   explicit InternalMetadata(Arena* arena, bool is_message_owned = false) {

--- a/src/google/protobuf/repeated_field_reflection_unittest.cc
+++ b/src/google/protobuf/repeated_field_reflection_unittest.cc
@@ -76,10 +76,10 @@ TEST(RepeatedFieldReflectionTest, RegularFields) {
       desc->FindFieldByName("repeated_foreign_message");
 
   // Get RepeatedField objects for all fields of interest.
-  const RepeatedField<int32_t>& rf_int32 =
-      refl->GetRepeatedField<int32_t>(message, fd_repeated_int32);
-  const RepeatedField<double>& rf_double =
-      refl->GetRepeatedField<double>(message, fd_repeated_double);
+  const RepeatedFieldRef<int32_t> rf_int32 =
+      refl->GetRepeatedFieldRef<int32_t>(message, fd_repeated_int32);
+  const RepeatedFieldRef<double> rf_double =
+      refl->GetRepeatedFieldRef<double>(message, fd_repeated_double);
 
   // Get mutable RepeatedField objects for all fields of interest.
   RepeatedField<int32_t>* mrf_int32 =

--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -847,7 +847,7 @@ class StringTypeHandler {
 // RepeatedPtrField is like RepeatedField, but used for repeated strings or
 // Messages.
 template <typename Element>
-class RepeatedPtrField final : private internal::RepeatedPtrFieldBase {
+class PROTOBUF_EXPORT_TEMPLATE_DECLARE RepeatedPtrField final : private internal::RepeatedPtrFieldBase {
 
  public:
   constexpr RepeatedPtrField();
@@ -1948,7 +1948,7 @@ UnsafeArenaAllocatedRepeatedPtrFieldBackInserter(
       mutable_field);
 }
 
-extern template class PROTOBUF_EXPORT_TEMPLATE_DECLARE
+extern template class
     RepeatedPtrField<std::string>;
 
 }  // namespace protobuf

--- a/src/google/protobuf/test_util_lite.h
+++ b/src/google/protobuf/test_util_lite.h
@@ -36,6 +36,7 @@
 #define GOOGLE_PROTOBUF_TEST_UTIL_LITE_H__
 
 #include <google/protobuf/unittest_lite.pb.h>
+#include <google/protobuf/port_def.inc>
 
 namespace google {
 namespace protobuf {
@@ -43,7 +44,7 @@ namespace protobuf {
 namespace unittest = protobuf_unittest;
 namespace unittest_import = protobuf_unittest_import;
 
-class TestUtilLite {
+class PROTOBUF_EXPORT TestUtilLite {
  public:
   // Set every field in the message to a unique value.
   static void SetAllFields(unittest::TestAllTypesLite* message);


### PR DESCRIPTION
This avoids the warning:
"ld: direct access in function ... to global weak symbol"
when building with Apples clang

Fixes #8958