### PR TITLE
Use PROTOBUF_CONSTEXPR instead of constexpr for kRepHeaderSize

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -655,7 +655,7 @@
 #define PROTOBUF_CONSTEXPR constexpr
 #else
 #define PROTOBUF_CONSTINIT
-#define PROTOBUF_CONSTEXPR inline
+#define PROTOBUF_CONSTEXPR
 #endif
 
 // Some globals with an empty non-trivial destructor are annotated with

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -346,7 +346,7 @@ class RepeatedField final {
   int total_size_;
   // Pad the Rep after arena allow for power-of-two byte sizes when
   // sizeof(Element) > sizeof(Arena*). eg for 16-byte objects.
-  static constexpr size_t kRepHeaderSize =
+  static PROTOBUF_CONSTEXPR const size_t kRepHeaderSize =
       sizeof(Arena*) < sizeof(Element) ? sizeof(Element) : sizeof(Arena*);
   struct Rep {
     Arena* arena;


### PR DESCRIPTION
Fixes "no matching function for call to 'CalculateReserveSize'" compiler errors with older clang versions.