### PR TITLE
Fix cmake install targets

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -128,12 +128,12 @@ configure_file(${protobuf_SOURCE_DIR}/cmake/protobuf-options.cmake
 if (protobuf_BUILD_PROTOC_BINARIES)
   export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
     NAMESPACE protobuf::
-    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/protobuf/protobuf-targets.cmake
   )
 else (protobuf_BUILD_PROTOC_BINARIES)
   export(TARGETS libprotobuf-lite libprotobuf
     NAMESPACE protobuf::
-    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/protobuf/protobuf-targets.cmake
   )
 endif (protobuf_BUILD_PROTOC_BINARIES)
 

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -138,14 +138,10 @@ else (protobuf_BUILD_PROTOC_BINARIES)
 endif (protobuf_BUILD_PROTOC_BINARIES)
 
 install(EXPORT protobuf-targets
+  FILE protobuf-targets.cmake
   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
   NAMESPACE protobuf::
-  COMPONENT protobuf-export)
-
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/
-  DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
   COMPONENT protobuf-export
-  PATTERN protobuf-targets.cmake EXCLUDE
 )
 
 option(protobuf_INSTALL_EXAMPLES "Install the examples folder" OFF)


### PR DESCRIPTION
Tried to capture most of the context in the commit messages, so I'll just paste them here:

> [Avoid exporting build tree targets to installation directory](https://github.com/protocolbuffers/protobuf/commit/da040de1eb646cfec2b41ba239b5f29bb808b041)
`export(TARGETS ...)` is meant to allow for build trees to be found
from other projects, however, writing the file to an installation
directory causes buildtree paths to be hardcoded in the installed
protobuf-targets.cmake

> [Install protobuf-targets.cmake from target, not build tree](https://github.com/protocolbuffers/protobuf/commit/66ca89b1c3745ecafb7649f19061481f6d4ed2b9)
This allows for installation prefixes to match the intended
installation directories, instead of being copied from
the build tree.

Fixes: #9809

TL;DR:
`export(TARGETS ...)` isn't meant to be used for installation, only local development. We should be using `install(EXPORT ...)` for providing relocatable target locations.