### PR TITLE
Be explicit with empty globs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -801,8 +801,10 @@ cc_test(
         "src/google/protobuf/**/*",
         # Files for csharp_bootstrap_unittest.cc.
         "conformance/**/*",
+    ]) + glob([
+        # Files for csharp_bootstrap_unittest.cc.
         "csharp/src/**/*",
-    ]),
+    ], allow_empty=True),
     includes = [
         "src/",
     ],
@@ -1493,7 +1495,7 @@ pkg_files(
         "missing",
         "protobuf*.pc.in",
         "test-driver",
-    ]) + [
+    ], allow_empty = True) + [
         "BUILD",
         "CHANGES.txt",
         "CMakeLists.txt",


### PR DESCRIPTION
There are empty globs that prevent to use com_google_protobuf with
--incompatible_disallow_empty_glob

Introduced in https://github.com/bazelbuild/bazel/issues/8195