### PR TITLE
[Python] Handle user-provided `--link-objects` and `--library-dirs`.

### DIFF
--- a/kokoro/release/python/macos/config.sh
+++ b/kokoro/release/python/macos/config.sh
@@ -27,11 +27,10 @@ function pre_build {
 
     # Build protoc and protobuf libraries
     use_bazel.sh 5.1.1
-    bazel build //:protoc
-    export PROTOC=$PWD/bazel-bin/protoc
-    mkdir src/.libs
-    ln -s $PWD/bazel-bin/libprotobuf.a src/.libs/libprotobuf.a
-    ln -s $PWD/bazel-bin/libprotobuf_lite.a src/.libs/libprotobuf-lite.a
+    bazel build -c opt //:protoc
+    local _bazel_bin=$(bazel info -c opt bazel-bin)
+    export PROTOC=${_bazel_bin}/protoc
+    export LIBPROTOBUF=${_bazel_bin}/libprotobuf.a
 
     # Generate python dependencies.
     pushd python
@@ -53,7 +52,8 @@ function bdist_wheel_cmd {
     # Modify build version
     pwd
     ls
-    python setup.py bdist_wheel --cpp_implementation --compile_static_extension
+    python setup.py build_ext --cpp_implementation -O${LIBPROTOBUF}
+    python setup.py bdist_wheel --cpp_implementation
     cp dist/*.whl $abs_wheelhouse
 }
 


### PR DESCRIPTION
If the user provides a `--link-objects` (or `-O`) flag that looks like
it points to libprotobuf, use that for static linking instead of using
the hard-coded path `../src/.libs/libprotobuf.a`. (Also, if we see
such a flag, assume they want to link it statically, even if they
don't provide `--compile_static_extension`.)

Similarly, if they provide a `--library-dirs=` (or `-L`), assume that
is the location to search, and don't add the hard-coded path
`../src/.libs`.