### PR TITLE
Fix protoc_release target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -186,6 +186,8 @@ exports_files(
     srcs = [
         "src/google/protobuf/any.proto",
         "src/google/protobuf/api.proto",
+        "src/google/protobuf/compiler/plugin.proto",
+        "src/google/protobuf/descriptor.proto",
         "src/google/protobuf/duration.proto",
         "src/google/protobuf/empty.proto",
         "src/google/protobuf/field_mask.proto",

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -17,25 +17,17 @@ package_naming(
 pkg_files(
     name = "wkt_protos_files",
     srcs = [
-        "//:any_proto",
-        "//:api_proto",
-        "//:duration_proto",
-        "//:empty_proto",
-        "//:field_mask_proto",
-        "//:source_context_proto",
-        "//:struct_proto",
-        "//:timestamp_proto",
-        "//:type_proto",
-        "//:wrappers_proto",
-    ],
-    prefix = "include/google/protobuf",
-    visibility = ["//visibility:private"],
-)
-
-pkg_files(
-    name = "descriptor_protos_files",
-    srcs = [
-        "//:descriptor_proto",
+        "//:src/google/protobuf/any.proto",
+        "//:src/google/protobuf/api.proto",
+        "//:src/google/protobuf/descriptor.proto",
+        "//:src/google/protobuf/duration.proto",
+        "//:src/google/protobuf/empty.proto",
+        "//:src/google/protobuf/field_mask.proto",
+        "//:src/google/protobuf/source_context.proto",
+        "//:src/google/protobuf/struct.proto",
+        "//:src/google/protobuf/timestamp.proto",
+        "//:src/google/protobuf/type.proto",
+        "//:src/google/protobuf/wrappers.proto",
     ],
     prefix = "include/google/protobuf",
     visibility = ["//visibility:private"],
@@ -43,7 +35,7 @@ pkg_files(
 
 pkg_files(
     name = "compiler_plugin_protos_files",
-    srcs = ["//:compiler_plugin_proto"],
+    srcs = ["//:src/google/protobuf/compiler/plugin.proto"],
     prefix = "include/google/protobuf/compiler",
     visibility = ["//visibility:private"],
 )
@@ -84,7 +76,6 @@ pkg_zip(
     name = "protoc_release",
     srcs = [
         ":compiler_plugin_protos_files",
-        ":descriptor_protos_files",
         ":protoc_files",
         ":protoc_readme",
         ":wkt_protos_files",


### PR DESCRIPTION
Edit the protoc_release target to package the proto files themselves instead of the proto descriptors.

Tested manually by building the artifact and inspecting the zip file. All contents were as expected.