### PR TITLE
Remove a bunch of clang-tidy warnings re explicit

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_enum_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_enum_field.h
@@ -56,7 +56,7 @@ class EnumFieldGenerator : public SingleFieldGenerator {
       bool include_external_types) const override;
 
  protected:
-  EnumFieldGenerator(const FieldDescriptor* descriptor);
+  explicit EnumFieldGenerator(const FieldDescriptor* descriptor);
   virtual ~EnumFieldGenerator();
 };
 
@@ -67,7 +67,7 @@ class RepeatedEnumFieldGenerator : public RepeatedFieldGenerator {
   virtual void FinishInitialization() override;
 
  protected:
-  RepeatedEnumFieldGenerator(const FieldDescriptor* descriptor);
+  explicit RepeatedEnumFieldGenerator(const FieldDescriptor* descriptor);
   virtual ~RepeatedEnumFieldGenerator();
 };
 

--- a/src/google/protobuf/compiler/objectivec/objectivec_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_field.h
@@ -95,7 +95,7 @@ class FieldGenerator {
   std::string raw_field_name() const { return variable("raw_field_name"); }
 
  protected:
-  FieldGenerator(const FieldDescriptor* descriptor);
+  explicit FieldGenerator(const FieldDescriptor* descriptor);
 
   virtual void FinishInitialization(void);
   bool WantsHasProperty(void) const;
@@ -119,7 +119,7 @@ class SingleFieldGenerator : public FieldGenerator {
   virtual bool RuntimeUsesHasBit(void) const override;
 
  protected:
-  SingleFieldGenerator(const FieldDescriptor* descriptor);
+  explicit SingleFieldGenerator(const FieldDescriptor* descriptor);
 };
 
 // Subclass with common support for when the field ends up as an ObjC Object.
@@ -134,7 +134,7 @@ class ObjCObjFieldGenerator : public SingleFieldGenerator {
   virtual void GeneratePropertyDeclaration(io::Printer* printer) const override;
 
  protected:
-  ObjCObjFieldGenerator(const FieldDescriptor* descriptor);
+  explicit ObjCObjFieldGenerator(const FieldDescriptor* descriptor);
 };
 
 class RepeatedFieldGenerator : public ObjCObjFieldGenerator {
@@ -152,14 +152,14 @@ class RepeatedFieldGenerator : public ObjCObjFieldGenerator {
   virtual bool RuntimeUsesHasBit(void) const override;
 
  protected:
-  RepeatedFieldGenerator(const FieldDescriptor* descriptor);
+  explicit RepeatedFieldGenerator(const FieldDescriptor* descriptor);
   virtual void FinishInitialization(void) override;
 };
 
 // Convenience class which constructs FieldGenerators for a Descriptor.
 class FieldGeneratorMap {
  public:
-  FieldGeneratorMap(const Descriptor* descriptor);
+  explicit FieldGeneratorMap(const Descriptor* descriptor);
   ~FieldGeneratorMap();
 
   FieldGeneratorMap(const FieldGeneratorMap&) = delete;

--- a/src/google/protobuf/compiler/objectivec/objectivec_map_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_map_field.h
@@ -50,7 +50,7 @@ class MapFieldGenerator : public RepeatedFieldGenerator {
   MapFieldGenerator& operator=(const MapFieldGenerator&) = delete;
 
  protected:
-  MapFieldGenerator(const FieldDescriptor* descriptor);
+  explicit MapFieldGenerator(const FieldDescriptor* descriptor);
   virtual ~MapFieldGenerator();
 
   virtual void DetermineObjectiveCClassDefinitions(

--- a/src/google/protobuf/compiler/objectivec/objectivec_message_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message_field.h
@@ -44,7 +44,7 @@ class MessageFieldGenerator : public ObjCObjFieldGenerator {
   friend FieldGenerator* FieldGenerator::Make(const FieldDescriptor* field);
 
  protected:
-  MessageFieldGenerator(const FieldDescriptor* descriptor);
+  explicit MessageFieldGenerator(const FieldDescriptor* descriptor);
 
   MessageFieldGenerator(const MessageFieldGenerator&) = delete;
   MessageFieldGenerator& operator=(const MessageFieldGenerator&) = delete;
@@ -63,7 +63,7 @@ class RepeatedMessageFieldGenerator : public RepeatedFieldGenerator {
   friend FieldGenerator* FieldGenerator::Make(const FieldDescriptor* field);
 
  protected:
-  RepeatedMessageFieldGenerator(const FieldDescriptor* descriptor);
+  explicit RepeatedMessageFieldGenerator(const FieldDescriptor* descriptor);
   virtual ~RepeatedMessageFieldGenerator();
 
   RepeatedMessageFieldGenerator(const RepeatedMessageFieldGenerator&) = delete;

--- a/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.h
@@ -42,7 +42,7 @@ class PrimitiveFieldGenerator : public SingleFieldGenerator {
   friend FieldGenerator* FieldGenerator::Make(const FieldDescriptor* field);
 
  protected:
-  PrimitiveFieldGenerator(const FieldDescriptor* descriptor);
+  explicit PrimitiveFieldGenerator(const FieldDescriptor* descriptor);
   virtual ~PrimitiveFieldGenerator();
 
   PrimitiveFieldGenerator(const PrimitiveFieldGenerator&) = delete;
@@ -58,7 +58,7 @@ class PrimitiveObjFieldGenerator : public ObjCObjFieldGenerator {
   friend FieldGenerator* FieldGenerator::Make(const FieldDescriptor* field);
 
  protected:
-  PrimitiveObjFieldGenerator(const FieldDescriptor* descriptor);
+  explicit PrimitiveObjFieldGenerator(const FieldDescriptor* descriptor);
   virtual ~PrimitiveObjFieldGenerator();
 
   PrimitiveObjFieldGenerator(const PrimitiveObjFieldGenerator&) = delete;
@@ -70,7 +70,7 @@ class RepeatedPrimitiveFieldGenerator : public RepeatedFieldGenerator {
   friend FieldGenerator* FieldGenerator::Make(const FieldDescriptor* field);
 
  protected:
-  RepeatedPrimitiveFieldGenerator(const FieldDescriptor* descriptor);
+  explicit RepeatedPrimitiveFieldGenerator(const FieldDescriptor* descriptor);
   virtual ~RepeatedPrimitiveFieldGenerator();
 
   RepeatedPrimitiveFieldGenerator(const RepeatedPrimitiveFieldGenerator&) =


### PR DESCRIPTION
 Remove a bunch of clang-tidy warnings about missing use of `explicit' on single arg ctors.