### PR TITLE
Add a github action workflow to run CocoaPods validation.

### DIFF
--- a/.github/workflows/objc_cocoapods.yml
+++ b/.github/workflows/objc_cocoapods.yml
@@ -1,0 +1,36 @@
+name: 'ObjC CocoaPods'
+
+on:
+  push:
+    paths:
+    - '.github/workflows/objc_cocoapods.yml'
+    - 'Protobuf.podspec'
+    - 'objectivec/**'
+    - '!objectivec/DevTools/**'
+    - '!objectivec/ProtocolBuffers_*.xcodeproj/**'
+    - '!objectivec/Tests/**'
+  pull_request:
+    paths:
+    - '.github/workflows/objc_cocoapods.yml'
+    - 'Protobuf.podspec'
+    - 'objectivec/**'
+    - '!objectivec/DevTools/**'
+    - '!objectivec/ProtocolBuffers_*.xcodeproj/**'
+    - '!objectivec/Tests/**'
+
+jobs:
+  pod-lib-lint:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        PLATFORM: ["ios", "macos", "tvos", "watchos"]
+        CONFIGURATION: ["Debug", "Release"]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Pod lib lint
+      run:  |
+        pod lib lint --verbose \
+          --configuration=${{ matrix.CONFIGURATION }} \
+          --platforms=${{ matrix.PLATFORM }} \
+          Protobuf.podspec

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -39,4 +39,12 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
   s.requires_arc = false
+
+  # The unittest need the generate sources from the testing related .proto
+  # files. So to add a `test_spec`, there would also need to be something like a
+  # `script_phases` to generate them, but there would also need to be a way to
+  # ensure `protoc` had be built. Another option would be to move to a model
+  # where the needed files are always generated and checked in. Neither of these
+  # seem that great at the moment, so the tests have *not* been wired into here
+  # at this time.
 end


### PR DESCRIPTION
- Run for all Apple configurations/platforms.
- Limit the action to only run when the ObjC source change.
- Document why the CocoaPods doesn't run the tests during the validation.

The kokoro objectivec_cocoapods_integration configuration can likely be retired
by retiring this.