### PR TITLE
Fix JS Generator Identifier when name is camel case

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -294,22 +294,6 @@ std::vector<std::string> ParseUpperCamel(const std::string& input) {
   return words;
 }
 
-std::vector<std::string> ParseLowerCamel(const std::string& input) {
-    std::vector<std::string> words;
-    std::string running = "";
-    for (int i = 0; i < input.size(); i++) {
-        if (i != 0 && input[i] >= 'A' && input[i] <= 'Z' && !running.empty()) {
-            words.push_back(running);
-            running.clear();
-        }
-        running += ToLowerASCII(input[i]);
-    }
-    if (!running.empty()) {
-        words.push_back(running);
-    }
-    return words;
-}
-
 bool IsUpperCamel(const std::string& input) {
     int wordLength = 0;
     std::string running = "";

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -314,7 +314,9 @@ bool IsUpperCamel(const std::string& input) {
     int wordLength = 0;
     std::string running = "";
     for (int i = 0; i < input.size(); i++) {
-        if (input[i] >= 'A' && input[i] <= 'Z' && !running.empty()) {
+        if (input[i] == '_') {
+            return false;
+        } else if (input[i] >= 'A' && input[i] <= 'Z' && !running.empty()) {
             if (wordLength > 0) {
                 return true;
             }
@@ -331,7 +333,9 @@ bool IsLowerCamel(const std::string& input) {
     int wordLength = 0;
     std::string running = "";
     for (int i = 0; i < input.size(); i++) {
-        if (i != 0 && input[i] >= 'A' && input[i] <= 'Z') {
+        if (input[i] == '_') {
+            return false;
+        } else if (i != 0 && input[i] >= 'A' && input[i] <= 'Z') {
             if (wordLength > 0) {
                 return true;
             }

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -514,19 +514,23 @@ std::string JSIdent(const GeneratorOptions& options,
                     const FieldDescriptor* field, bool is_upper_camel,
                     bool is_map, bool drop_list) {
   std::string result;
-  std::string name = field->type() == FieldDescriptor::TYPE_GROUP
-          ? field->message_type()->name()
-          : field->name();
 
-  if (is_upper_camel && IsUpperCamel(name)) {
-      result = name;
-  } else if (!is_upper_camel && IsLowerCamel(name)) {
-      result = name;
-  } else if (is_upper_camel) {
-      result = ToUpperCamel(ParseLowerUnderscore(name));
+  if (field->type() == FieldDescriptor::TYPE_GROUP) {
+      result = is_upper_camel
+               ? ToUpperCamel(ParseUpperCamel(field->message_type()->name()))
+               : ToLowerCamel(ParseUpperCamel(field->message_type()->name()));
   } else {
-      result = ToLowerCamel(ParseLowerUnderscore(name));
+      if (is_upper_camel && IsUpperCamel(field->name())) {
+          result = field->name();
+      } else if (!is_upper_camel && IsLowerCamel(field->name())) {
+          result = field->name();
+      } else if (is_upper_camel) {
+          result = ToUpperCamel(ParseLowerUnderscore(field->name()));
+      } else {
+          result = ToLowerCamel(ParseLowerUnderscore(field->name()));
+      }
   }
+
   if (is_map || field->is_map()) {
     // JSPB-style or proto3-style map.
     result += "Map";

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -294,6 +294,22 @@ std::vector<std::string> ParseUpperCamel(const std::string& input) {
   return words;
 }
 
+std::vector<std::string> ParseLowerCamel(const std::string& input) {
+  std::vector<std::string> words;
+  std::string running = "";
+  for (int i = 0; i < input.size(); i++) {
+    if (i != 0 && input[i] >= 'A' && input[i] <= 'Z' && !running.empty()) {
+      words.push_back(running);
+      running.clear();
+    }
+    running += ToLowerASCII(input[i]);
+  }
+  if (!running.empty()) {
+    words.push_back(running);
+  }
+  return words;
+}
+
 bool IsUpperCamel(const std::string& input) {
     int wordLength = 0;
     std::string running = "";
@@ -506,8 +522,12 @@ std::string JSIdent(const GeneratorOptions& options,
   } else {
       if (is_upper_camel && IsUpperCamel(field->name())) {
           result = field->name();
+      } else if (is_upper_camel && IsLowerCamel(field->name())) {
+          result = ToUpperCamel(ParseLowerCamel(field->name()));
       } else if (!is_upper_camel && IsLowerCamel(field->name())) {
           result = field->name();
+      } else if (!is_upper_camel && IsUpperCamel(field->name())) {
+          result = ToLowerCamel(ParseUpperCamel(field->name()));
       } else if (is_upper_camel) {
           result = ToUpperCamel(ParseLowerUnderscore(field->name()));
       } else {

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -48,7 +48,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <iostream>
 
 namespace google {
 namespace protobuf {

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -311,40 +311,26 @@ std::vector<std::string> ParseLowerCamel(const std::string& input) {
 }
 
 bool IsUpperCamel(const std::string& input) {
-    int wordLength = 0;
-    std::string running = "";
     for (int i = 0; i < input.size(); i++) {
         if (input[i] == '_') {
             return false;
-        } else if (input[i] >= 'A' && input[i] <= 'Z' && !running.empty()) {
-            if (wordLength > 0) {
-                return true;
-            }
-            ++wordLength;
-            running.clear();
+        } else if (input[i] >= 'A' && input[i] <= 'Z') {
+            return true;
         }
-        running += input[i];
     }
 
     return false;
 }
 
 bool IsLowerCamel(const std::string& input) {
-    int wordLength = 0;
-    std::string running = "";
     for (int i = 0; i < input.size(); i++) {
         if (input[i] == '_') {
             return false;
         } else if (i != 0 && input[i] >= 'A' && input[i] <= 'Z') {
-            if (wordLength > 0) {
-                return true;
-            }
-            ++wordLength;
-            running.clear();
+            return true;
         } else if (i == 0 && input[i] >= 'A' && input[i] <= 'Z') {
             return false;
         }
-        running += input[i];
     }
 
     return false;

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -48,6 +48,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 namespace google {
 namespace protobuf {
@@ -311,10 +312,16 @@ std::vector<std::string> ParseLowerCamel(const std::string& input) {
 }
 
 bool IsUpperCamel(const std::string& input) {
+    if (input.empty()) {
+        return false;
+    }
+
+    if (input.find('_') != string::npos) {
+        return false;
+    }
+
     for (int i = 0; i < input.size(); i++) {
-        if (input[i] == '_') {
-            return false;
-        } else if (input[i] >= 'A' && input[i] <= 'Z') {
+        if (input[i] >= 'A' && input[i] <= 'Z') {
             return true;
         }
     }
@@ -323,13 +330,21 @@ bool IsUpperCamel(const std::string& input) {
 }
 
 bool IsLowerCamel(const std::string& input) {
+    if (input.empty()) {
+        return false;
+    }
+
+    if (input.find('_') != string::npos) {
+        return false;
+    }
+
+    if (input[0] >= 'A' && input[0] <= 'Z') {
+        return false;
+    }
+
     for (int i = 0; i < input.size(); i++) {
-        if (input[i] == '_') {
-            return false;
-        } else if (i != 0 && input[i] >= 'A' && input[i] <= 'Z') {
+        if (i != 0 && input[i] >= 'A' && input[i] <= 'Z') {
             return true;
-        } else if (i == 0 && input[i] >= 'A' && input[i] <= 'Z') {
-            return false;
         }
     }
 

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -311,6 +311,16 @@ std::vector<std::string> ParseLowerCamel(const std::string& input) {
   return words;
 }
 
+bool HasUpper(const std::string& input) {
+    for (int i = 0; i < input.size(); i++) {
+        if (input[i] >= 'A' && input[i] <= 'Z') {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool IsUpperCamel(const std::string& input) {
     if (input.empty()) {
         return false;
@@ -320,13 +330,7 @@ bool IsUpperCamel(const std::string& input) {
         return false;
     }
 
-    for (int i = 0; i < input.size(); i++) {
-        if (input[i] >= 'A' && input[i] <= 'Z') {
-            return true;
-        }
-    }
-
-    return false;
+    return HasUpper(input);
 }
 
 bool IsLowerCamel(const std::string& input) {
@@ -342,13 +346,7 @@ bool IsLowerCamel(const std::string& input) {
         return false;
     }
 
-    for (int i = 0; i < input.size(); i++) {
-        if (i != 0 && input[i] >= 'A' && input[i] <= 'Z') {
-            return true;
-        }
-    }
-
-    return false;
+    return HasUpper(input);
 }
 
 std::string ToLowerCamel(const std::vector<std::string>& words) {

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -316,7 +316,7 @@ bool IsUpperCamel(const std::string& input) {
         return false;
     }
 
-    if (input.find('_') != string::npos) {
+    if (input.find('_') != std::string::npos) {
         return false;
     }
 
@@ -334,7 +334,7 @@ bool IsLowerCamel(const std::string& input) {
         return false;
     }
 
-    if (input.find('_') != string::npos) {
+    if (input.find('_') != std::string::npos) {
         return false;
     }
 

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -330,6 +330,10 @@ bool IsUpperCamel(const std::string& input) {
         return false;
     }
 
+    if (input[0] < 'A' || input[0] > 'Z') {
+        return false;
+    }
+
     return HasUpper(input);
 }
 


### PR DESCRIPTION
This PR fixes JS Generator when field name is camel case
https://github.com/protocolbuffers/protobuf/issues/8608

example

```proto
message Message {
    int32 someCamelCaseMessage = 1;
}
```