### PR TITLE
Added cmake abseil include guard

### DIFF
--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -1,4 +1,7 @@
-if(protobuf_ABSL_PROVIDER STREQUAL "module")
+if(TARGET absl::strings)
+  # If absl is included already, skip including it.
+  # (https://github.com/grpc/grpc/issues/29608)
+elseif(protobuf_ABSL_PROVIDER STREQUAL "module")
   if(NOT ABSL_ROOT_DIR)
     set(ABSL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/abseil-cpp)
   endif()


### PR DESCRIPTION
This fix is needed to prevent gRPC from having duplicate definitions of abseil targets. Once protobuf started depending on Abseil (by #9793), both gRPC and Protobuf are trying to include abseil project, resulting in calling add_subdirectory toward abseil-cpp throwing a bunch of errors.

To avoid this error, an easy solution is to introduce an inclusion guard, we can think of a better solution in future but this is good enough as a short-term solution. The same fix will be added to gRPC as well.