### PR TITLE
Use __constinit only in GCC 12.2 and up

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -650,7 +650,7 @@
      (!defined(__APPLE__) && __clang_major__ >= 12))
 #define PROTOBUF_CONSTINIT [[clang::require_constant_initialization]]
 #define PROTOBUF_CONSTEXPR constexpr
-#elif PROTOBUF_GNUC_MIN(12, 0)
+#elif PROTOBUF_GNUC_MIN(12, 2)
 #define PROTOBUF_CONSTINIT __constinit
 #define PROTOBUF_CONSTEXPR constexpr
 #else


### PR DESCRIPTION
Fixes #9916. GCC appears to have a bug preventing our use of __constinit
from working correctly, but this bug will be fixed in GCC 12.2.