### PR TITLE
Fix 9825, Java's memoized hash code can fail to be memoized.

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/AbstractMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/AbstractMessage.java
@@ -158,12 +158,13 @@ public abstract class AbstractMessage
   @Override
   public int hashCode() {
     int hash = memoizedHashCode;
-    if (hash == 0) {
+    if (!memoizedHashCodeSet) {
       hash = 41;
       hash = (19 * hash) + getDescriptorForType().hashCode();
       hash = hashFields(hash, getAllFields());
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
+      memoizedHashCodeSet = true;
     }
     return hash;
   }

--- a/java/core/src/main/java/com/google/protobuf/AbstractMessageLite.java
+++ b/java/core/src/main/java/com/google/protobuf/AbstractMessageLite.java
@@ -51,6 +51,7 @@ public abstract class AbstractMessageLite<
         BuilderType extends AbstractMessageLite.Builder<MessageType, BuilderType>>
     implements MessageLite {
   protected int memoizedHashCode = 0;
+  protected boolean memoizedHashCodeSet = false;
 
   @Override
   public ByteString toByteString() {

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java
@@ -106,10 +106,11 @@ public abstract class GeneratedMessageLite<
   @SuppressWarnings("unchecked") // Guaranteed by runtime
   @Override
   public int hashCode() {
-    if (memoizedHashCode != 0) {
+    if (memoizedHashCodeSet) {
       return memoizedHashCode;
     }
     memoizedHashCode = Protobuf.getInstance().schemaFor(this).hashCode(this);
+    memoizedHashCodeSet = true;
     return memoizedHashCode;
   }
 

--- a/java/lite/src/test/java/com/google/protobuf/LiteTest.java
+++ b/java/lite/src/test/java/com/google/protobuf/LiteTest.java
@@ -204,7 +204,7 @@ public class LiteTest {
     int hashCode = message.hashCode();
     assertThat(hashCode).isNotEqualTo(0);
     assertThat(hashCode).isEqualTo(message.memoizedHashCode);
-    assertThat(message.memoizedHashCodeSet).is();
+    assertThat(message.memoizedHashCodeSet).isTrue();
 
     // Test isInitialized is memoized
     Field memo = message.getClass().getDeclaredField("memoizedIsInitialized");

--- a/java/lite/src/test/java/com/google/protobuf/LiteTest.java
+++ b/java/lite/src/test/java/com/google/protobuf/LiteTest.java
@@ -200,9 +200,11 @@ public class LiteTest {
 
     // Test hashCode is memoized
     assertThat(message.memoizedHashCode).isEqualTo(0);
+    assertThat(message.memoizedHashCodeSet).isFalse();
     int hashCode = message.hashCode();
     assertThat(hashCode).isNotEqualTo(0);
     assertThat(hashCode).isEqualTo(message.memoizedHashCode);
+    assertThat(message.memoizedHashCodeSet).is();
 
     // Test isInitialized is memoized
     Field memo = message.getClass().getDeclaredField("memoizedIsInitialized");

--- a/src/google/protobuf/compiler/java/message.cc
+++ b/src/google/protobuf/compiler/java/message.cc
@@ -1084,7 +1084,7 @@ void ImmutableMessageGenerator::GenerateEqualsAndHashCode(
       "@java.lang.Override\n"
       "public int hashCode() {\n");
   printer->Indent();
-  printer->Print("if (memoizedHashCode != 0) {\n");
+  printer->Print("if (memoizedHashCodeSet) {\n");
   printer->Indent();
   printer->Print("return memoizedHashCode;\n");
   printer->Outdent();
@@ -1145,6 +1145,7 @@ void ImmutableMessageGenerator::GenerateEqualsAndHashCode(
   printer->Print("hash = (29 * hash) + unknownFields.hashCode();\n");
   printer->Print(
       "memoizedHashCode = hash;\n"
+      "memoizedHashCodeSet = true;\n"
       "return hash;\n");
   printer->Outdent();
   printer->Print(


### PR DESCRIPTION
Fixes https://github.com/protocolbuffers/protobuf/issues/9825.