### PR TITLE
[do not merge] Remove the special-case code that suppresses pure-PHP properties.

### DIFF
--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -58,7 +58,7 @@ upb_DefPool *get_global_symtab();
 #if PHP_VERSION_ID < 80000
 #define PROTO_VAL zval
 #define PROTO_STR zval
-#define PROTO_VAL_P(obj) (void*)Z_OBJ_P(obj)
+#define PROTO_VAL_P(obj) (zend_object*)Z_OBJ_P(obj)
 #define PROTO_STRVAL_P(obj) Z_STRVAL_P(obj)
 #define PROTO_STRLEN_P(obj) Z_STRLEN_P(obj)
 #define ZVAL_OBJ_COPY(z, o) do { ZVAL_OBJ(z, o); GC_ADDREF(o); } while (0)
@@ -69,7 +69,7 @@ upb_DefPool *get_global_symtab();
 #else
 #define PROTO_VAL zend_object
 #define PROTO_STR zend_string
-#define PROTO_VAL_P(obj) (void*)(obj)
+#define PROTO_VAL_P(obj) (zend_object*)(obj)
 #define PROTO_STRVAL_P(obj) ZSTR_VAL(obj)
 #define PROTO_STRLEN_P(obj) ZSTR_LEN(obj)
 #endif

--- a/php/ext/google/protobuf/wkt.inc
+++ b/php/ext/google/protobuf/wkt.inc
@@ -65,7 +65,7 @@ static PHP_METHOD(google_protobuf_Any, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Any, getTypeUrl) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "type_url");
   zval ret;
@@ -74,7 +74,7 @@ static PHP_METHOD(google_protobuf_Any, getTypeUrl) {
 }
 
 static PHP_METHOD(google_protobuf_Any, setTypeUrl) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "type_url");
   zval *val;
@@ -87,7 +87,7 @@ static PHP_METHOD(google_protobuf_Any, setTypeUrl) {
 }
 
 static PHP_METHOD(google_protobuf_Any, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -96,7 +96,7 @@ static PHP_METHOD(google_protobuf_Any, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_Any, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -210,7 +210,7 @@ static PHP_METHOD(google_protobuf_Api, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Api, getName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval ret;
@@ -219,7 +219,7 @@ static PHP_METHOD(google_protobuf_Api, getName) {
 }
 
 static PHP_METHOD(google_protobuf_Api, setName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval *val;
@@ -232,7 +232,7 @@ static PHP_METHOD(google_protobuf_Api, setName) {
 }
 
 static PHP_METHOD(google_protobuf_Api, getMethods) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "methods");
   zval ret;
@@ -241,7 +241,7 @@ static PHP_METHOD(google_protobuf_Api, getMethods) {
 }
 
 static PHP_METHOD(google_protobuf_Api, setMethods) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "methods");
   zval *val;
@@ -254,7 +254,7 @@ static PHP_METHOD(google_protobuf_Api, setMethods) {
 }
 
 static PHP_METHOD(google_protobuf_Api, getOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval ret;
@@ -263,7 +263,7 @@ static PHP_METHOD(google_protobuf_Api, getOptions) {
 }
 
 static PHP_METHOD(google_protobuf_Api, setOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval *val;
@@ -276,7 +276,7 @@ static PHP_METHOD(google_protobuf_Api, setOptions) {
 }
 
 static PHP_METHOD(google_protobuf_Api, getVersion) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "version");
   zval ret;
@@ -285,7 +285,7 @@ static PHP_METHOD(google_protobuf_Api, getVersion) {
 }
 
 static PHP_METHOD(google_protobuf_Api, setVersion) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "version");
   zval *val;
@@ -298,7 +298,7 @@ static PHP_METHOD(google_protobuf_Api, setVersion) {
 }
 
 static PHP_METHOD(google_protobuf_Api, getSourceContext) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "source_context");
   zval ret;
@@ -307,7 +307,7 @@ static PHP_METHOD(google_protobuf_Api, getSourceContext) {
 }
 
 static PHP_METHOD(google_protobuf_Api, setSourceContext) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "source_context");
   zval *val;
@@ -320,7 +320,7 @@ static PHP_METHOD(google_protobuf_Api, setSourceContext) {
 }
 
 static PHP_METHOD(google_protobuf_Api, getMixins) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "mixins");
   zval ret;
@@ -329,7 +329,7 @@ static PHP_METHOD(google_protobuf_Api, getMixins) {
 }
 
 static PHP_METHOD(google_protobuf_Api, setMixins) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "mixins");
   zval *val;
@@ -342,7 +342,7 @@ static PHP_METHOD(google_protobuf_Api, setMixins) {
 }
 
 static PHP_METHOD(google_protobuf_Api, getSyntax) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "syntax");
   zval ret;
@@ -351,7 +351,7 @@ static PHP_METHOD(google_protobuf_Api, getSyntax) {
 }
 
 static PHP_METHOD(google_protobuf_Api, setSyntax) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "syntax");
   zval *val;
@@ -404,7 +404,7 @@ static PHP_METHOD(google_protobuf_Method, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Method, getName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval ret;
@@ -413,7 +413,7 @@ static PHP_METHOD(google_protobuf_Method, getName) {
 }
 
 static PHP_METHOD(google_protobuf_Method, setName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval *val;
@@ -426,7 +426,7 @@ static PHP_METHOD(google_protobuf_Method, setName) {
 }
 
 static PHP_METHOD(google_protobuf_Method, getRequestTypeUrl) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "request_type_url");
   zval ret;
@@ -435,7 +435,7 @@ static PHP_METHOD(google_protobuf_Method, getRequestTypeUrl) {
 }
 
 static PHP_METHOD(google_protobuf_Method, setRequestTypeUrl) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "request_type_url");
   zval *val;
@@ -448,7 +448,7 @@ static PHP_METHOD(google_protobuf_Method, setRequestTypeUrl) {
 }
 
 static PHP_METHOD(google_protobuf_Method, getRequestStreaming) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "request_streaming");
   zval ret;
@@ -457,7 +457,7 @@ static PHP_METHOD(google_protobuf_Method, getRequestStreaming) {
 }
 
 static PHP_METHOD(google_protobuf_Method, setRequestStreaming) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "request_streaming");
   zval *val;
@@ -470,7 +470,7 @@ static PHP_METHOD(google_protobuf_Method, setRequestStreaming) {
 }
 
 static PHP_METHOD(google_protobuf_Method, getResponseTypeUrl) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "response_type_url");
   zval ret;
@@ -479,7 +479,7 @@ static PHP_METHOD(google_protobuf_Method, getResponseTypeUrl) {
 }
 
 static PHP_METHOD(google_protobuf_Method, setResponseTypeUrl) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "response_type_url");
   zval *val;
@@ -492,7 +492,7 @@ static PHP_METHOD(google_protobuf_Method, setResponseTypeUrl) {
 }
 
 static PHP_METHOD(google_protobuf_Method, getResponseStreaming) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "response_streaming");
   zval ret;
@@ -501,7 +501,7 @@ static PHP_METHOD(google_protobuf_Method, getResponseStreaming) {
 }
 
 static PHP_METHOD(google_protobuf_Method, setResponseStreaming) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "response_streaming");
   zval *val;
@@ -514,7 +514,7 @@ static PHP_METHOD(google_protobuf_Method, setResponseStreaming) {
 }
 
 static PHP_METHOD(google_protobuf_Method, getOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval ret;
@@ -523,7 +523,7 @@ static PHP_METHOD(google_protobuf_Method, getOptions) {
 }
 
 static PHP_METHOD(google_protobuf_Method, setOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval *val;
@@ -536,7 +536,7 @@ static PHP_METHOD(google_protobuf_Method, setOptions) {
 }
 
 static PHP_METHOD(google_protobuf_Method, getSyntax) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "syntax");
   zval ret;
@@ -545,7 +545,7 @@ static PHP_METHOD(google_protobuf_Method, getSyntax) {
 }
 
 static PHP_METHOD(google_protobuf_Method, setSyntax) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "syntax");
   zval *val;
@@ -598,7 +598,7 @@ static PHP_METHOD(google_protobuf_Mixin, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Mixin, getName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval ret;
@@ -607,7 +607,7 @@ static PHP_METHOD(google_protobuf_Mixin, getName) {
 }
 
 static PHP_METHOD(google_protobuf_Mixin, setName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval *val;
@@ -620,7 +620,7 @@ static PHP_METHOD(google_protobuf_Mixin, setName) {
 }
 
 static PHP_METHOD(google_protobuf_Mixin, getRoot) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "root");
   zval ret;
@@ -629,7 +629,7 @@ static PHP_METHOD(google_protobuf_Mixin, getRoot) {
 }
 
 static PHP_METHOD(google_protobuf_Mixin, setRoot) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "root");
   zval *val;
@@ -713,7 +713,7 @@ static PHP_METHOD(google_protobuf_Duration, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Duration, getSeconds) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "seconds");
   zval ret;
@@ -722,7 +722,7 @@ static PHP_METHOD(google_protobuf_Duration, getSeconds) {
 }
 
 static PHP_METHOD(google_protobuf_Duration, setSeconds) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "seconds");
   zval *val;
@@ -735,7 +735,7 @@ static PHP_METHOD(google_protobuf_Duration, setSeconds) {
 }
 
 static PHP_METHOD(google_protobuf_Duration, getNanos) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "nanos");
   zval ret;
@@ -744,7 +744,7 @@ static PHP_METHOD(google_protobuf_Duration, getNanos) {
 }
 
 static PHP_METHOD(google_protobuf_Duration, setNanos) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "nanos");
   zval *val;
@@ -892,7 +892,7 @@ static PHP_METHOD(google_protobuf_FieldMask, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_FieldMask, getPaths) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "paths");
   zval ret;
@@ -901,7 +901,7 @@ static PHP_METHOD(google_protobuf_FieldMask, getPaths) {
 }
 
 static PHP_METHOD(google_protobuf_FieldMask, setPaths) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "paths");
   zval *val;
@@ -983,7 +983,7 @@ static PHP_METHOD(google_protobuf_SourceContext, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_SourceContext, getFileName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "file_name");
   zval ret;
@@ -992,7 +992,7 @@ static PHP_METHOD(google_protobuf_SourceContext, getFileName) {
 }
 
 static PHP_METHOD(google_protobuf_SourceContext, setFileName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "file_name");
   zval *val;
@@ -1090,7 +1090,7 @@ static PHP_METHOD(google_protobuf_Struct, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Struct, getFields) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "fields");
   zval ret;
@@ -1099,7 +1099,7 @@ static PHP_METHOD(google_protobuf_Struct, getFields) {
 }
 
 static PHP_METHOD(google_protobuf_Struct, setFields) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "fields");
   zval *val;
@@ -1140,7 +1140,7 @@ static PHP_METHOD(google_protobuf_Struct_FieldsEntry, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Struct_FieldsEntry, getKey) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "key");
   zval ret;
@@ -1149,7 +1149,7 @@ static PHP_METHOD(google_protobuf_Struct_FieldsEntry, getKey) {
 }
 
 static PHP_METHOD(google_protobuf_Struct_FieldsEntry, setKey) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "key");
   zval *val;
@@ -1162,7 +1162,7 @@ static PHP_METHOD(google_protobuf_Struct_FieldsEntry, setKey) {
 }
 
 static PHP_METHOD(google_protobuf_Struct_FieldsEntry, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -1171,7 +1171,7 @@ static PHP_METHOD(google_protobuf_Struct_FieldsEntry, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_Struct_FieldsEntry, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -1214,7 +1214,7 @@ static PHP_METHOD(google_protobuf_Value, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Value, getNullValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "null_value");
   zval ret;
@@ -1223,7 +1223,7 @@ static PHP_METHOD(google_protobuf_Value, getNullValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, setNullValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "null_value");
   zval *val;
@@ -1236,7 +1236,7 @@ static PHP_METHOD(google_protobuf_Value, setNullValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, getNumberValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "number_value");
   zval ret;
@@ -1245,7 +1245,7 @@ static PHP_METHOD(google_protobuf_Value, getNumberValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, setNumberValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "number_value");
   zval *val;
@@ -1258,7 +1258,7 @@ static PHP_METHOD(google_protobuf_Value, setNumberValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, getStringValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "string_value");
   zval ret;
@@ -1267,7 +1267,7 @@ static PHP_METHOD(google_protobuf_Value, getStringValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, setStringValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "string_value");
   zval *val;
@@ -1280,7 +1280,7 @@ static PHP_METHOD(google_protobuf_Value, setStringValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, getBoolValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "bool_value");
   zval ret;
@@ -1289,7 +1289,7 @@ static PHP_METHOD(google_protobuf_Value, getBoolValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, setBoolValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "bool_value");
   zval *val;
@@ -1302,7 +1302,7 @@ static PHP_METHOD(google_protobuf_Value, setBoolValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, getStructValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "struct_value");
   zval ret;
@@ -1311,7 +1311,7 @@ static PHP_METHOD(google_protobuf_Value, getStructValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, setStructValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "struct_value");
   zval *val;
@@ -1324,7 +1324,7 @@ static PHP_METHOD(google_protobuf_Value, setStructValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, getListValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "list_value");
   zval ret;
@@ -1333,7 +1333,7 @@ static PHP_METHOD(google_protobuf_Value, getListValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, setListValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "list_value");
   zval *val;
@@ -1346,7 +1346,7 @@ static PHP_METHOD(google_protobuf_Value, setListValue) {
 }
 
 static PHP_METHOD(google_protobuf_Value, getKind) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_OneofDef *oneof = upb_MessageDef_FindOneofByName(
       intern->desc->msgdef, "kind");
   const upb_FieldDef *field = 
@@ -1393,7 +1393,7 @@ static PHP_METHOD(google_protobuf_ListValue, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_ListValue, getValues) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "values");
   zval ret;
@@ -1402,7 +1402,7 @@ static PHP_METHOD(google_protobuf_ListValue, getValues) {
 }
 
 static PHP_METHOD(google_protobuf_ListValue, setValues) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "values");
   zval *val;
@@ -1604,7 +1604,7 @@ static PHP_METHOD(google_protobuf_Type, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Type, getName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval ret;
@@ -1613,7 +1613,7 @@ static PHP_METHOD(google_protobuf_Type, getName) {
 }
 
 static PHP_METHOD(google_protobuf_Type, setName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval *val;
@@ -1626,7 +1626,7 @@ static PHP_METHOD(google_protobuf_Type, setName) {
 }
 
 static PHP_METHOD(google_protobuf_Type, getFields) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "fields");
   zval ret;
@@ -1635,7 +1635,7 @@ static PHP_METHOD(google_protobuf_Type, getFields) {
 }
 
 static PHP_METHOD(google_protobuf_Type, setFields) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "fields");
   zval *val;
@@ -1648,7 +1648,7 @@ static PHP_METHOD(google_protobuf_Type, setFields) {
 }
 
 static PHP_METHOD(google_protobuf_Type, getOneofs) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "oneofs");
   zval ret;
@@ -1657,7 +1657,7 @@ static PHP_METHOD(google_protobuf_Type, getOneofs) {
 }
 
 static PHP_METHOD(google_protobuf_Type, setOneofs) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "oneofs");
   zval *val;
@@ -1670,7 +1670,7 @@ static PHP_METHOD(google_protobuf_Type, setOneofs) {
 }
 
 static PHP_METHOD(google_protobuf_Type, getOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval ret;
@@ -1679,7 +1679,7 @@ static PHP_METHOD(google_protobuf_Type, getOptions) {
 }
 
 static PHP_METHOD(google_protobuf_Type, setOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval *val;
@@ -1692,7 +1692,7 @@ static PHP_METHOD(google_protobuf_Type, setOptions) {
 }
 
 static PHP_METHOD(google_protobuf_Type, getSourceContext) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "source_context");
   zval ret;
@@ -1701,7 +1701,7 @@ static PHP_METHOD(google_protobuf_Type, getSourceContext) {
 }
 
 static PHP_METHOD(google_protobuf_Type, setSourceContext) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "source_context");
   zval *val;
@@ -1714,7 +1714,7 @@ static PHP_METHOD(google_protobuf_Type, setSourceContext) {
 }
 
 static PHP_METHOD(google_protobuf_Type, getSyntax) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "syntax");
   zval ret;
@@ -1723,7 +1723,7 @@ static PHP_METHOD(google_protobuf_Type, getSyntax) {
 }
 
 static PHP_METHOD(google_protobuf_Type, setSyntax) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "syntax");
   zval *val;
@@ -1774,7 +1774,7 @@ static PHP_METHOD(google_protobuf_Field, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Field, getKind) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "kind");
   zval ret;
@@ -1783,7 +1783,7 @@ static PHP_METHOD(google_protobuf_Field, getKind) {
 }
 
 static PHP_METHOD(google_protobuf_Field, setKind) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "kind");
   zval *val;
@@ -1796,7 +1796,7 @@ static PHP_METHOD(google_protobuf_Field, setKind) {
 }
 
 static PHP_METHOD(google_protobuf_Field, getCardinality) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "cardinality");
   zval ret;
@@ -1805,7 +1805,7 @@ static PHP_METHOD(google_protobuf_Field, getCardinality) {
 }
 
 static PHP_METHOD(google_protobuf_Field, setCardinality) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "cardinality");
   zval *val;
@@ -1818,7 +1818,7 @@ static PHP_METHOD(google_protobuf_Field, setCardinality) {
 }
 
 static PHP_METHOD(google_protobuf_Field, getNumber) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "number");
   zval ret;
@@ -1827,7 +1827,7 @@ static PHP_METHOD(google_protobuf_Field, getNumber) {
 }
 
 static PHP_METHOD(google_protobuf_Field, setNumber) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "number");
   zval *val;
@@ -1840,7 +1840,7 @@ static PHP_METHOD(google_protobuf_Field, setNumber) {
 }
 
 static PHP_METHOD(google_protobuf_Field, getName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval ret;
@@ -1849,7 +1849,7 @@ static PHP_METHOD(google_protobuf_Field, getName) {
 }
 
 static PHP_METHOD(google_protobuf_Field, setName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval *val;
@@ -1862,7 +1862,7 @@ static PHP_METHOD(google_protobuf_Field, setName) {
 }
 
 static PHP_METHOD(google_protobuf_Field, getTypeUrl) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "type_url");
   zval ret;
@@ -1871,7 +1871,7 @@ static PHP_METHOD(google_protobuf_Field, getTypeUrl) {
 }
 
 static PHP_METHOD(google_protobuf_Field, setTypeUrl) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "type_url");
   zval *val;
@@ -1884,7 +1884,7 @@ static PHP_METHOD(google_protobuf_Field, setTypeUrl) {
 }
 
 static PHP_METHOD(google_protobuf_Field, getOneofIndex) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "oneof_index");
   zval ret;
@@ -1893,7 +1893,7 @@ static PHP_METHOD(google_protobuf_Field, getOneofIndex) {
 }
 
 static PHP_METHOD(google_protobuf_Field, setOneofIndex) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "oneof_index");
   zval *val;
@@ -1906,7 +1906,7 @@ static PHP_METHOD(google_protobuf_Field, setOneofIndex) {
 }
 
 static PHP_METHOD(google_protobuf_Field, getPacked) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "packed");
   zval ret;
@@ -1915,7 +1915,7 @@ static PHP_METHOD(google_protobuf_Field, getPacked) {
 }
 
 static PHP_METHOD(google_protobuf_Field, setPacked) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "packed");
   zval *val;
@@ -1928,7 +1928,7 @@ static PHP_METHOD(google_protobuf_Field, setPacked) {
 }
 
 static PHP_METHOD(google_protobuf_Field, getOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval ret;
@@ -1937,7 +1937,7 @@ static PHP_METHOD(google_protobuf_Field, getOptions) {
 }
 
 static PHP_METHOD(google_protobuf_Field, setOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval *val;
@@ -1950,7 +1950,7 @@ static PHP_METHOD(google_protobuf_Field, setOptions) {
 }
 
 static PHP_METHOD(google_protobuf_Field, getJsonName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "json_name");
   zval ret;
@@ -1959,7 +1959,7 @@ static PHP_METHOD(google_protobuf_Field, getJsonName) {
 }
 
 static PHP_METHOD(google_protobuf_Field, setJsonName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "json_name");
   zval *val;
@@ -1972,7 +1972,7 @@ static PHP_METHOD(google_protobuf_Field, setJsonName) {
 }
 
 static PHP_METHOD(google_protobuf_Field, getDefaultValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "default_value");
   zval ret;
@@ -1981,7 +1981,7 @@ static PHP_METHOD(google_protobuf_Field, getDefaultValue) {
 }
 
 static PHP_METHOD(google_protobuf_Field, setDefaultValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "default_value");
   zval *val;
@@ -2210,7 +2210,7 @@ static PHP_METHOD(google_protobuf_Enum, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Enum, getName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval ret;
@@ -2219,7 +2219,7 @@ static PHP_METHOD(google_protobuf_Enum, getName) {
 }
 
 static PHP_METHOD(google_protobuf_Enum, setName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval *val;
@@ -2232,7 +2232,7 @@ static PHP_METHOD(google_protobuf_Enum, setName) {
 }
 
 static PHP_METHOD(google_protobuf_Enum, getEnumvalue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "enumvalue");
   zval ret;
@@ -2241,7 +2241,7 @@ static PHP_METHOD(google_protobuf_Enum, getEnumvalue) {
 }
 
 static PHP_METHOD(google_protobuf_Enum, setEnumvalue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "enumvalue");
   zval *val;
@@ -2254,7 +2254,7 @@ static PHP_METHOD(google_protobuf_Enum, setEnumvalue) {
 }
 
 static PHP_METHOD(google_protobuf_Enum, getOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval ret;
@@ -2263,7 +2263,7 @@ static PHP_METHOD(google_protobuf_Enum, getOptions) {
 }
 
 static PHP_METHOD(google_protobuf_Enum, setOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval *val;
@@ -2276,7 +2276,7 @@ static PHP_METHOD(google_protobuf_Enum, setOptions) {
 }
 
 static PHP_METHOD(google_protobuf_Enum, getSourceContext) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "source_context");
   zval ret;
@@ -2285,7 +2285,7 @@ static PHP_METHOD(google_protobuf_Enum, getSourceContext) {
 }
 
 static PHP_METHOD(google_protobuf_Enum, setSourceContext) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "source_context");
   zval *val;
@@ -2298,7 +2298,7 @@ static PHP_METHOD(google_protobuf_Enum, setSourceContext) {
 }
 
 static PHP_METHOD(google_protobuf_Enum, getSyntax) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "syntax");
   zval ret;
@@ -2307,7 +2307,7 @@ static PHP_METHOD(google_protobuf_Enum, getSyntax) {
 }
 
 static PHP_METHOD(google_protobuf_Enum, setSyntax) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "syntax");
   zval *val;
@@ -2356,7 +2356,7 @@ static PHP_METHOD(google_protobuf_EnumValue, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_EnumValue, getName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval ret;
@@ -2365,7 +2365,7 @@ static PHP_METHOD(google_protobuf_EnumValue, getName) {
 }
 
 static PHP_METHOD(google_protobuf_EnumValue, setName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval *val;
@@ -2378,7 +2378,7 @@ static PHP_METHOD(google_protobuf_EnumValue, setName) {
 }
 
 static PHP_METHOD(google_protobuf_EnumValue, getNumber) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "number");
   zval ret;
@@ -2387,7 +2387,7 @@ static PHP_METHOD(google_protobuf_EnumValue, getNumber) {
 }
 
 static PHP_METHOD(google_protobuf_EnumValue, setNumber) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "number");
   zval *val;
@@ -2400,7 +2400,7 @@ static PHP_METHOD(google_protobuf_EnumValue, setNumber) {
 }
 
 static PHP_METHOD(google_protobuf_EnumValue, getOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval ret;
@@ -2409,7 +2409,7 @@ static PHP_METHOD(google_protobuf_EnumValue, getOptions) {
 }
 
 static PHP_METHOD(google_protobuf_EnumValue, setOptions) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "options");
   zval *val;
@@ -2454,7 +2454,7 @@ static PHP_METHOD(google_protobuf_Option, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Option, getName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval ret;
@@ -2463,7 +2463,7 @@ static PHP_METHOD(google_protobuf_Option, getName) {
 }
 
 static PHP_METHOD(google_protobuf_Option, setName) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "name");
   zval *val;
@@ -2476,7 +2476,7 @@ static PHP_METHOD(google_protobuf_Option, setName) {
 }
 
 static PHP_METHOD(google_protobuf_Option, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -2485,7 +2485,7 @@ static PHP_METHOD(google_protobuf_Option, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_Option, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -2635,7 +2635,7 @@ static PHP_METHOD(google_protobuf_Timestamp, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Timestamp, getSeconds) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "seconds");
   zval ret;
@@ -2644,7 +2644,7 @@ static PHP_METHOD(google_protobuf_Timestamp, getSeconds) {
 }
 
 static PHP_METHOD(google_protobuf_Timestamp, setSeconds) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "seconds");
   zval *val;
@@ -2657,7 +2657,7 @@ static PHP_METHOD(google_protobuf_Timestamp, setSeconds) {
 }
 
 static PHP_METHOD(google_protobuf_Timestamp, getNanos) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "nanos");
   zval ret;
@@ -2666,7 +2666,7 @@ static PHP_METHOD(google_protobuf_Timestamp, getNanos) {
 }
 
 static PHP_METHOD(google_protobuf_Timestamp, setNanos) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "nanos");
   zval *val;
@@ -2765,7 +2765,7 @@ static PHP_METHOD(google_protobuf_DoubleValue, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_DoubleValue, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -2774,7 +2774,7 @@ static PHP_METHOD(google_protobuf_DoubleValue, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_DoubleValue, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -2815,7 +2815,7 @@ static PHP_METHOD(google_protobuf_FloatValue, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_FloatValue, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -2824,7 +2824,7 @@ static PHP_METHOD(google_protobuf_FloatValue, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_FloatValue, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -2865,7 +2865,7 @@ static PHP_METHOD(google_protobuf_Int64Value, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Int64Value, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -2874,7 +2874,7 @@ static PHP_METHOD(google_protobuf_Int64Value, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_Int64Value, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -2915,7 +2915,7 @@ static PHP_METHOD(google_protobuf_UInt64Value, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_UInt64Value, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -2924,7 +2924,7 @@ static PHP_METHOD(google_protobuf_UInt64Value, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_UInt64Value, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -2965,7 +2965,7 @@ static PHP_METHOD(google_protobuf_Int32Value, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_Int32Value, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -2974,7 +2974,7 @@ static PHP_METHOD(google_protobuf_Int32Value, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_Int32Value, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -3015,7 +3015,7 @@ static PHP_METHOD(google_protobuf_UInt32Value, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_UInt32Value, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -3024,7 +3024,7 @@ static PHP_METHOD(google_protobuf_UInt32Value, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_UInt32Value, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -3065,7 +3065,7 @@ static PHP_METHOD(google_protobuf_BoolValue, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_BoolValue, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -3074,7 +3074,7 @@ static PHP_METHOD(google_protobuf_BoolValue, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_BoolValue, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -3115,7 +3115,7 @@ static PHP_METHOD(google_protobuf_StringValue, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_StringValue, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -3124,7 +3124,7 @@ static PHP_METHOD(google_protobuf_StringValue, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_StringValue, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;
@@ -3165,7 +3165,7 @@ static PHP_METHOD(google_protobuf_BytesValue, __construct) {
 }
 
 static PHP_METHOD(google_protobuf_BytesValue, getValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval ret;
@@ -3174,7 +3174,7 @@ static PHP_METHOD(google_protobuf_BytesValue, getValue) {
 }
 
 static PHP_METHOD(google_protobuf_BytesValue, setValue) {
-  Message* intern = (Message*)Z_OBJ_P(getThis());
+  Message* intern = Message_FromZvalPtr(getThis());
   const upb_FieldDef *f = upb_MessageDef_FindFieldByName(
       intern->desc->msgdef, "value");
   zval *val;

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -2046,7 +2046,7 @@ void GenerateCMessage(const Descriptor* message, io::Printer* printer) {
     auto field = message->field(i);
     printer->Print(
       "static PHP_METHOD($c_name$, get$camel_name$) {\n"
-      "  Message* intern = (Message*)Z_OBJ_P(getThis());\n"
+      "  Message* intern = Message_FromZvalPtr(getThis());\n"
       "  const upb_FieldDef *f = upb_MessageDef_FindFieldByName(\n"
       "      intern->desc->msgdef, \"$name$\");\n"
       "  zval ret;\n"
@@ -2055,7 +2055,7 @@ void GenerateCMessage(const Descriptor* message, io::Printer* printer) {
       "}\n"
       "\n"
       "static PHP_METHOD($c_name$, set$camel_name$) {\n"
-      "  Message* intern = (Message*)Z_OBJ_P(getThis());\n"
+      "  Message* intern = Message_FromZvalPtr(getThis());\n"
       "  const upb_FieldDef *f = upb_MessageDef_FindFieldByName(\n"
       "      intern->desc->msgdef, \"$name$\");\n"
       "  zval *val;\n"
@@ -2076,7 +2076,7 @@ void GenerateCMessage(const Descriptor* message, io::Printer* printer) {
     auto oneof = message->oneof_decl(i);
     printer->Print(
       "static PHP_METHOD($c_name$, get$camel_name$) {\n"
-      "  Message* intern = (Message*)Z_OBJ_P(getThis());\n"
+      "  Message* intern = Message_FromZvalPtr(getThis());\n"
       "  const upb_OneofDef *oneof = upb_MessageDef_FindOneofByName(\n"
       "      intern->desc->msgdef, \"$name$\");\n"
       "  const upb_FieldDef *field = \n"


### PR DESCRIPTION
There is a chance this may fix some SEGVs seen on PHP 8.1 when
OPCache is enabled:
  https://github.com/protocolbuffers/protobuf/issues/9446#issuecomment-1119517310

However this also will increase memory usage of PHP protos, and
will likely introduce CPU overhead also. Therefore we probably don't
want to release the code in this state.

If this indeed fixes the SEGVs being seen, we should redesign the generated
code to no longer create properties unless pure-PHP is being used.

cc: @bshaffer 