### PR TITLE
[Bazel/C++] Factor out compiler packages.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -82,13 +82,32 @@ cc_library(
 
 cc_library(
     name = "protobuf",
+    hdrs = glob([
+        "src/**/*.h",
+        "src/**/*.inc",
+    ]),
+    copts = COPTS,
+    includes = ["src/"],
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":internal_protobuf_full",
+        "//src/google/protobuf/compiler:importer",
+    ],
+)
+
+# `:internal_protobuf_full` is an internal target which has the non-lite
+# portions of the protobuf runtime.
+#
+# Users of the full runtime should depend upon `:protobuf` instead, which
+# also includes the util library.
+cc_library(
+    name = "internal_protobuf_full",
     srcs = [
         # AUTOGEN(protobuf_srcs)
         "src/google/protobuf/any.cc",
         "src/google/protobuf/any.pb.cc",
         "src/google/protobuf/api.pb.cc",
-        "src/google/protobuf/compiler/importer.cc",
-        "src/google/protobuf/compiler/parser.cc",
         "src/google/protobuf/descriptor.cc",
         "src/google/protobuf/descriptor.pb.cc",
         "src/google/protobuf/descriptor_database.cc",
@@ -140,7 +159,9 @@ cc_library(
     copts = COPTS,
     includes = ["src/"],
     linkopts = LINK_OPTS,
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//:__subpackages__",  # this target is only to break circular deps
+    ],
     deps = [
         ":protobuf_lite",
         "//src/google/protobuf/io",
@@ -184,10 +205,7 @@ filegroup(
 
 filegroup(
     name = "built_in_runtime_protos",
-    srcs = [
-        "src/google/protobuf/compiler/plugin.proto",
-        "src/google/protobuf/descriptor.proto",
-    ],
+    srcs = ["src/google/protobuf/descriptor.proto"],
     visibility = ["//:__subpackages__"],
 )
 
@@ -332,12 +350,10 @@ proto_library(
 
 # Built-in runtime types
 
-proto_library(
+alias(
     name = "compiler_plugin_proto",
-    srcs = ["src/google/protobuf/compiler/plugin.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf/compiler:plugin_proto",
     visibility = ["//visibility:public"],
-    deps = ["//:descriptor_proto"],
 )
 
 proto_library(
@@ -351,107 +367,11 @@ proto_library(
 # Protocol Buffers Compiler
 ################################################################################
 
-cc_library(
-    name = "protoc_lib",
-    srcs = [
-        # AUTOGEN(protoc_lib_srcs)
-        "src/google/protobuf/compiler/code_generator.cc",
-        "src/google/protobuf/compiler/command_line_interface.cc",
-        "src/google/protobuf/compiler/cpp/enum.cc",
-        "src/google/protobuf/compiler/cpp/enum_field.cc",
-        "src/google/protobuf/compiler/cpp/extension.cc",
-        "src/google/protobuf/compiler/cpp/field.cc",
-        "src/google/protobuf/compiler/cpp/file.cc",
-        "src/google/protobuf/compiler/cpp/generator.cc",
-        "src/google/protobuf/compiler/cpp/helpers.cc",
-        "src/google/protobuf/compiler/cpp/map_field.cc",
-        "src/google/protobuf/compiler/cpp/message.cc",
-        "src/google/protobuf/compiler/cpp/message_field.cc",
-        "src/google/protobuf/compiler/cpp/padding_optimizer.cc",
-        "src/google/protobuf/compiler/cpp/parse_function_generator.cc",
-        "src/google/protobuf/compiler/cpp/primitive_field.cc",
-        "src/google/protobuf/compiler/cpp/service.cc",
-        "src/google/protobuf/compiler/cpp/string_field.cc",
-        "src/google/protobuf/compiler/csharp/csharp_doc_comment.cc",
-        "src/google/protobuf/compiler/csharp/csharp_enum.cc",
-        "src/google/protobuf/compiler/csharp/csharp_enum_field.cc",
-        "src/google/protobuf/compiler/csharp/csharp_field_base.cc",
-        "src/google/protobuf/compiler/csharp/csharp_generator.cc",
-        "src/google/protobuf/compiler/csharp/csharp_helpers.cc",
-        "src/google/protobuf/compiler/csharp/csharp_map_field.cc",
-        "src/google/protobuf/compiler/csharp/csharp_message.cc",
-        "src/google/protobuf/compiler/csharp/csharp_message_field.cc",
-        "src/google/protobuf/compiler/csharp/csharp_primitive_field.cc",
-        "src/google/protobuf/compiler/csharp/csharp_reflection_class.cc",
-        "src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc",
-        "src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc",
-        "src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc",
-        "src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc",
-        "src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc",
-        "src/google/protobuf/compiler/java/context.cc",
-        "src/google/protobuf/compiler/java/doc_comment.cc",
-        "src/google/protobuf/compiler/java/enum.cc",
-        "src/google/protobuf/compiler/java/enum_field.cc",
-        "src/google/protobuf/compiler/java/enum_field_lite.cc",
-        "src/google/protobuf/compiler/java/enum_lite.cc",
-        "src/google/protobuf/compiler/java/extension.cc",
-        "src/google/protobuf/compiler/java/extension_lite.cc",
-        "src/google/protobuf/compiler/java/field.cc",
-        "src/google/protobuf/compiler/java/file.cc",
-        "src/google/protobuf/compiler/java/generator.cc",
-        "src/google/protobuf/compiler/java/generator_factory.cc",
-        "src/google/protobuf/compiler/java/helpers.cc",
-        "src/google/protobuf/compiler/java/kotlin_generator.cc",
-        "src/google/protobuf/compiler/java/map_field.cc",
-        "src/google/protobuf/compiler/java/map_field_lite.cc",
-        "src/google/protobuf/compiler/java/message.cc",
-        "src/google/protobuf/compiler/java/message_builder.cc",
-        "src/google/protobuf/compiler/java/message_builder_lite.cc",
-        "src/google/protobuf/compiler/java/message_field.cc",
-        "src/google/protobuf/compiler/java/message_field_lite.cc",
-        "src/google/protobuf/compiler/java/message_lite.cc",
-        "src/google/protobuf/compiler/java/name_resolver.cc",
-        "src/google/protobuf/compiler/java/primitive_field.cc",
-        "src/google/protobuf/compiler/java/primitive_field_lite.cc",
-        "src/google/protobuf/compiler/java/service.cc",
-        "src/google/protobuf/compiler/java/shared_code_generator.cc",
-        "src/google/protobuf/compiler/java/string_field.cc",
-        "src/google/protobuf/compiler/java/string_field_lite.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_enum.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_extension.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_field.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_file.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_generator.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_helpers.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_map_field.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_message.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_message_field.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_oneof.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc",
-        "src/google/protobuf/compiler/php/php_generator.cc",
-        "src/google/protobuf/compiler/plugin.cc",
-        "src/google/protobuf/compiler/plugin.pb.cc",
-        "src/google/protobuf/compiler/python/generator.cc",
-        "src/google/protobuf/compiler/python/helpers.cc",
-        "src/google/protobuf/compiler/python/pyi_generator.cc",
-        "src/google/protobuf/compiler/ruby/ruby_generator.cc",
-        "src/google/protobuf/compiler/subprocess.cc",
-        "src/google/protobuf/compiler/zip_writer.cc",
-    ],
-    copts = COPTS,
-    includes = ["src/"],
-    linkopts = LINK_OPTS,
-    visibility = ["//visibility:public"],
-    deps = [":protobuf"],
-)
-
 cc_binary(
     name = "protoc",
-    srcs = ["src/google/protobuf/compiler/main.cc"],
     linkopts = LINK_OPTS,
     visibility = ["//visibility:public"],
-    deps = [":protoc_lib"],
+    deps = ["//src/google/protobuf/compiler:protoc_lib"],
 )
 
 ################################################################################
@@ -502,8 +422,6 @@ proto_library(
 RELATIVE_TEST_PROTOS = [
     # AUTOGEN(test_protos)
     "google/protobuf/any_test.proto",
-    "google/protobuf/compiler/cpp/test_bad_identifiers.proto",
-    "google/protobuf/compiler/cpp/test_large_enum_value.proto",
     "google/protobuf/map_proto2_unittest.proto",
     "google/protobuf/map_unittest.proto",
     "google/protobuf/unittest.proto",
@@ -634,63 +552,61 @@ cc_proto_library(
 
 cc_proto_library(
     name = "cc_test_protos",
+    visibility = ["//src/google/protobuf/compiler:__subpackages__"],
     deps = [":test_protos"],
 )
 
-COMMON_TEST_SRCS = [
-    # AUTOGEN(common_test_srcs)
-    "src/google/protobuf/arena_test_util.cc",
-    "src/google/protobuf/map_lite_test_util.cc",
-    "src/google/protobuf/test_util_lite.cc",
-    "src/google/protobuf/map_test_util.inc",
-    "src/google/protobuf/reflection_tester.cc",
-    "src/google/protobuf/test_util.cc",
-    "src/google/protobuf/test_util.inc",
-]
+filegroup(
+    name = "descriptor_cc_srcs",
+    testonly = 1,
+    data = [
+        "src/google/protobuf/descriptor.pb.cc",
+        "src/google/protobuf/descriptor.pb.h",
+    ],
+    visibility = ["//src/google/protobuf/compiler/cpp:__pkg__"],
+)
 
-cc_binary(
-    name = "test_plugin",
-    testonly = True,
+cc_library(
+    name = "test_util",
+    testonly = 1,
     srcs = [
-        # AUTOGEN(test_plugin_srcs)
-        "src/google/protobuf/compiler/mock_code_generator.cc",
-        "src/google/protobuf/compiler/test_plugin.cc",
+        "src/google/protobuf/arena_test_util.cc",
+        "src/google/protobuf/map_lite_test_util.cc",
+        "src/google/protobuf/reflection_tester.cc",
+        "src/google/protobuf/test_util.cc",
+        "src/google/protobuf/test_util_lite.cc",
+    ],
+    hdrs = [
+        "src/google/protobuf/arena_test_util.h",
+        "src/google/protobuf/map_lite_test_util.h",
+        "src/google/protobuf/map_test_util.h",
+        "src/google/protobuf/map_test_util_impl.h",
+        "src/google/protobuf/test_util.h",
+        "src/google/protobuf/test_util2.h",
+        "src/google/protobuf/test_util_lite.h",
     ],
     copts = COPTS,
+    includes = ["src"],
+    textual_hdrs = [
+        "src/google/protobuf/map_test_util.inc",
+        "src/google/protobuf/test_util.inc",
+    ],
+    visibility = ["//:__subpackages__"],
     deps = [
-        ":protobuf",
-        ":protoc_lib",
-        "//src/google/protobuf/testing",
+        ":cc_lite_test_protos",
+        ":cc_test_protos",
         "@com_google_googletest//:gtest",
     ],
 )
 
 cc_test(
     name = "protobuf_test",
-    srcs = COMMON_TEST_SRCS + [
+    srcs = [
         # AUTOGEN(test_srcs)
         "src/google/protobuf/any_test.cc",
         "src/google/protobuf/arena_unittest.cc",
         "src/google/protobuf/arenastring_unittest.cc",
         "src/google/protobuf/arenaz_sampler_test.cc",
-        "src/google/protobuf/compiler/annotation_test_util.cc",
-        "src/google/protobuf/compiler/command_line_interface_unittest.cc",
-        "src/google/protobuf/compiler/cpp/bootstrap_unittest.cc",
-        "src/google/protobuf/compiler/cpp/metadata_test.cc",
-        "src/google/protobuf/compiler/cpp/move_unittest.cc",
-        "src/google/protobuf/compiler/cpp/plugin_unittest.cc",
-        "src/google/protobuf/compiler/cpp/unittest.cc",
-        "src/google/protobuf/compiler/cpp/unittest.inc",
-        "src/google/protobuf/compiler/csharp/csharp_bootstrap_unittest.cc",
-        "src/google/protobuf/compiler/csharp/csharp_generator_unittest.cc",
-        "src/google/protobuf/compiler/importer_unittest.cc",
-        "src/google/protobuf/compiler/java/doc_comment_unittest.cc",
-        "src/google/protobuf/compiler/java/plugin_unittest.cc",
-        "src/google/protobuf/compiler/mock_code_generator.cc",
-        "src/google/protobuf/compiler/objectivec/objectivec_helpers_unittest.cc",
-        "src/google/protobuf/compiler/parser_unittest.cc",
-        "src/google/protobuf/compiler/python/plugin_unittest.cc",
-        "src/google/protobuf/compiler/ruby/ruby_generator_unittest.cc",
         "src/google/protobuf/descriptor_database_unittest.cc",
         "src/google/protobuf/descriptor_unittest.cc",
         "src/google/protobuf/drop_unknown_fields_test.cc",
@@ -739,9 +655,6 @@ cc_test(
         ],
     }),
     data = [
-        # Files for csharp_bootstrap_unittest.cc.
-        "//conformance:all_files",
-        ":test_plugin",
         ":testdata",
     ] + glob([
         "src/google/protobuf/**/*",
@@ -760,7 +673,7 @@ cc_test(
         ":cc_lite_test_protos",
         ":cc_test_protos",
         ":protobuf",
-        ":protoc_lib",
+        ":test_util",
         "//src/google/protobuf/testing",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -143,7 +143,7 @@ java_binary(
 filegroup(
     name = "all_files",
     srcs = glob(["**/*"]),
-    visibility = ["//:__pkg__"],
+    visibility = ["//src/google/protobuf/compiler/csharp:__pkg__"],
 )
 
 pkg_files(

--- a/csharp/BUILD.bazel
+++ b/csharp/BUILD.bazel
@@ -4,6 +4,25 @@
 
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 
+filegroup(
+    name = "wkt_cs_srcs",
+    data = [
+        "src/Google.Protobuf.Conformance/Conformance.cs",
+        "src/Google.Protobuf/Reflection/Descriptor.cs",
+        "src/Google.Protobuf/WellKnownTypes/Any.cs",
+        "src/Google.Protobuf/WellKnownTypes/Api.cs",
+        "src/Google.Protobuf/WellKnownTypes/Duration.cs",
+        "src/Google.Protobuf/WellKnownTypes/Empty.cs",
+        "src/Google.Protobuf/WellKnownTypes/FieldMask.cs",
+        "src/Google.Protobuf/WellKnownTypes/SourceContext.cs",
+        "src/Google.Protobuf/WellKnownTypes/Struct.cs",
+        "src/Google.Protobuf/WellKnownTypes/Timestamp.cs",
+        "src/Google.Protobuf/WellKnownTypes/Type.cs",
+        "src/Google.Protobuf/WellKnownTypes/Wrappers.cs",
+    ],
+    visibility = ["//src/google/protobuf/compiler/csharp:__pkg__"],
+)
+
 pkg_files(
     name = "dist_files",
     srcs = glob([

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -320,7 +320,7 @@ gen_file_lists(
     src_libs = {
         # source rule: name in generated file
         "//:protobuf": "libprotobuf",
-        "//:protoc_lib": "libprotoc",
+        "//src/google/protobuf/compiler:protoc_lib": "libprotoc",
         "//:protobuf_lite": "libprotobuf_lite",
     },
 )

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -105,10 +105,11 @@ pkg_filegroup(
     srcs = [
         ":dist_files",
         "//:common_dist_files",
-        "//:cpp_dist_files",  # to build protoc
+        "//:cpp_dist_files",
         "//benchmarks:all_dist_files",
         "//build_defs:dist_files",
         "//conformance:all_dist_files",
+        "//src/google/protobuf/compiler:all_dist_files",
         "//src/google/protobuf/io:dist_files",
         "//src/google/protobuf/stubs:dist_files",
         "//src/google/protobuf/testing:dist_files",
@@ -121,6 +122,7 @@ pkg_filegroup(
     srcs = [
         ":dist_common",
         "//:cpp_dist_files",
+        "//src/google/protobuf/compiler:all_dist_files",
     ],
 )
 

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -387,6 +387,7 @@ cc_dist_library(
         "//:arena",
         "//:protobuf",
         "//:protobuf_lite",
+        "//src/google/protobuf/compiler:importer",
         "//src/google/protobuf/io",
         "//src/google/protobuf/io:gzip_stream",
         "//src/google/protobuf/io:io_win32",

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -41,13 +41,6 @@ pkg_files(
     visibility = ["//visibility:private"],
 )
 
-pkg_files(
-    name = "compiler_plugin_protos_files",
-    srcs = ["//:compiler_plugin_proto"],
-    prefix = "include/google/protobuf/compiler",
-    visibility = ["//visibility:private"],
-)
-
 ################################################################################
 # Generates protoc release artifacts.
 ################################################################################
@@ -83,11 +76,11 @@ pkg_files(
 pkg_zip(
     name = "protoc_release",
     srcs = [
-        ":compiler_plugin_protos_files",
         ":descriptor_protos_files",
         ":protoc_files",
         ":protoc_readme",
         ":wkt_protos_files",
+        "//src/google/protobuf/compiler:compiler_plugin_protos_files",
     ],
     package_file_name = "protoc-{version}-{platform}.zip",
     package_variables = ":protobuf_pkg_naming",
@@ -98,7 +91,6 @@ pkg_zip(
 #
 # TODO: these will eventually replace autotools for release artifact packaging.
 ################################################################################
-
 
 pkg_filegroup(
     name = "dist_common",

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -541,7 +541,15 @@ protoc_inputs =                                                   \
 EXTRA_DIST =                                                   \
   $(protoc_inputs)                                             \
   README.md                                                    \
+  google/protobuf/compiler/BUILD.bazel                         \
+  google/protobuf/compiler/cpp/BUILD.bazel                     \
+  google/protobuf/compiler/csharp/BUILD.bazel                  \
+  google/protobuf/compiler/java/BUILD.bazel                    \
+  google/protobuf/compiler/objectivec/BUILD.bazel              \
   google/protobuf/compiler/package_info.h                      \
+  google/protobuf/compiler/php/BUILD.bazel                     \
+  google/protobuf/compiler/python/BUILD.bazel                  \
+  google/protobuf/compiler/ruby/BUILD.bazel                    \
   google/protobuf/compiler/ruby/ruby_generated_code.proto      \
   google/protobuf/compiler/ruby/ruby_generated_code_pb.rb      \
   google/protobuf/compiler/ruby/ruby_generated_code_proto2.proto \

--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -1,0 +1,308 @@
+################################################################################
+# Protocol Buffers Compiler
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load(
+    "@rules_pkg//:mappings.bzl",
+    "pkg_attributes",
+    "pkg_filegroup",
+    "pkg_files",
+    "strip_prefix",
+)
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
+proto_library(
+    name = "plugin_proto",
+    srcs = ["plugin.proto"],
+    visibility = ["//:__pkg__"],
+    deps = ["//:descriptor_proto"],
+)
+
+cc_library(
+    name = "importer",
+    srcs = [
+        "importer.cc",
+        "parser.cc",
+    ],
+    hdrs = [
+        "importer.h",
+        "parser.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/compiler",
+    visibility = ["//visibility:public"],
+    deps = ["//:internal_protobuf_full"],
+)
+
+cc_library(
+    name = "code_generator",
+    srcs = [
+        "code_generator.cc",
+        "plugin.cc",
+        "plugin.pb.cc",
+    ],
+    hdrs = [
+        "code_generator.h",
+        "plugin.h",
+        "plugin.pb.h",
+        "scc.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/compiler",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:protobuf",
+    ],
+)
+
+cc_library(
+    name = "command_line_interface",
+    srcs = [
+        "command_line_interface.cc",
+        "subprocess.cc",
+        "zip_writer.cc",
+    ],
+    hdrs = [
+        "command_line_interface.h",
+        "subprocess.h",
+        "zip_writer.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/compiler",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":code_generator",
+        ":importer",
+        "//:protobuf",
+    ],
+)
+
+cc_library(
+    name = "protoc_lib",
+    srcs = [
+        "main.cc",
+    ],
+    copts = COPTS,
+    visibility = [
+        "//:__pkg__",
+        "//pkg:__pkg__",
+    ],
+    deps = [
+        ":code_generator",
+        ":command_line_interface",
+        ":importer",
+        "//:protobuf",
+        "//src/google/protobuf/compiler/cpp",
+        "//src/google/protobuf/compiler/csharp",
+        "//src/google/protobuf/compiler/java",
+        "//src/google/protobuf/compiler/objectivec",
+        "//src/google/protobuf/compiler/php",
+        "//src/google/protobuf/compiler/python",
+        "//src/google/protobuf/compiler/ruby",
+    ],
+)
+
+# Note: this is an alias for now. In the future, this rule will become the
+# cc_binary for protoc, and //:protoc will become an alias.
+alias(
+    name = "protoc",
+    actual = "//:protoc",
+    visibility = ["//visibility:public"],
+)
+
+################################################################################
+# Tests and support libraries
+################################################################################
+
+cc_library(
+    name = "annotation_test_util",
+    testonly = 1,
+    srcs = ["annotation_test_util.cc"],
+    hdrs = ["annotation_test_util.h"],
+    copts = COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":code_generator",
+        ":command_line_interface",
+        "//:protobuf",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/testing",
+    ],
+)
+
+################################################################################
+# Tests
+################################################################################
+
+filegroup(
+    name = "plugin_proto_srcs",
+    testonly = 1,
+    srcs = [
+        "plugin.pb.cc",
+        "plugin.pb.h",
+        "plugin.proto",
+    ],
+    visibility = [
+        "//src/google/protobuf/compiler/cpp:__pkg__",
+    ],
+)
+
+cc_library(
+    name = "mock_code_generator",
+    testonly = 1,
+    srcs = ["mock_code_generator.cc"],
+    hdrs = ["mock_code_generator.h"],
+    copts = COPTS,
+    deps = [
+        ":code_generator",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/testing",
+    ],
+)
+
+cc_binary(
+    name = "test_plugin",
+    testonly = 1,
+    srcs = ["test_plugin.cc"],
+    copts = COPTS,
+    deps = [
+        ":code_generator",
+        ":mock_code_generator",
+    ],
+)
+
+cc_test(
+    name = "command_line_interface_unittest",
+    srcs = ["command_line_interface_unittest.cc"],
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": [
+            "-Wno-deprecated",
+            "-Wno-deprecated-declarations",
+        ],
+    }) + [
+        "-DGOOGLE_PROTOBUF_TEST_PLUGIN_PATH=\\\"src/google/protobuf/compiler/test_plugin\\\"",
+    ],
+    data = [
+        ":test_plugin",
+        "//:test_proto_srcs",
+        "//:testdata",
+    ],
+    deps = [
+        ":code_generator",
+        ":command_line_interface",
+        ":mock_code_generator",
+        "//:cc_test_protos",
+        "//:protobuf",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "importer_unittest",
+    srcs = ["importer_unittest.cc"],
+    copts = COPTS,
+    deps = [
+        ":importer",
+        "//:protobuf",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "parser_unittest",
+    srcs = ["parser_unittest.cc"],
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": [
+            "-Wno-deprecated",
+            "-Wno-deprecated-declarations",
+        ],
+    }),
+    deps = [
+        ":importer",
+        "//:cc_test_protos",
+        "//:protobuf",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+################################################################################
+# Generates protoc release artifacts.
+################################################################################
+
+genrule(
+    name = "protoc_readme",
+    outs = ["readme.txt"],
+    cmd = """
+echo "Protocol Buffers - Google's data interchange format
+Copyright 2008 Google Inc.
+https://developers.google.com/protocol-buffers/
+This package contains a precompiled binary version of the protocol buffer
+compiler (protoc). This binary is intended for users who want to use Protocol
+Buffers in languages other than C++ but do not want to compile protoc
+themselves. To install, simply place this binary somewhere in your PATH.
+If you intend to use the included well known types then don't forget to
+copy the contents of the 'include' directory somewhere as well, for example
+into '/usr/local/include/'.
+Please refer to our official github site for more installation instructions:
+  https://github.com/protocolbuffers/protobuf" > $@
+    """,
+    visibility = ["//:__pkg__"],
+)
+
+pkg_files(
+    name = "compiler_plugin_protos_files",
+    srcs = ["plugin.proto"],
+    prefix = "include/google/protobuf/compiler",
+    visibility = ["//:__pkg__"],
+)
+
+pkg_files(
+    name = "protoc_files",
+    srcs = [":protoc"],
+    attributes = pkg_attributes(mode = "0555"),
+    prefix = "bin/",
+    visibility = ["//:__pkg__"],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+)
+
+# Convenience pkg_filegroup: includes all code generators.
+pkg_filegroup(
+    name = "all_dist_files",
+    srcs = [
+        ":dist_files",
+        "//src/google/protobuf/compiler/cpp:dist_files",
+        "//src/google/protobuf/compiler/csharp:dist_files",
+        "//src/google/protobuf/compiler/java:dist_files",
+        "//src/google/protobuf/compiler/objectivec:dist_files",
+        "//src/google/protobuf/compiler/php:dist_files",
+        "//src/google/protobuf/compiler/python:dist_files",
+        "//src/google/protobuf/compiler/ruby:dist_files",
+    ],
+    visibility = ["//pkg:__pkg__"],
+)

--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -270,7 +270,7 @@ pkg_files(
     name = "compiler_plugin_protos_files",
     srcs = ["plugin.proto"],
     prefix = "include/google/protobuf/compiler",
-    visibility = ["//:__pkg__"],
+    visibility = ["//pkg:__pkg__"],
 )
 
 pkg_files(

--- a/src/google/protobuf/compiler/cpp/BUILD.bazel
+++ b/src/google/protobuf/compiler/cpp/BUILD.bazel
@@ -1,0 +1,190 @@
+################################################################################
+# Protocol Buffers Compiler - C++ code generator
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
+cc_library(
+    name = "cpp",
+    srcs = [
+        "enum.cc",
+        "enum_field.cc",
+        "extension.cc",
+        "field.cc",
+        "file.cc",
+        "generator.cc",
+        "helpers.cc",
+        "map_field.cc",
+        "message.cc",
+        "message_field.cc",
+        "padding_optimizer.cc",
+        "parse_function_generator.cc",
+        "primitive_field.cc",
+        "service.cc",
+        "string_field.cc",
+    ],
+    hdrs = [
+        "enum.h",
+        "enum_field.h",
+        "extension.h",
+        "field.h",
+        "file.h",
+        "generator.h",
+        "helpers.h",
+        "map_field.h",
+        "message.h",
+        "message_field.h",
+        "message_layout_helper.h",
+        "names.h",
+        "options.h",
+        "padding_optimizer.h",
+        "parse_function_generator.h",
+        "primitive_field.h",
+        "service.h",
+        "string_field.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/compiler/cpp",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    deps = [
+        "//:protobuf",
+        "//src/google/protobuf/compiler:code_generator",
+    ],
+)
+
+proto_library(
+    name = "test_bad_identifiers_proto",
+    testonly = 1,
+    srcs = ["test_bad_identifiers.proto"],
+    strip_import_prefix = "/src",
+)
+
+cc_proto_library(
+    name = "test_bad_identifiers_cc_proto",
+    testonly = 1,
+    deps = [":test_bad_identifiers_proto"],
+)
+
+proto_library(
+    name = "test_large_enum_value_proto",
+    testonly = 1,
+    srcs = ["test_large_enum_value.proto"],
+    strip_import_prefix = "/src",
+)
+
+cc_proto_library(
+    name = "test_large_enum_value_cc_proto",
+    testonly = 1,
+    deps = [":test_large_enum_value_proto"],
+)
+
+cc_test(
+    name = "unittest",
+    srcs = [
+        "unittest.cc",
+        "unittest.h",
+        "unittest.inc",
+    ],
+    data = [
+        "//:test_proto_srcs",
+        "//:testdata",
+    ],
+    deps = [
+        ":cpp",
+        ":test_bad_identifiers_cc_proto",
+        "//:cc_test_protos",
+        "//:protobuf",
+        "//src/google/protobuf/compiler:importer",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "bootstrap_unittest",
+    srcs = ["bootstrap_unittest.cc"],
+    data = [
+        "//:built_in_runtime_protos",
+        "//:descriptor_cc_srcs",
+        "//:testdata",
+        "//:well_known_type_protos",
+        "//src/google/protobuf/compiler:plugin_proto_srcs",
+    ],
+    deps = [
+        ":cpp",
+        "//:protobuf",
+        "//src/google/protobuf/compiler:importer",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "message_size_unittest",
+    srcs = ["message_size_unittest.cc"],
+    deps = [
+        "//:cc_test_protos",
+        "//:protobuf",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "metadata_test",
+    srcs = ["metadata_test.cc"],
+    deps = [
+        ":cpp",
+        "//:protobuf",
+        "//src/google/protobuf/compiler:annotation_test_util",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "move_unittest",
+    srcs = ["move_unittest.cc"],
+    deps = [
+        "//:cc_test_protos",
+        "//:protobuf",
+        "//:test_util",
+        "//src/google/protobuf/stubs:lite",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "plugin_unittest",
+    srcs = ["plugin_unittest.cc"],
+    deps = [
+        ":cpp",
+        "//:protobuf",
+        "//src/google/protobuf/compiler:command_line_interface",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/csharp/BUILD.bazel
+++ b/src/google/protobuf/compiler/csharp/BUILD.bazel
@@ -1,0 +1,106 @@
+################################################################################
+# Protocol Buffers Compiler - C# code generator
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
+cc_library(
+    name = "csharp",
+    srcs = [
+        "csharp_doc_comment.cc",
+        "csharp_enum.cc",
+        "csharp_enum_field.cc",
+        "csharp_field_base.cc",
+        "csharp_generator.cc",
+        "csharp_helpers.cc",
+        "csharp_map_field.cc",
+        "csharp_message.cc",
+        "csharp_message_field.cc",
+        "csharp_primitive_field.cc",
+        "csharp_reflection_class.cc",
+        "csharp_repeated_enum_field.cc",
+        "csharp_repeated_message_field.cc",
+        "csharp_repeated_primitive_field.cc",
+        "csharp_source_generator_base.cc",
+        "csharp_wrapper_field.cc",
+    ],
+    hdrs = [
+        "csharp_doc_comment.h",
+        "csharp_enum.h",
+        "csharp_enum_field.h",
+        "csharp_field_base.h",
+        "csharp_generator.h",
+        "csharp_helpers.h",
+        "csharp_map_field.h",
+        "csharp_message.h",
+        "csharp_message_field.h",
+        "csharp_names.h",
+        "csharp_options.h",
+        "csharp_primitive_field.h",
+        "csharp_reflection_class.h",
+        "csharp_repeated_enum_field.h",
+        "csharp_repeated_message_field.h",
+        "csharp_repeated_primitive_field.h",
+        "csharp_source_generator_base.h",
+        "csharp_wrapper_field.h",
+    ],
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": ["-Wno-overloaded-virtual"],
+    }),
+    include_prefix = "google/protobuf/compiler/csharp",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    deps = [
+        "//:protobuf",
+        "//src/google/protobuf/compiler:code_generator",
+    ],
+)
+
+cc_test(
+    name = "bootstrap_unittest",
+    srcs = ["csharp_bootstrap_unittest.cc"],
+    data = [
+        "//:built_in_runtime_protos",
+        "//:testdata",
+        "//:well_known_type_protos",
+        "//conformance:all_files",
+        "//conformance:conformance_proto",
+        "//csharp:wkt_cs_srcs",
+    ],
+    deps = [
+        ":csharp",
+        "//:protobuf",
+        "//src/google/protobuf/compiler:importer",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "generator_unittest",
+    srcs = ["csharp_generator_unittest.cc"],
+    deps = [
+        ":csharp",
+        "//:protobuf",
+        "//src/google/protobuf/compiler:command_line_interface",
+        "//src/google/protobuf/io",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/java/BUILD.bazel
+++ b/src/google/protobuf/compiler/java/BUILD.bazel
@@ -1,0 +1,123 @@
+################################################################################
+# Protocol Buffers Compiler - Java code generator
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
+cc_library(
+    name = "java",
+    srcs = [
+        "context.cc",
+        "doc_comment.cc",
+        "enum.cc",
+        "enum_field.cc",
+        "enum_field_lite.cc",
+        "enum_lite.cc",
+        "extension.cc",
+        "extension_lite.cc",
+        "field.cc",
+        "file.cc",
+        "generator.cc",
+        "generator_factory.cc",
+        "helpers.cc",
+        "kotlin_generator.cc",
+        "map_field.cc",
+        "map_field_lite.cc",
+        "message.cc",
+        "message_builder.cc",
+        "message_builder_lite.cc",
+        "message_field.cc",
+        "message_field_lite.cc",
+        "message_lite.cc",
+        "name_resolver.cc",
+        "primitive_field.cc",
+        "primitive_field_lite.cc",
+        "service.cc",
+        "shared_code_generator.cc",
+        "string_field.cc",
+        "string_field_lite.cc",
+    ],
+    hdrs = [
+        "context.h",
+        "doc_comment.h",
+        "enum.h",
+        "enum_field.h",
+        "enum_field_lite.h",
+        "enum_lite.h",
+        "extension.h",
+        "extension_lite.h",
+        "field.h",
+        "file.h",
+        "generator.h",
+        "generator_factory.h",
+        "helpers.h",
+        "kotlin_generator.h",
+        "map_field.h",
+        "map_field_lite.h",
+        "message.h",
+        "message_builder.h",
+        "message_builder_lite.h",
+        "message_field.h",
+        "message_field_lite.h",
+        "message_lite.h",
+        "name_resolver.h",
+        "names.h",
+        "options.h",
+        "primitive_field.h",
+        "primitive_field_lite.h",
+        "service.h",
+        "shared_code_generator.h",
+        "string_field.h",
+        "string_field_lite.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/compiler/java",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    deps = [
+        "//:protobuf",
+        "//src/google/protobuf/compiler:code_generator",
+    ],
+)
+
+cc_test(
+    name = "doc_comment_unittest",
+    srcs = ["doc_comment_unittest.cc"],
+    data = [
+        "//:built_in_runtime_protos",
+        "//:well_known_type_protos",
+        "//conformance:conformance_proto",
+    ],
+    deps = [
+        ":java",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "plugin_unittest",
+    srcs = ["plugin_unittest.cc"],
+    deps = [
+        ":java",
+        "//:protobuf",
+        "//src/google/protobuf/compiler:command_line_interface",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs:lite",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/objectivec/BUILD.bazel
+++ b/src/google/protobuf/compiler/objectivec/BUILD.bazel
@@ -1,0 +1,69 @@
+################################################################################
+# Protocol Buffers Compiler - ObjC code generator
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
+cc_library(
+    name = "objectivec",
+    srcs = [
+        "objectivec_enum.cc",
+        "objectivec_enum_field.cc",
+        "objectivec_extension.cc",
+        "objectivec_field.cc",
+        "objectivec_file.cc",
+        "objectivec_generator.cc",
+        "objectivec_helpers.cc",
+        "objectivec_map_field.cc",
+        "objectivec_message.cc",
+        "objectivec_message_field.cc",
+        "objectivec_oneof.cc",
+        "objectivec_primitive_field.cc",
+    ],
+    hdrs = [
+        "objectivec_enum.h",
+        "objectivec_enum_field.h",
+        "objectivec_extension.h",
+        "objectivec_field.h",
+        "objectivec_file.h",
+        "objectivec_generator.h",
+        "objectivec_helpers.h",
+        "objectivec_map_field.h",
+        "objectivec_message.h",
+        "objectivec_message_field.h",
+        "objectivec_nsobject_methods.h",
+        "objectivec_oneof.h",
+        "objectivec_primitive_field.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/compiler/objectivec",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    deps = [
+        "//:protobuf",
+        "//src/google/protobuf/compiler:code_generator",
+    ],
+)
+
+cc_test(
+    name = "helpers_unittest",
+    srcs = ["objectivec_helpers_unittest.cc"],
+    deps = [
+        ":objectivec",
+        "//src/google/protobuf/io",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/php/BUILD.bazel
+++ b/src/google/protobuf/compiler/php/BUILD.bazel
@@ -1,0 +1,31 @@
+################################################################################
+# Protocol Buffers Compiler - PHP code generator
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
+cc_library(
+    name = "php",
+    srcs = ["php_generator.cc"],
+    hdrs = ["php_generator.h"],
+    copts = COPTS,
+    include_prefix = "google/protobuf/compiler/php",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    deps = [
+        "//:protobuf",
+        "//src/google/protobuf/compiler:code_generator",
+    ],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/python/BUILD.bazel
+++ b/src/google/protobuf/compiler/python/BUILD.bazel
@@ -1,0 +1,53 @@
+################################################################################
+# Protocol Buffers Compiler - Python code generator
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
+cc_library(
+    name = "python",
+    srcs = [
+        "generator.cc",
+        "helpers.cc",
+        "pyi_generator.cc",
+    ],
+    hdrs = [
+        "generator.h",
+        "helpers.h",
+        "pyi_generator.h",
+    ],
+    copts = COPTS,
+    include_prefix = "google/protobuf/compiler/python",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    deps = [
+        "//:protobuf",
+        "//src/google/protobuf/compiler:code_generator",
+    ],
+)
+
+cc_test(
+    name = "plugin_unittest",
+    srcs = ["plugin_unittest.cc"],
+    copts = COPTS,
+    deps = [
+        ":python",
+        "//src/google/protobuf/compiler:command_line_interface",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/ruby/BUILD.bazel
+++ b/src/google/protobuf/compiler/ruby/BUILD.bazel
@@ -1,0 +1,58 @@
+################################################################################
+# Protocol Buffers Compiler - Ruby code generator
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
+cc_library(
+    name = "ruby",
+    srcs = ["ruby_generator.cc"],
+    hdrs = ["ruby_generator.h"],
+    copts = COPTS,
+    include_prefix = "google/protobuf/compiler/ruby",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    deps = [
+        "//:protobuf",
+        "//src/google/protobuf/compiler:code_generator",
+    ],
+)
+
+cc_test(
+    name = "generator_unittest",
+    srcs = ["ruby_generator_unittest.cc"],
+    data = [
+        "ruby_generated_code.proto",
+        "ruby_generated_code_pb.rb",
+        "ruby_generated_code_proto2.proto",
+        "ruby_generated_code_proto2_import.proto",
+        "ruby_generated_code_proto2_pb.rb",
+        "ruby_generated_pkg_explicit.proto",
+        "ruby_generated_pkg_explicit_legacy.proto",
+        "ruby_generated_pkg_explicit_legacy_pb.rb",
+        "ruby_generated_pkg_explicit_pb.rb",
+        "ruby_generated_pkg_implicit.proto",
+        "ruby_generated_pkg_implicit_pb.rb",
+        "//:testdata",
+    ],
+    deps = [
+        ":ruby",
+        "//src/google/protobuf/compiler:command_line_interface",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)


### PR DESCRIPTION
This change adds packages for protoc sources under src/google/protobuf/compiler (this is similar to what was done in #9980).