### PR TITLE
Move private utf8 helpers to anonymous namespace

### DIFF
--- a/src/google/protobuf/stubs/structurally_valid.cc
+++ b/src/google/protobuf/stubs/structurally_valid.cc
@@ -381,6 +381,8 @@ static inline bool InStateZero(const UTF8ScanObj* st, const uint8* Tbl) {
   return (static_cast<uint32>(Tbl - Tbl0) < st->state0_size);
 }
 
+namespace {
+
 // Scan a UTF-8 string based on state table.
 // Always scan complete UTF-8 characters
 // Set number of bytes scanned. Return reason for exiting
@@ -539,7 +541,6 @@ int UTF8GenericScanFastAscii(const UTF8ScanObj* st,
 //   UTF-8 strings.  Since UTF-8 validation is only used for debugging
 //   anyway, we simply always return success if initialization hasn't
 //   occurred yet.
-namespace {
 
 bool module_initialized_ = false;
 


### PR DESCRIPTION
This trivial change hints compiler to inline the utf8 helpers and
generate code with better performance.

Tested on skylake, with clang-12 and gcc-9.3. Observed about 10%
improvement from `google_message1_proto3_serialize` benchmark,
with default ./configure parameters. Similar improvement on arm.