### PR TITLE
21.x Backport: Ruby: Support x64-mingw-ucrt platform

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -103,7 +103,7 @@ else
     ext.lib_dir = "lib/google"
     ext.cross_compile = true
     ext.cross_platform = [
-      'x86-mingw32', 'x64-mingw32',
+      'x86-mingw32', 'x64-mingw32', 'x64-mingw-ucrt',
       'x86_64-linux', 'x86-linux',
       'x86_64-darwin', 'arm64-darwin',
     ]
@@ -126,7 +126,7 @@ else
   task 'gem:windows' do
     sh "rm Gemfile.lock"
     require 'rake_compiler_dock'
-    ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux'].each do |plat|
+    ['x86-mingw32', 'x64-mingw32', 'x64-mingw-ucrt', 'x86_64-linux', 'x86-linux'].each do |plat|
       RakeCompilerDock.sh <<-"EOT", platform: plat
         bundle && \
         IN_DOCKER=true rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem RUBY_CC_VERSION=3.1.0:3.0.0:2.7.0:2.6.0:2.5.0


### PR DESCRIPTION
Backport of https://github.com/protocolbuffers/protobuf/pull/9963 to the 21.x branch.

@haberman 