### PR TITLE
Do not use range based UTF-8 validation in truffleruby

### DIFF
--- a/third_party/utf8_range/utf8_range.h
+++ b/third_party/utf8_range/utf8_range.h
@@ -1,5 +1,5 @@
 
-#if (defined(__ARM_NEON) && defined(__aarch64__)) || defined(__SSE4_1__)
+#if ((defined(__ARM_NEON) && defined(__aarch64__)) || defined(__SSE4_1__)) && !defined(TRUFFLERUBY)
 int utf8_range2(const unsigned char* data, int len);
 #else
 int utf8_naive(const unsigned char* data, int len);


### PR DESCRIPTION
This PR fixes the `missing LLVM builtin: llvm.x86.ssse3.pshuf.b.128` in https://github.com/oracle/truffleruby/issues/2640 by forcing it to compile with old `utf8_naive` when [the macro `TRUFFLERUBY`](https://github.com/oracle/truffleruby/blob/master/doc/user/compatibility.md#identification) is defined.
