### PR TITLE
[Bazel/C++] Factor out stubs, io, and testing libraries.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -656,6 +656,7 @@ cc_binary(
         "src/google/protobuf/compiler/mock_code_generator.cc",
         "src/google/protobuf/compiler/test_plugin.cc",
     ],
+    copts = COPTS,
     deps = [
         ":protobuf",
         ":protoc_lib",
@@ -912,15 +913,15 @@ alias(
 
 proto_library(
     name = "test_messages_proto2_proto",
-    strip_import_prefix = "src",
     srcs = ["src/google/protobuf/test_messages_proto2.proto"],
+    strip_import_prefix = "src",
     visibility = ["//visibility:public"],
 )
 
 proto_library(
     name = "test_messages_proto3_proto",
-    strip_import_prefix = "src",
     srcs = ["src/google/protobuf/test_messages_proto3.proto"],
+    strip_import_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
         ":any_proto",
@@ -1003,8 +1004,8 @@ proto_library(
         "src/google/protobuf/unittest_import_public_lite.proto",
         "src/google/protobuf/unittest_lite.proto",
     ],
-    visibility = ["//java/kotlin-lite:__subpackages__"],
     strip_import_prefix = "src",
+    visibility = ["//java/kotlin-lite:__subpackages__"],
 )
 
 proto_library(
@@ -1015,8 +1016,8 @@ proto_library(
         "src/google/protobuf/unittest_import.proto",
         "src/google/protobuf/unittest_import_public.proto",
     ],
-    visibility = ["//java/kotlin:__subpackages__"],
     strip_import_prefix = "src",
+    visibility = ["//java/kotlin:__subpackages__"],
 )
 
 proto_library(
@@ -1026,11 +1027,11 @@ proto_library(
         "src/google/protobuf/unittest_import_public.proto",
         "src/google/protobuf/unittest_proto3.proto",
     ],
+    strip_import_prefix = "src",
     visibility = [
         "//java/kotlin:__subpackages__",
         "//java/kotlin-lite:__subpackages__",
     ],
-    strip_import_prefix = "src",
 )
 
 ################################################################################

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,11 +21,35 @@ exports_files(["LICENSE"])
 ################################################################################
 
 cc_library(
+    name = "port_def",
+    hdrs = ["src/google/protobuf/port.h"],
+    includes = ["src"],
+    textual_hdrs = [
+        "src/google/protobuf/port_def.inc",
+        "src/google/protobuf/port_undef.inc",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+cc_library(
+    name = "arena",
+    srcs = ["src/google/protobuf/arena.cc"],
+    hdrs = [
+        "src/google/protobuf/arena.h",
+        "src/google/protobuf/arena_impl.h",
+        "src/google/protobuf/arenaz_sampler.h",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//src/google/protobuf/stubs:lite",
+    ],
+)
+
+cc_library(
     name = "protobuf_lite",
     srcs = [
         # AUTOGEN(protobuf_lite_srcs)
         "src/google/protobuf/any_lite.cc",
-        "src/google/protobuf/arena.cc",
         "src/google/protobuf/arenastring.cc",
         "src/google/protobuf/arenaz_sampler.cc",
         "src/google/protobuf/extension_set.cc",
@@ -34,27 +58,11 @@ cc_library(
         "src/google/protobuf/generated_message_util.cc",
         "src/google/protobuf/implicit_weak_message.cc",
         "src/google/protobuf/inlined_string_field.cc",
-        "src/google/protobuf/io/coded_stream.cc",
-        "src/google/protobuf/io/io_win32.cc",
-        "src/google/protobuf/io/strtod.cc",
-        "src/google/protobuf/io/zero_copy_stream.cc",
-        "src/google/protobuf/io/zero_copy_stream_impl.cc",
-        "src/google/protobuf/io/zero_copy_stream_impl_lite.cc",
         "src/google/protobuf/map.cc",
         "src/google/protobuf/message_lite.cc",
         "src/google/protobuf/parse_context.cc",
         "src/google/protobuf/repeated_field.cc",
         "src/google/protobuf/repeated_ptr_field.cc",
-        "src/google/protobuf/stubs/bytestream.cc",
-        "src/google/protobuf/stubs/common.cc",
-        "src/google/protobuf/stubs/int128.cc",
-        "src/google/protobuf/stubs/status.cc",
-        "src/google/protobuf/stubs/statusor.cc",
-        "src/google/protobuf/stubs/stringpiece.cc",
-        "src/google/protobuf/stubs/stringprintf.cc",
-        "src/google/protobuf/stubs/structurally_valid.cc",
-        "src/google/protobuf/stubs/strutil.cc",
-        "src/google/protobuf/stubs/time.cc",
         "src/google/protobuf/wire_format_lite.cc",
     ],
     hdrs = glob([
@@ -65,6 +73,11 @@ cc_library(
     includes = ["src/"],
     linkopts = LINK_OPTS,
     visibility = ["//visibility:public"],
+    deps = [
+        ":arena",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs:lite",
+    ],
 )
 
 cc_library(
@@ -87,16 +100,12 @@ cc_library(
         "src/google/protobuf/generated_message_bases.cc",
         "src/google/protobuf/generated_message_reflection.cc",
         "src/google/protobuf/generated_message_tctable_full.cc",
-        "src/google/protobuf/io/gzip_stream.cc",
-        "src/google/protobuf/io/printer.cc",
-        "src/google/protobuf/io/tokenizer.cc",
         "src/google/protobuf/map_field.cc",
         "src/google/protobuf/message.cc",
         "src/google/protobuf/reflection_ops.cc",
         "src/google/protobuf/service.cc",
         "src/google/protobuf/source_context.pb.cc",
         "src/google/protobuf/struct.pb.cc",
-        "src/google/protobuf/stubs/substitute.cc",
         "src/google/protobuf/text_format.cc",
         "src/google/protobuf/timestamp.pb.cc",
         "src/google/protobuf/type.pb.cc",
@@ -132,10 +141,14 @@ cc_library(
     includes = ["src/"],
     linkopts = LINK_OPTS,
     visibility = ["//visibility:public"],
-    deps = [":protobuf_lite"] + select({
-        "//build_defs:config_msvc": [],
-        "//conditions:default": ["@zlib//:zlib"],
-    }),
+    deps = [
+        ":protobuf_lite",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/io:gzip_stream",
+        "//src/google/protobuf/io:printer",
+        "//src/google/protobuf/io:tokenizer",
+        "//src/google/protobuf/stubs",
+    ],
 )
 
 # This provides just the header files for use in projects that need to build
@@ -447,7 +460,9 @@ cc_binary(
 
 filegroup(
     name = "testdata",
-    srcs = glob(["src/google/protobuf/testdata/**/*"]),
+    srcs = glob(["src/google/protobuf/testdata/**/*"]) + [
+        "src/google/protobuf/descriptor.cc",
+    ],
     visibility = [
         "//:__subpackages__",
         "@upb//:__subpackages__",
@@ -631,8 +646,6 @@ COMMON_TEST_SRCS = [
     "src/google/protobuf/reflection_tester.cc",
     "src/google/protobuf/test_util.cc",
     "src/google/protobuf/test_util.inc",
-    "src/google/protobuf/testing/file.cc",
-    "src/google/protobuf/testing/googletest.cc",
 ]
 
 cc_binary(
@@ -642,26 +655,12 @@ cc_binary(
         # AUTOGEN(test_plugin_srcs)
         "src/google/protobuf/compiler/mock_code_generator.cc",
         "src/google/protobuf/compiler/test_plugin.cc",
-        "src/google/protobuf/testing/file.cc",
     ],
     deps = [
         ":protobuf",
         ":protoc_lib",
+        "//src/google/protobuf/testing",
         "@com_google_googletest//:gtest",
-    ],
-)
-
-cc_test(
-    name = "win32_test",
-    srcs = ["src/google/protobuf/io/io_win32_unittest.cc"],
-    tags = [
-        "manual",
-        "windows",
-    ],
-    deps = [
-        ":protobuf_lite",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -699,11 +698,6 @@ cc_test(
         "src/google/protobuf/generated_message_reflection_unittest.cc",
         "src/google/protobuf/generated_message_tctable_lite_test.cc",
         "src/google/protobuf/inlined_string_field_unittest.cc",
-        "src/google/protobuf/io/coded_stream_unittest.cc",
-        "src/google/protobuf/io/io_win32_unittest.cc",
-        "src/google/protobuf/io/printer_unittest.cc",
-        "src/google/protobuf/io/tokenizer_unittest.cc",
-        "src/google/protobuf/io/zero_copy_stream_unittest.cc",
         "src/google/protobuf/map_field_test.cc",
         "src/google/protobuf/map_test.cc",
         "src/google/protobuf/map_test.inc",
@@ -718,17 +712,6 @@ cc_test(
         "src/google/protobuf/reflection_ops_unittest.cc",
         "src/google/protobuf/repeated_field_reflection_unittest.cc",
         "src/google/protobuf/repeated_field_unittest.cc",
-        "src/google/protobuf/stubs/bytestream_unittest.cc",
-        "src/google/protobuf/stubs/common_unittest.cc",
-        "src/google/protobuf/stubs/int128_unittest.cc",
-        "src/google/protobuf/stubs/status_test.cc",
-        "src/google/protobuf/stubs/statusor_test.cc",
-        "src/google/protobuf/stubs/stringpiece_unittest.cc",
-        "src/google/protobuf/stubs/stringprintf_unittest.cc",
-        "src/google/protobuf/stubs/structurally_valid_unittest.cc",
-        "src/google/protobuf/stubs/strutil_unittest.cc",
-        "src/google/protobuf/stubs/template_util_unittest.cc",
-        "src/google/protobuf/stubs/time_test.cc",
         "src/google/protobuf/text_format_unittest.cc",
         "src/google/protobuf/unknown_field_set_unittest.cc",
         "src/google/protobuf/util/delimited_message_util_test.cc",
@@ -758,6 +741,7 @@ cc_test(
         # Files for csharp_bootstrap_unittest.cc.
         "//conformance:all_files",
         ":test_plugin",
+        ":testdata",
     ] + glob([
         "src/google/protobuf/**/*",
     ]) + glob(
@@ -776,12 +760,10 @@ cc_test(
         ":cc_test_protos",
         ":protobuf",
         ":protoc_lib",
+        "//src/google/protobuf/testing",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-    ] + select({
-        "//build_defs:config_msvc": [],
-        "//conditions:default": ["@zlib//:zlib"],
-    }),
+    ],
 )
 
 ################################################################################

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -33,12 +33,12 @@ cc_library(
 
 cc_library(
     name = "arena",
-    srcs = ["src/google/protobuf/arena.cc"],
-    hdrs = [
-        "src/google/protobuf/arena.h",
+    srcs = [
+        "src/google/protobuf/arena.cc",
         "src/google/protobuf/arena_impl.h",
         "src/google/protobuf/arenaz_sampler.h",
     ],
+    hdrs = ["src/google/protobuf/arena.h"],
     visibility = ["//:__subpackages__"],
     deps = [
         "//src/google/protobuf/stubs:lite",

--- a/kokoro/linux/bazel/build.sh
+++ b/kokoro/linux/bazel/build.sh
@@ -32,7 +32,10 @@ bazel test -k --copt=-Werror --host_copt=-Werror \
   //:protoc \
   //:protobuf \
   //:protobuf_python \
-  //:protobuf_test
+  //:protobuf_test \
+  //src/google/protobuf/io:all \
+  //src/google/protobuf/stubs:all \
+  //src/google/protobuf/testing:all
 trap - EXIT
 
 pushd examples

--- a/kokoro/linux/bazel_distcheck/build.sh
+++ b/kokoro/linux/bazel_distcheck/build.sh
@@ -20,6 +20,9 @@ TEST_TARGETS=(
   //java:tests
   //python:all
   //:protobuf_test
+  //src/google/protobuf/io:all
+  //src/google/protobuf/stubs:all
+  //src/google/protobuf/testing:all
   @com_google_protobuf_examples//...
 )
 

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -99,6 +99,7 @@ pkg_zip(
 # TODO: these will eventually replace autotools for release artifact packaging.
 ################################################################################
 
+
 pkg_filegroup(
     name = "dist_common",
     srcs = [
@@ -108,6 +109,9 @@ pkg_filegroup(
         "//benchmarks:all_dist_files",
         "//build_defs:dist_files",
         "//conformance:all_dist_files",
+        "//src/google/protobuf/io:dist_files",
+        "//src/google/protobuf/stubs:dist_files",
+        "//src/google/protobuf/testing:dist_files",
         "@com_google_protobuf_examples//:dist_files",
     ],
 )

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -357,10 +357,14 @@ cc_dist_library(
         "//build_defs:config_msvc": [],
         "//conditions:default": ["-lpthread"],
     }),
-    deps = [
-        "//:protobuf_lite",
-    ],
     tags = ["manual"],
+    deps = [
+        "//:arena",
+        "//:protobuf_lite",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/io:io_win32",
+        "//src/google/protobuf/stubs:lite",
+    ],
 )
 
 cc_dist_library(
@@ -372,11 +376,19 @@ cc_dist_library(
             "-lpthread",
         ],
     }),
+    tags = ["manual"],
     deps = [
+        "//:arena",
         "//:protobuf",
         "//:protobuf_lite",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/io:gzip_stream",
+        "//src/google/protobuf/io:io_win32",
+        "//src/google/protobuf/io:printer",
+        "//src/google/protobuf/io:tokenizer",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/stubs:lite",
     ],
-    tags = ["manual"],
 )
 
 ################################################################################

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -554,10 +554,12 @@ EXTRA_DIST =                                                   \
   google/protobuf/compiler/ruby/ruby_generated_pkg_implicit.proto \
   google/protobuf/compiler/ruby/ruby_generated_pkg_implicit_pb.rb \
   google/protobuf/compiler/zip_output_unittest.sh              \
+  google/protobuf/io/BUILD.bazel                               \
   google/protobuf/io/gzip_stream.h                             \
   google/protobuf/io/gzip_stream_unittest.sh                   \
   google/protobuf/io/package_info.h                            \
   google/protobuf/package_info.h                               \
+  google/protobuf/stubs/BUILD.bazel                            \
   google/protobuf/test_messages_proto2.proto                   \
   google/protobuf/test_messages_proto3.proto                   \
   google/protobuf/testdata/bad_utf8_string                     \
@@ -573,6 +575,7 @@ EXTRA_DIST =                                                   \
   google/protobuf/testdata/text_format_unittest_data_pointy_oneof.txt \
   google/protobuf/testdata/text_format_unittest_extensions_data.txt \
   google/protobuf/testdata/text_format_unittest_extensions_data_pointy.txt \
+  google/protobuf/testing/BUILD.bazel                          \
   google/protobuf/util/package_info.h                          \
   libprotobuf-lite.map                                         \
   libprotobuf.map                                              \

--- a/src/google/protobuf/io/BUILD.bazel
+++ b/src/google/protobuf/io/BUILD.bazel
@@ -1,6 +1,7 @@
 # Protobuf IO library.
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
 
 package(
@@ -131,4 +132,15 @@ cc_test(
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//pkg:__pkg__"],
 )

--- a/src/google/protobuf/io/BUILD.bazel
+++ b/src/google/protobuf/io/BUILD.bazel
@@ -1,0 +1,134 @@
+# Protobuf IO library.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "io",
+    srcs = [
+        "coded_stream.cc",
+        "zero_copy_stream.cc",
+        "zero_copy_stream_impl.cc",
+        "zero_copy_stream_impl_lite.cc",
+    ],
+    hdrs = [
+        "coded_stream.h",
+        "zero_copy_stream.h",
+        "zero_copy_stream_impl.h",
+        "zero_copy_stream_impl_lite.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/io",
+    deps = [
+        ":io_win32",
+        "//:arena",
+        "//src/google/protobuf/stubs:lite",
+    ],
+)
+
+cc_library(
+    name = "printer",
+    srcs = ["printer.cc"],
+    hdrs = ["printer.h"],
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": ["-Wno-maybe-uninitialized"],
+    }),
+    include_prefix = "google/protobuf/io",
+    deps = [
+        ":io",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_library(
+    name = "tokenizer",
+    srcs = [
+        "strtod.cc",
+        "tokenizer.cc",
+    ],
+    hdrs = [
+        "strtod.h",
+        "tokenizer.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/io",
+    deps = [
+        ":io",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_library(
+    name = "gzip_stream",
+    srcs = ["gzip_stream.cc"],
+    hdrs = ["gzip_stream.h"],
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": ["-Wno-maybe-uninitialized"],
+    }),
+    include_prefix = "google/protobuf/io",
+    deps = [
+        ":io",
+        "//src/google/protobuf/stubs",
+    ] + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": ["@zlib//:zlib"],
+    }),
+)
+
+cc_library(
+    name = "io_win32",
+    srcs = ["io_win32.cc"],
+    hdrs = ["io_win32.h"],
+    copts = COPTS,
+    include_prefix = "google/protobuf/io",
+    visibility = ["//pkg:__pkg__"],
+    deps = [
+        "//:arena",
+        "//src/google/protobuf/stubs:lite",
+    ],
+)
+
+cc_test(
+    name = "io_test",
+    srcs = [
+        "coded_stream_unittest.cc",
+        "printer_unittest.cc",
+        "tokenizer_unittest.cc",
+        "zero_copy_stream_unittest.cc",
+    ],
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": ["-Wno-maybe-uninitialized"],
+    }),
+    data = [
+        "//:testdata",
+    ],
+    deps = [
+        ":gzip_stream",
+        ":io",
+        "//:protobuf",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "win32_test",
+    srcs = ["io_win32_unittest.cc"],
+    tags = [
+        "manual",
+        "windows",
+    ],
+    deps = [
+        "//:protobuf_lite",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/google/protobuf/stubs/BUILD.bazel
+++ b/src/google/protobuf/stubs/BUILD.bazel
@@ -2,6 +2,7 @@
 #   These are utilities that mirror the behavior of internal Google code.
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
 
 package(
@@ -123,4 +124,15 @@ cc_test(
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//pkg:__pkg__"],
 )

--- a/src/google/protobuf/stubs/BUILD.bazel
+++ b/src/google/protobuf/stubs/BUILD.bazel
@@ -1,0 +1,126 @@
+# Protobuf stubs library.
+#   These are utilities that mirror the behavior of internal Google code.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
+
+package(
+    default_visibility = ["//:__subpackages__"],
+)
+
+cc_library(
+    name = "lite",
+    srcs = [
+        "bytestream.cc",
+        "common.cc",
+        "int128.cc",
+        "status.cc",
+        "statusor.cc",
+        "stringpiece.cc",
+        "stringprintf.cc",
+        "structurally_valid.cc",
+        "strutil.cc",
+        "time.cc",
+    ],
+    hdrs = [
+        "bytestream.h",
+        "callback.h",
+        "casts.h",
+        "common.h",
+        "hash.h",
+        "int128.h",
+        "logging.h",
+        "macros.h",
+        "map_util.h",
+        "mathutil.h",
+        "mutex.h",
+        "once.h",
+        "platform_macros.h",
+        "port.h",
+        "status.h",
+        "status_macros.h",
+        "statusor.h",
+        "stl_util.h",
+        "stringpiece.h",
+        "stringprintf.h",
+        "strutil.h",
+        "template_util.h",
+        "time.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/stubs",
+    linkopts = LINK_OPTS,
+    deps = ["//:port_def"],
+)
+
+cc_library(
+    name = "stubs",
+    srcs = [
+        "substitute.cc",
+    ],
+    hdrs = [
+        "substitute.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/stubs",
+    textual_hdrs = [
+        "bytestream.h",
+        "callback.h",
+        "casts.h",
+        "common.h",
+        "hash.h",
+        "int128.h",
+        "logging.h",
+        "macros.h",
+        "map_util.h",
+        "mathutil.h",
+        "mutex.h",
+        "once.h",
+        "platform_macros.h",
+        "port.h",
+        "status.h",
+        "status_macros.h",
+        "statusor.h",
+        "stl_util.h",
+        "stringpiece.h",
+        "stringprintf.h",
+        "strutil.h",
+        "template_util.h",
+        "time.h",
+    ],
+    deps = [
+        ":lite",
+        "//:port_def",
+    ],
+)
+
+cc_test(
+    name = "stubs_test",
+    srcs = [
+        "bytestream_unittest.cc",
+        "common_unittest.cc",
+        "int128_unittest.cc",
+        "status_test.cc",
+        "statusor_test.cc",
+        "stringpiece_unittest.cc",
+        "stringprintf_unittest.cc",
+        "structurally_valid_unittest.cc",
+        "strutil_unittest.cc",
+        "template_util_unittest.cc",
+        "time_test.cc",
+    ],
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": [
+            "-Wno-deprecated-declarations",
+        ],
+    }),
+    linkopts = LINK_OPTS,
+    deps = [
+        ":lite",
+        ":stubs",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/google/protobuf/testing/BUILD.bazel
+++ b/src/google/protobuf/testing/BUILD.bazel
@@ -2,6 +2,7 @@
 #   This package contains testonly utilities used in C++ unit tests.
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
 
 package(default_visibility = ["//:__subpackages__"])
@@ -26,4 +27,15 @@ cc_library(
         "//src/google/protobuf/stubs:lite",
         "@com_google_googletest//:gtest",
     ],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//pkg:__pkg__"],
 )

--- a/src/google/protobuf/testing/BUILD.bazel
+++ b/src/google/protobuf/testing/BUILD.bazel
@@ -1,0 +1,29 @@
+# Protobuf testing support.
+#   This package contains testonly utilities used in C++ unit tests.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
+
+package(default_visibility = ["//:__subpackages__"])
+
+cc_library(
+    name = "testing",
+    testonly = 1,
+    srcs = [
+        "file.cc",
+        "googletest.cc",
+    ],
+    hdrs = [
+        "file.h",
+        "googletest.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/testing",
+    linkopts = LINK_OPTS,
+    deps = [
+        "//:protobuf_lite",  # for ShutdownProtobufLibrary
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs:lite",
+        "@com_google_googletest//:gtest",
+    ],
+)


### PR DESCRIPTION
This change creates packages under `src/google/protobuf/{io,stubs,testing}` and moves build definitions there. Future changes will handle `.../util` and `.../compiler`, and finally `src/google/protobuf`.