### PR TITLE
Ruby: Support x64-mingw-ucrt platform

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -103,7 +103,7 @@ else
     ext.lib_dir = "lib/google"
     ext.cross_compile = true
     ext.cross_platform = [
-      'x86-mingw32', 'x64-mingw32',
+      'x86-mingw32', 'x64-mingw32', 'x64-mingw-ucrt',
       'x86_64-linux', 'x86-linux',
       'x86_64-darwin', 'arm64-darwin',
     ]
@@ -126,7 +126,7 @@ else
   task 'gem:windows' do
     sh "rm Gemfile.lock"
     require 'rake_compiler_dock'
-    ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux'].each do |plat|
+    ['x86-mingw32', 'x64-mingw32', 'x64-mingw-ucrt', 'x86_64-linux', 'x86-linux'].each do |plat|
       RakeCompilerDock.sh <<-"EOT", platform: plat
         bundle && \
         IN_DOCKER=true rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem RUBY_CC_VERSION=3.1.0:3.0.0:2.7.0:2.6.0:2.5.0


### PR DESCRIPTION
This PR adds support for Ruby `x64-mingw-ucrt` platform, which is the new platform Windows Ruby Installer uses as of Ruby 3.1.

As of [3.21.0.rc.1](https://rubygems.org/gems/google-protobuf/versions/3.21.0.rc.1) protobuf is not including a `x64-mingw-ucrt` gem package. Refer to [nokogiri](https://rubygems.org/gems/nokogiri/versions/1.13.6-x64-mingw-ucrt) for the expected `x64-mingw-ucrt` package we should see.

Refer to this GRPC ticket for details: https://github.com/grpc/grpc/issues/29666