### PR TITLE
Add disallowment of setting numpy singleton arrays and multi-dimensio…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -73,8 +73,8 @@
     JSON serializations with UTF-8 or other non-ASCII encodings.
   * Added experimental support for directly assigning numpy scalars and array.
   * Improve the calculation of public_dependencies in DescriptorPool.
-  * Disallow setting fields to numpy singleton arrays or repeated fields to numpy
-    multi-dimensional arrays.
+  * [Breaking Change] Disallow setting fields to numpy singleton arrays or repeated fields to numpy
+    multi-dimensional arrays. Numpy arrays should be indexed or flattened explicitly before assignment.
 
   Compiler
   * Migrate IsDefault(const std::string*) and UnsafeSetDefault(const std::string*)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -73,6 +73,8 @@
     JSON serializations with UTF-8 or other non-ASCII encodings.
   * Added experimental support for directly assigning numpy scalars and array.
   * Improve the calculation of public_dependencies in DescriptorPool.
+  * Disallow setting fields to numpy singleton arrays or repeated fields to numpy
+    multi-dimensional arrays.
 
   Compiler
   * Migrate IsDefault(const std::string*) and UnsafeSetDefault(const std::string*)


### PR DESCRIPTION
Add disallowment of setting numpy singleton arrays and multi-dimensional arrays to fields/repeated fields to CHANGES.txt, which was missed in a previous git sync and 3.20.0 release (release notes have been updated). This is a minor breaking change and should be documented. (#9782)