### PR TITLE
[Bazel/macOS] Use the constructed environment when running libtool.

### DIFF
--- a/pkg/cc_dist_library.bzl
+++ b/pkg/cc_dist_library.bzl
@@ -51,7 +51,7 @@ def _create_archive_action(
                 cc_toolchain.all_files,
             ],
         ),
-        use_default_shell_env = True,
+        use_default_shell_env = False,
         outputs = [output_file],
         mnemonic = "CppArchiveDist",
     )


### PR DESCRIPTION
This fixes errors like: `SDKROOT: unbound variable` when building a
cc_dist_library rule (because it isn't in the default shell environment).