### PR TITLE
Add initial version.json file for 21-dev

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,0 +1,17 @@
+{
+    "main": {
+        "protoc_version": "21-dev",
+        "lts": false,
+        "date": "2022-04-22",
+        "languages": {
+            "cpp": "3.21-dev",
+            "csharp": "3.21-dev",
+            "java": "3.21-dev",
+            "javascript": "3.21-dev",
+            "objectivec": "3.21-dev",
+            "php": "3.21-dev",
+            "python": "3.21-dev",
+            "ruby": "3.21-dev"
+        }
+    }
+}


### PR DESCRIPTION
Add initial version.json file for 21-dev.

This is slightly redundant with PR https://github.com/protocolbuffers/protobuf/pull/9764 which also included the initial `version.json` file, but separating `version.json` to make it easier to test other changes to the release scripts.