### PR TITLE
Update CMakeLists.txt to handle new version scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,21 +99,19 @@ string(REGEX REPLACE        "${protobuf_AC_INIT_REGEX}" "\\2"
 string(REGEX REPLACE        "${protobuf_AC_INIT_REGEX}" "\\3"
     protobuf_CONTACT        "${protobuf_AC_INIT_LINE}")
 # Parse version tweaks
-set(protobuf_VERSION_REGEX "^([0-9]+)\\.([0-9]+)\\.([0-9]+)([-]rc[-]|\\.)?([0-9]*)$")
+set(protobuf_VERSION_REGEX "^([0-9]+)\\.([0-9]+)([-]rc[-]|\\.)?([0-9]*)$")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\1"
   protobuf_VERSION_MAJOR "${protobuf_VERSION_STRING}")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\2"
   protobuf_VERSION_MINOR "${protobuf_VERSION_STRING}")
-string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\3"
-  protobuf_VERSION_PATCH "${protobuf_VERSION_STRING}")
-string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\5"
+string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\4"
   protobuf_VERSION_PRERELEASE "${protobuf_VERSION_STRING}")
 
 message(STATUS "${protobuf_VERSION_PRERELEASE}")
 
 # Package version
 set(protobuf_VERSION
-  "${protobuf_VERSION_MAJOR}.${protobuf_VERSION_MINOR}.${protobuf_VERSION_PATCH}")
+  "${protobuf_VERSION_MAJOR}.${protobuf_VERSION_MINOR}")
 
 if(protobuf_VERSION_PRERELEASE)
   set(protobuf_VERSION "${protobuf_VERSION}.${protobuf_VERSION_PRERELEASE}")


### PR DESCRIPTION
Our version regex expected something like 1.2.3-rc-1, but we are
changing the version scheme so that protoc will have a version more like
1.2-rc-1. This commit fixes the regex to handle the new scheme.