### PR TITLE
add Kokoro config for OpenJDK11

### DIFF
--- a/kokoro/linux/java_jdk11/build.sh
+++ b/kokoro/linux/java_jdk11/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# This is the top-level script we give to Kokoro as the entry point for
+# running the "pull request" project:
+#
+# This script selects a specific Dockerfile (for building a Docker image) and
+# a script to run inside that image.  Then we delegate to the general
+# build_and_run_docker.sh script.
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+export DOCKERHUB_ORGANIZATION=protobuftesting
+# The image of the Dockerfile sha1 is fetched from the organization
+export DOCKERFILE_DIR=kokoro/linux/dockerfile/test/java_stretch
+export DOCKER_RUN_SCRIPT=kokoro/linux/pull_request_in_docker.sh
+export OUTPUT_DIR=testoutput
+export TEST_SET="java_jdk11"
+./kokoro/linux/build_and_run_docker.sh

--- a/kokoro/linux/java_jdk11/continuous.cfg
+++ b/kokoro/linux/java_jdk11/continuous.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/java_linkage_monitor/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/linux/java_jdk11/continuous.cfg
+++ b/kokoro/linux/java_jdk11/continuous.cfg
@@ -1,7 +1,7 @@
 # Config file for running tests in Kokoro
 
 # Location of the build script in repository
-build_file: "protobuf/kokoro/linux/java_linkage_monitor/build.sh"
+build_file: "protobuf/kokoro/linux/java_jdk11/build.sh"
 timeout_mins: 120
 
 action {

--- a/kokoro/linux/java_jdk11/presubmit.cfg
+++ b/kokoro/linux/java_jdk11/presubmit.cfg
@@ -1,0 +1,12 @@
+# Config file for running Linkage Monitor in Kokoro
+# https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/linkage-monitor
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/java_linkage_monitor/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+  }
+}

--- a/kokoro/linux/java_jdk11/presubmit.cfg
+++ b/kokoro/linux/java_jdk11/presubmit.cfg
@@ -2,7 +2,7 @@
 # https://github.com/GoogleCloudPlatform/cloud-opensource-java/tree/master/linkage-monitor
 
 # Location of the build script in repository
-build_file: "protobuf/kokoro/linux/java_linkage_monitor/build.sh"
+build_file: "protobuf/kokoro/linux/java_jdk11/build.sh"
 timeout_mins: 120
 
 action {


### PR DESCRIPTION
@acozzette Please consider whether this is the correct Dockerfile for this job. For JDK17 (coming up soon) I will need to either modify this one or add a new one that includes OpenJDK 17. 

Also, I'm assuming we put this in Github first and then add the configs in piper. 