### PR TITLE
Move rules_pkg targets into //pkg, and add experimental C++ library rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -526,69 +526,6 @@ cc_binary(
 )
 
 ################################################################################
-# Generates protoc release artifacts.
-################################################################################
-
-genrule(
-    name = "protoc_readme",
-    outs = ["readme.txt"],
-    cmd = """
-echo "Protocol Buffers - Google's data interchange format
-Copyright 2008 Google Inc.
-https://developers.google.com/protocol-buffers/
-This package contains a precompiled binary version of the protocol buffer
-compiler (protoc). This binary is intended for users who want to use Protocol
-Buffers in languages other than C++ but do not want to compile protoc
-themselves. To install, simply place this binary somewhere in your PATH.
-If you intend to use the included well known types then don't forget to
-copy the contents of the 'include' directory somewhere as well, for example
-into '/usr/local/include/'.
-Please refer to our official github site for more installation instructions:
-  https://github.com/protocolbuffers/protobuf" > $@
-    """,
-    visibility = ["//visibility:private"],
-)
-
-# plugin.proto is excluded from this list because it belongs in a nested folder (protobuf/compiler/plugin.proto)
-pkg_files(
-    name = "wkt_protos_files",
-    srcs = [value[0] for value in WELL_KNOWN_PROTO_MAP.values() if not value[0].endswith("plugin.proto")],
-    prefix = "include/google/protobuf",
-    visibility = ["//visibility:private"],
-)
-
-pkg_files(
-    name = "compiler_plugin_protos_files",
-    srcs = ["src/google/protobuf/compiler/plugin.proto"],
-    prefix = "include/google/protobuf/compiler",
-    visibility = ["//visibility:private"],
-)
-
-pkg_files(
-    name = "protoc_files",
-    srcs = [":protoc"],
-    attributes = pkg_attributes(mode = "0555"),
-    prefix = "bin/",
-    visibility = ["//visibility:private"],
-)
-
-package_naming(
-    name = "protoc_pkg_naming",
-)
-
-pkg_zip(
-    name = "protoc_release",
-    srcs = [
-        "readme.txt",
-        ":compiler_plugin_protos_files",
-        ":protoc_files",
-        ":wkt_protos_files",
-    ],
-    package_file_name = "protoc-{version}-{platform}.zip",
-    package_variables = ":protoc_pkg_naming",
-)
-
-################################################################################
 # Tests
 ################################################################################
 

--- a/BUILD
+++ b/BUILD
@@ -2,8 +2,6 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test", "objc_library", native_cc_proto_library = "cc_proto_library")
-load("@rules_pkg//:pkg.bzl", "pkg_zip")
-load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
 load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_lite_proto_library", "java_proto_library")

--- a/BUILD
+++ b/BUILD
@@ -2,6 +2,8 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test", "objc_library", native_cc_proto_library = "cc_proto_library")
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
+load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
 load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_lite_proto_library", "java_proto_library")

--- a/BUILD
+++ b/BUILD
@@ -2,13 +2,12 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test", "objc_library", native_cc_proto_library = "cc_proto_library")
-load("@rules_pkg//:pkg.bzl", "pkg_zip")
-load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
 load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_lite_proto_library", "java_proto_library")
 load(":cc_proto_blacklist_test.bzl", "cc_proto_blacklist_test")
 load(":protobuf_release.bzl", "package_naming")
+
 licenses(["notice"])
 
 exports_files(["LICENSE"])
@@ -353,6 +352,11 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+exports_files(
+    srcs = WELL_KNOWN_PROTOS,
+    visibility = ["//pkg:__pkg__"],
+)
+
 filegroup(
     name = "lite_well_known_protos",
     srcs = LITE_WELL_KNOWN_PROTOS,
@@ -519,14 +523,13 @@ cc_binary(
     deps = [":protoc_lib"],
 )
 
-
 ################################################################################
 # Generates protoc release artifacts.
 ################################################################################
 
 genrule(
     name = "protoc_readme",
-    visibility = ["//visibility:private"],
+    outs = ["readme.txt"],
     cmd = """
 echo "Protocol Buffers - Google's data interchange format
 Copyright 2008 Google Inc.
@@ -541,30 +544,30 @@ into '/usr/local/include/'.
 Please refer to our official github site for more installation instructions:
   https://github.com/protocolbuffers/protobuf" > $@
     """,
-    outs = ["readme.txt"],
+    visibility = ["//visibility:private"],
 )
 
 # plugin.proto is excluded from this list because it belongs in a nested folder (protobuf/compiler/plugin.proto)
 pkg_files(
     name = "wkt_protos_files",
-    srcs =  [value[0] for value in WELL_KNOWN_PROTO_MAP.values() if not value[0].endswith("plugin.proto")],
-    visibility = ["//visibility:private"],
+    srcs = [value[0] for value in WELL_KNOWN_PROTO_MAP.values() if not value[0].endswith("plugin.proto")],
     prefix = "include/google/protobuf",
+    visibility = ["//visibility:private"],
 )
 
 pkg_files(
     name = "compiler_plugin_protos_files",
-    srcs =  ["src/google/protobuf/compiler/plugin.proto"],
-    visibility = ["//visibility:private"],
+    srcs = ["src/google/protobuf/compiler/plugin.proto"],
     prefix = "include/google/protobuf/compiler",
+    visibility = ["//visibility:private"],
 )
 
 pkg_files(
     name = "protoc_files",
-    srcs =  [":protoc"],
+    srcs = [":protoc"],
     attributes = pkg_attributes(mode = "0555"),
-    visibility = ["//visibility:private"],
     prefix = "bin/",
+    visibility = ["//visibility:private"],
 )
 
 package_naming(
@@ -573,14 +576,14 @@ package_naming(
 
 pkg_zip(
     name = "protoc_release",
-    package_file_name = "protoc-{version}-{platform}.zip",
-    package_variables = ":protoc_pkg_naming",
     srcs = [
+        "readme.txt",
+        ":compiler_plugin_protos_files",
         ":protoc_files",
         ":wkt_protos_files",
-        ":compiler_plugin_protos_files",
-        "readme.txt",
     ],
+    package_file_name = "protoc-{version}-{platform}.zip",
+    package_variables = ":protoc_pkg_naming",
 )
 
 ################################################################################
@@ -905,10 +908,10 @@ internal_gen_kt_protos(
 
 internal_gen_kt_protos(
     name = "gen_well_known_protos_kotlinlite",
+    lite = True,
     visibility = [
         "//java:__subpackages__",
     ],
-    lite = True,
     deps = [proto + "_proto" for proto in LITE_WELL_KNOWN_PROTO_MAP.keys()],
 )
 
@@ -1340,17 +1343,16 @@ cc_binary(
 #     ],
 # )
 
-
 java_proto_library(
     name = "java_test_protos",
-    deps = [":generic_test_protos"],
     visibility = ["//java:__subpackages__"],
+    deps = [":generic_test_protos"],
 )
 
 java_lite_proto_library(
     name = "java_lite_test_protos",
-    deps = [":generic_test_protos"],
     visibility = ["//java:__subpackages__"],
+    deps = [":generic_test_protos"],
 )
 
 java_proto_library(
@@ -1452,57 +1454,57 @@ filegroup(
 proto_library(
     name = "kt_unittest_lite",
     srcs = [
-        "src/google/protobuf/unittest_lite.proto",
+        "src/google/protobuf/map_lite_unittest.proto",
         "src/google/protobuf/unittest_import_lite.proto",
         "src/google/protobuf/unittest_import_public_lite.proto",
-        "src/google/protobuf/map_lite_unittest.proto",
+        "src/google/protobuf/unittest_lite.proto",
     ],
     strip_import_prefix = "src",
 )
 
 internal_gen_kt_protos(
     name = "gen_kotlin_unittest_lite",
-    deps = [":kt_unittest_lite"],
     lite = True,
     visibility = ["//java:__subpackages__"],
+    deps = [":kt_unittest_lite"],
 )
 
 proto_library(
     name = "kt_unittest",
     srcs = [
+        "src/google/protobuf/map_proto2_unittest.proto",
         "src/google/protobuf/unittest.proto",
         "src/google/protobuf/unittest_import.proto",
         "src/google/protobuf/unittest_import_public.proto",
-        "src/google/protobuf/map_proto2_unittest.proto",
     ],
     strip_import_prefix = "src",
 )
 
 internal_gen_kt_protos(
     name = "gen_kotlin_unittest",
-    deps = [":kt_unittest"],
     visibility = ["//java:__subpackages__"],
+    deps = [":kt_unittest"],
 )
 
 proto_library(
     name = "kt_proto3_unittest",
     srcs = [
-        "src/google/protobuf/unittest_proto3.proto",
         "src/google/protobuf/unittest_import.proto",
         "src/google/protobuf/unittest_import_public.proto",
+        "src/google/protobuf/unittest_proto3.proto",
     ],
     strip_import_prefix = "src",
 )
 
 internal_gen_kt_protos(
     name = "gen_kotlin_proto3_unittest_lite",
-    deps = [":kt_proto3_unittest"],
     lite = True,
     visibility = ["//java:__subpackages__"],
+    deps = [":kt_proto3_unittest"],
 )
 
 internal_gen_kt_protos(
     name = "gen_kotlin_proto3_unittest",
-    deps = [":kt_proto3_unittest"],
     visibility = ["//java:__subpackages__"],
+    deps = [":kt_proto3_unittest"],
 )

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -1,0 +1,66 @@
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
+load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_files")
+load("//:protobuf_release.bzl", "package_naming")
+load(":cc_dist_library.bzl", "cc_dist_library")
+
+# Map of all well known protos.
+# name => (include path, imports)
+WELL_KNOWN_PROTO_MAP = {
+    "any": ("src/google/protobuf/any.proto", []),
+    "api": (
+        "src/google/protobuf/api.proto",
+        [
+            "source_context",
+            "type",
+        ],
+    ),
+    "descriptor": ("src/google/protobuf/descriptor.proto", []),
+    "duration": ("src/google/protobuf/duration.proto", []),
+    "empty": ("src/google/protobuf/empty.proto", []),
+    "field_mask": ("src/google/protobuf/field_mask.proto", []),
+    "source_context": ("src/google/protobuf/source_context.proto", []),
+    "struct": ("src/google/protobuf/struct.proto", []),
+    "timestamp": ("src/google/protobuf/timestamp.proto", []),
+    "type": (
+        "src/google/protobuf/type.proto",
+        [
+            "any",
+            "source_context",
+        ],
+    ),
+    "wrappers": ("src/google/protobuf/wrappers.proto", []),
+}
+
+# plugin.proto is excluded from this list because it belongs in a nested folder (protobuf/compiler/plugin.proto)
+pkg_files(
+    name = "wkt_protos_files",
+    srcs = ["//:" + value[0] for value in WELL_KNOWN_PROTO_MAP.values() if not value[0].endswith("plugin.proto")],
+    prefix = "include/google/protobuf",
+    visibility = ["//visibility:private"],
+)
+
+package_naming(
+    name = "protoc_pkg_naming",
+)
+
+pkg_zip(
+    name = "protoc_release",
+    srcs = [
+        ":wkt_protos_files",
+        "//src/google/protobuf/compiler:compiler_plugin_protos_files",
+        "//src/google/protobuf/compiler:protoc_files",
+        "//src/google/protobuf/compiler:readme.txt",
+    ],
+    package_file_name = "protoc-{version}-{platform}.zip",
+    package_variables = ":protoc_pkg_naming",
+)
+
+cc_dist_library(
+    name = "protobuf_lite",
+    deps = [
+        "//:arena",
+        "//:protobuf_lite",
+        "//src/google/protobuf/io:lite",
+        "//src/google/protobuf/stubs:lite",
+    ],
+)

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -58,22 +58,13 @@ pkg_zip(
 cc_dist_library(
     name = "protobuf_lite",
     deps = [
-        "//:arena",
         "//:protobuf_lite",
-        "//src/google/protobuf/io:lite",
-        "//src/google/protobuf/stubs:lite",
     ],
 )
 
 cc_dist_library(
     name = "protobuf",
     deps = [
-        "//:arena",
         "//:protobuf",
-        "//:protobuf_lite",
-        "//src/google/protobuf/io",
-        "//src/google/protobuf/io:lite",
-        "//src/google/protobuf/stubs",
-        "//src/google/protobuf/stubs:lite",
     ],
 )

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -3,39 +3,69 @@ load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_files")
 load("//:protobuf_release.bzl", "package_naming")
 load(":cc_dist_library.bzl", "cc_dist_library")
 
-# Map of all well known protos.
-# name => (include path, imports)
-WELL_KNOWN_PROTO_MAP = {
-    "any": ("src/google/protobuf/any.proto", []),
-    "api": (
-        "src/google/protobuf/api.proto",
-        [
-            "source_context",
-            "type",
-        ],
-    ),
-    "descriptor": ("src/google/protobuf/descriptor.proto", []),
-    "duration": ("src/google/protobuf/duration.proto", []),
-    "empty": ("src/google/protobuf/empty.proto", []),
-    "field_mask": ("src/google/protobuf/field_mask.proto", []),
-    "source_context": ("src/google/protobuf/source_context.proto", []),
-    "struct": ("src/google/protobuf/struct.proto", []),
-    "timestamp": ("src/google/protobuf/timestamp.proto", []),
-    "type": (
-        "src/google/protobuf/type.proto",
-        [
-            "any",
-            "source_context",
-        ],
-    ),
-    "wrappers": ("src/google/protobuf/wrappers.proto", []),
-}
-
-# plugin.proto is excluded from this list because it belongs in a nested folder (protobuf/compiler/plugin.proto)
 pkg_files(
     name = "wkt_protos_files",
-    srcs = ["//:" + value[0] for value in WELL_KNOWN_PROTO_MAP.values() if not value[0].endswith("plugin.proto")],
+    srcs = [
+        "//:any_proto",
+        "//:api_proto",
+        "//:duration_proto",
+        "//:empty_proto",
+        "//:field_mask_proto",
+        "//:source_context_proto",
+        "//:struct_proto",
+        "//:timestamp_proto",
+        "//:type_proto",
+        "//:wrappers_proto",
+    ],
     prefix = "include/google/protobuf",
+    visibility = ["//visibility:private"],
+)
+
+pkg_files(
+    name = "descriptor_protos_files",
+    srcs = [
+        "//:descriptor_proto",
+    ],
+    prefix = "include/google/protobuf",
+    visibility = ["//visibility:private"],
+)
+
+pkg_files(
+    name = "compiler_plugin_protos_files",
+    srcs = ["//:compiler_plugin_proto"],
+    prefix = "include/google/protobuf/compiler",
+    visibility = ["//visibility:private"],
+)
+
+################################################################################
+# Generates protoc release artifacts.
+################################################################################
+
+genrule(
+    name = "protoc_readme",
+    outs = ["readme.txt"],
+    cmd = """
+echo "Protocol Buffers - Google's data interchange format
+Copyright 2008 Google Inc.
+https://developers.google.com/protocol-buffers/
+This package contains a precompiled binary version of the protocol buffer
+compiler (protoc). This binary is intended for users who want to use Protocol
+Buffers in languages other than C++ but do not want to compile protoc
+themselves. To install, simply place this binary somewhere in your PATH.
+If you intend to use the included well known types then don't forget to
+copy the contents of the 'include' directory somewhere as well, for example
+into '/usr/local/include/'.
+Please refer to our official github site for more installation instructions:
+  https://github.com/protocolbuffers/protobuf" > $@
+    """,
+    visibility = ["//visibility:private"],
+)
+
+pkg_files(
+    name = "protoc_files",
+    srcs = ["//:protoc"],
+    attributes = pkg_attributes(mode = "0555"),
+    prefix = "bin/",
     visibility = ["//visibility:private"],
 )
 
@@ -46,14 +76,19 @@ package_naming(
 pkg_zip(
     name = "protoc_release",
     srcs = [
+        ":compiler_plugin_protos_files",
+        ":descriptor_protos_files",
+        ":protoc_files",
+        ":protoc_readme",
         ":wkt_protos_files",
-        "//src/google/protobuf/compiler:compiler_plugin_protos_files",
-        "//src/google/protobuf/compiler:protoc_files",
-        "//src/google/protobuf/compiler:readme.txt",
     ],
     package_file_name = "protoc-{version}-{platform}.zip",
     package_variables = ":protoc_pkg_naming",
 )
+
+################################################################################
+# Protobuf runtime libraries.
+################################################################################
 
 cc_dist_library(
     name = "protobuf_lite",

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -64,3 +64,16 @@ cc_dist_library(
         "//src/google/protobuf/stubs:lite",
     ],
 )
+
+cc_dist_library(
+    name = "protobuf",
+    deps = [
+        "//:arena",
+        "//:protobuf",
+        "//:protobuf_lite",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/io:lite",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/stubs:lite",
+    ],
+)

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -92,6 +92,10 @@ pkg_zip(
 
 cc_dist_library(
     name = "protobuf_lite",
+    linkopts = select({
+        "//:msvc": [],
+        "//conditions:default": ["-lpthread"],
+    }),
     deps = [
         "//:protobuf_lite",
     ],
@@ -99,7 +103,15 @@ cc_dist_library(
 
 cc_dist_library(
     name = "protobuf",
+    linkopts = select({
+        "//:msvc": [],
+        "//conditions:default": [
+            "-lz",
+            "-lpthread",
+        ],
+    }),
     deps = [
         "//:protobuf",
+        "//:protobuf_lite",
     ],
 )

--- a/pkg/cc_dist_library.bzl
+++ b/pkg/cc_dist_library.bzl
@@ -1,0 +1,129 @@
+# Rules for distributable C++ libraries
+
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+
+def _create_archive(ctx, cc_toolchain_info, name, objs):
+    ar_out = ctx.actions.declare_file(name)
+
+    ar_args = ctx.actions.args()
+    ar_args.use_param_file("@%s")
+    ar_args.add("cr")
+    ar_args.add(ar_out)
+    ar_args.add_all(objs)
+
+    ctx.actions.run(
+        mnemonic = "CcCreateArchive",
+        executable = cc_toolchain_info.ar_executable,
+        arguments = [ar_args],
+        inputs = objs,
+        outputs = [ar_out],
+    )
+
+    return ar_out
+
+def _cc_dist_library_impl(ctx):
+    cc_toolchain_info = find_cc_toolchain(ctx)
+    if cc_toolchain_info.ar_executable == None:
+        return []
+
+    # Collect the set of object files from the immediate deps.
+    objs = []
+    pic_objs = []
+    for dep in ctx.attr.deps:
+        if CcInfo not in dep:
+            continue
+
+        link_ctx = dep[CcInfo].linking_context
+        if link_ctx == None:
+            continue
+
+        linker_inputs = link_ctx.linker_inputs.to_list()
+        for link_input in linker_inputs:
+            for lib in link_input.libraries:
+                if lib.objects != None:
+                    objs.extend(lib.objects)
+                if lib.pic_objects != None:
+                    pic_objs.extend(lib.pic_objects)
+
+    # For static libraries, use `ar` to construct an archive with all of
+    # the immediate deps' objects.
+    stemname = "lib" + ctx.label.name
+    outputs = []
+
+    if len(objs) > 0:
+        if cc_toolchain_info.ar_executable != None:
+            outputs.append(_create_archive(
+                ctx,
+                cc_toolchain_info,
+                stemname + ".a",
+                objs,
+            ))
+
+    if len(pic_objs) > 0:
+        if cc_toolchain_info.ar_executable != None:
+            outputs.append(_create_archive(
+                ctx,
+                cc_toolchain_info,
+                stemname + ".pic.a",
+                pic_objs,
+            ))
+
+    # For dynamic libraries, use the `cc_common.link` command to ensure
+    # everything gets built correctly according to toolchain definitions.
+
+    compilation_outputs = cc_common.create_compilation_outputs(
+        objects = depset(objs),
+        pic_objects = depset(pic_objs),
+    )
+
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain_info,
+    )
+
+    link_output = cc_common.link(
+        actions = ctx.actions,
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain_info,
+        compilation_outputs = compilation_outputs,
+        name = ctx.label.name,
+        output_type = "dynamic_library",
+    )
+
+    library_to_link = link_output.library_to_link
+
+    linking_context = cc_common.create_linking_context(
+        linker_inputs = depset([
+            cc_common.create_linker_input(
+                owner = ctx.label,
+                libraries = depset([library_to_link]),
+            ),
+        ]),
+    )
+
+    if library_to_link.dynamic_library != None:
+        outputs.append(library_to_link.dynamic_library)
+
+    if library_to_link.interface_library != None:
+        outputs.append(library_to_link.interface_library)
+
+    return [
+        DefaultInfo(files = depset(outputs)),
+        CcInfo(linking_context = linking_context),
+    ]
+
+cc_dist_library = rule(
+    implementation = _cc_dist_library_impl,
+    attrs = {
+        "deps": attr.label_list(),
+        # C++ toolchain before https://github.com/bazelbuild/bazel/issues/7260:
+        "_cc_toolchain": attr.label(
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
+        ),
+    },
+    toolchains = [
+        # C++ toolchain after https://github.com/bazelbuild/bazel/issues/7260:
+        "@bazel_tools//tools/cpp:toolchain_type",
+    ],
+    fragments = ["cpp"],
+)

--- a/pkg/cc_dist_library.bzl
+++ b/pkg/cc_dist_library.bzl
@@ -130,8 +130,7 @@ def _cc_dist_library_impl(ctx):
         compilation_outputs = compilation_outputs,
         name = ctx.label.name,
         output_type = "dynamic_library",
-        # TODO(dlj): need to handle -lz -lpthread
-        # user_link_flags = [],
+        user_link_flags = ctx.attr.linkopts,
     )
     library_to_link = link_output.library_to_link
 
@@ -171,6 +170,7 @@ cc_dist_library = rule(
     implementation = _cc_dist_library_impl,
     attrs = {
         "deps": attr.label_list(),
+        "linkopts": attr.string_list(),
         # C++ toolchain before https://github.com/bazelbuild/bazel/issues/7260:
         "_cc_toolchain": attr.label(
             default = Label("@rules_cc//cc:current_cc_toolchain"),


### PR DESCRIPTION
This change moves the `pkg_*` rules into the `//pkg` package, which cleans up the root package.

It also adds an experimental `cc_dist_library` rule, which is similar to Bazel's `cc_import` rule. The goal of `cc_dist_library` is to produce output libraries from several targets. For example, splitting `//:protobuf` into multiple targets means that `bazel-bin/libprotobuf.a` won't contain all of the objects. The `cc_dist_library` creates a single library from several different `cc_library` targets. This may be useful for future packaging targets.