### PR TITLE
fix: phpdoc for repeatedfield

### DIFF
--- a/php/src/Google/Protobuf/Internal/RepeatedField.php
+++ b/php/src/Google/Protobuf/Internal/RepeatedField.php
@@ -134,7 +134,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * This will also be called for: $arr []= $ele and $arr[0] = ele
      *
-     * @param integer $offset The index of the element to be assigned.
+     * @param int|null $offset The index of the element to be assigned.
      * @param mixed $value The element to be assigned.
      * @return void
      * @throws \ErrorException Invalid type for index.

--- a/php/src/Google/Protobuf/Internal/RepeatedField.php
+++ b/php/src/Google/Protobuf/Internal/RepeatedField.php
@@ -118,7 +118,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      * This will also be called for: $ele = $arr[0]
      *
      * @param integer $offset The index of the element to be fetched.
-     * @return object The stored element at given index.
+     * @return mixed The stored element at given index.
      * @throws \ErrorException Invalid type for index.
      * @throws \ErrorException Non-existing index.
      * @todo need to add return type mixed (require update php version to 8.0)
@@ -135,7 +135,7 @@ class RepeatedField implements \ArrayAccess, \IteratorAggregate, \Countable
      * This will also be called for: $arr []= $ele and $arr[0] = ele
      *
      * @param integer $offset The index of the element to be assigned.
-     * @param object $value The element to be assigned.
+     * @param mixed $value The element to be assigned.
      * @return void
      * @throws \ErrorException Invalid type for index.
      * @throws \ErrorException Non-existing index.


### PR DESCRIPTION
I have found two issues with PHP protobuf's `RepeatedField` when using static analyzers:
1. The PHPDoc says that the first argument to `offsetSet` is an `integer`, but this value can also be `null`, in the case when a `RepeatedField` is being appended to (e.g. `$repeatedField[] = $someRepeatedValue`). Without marking the first argument as optional, static analyzers think that instances of `RepeatedField` cannot be appended to.
1. The PHPDoc says that `offsetSet` accepts `object` and `offsetGet` returns `object`. But `object` excludes primitive types in PHP such as `string` `int`, `bool`, and `array`. I believe it should accept primitives, and as a result, in certain circumstances the static analyzers are failing. I've tested this with using the accepted PHP type [`mixed`](https://www.php.net/manual/en/language.types.declarations.php), which represents any `object` or primitive. The keyword only exists in PHP 8.0, but this is acceptable documentation for any version of PHP.