### PR TITLE
include python/google/__init__.py to python_srcs for bazel rules

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -121,7 +121,7 @@ py_library(
     name = "python_srcs",
     srcs = glob(
         [
-            "google/protobuf/**/*.py",
+            "google/**/*.py",
         ],
         exclude = [
             "google/protobuf/internal/*_test.py",


### PR DESCRIPTION
google.* python's name space is shared between packages(e.g. google.oauth2, google.cloud ...)
pkg_resources magic required in all google/__init__.py files for it to work.

if src/google/__init__.py is not included, bazel will generate an empty __init__.py.
which breaks import of other modules, in case protobuf included as bazel dependency 