### PR TITLE
Improve range handling logic of `RepeatedField`

### DIFF
--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
@@ -141,12 +141,12 @@ public class RubyRepeatedField extends RubyObject {
       } else if (arg instanceof RubyRange) {
         RubyRange range = ((RubyRange) arg);
 
-        int beg = RubyNumeric.num2int(range.first(context));
-        int len = RubyNumeric.num2int(range.size(context));
+        int beg = normalizeArrayIndex(range.first(context));
+        int last = normalizeArrayIndex(range.last(context));
 
-        if (len == 0) return context.runtime.newEmptyArray();
+        if (last-beg < 0) return context.runtime.newEmptyArray();
 
-        return this.storage.subseq(beg, len);
+        return this.storage.subseq(beg, last - beg + (range.isExcludeEnd() ? 0 : 1));
       }
     }
     /* assume 2 arguments */

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -176,6 +176,51 @@ class RepeatedFieldTest < Test::Unit::TestCase
       arr[0..2]
     end
     check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      arr[0..5]
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      arr[0..-1]
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      arr[0..-3]
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      arr[0...-1] # Exclusive range
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      arr[0...-3] # Exclusive range
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      arr[-2..-1]
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      arr[-5..-1]
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      # Infinite range; introduce in Ruby 2.7.
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
+        eval "arr[0..]"
+      end
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      # Beginless range; introduced in Ruby 2.7.
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
+        eval "arr[..-1]"
+      end
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      # Infinite range; introduce in Ruby 2.7.
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
+        eval "arr[0...]" # Exclusive range
+      end
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      # Beginless range; introduced in Ruby 2.7.
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
+        eval "arr[...-1]" # Exclusive range
+      end
+    end
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
       arr[-1, 1]
     end
     check_self_modifying_method(m.repeated_string, reference_arr) do |arr|


### PR DESCRIPTION
Adds support for negative start or end and exclusive ends.

Includes regression tests contributed mostly by @lucthev. Fixes #9751.