### PR TITLE
ObjC: Revise the minimal extension deps algorithm.

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
@@ -269,9 +269,10 @@ bool ObjectiveCGenerator::GenerateAll(
     return false;
   }
 
+  FileGenerator::CommonState state;
   for (int i = 0; i < files.size(); i++) {
     const FileDescriptor* file = files[i];
-    FileGenerator file_generator(file, generation_options);
+    FileGenerator file_generator(file, generation_options, state);
     std::string filepath = FilePath(file);
 
     // Generate header.


### PR DESCRIPTION
When generating, it isn't uncommon to have generate >1 file at a time, and it is
likely that one file will include another. So cache the results as the
calculation is done so the work isn't repeated.

The previous pruning method didn't have any concept of tracking already done
work, this changes the algorithm to avoid the repeated work to make things more
minimal on the way up.

Some extremely deep proto graphs, this takes the generation time from around 15
min to under 45 seconds.