### PR TITLE
Remove various unused includes

### DIFF
--- a/python/google/protobuf/pyext/extension_dict.h
+++ b/python/google/protobuf/pyext/extension_dict.h
@@ -37,8 +37,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-#include <memory>
-
 #include <google/protobuf/pyext/message.h>
 
 namespace google {

--- a/python/google/protobuf/pyext/map_container.h
+++ b/python/google/protobuf/pyext/map_container.h
@@ -35,7 +35,6 @@
 #include <Python.h>
 
 #include <cstdint>
-#include <memory>
 
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>

--- a/python/google/protobuf/pyext/repeated_composite_container.h
+++ b/python/google/protobuf/pyext/repeated_composite_container.h
@@ -37,10 +37,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-#include <memory>
-#include <string>
-#include <vector>
-
 #include <google/protobuf/pyext/message.h>
 
 namespace google {

--- a/python/google/protobuf/pyext/repeated_scalar_container.h
+++ b/python/google/protobuf/pyext/repeated_scalar_container.h
@@ -37,8 +37,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-#include <memory>
-
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/pyext/message.h>
 

--- a/src/google/protobuf/compiler/csharp/csharp_enum_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_enum_field.h
@@ -31,8 +31,6 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_CSHARP_ENUM_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_CSHARP_ENUM_FIELD_H__
 
-#include <string>
-
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/csharp/csharp_primitive_field.h>
 

--- a/src/google/protobuf/compiler/csharp/csharp_map_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_map_field.h
@@ -31,8 +31,6 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_CSHARP_MAP_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_CSHARP_MAP_FIELD_H__
 
-#include <string>
-
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/csharp/csharp_field_base.h>
 

--- a/src/google/protobuf/compiler/csharp/csharp_message_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_message_field.h
@@ -31,8 +31,6 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_CSHARP_MESSAGE_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_CSHARP_MESSAGE_FIELD_H__
 
-#include <string>
-
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/csharp/csharp_field_base.h>
 

--- a/src/google/protobuf/compiler/csharp/csharp_primitive_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_primitive_field.h
@@ -31,8 +31,6 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_CSHARP_PRIMITIVE_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_CSHARP_PRIMITIVE_FIELD_H__
 
-#include <string>
-
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/csharp/csharp_field_base.h>
 

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.h
@@ -31,8 +31,6 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_CSHARP_REPEATED_ENUM_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_CSHARP_REPEATED_ENUM_FIELD_H__
 
-#include <string>
-
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/csharp/csharp_field_base.h>
 

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.h
@@ -31,8 +31,6 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_CSHARP_REPEATED_MESSAGE_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_CSHARP_REPEATED_MESSAGE_FIELD_H__
 
-#include <string>
-
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/csharp/csharp_field_base.h>
 

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.h
@@ -31,8 +31,6 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_CSHARP_REPEATED_PRIMITIVE_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_CSHARP_REPEATED_PRIMITIVE_FIELD_H__
 
-#include <string>
-
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/csharp/csharp_field_base.h>
 

--- a/src/google/protobuf/compiler/csharp/csharp_wrapper_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_wrapper_field.h
@@ -31,8 +31,6 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_CSHARP_WRAPPER_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_CSHARP_WRAPPER_FIELD_H__
 
-#include <string>
-
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/csharp/csharp_field_base.h>
 

--- a/src/google/protobuf/compiler/java/message_lite.h
+++ b/src/google/protobuf/compiler/java/message_lite.h
@@ -35,9 +35,6 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_JAVA_MESSAGE_LITE_H__
 #define GOOGLE_PROTOBUF_COMPILER_JAVA_MESSAGE_LITE_H__
 
-#include <map>
-#include <string>
-
 #include <google/protobuf/compiler/java/field.h>
 #include <google/protobuf/compiler/java/message.h>
 

--- a/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.h
@@ -31,8 +31,6 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_PRIMITIVE_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_PRIMITIVE_FIELD_H__
 
-#include <map>
-#include <string>
 #include <google/protobuf/compiler/objectivec/objectivec_field.h>
 
 namespace google {

--- a/src/google/protobuf/generated_message_reflection.h
+++ b/src/google/protobuf/generated_message_reflection.h
@@ -38,9 +38,6 @@
 #ifndef GOOGLE_PROTOBUF_GENERATED_MESSAGE_REFLECTION_H__
 #define GOOGLE_PROTOBUF_GENERATED_MESSAGE_REFLECTION_H__
 
-#include <string>
-#include <vector>
-
 #include <google/protobuf/stubs/casts.h>
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/once.h>

--- a/src/google/protobuf/io/zero_copy_stream.h
+++ b/src/google/protobuf/io/zero_copy_stream.h
@@ -108,8 +108,6 @@
 #define GOOGLE_PROTOBUF_IO_ZERO_COPY_STREAM_H__
 
 
-#include <string>
-
 #include <google/protobuf/stubs/common.h>
 
 

--- a/src/google/protobuf/wire_format.h
+++ b/src/google/protobuf/wire_format.h
@@ -40,8 +40,6 @@
 #define GOOGLE_PROTOBUF_WIRE_FORMAT_H__
 
 
-#include <string>
-
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/stubs/casts.h>


### PR DESCRIPTION
These headers pull in STL headers without actually using anything from the STL.