### PR TITLE
Make genrule portable for windows

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -477,10 +477,12 @@ def internal_copied_filegroup(name, srcs, strip_prefix, dest, **kwargs):
         name = name + "_genrule",
         srcs = srcs,
         outs = outs,
-        cmd = " && ".join(
+        cmd_bash = " && ".join(
             ["cp $(location %s) $(location %s)" %
-             (s, _RelativeOutputPath(s, strip_prefix, dest)) for s in srcs],
-        ),
+             (s, _RelativeOutputPath(s, strip_prefix, dest)) for s in srcs]),
+        cmd_bat = " && ".join(
+            ["@copy /Y $(location %s) $(location %s) >NUL" %
+             (s, _RelativeOutputPath(s, strip_prefix, dest)) for s in srcs]),
     )
 
     native.filegroup(

--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -27,7 +27,11 @@ genrule(
     name = "copy_public_headers",
     srcs = _ZLIB_HEADERS,
     outs = _ZLIB_PREFIXED_HEADERS,
-    cmd = "cp $(SRCS) $(@D)/zlib/include/",
+    cmd_bash = "cp $(SRCS) $(@D)/zlib/include/",
+    cmd_bat = " && ".join(
+        ["@copy /Y $(location %s) $(@D)\\zlib\\include\\  >NUL" %
+         s for s in _ZLIB_HEADERS],
+    ),
 )
 
 cc_library(


### PR DESCRIPTION
When calling this genrule under windows it requires a bash to be available on the system.

Especially on newer windows machines this can be quite annoying since a bash exists that acts as an "Ad" for wsl:

```
C:\Windows\system32\bash.exe -c <...many arguments...>
# Configuration: fb8154cc422f6ac561b4e6c2932e00bdc2db9f196bfcf3968846bfb708d586ee
# Execution platform: @local_config_platform//:host
F³r das Windows-Subsystem f³r Linux wurden keine Distributionen installiert.
Distributionen zur Installation finden Sie im Microsoft Store:
https://aka.ms/wslstore
```

It can be fixed to use windows native commands to do these basic file-operations.
The attribute is available since bazel 0.29.0 so i hope this is backwards compatible enough.