### PR TITLE
Remove duplicate java generated code

### DIFF
--- a/java/kotlin/generate-sources-build.xml
+++ b/java/kotlin/generate-sources-build.xml
@@ -3,7 +3,6 @@
     <mkdir dir="${generated.sources.dir}"/>
     <exec executable="${protoc}">
         <arg value="--kotlin_out=${generated.sources.dir}"/>
-        <arg value="--java_out=${generated.sources.dir}"/>
         <arg value="--proto_path=${protobuf.source.dir}"/>
         <arg value="${protobuf.source.dir}/google/protobuf/any.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/api.proto"/>


### PR DESCRIPTION
Remove the java generator for well known types in Kotlin since it is already provided by the Java package as reported in #9902.