### PR TITLE
[Bazel/C++] Factor out util library

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,6 +31,11 @@ cc_library(
     visibility = ["//:__subpackages__"],
 )
 
+# Protobuf runtime: this is the primary C++ public target.
+#
+# Users of generated protobuf code (i.e. `#include "path/to/header.pb.h"`)
+# or Protobuf public APIs should use this target or `:protobuf_lite` (see
+# caveats below for the "lite" runtime).
 cc_library(
     name = "arena",
     srcs = [
@@ -45,6 +50,15 @@ cc_library(
     ],
 )
 
+# The "lite" runtime works for .proto files that specify the option:
+#     optimize_for = LITE_RUNTIME;
+#
+# The lite runtime does not include the `Reflection` APIs (including
+# `Descriptor` and related types) or Well-Known Types.
+#
+# See also:
+#     https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#message
+#     https://developers.google.com/protocol-buffers/docs/reference/google.protobuf
 cc_library(
     name = "protobuf_lite",
     srcs = [
@@ -73,6 +87,7 @@ cc_library(
     includes = ["src/"],
     linkopts = LINK_OPTS,
     visibility = ["//visibility:public"],
+    # In Bazel 6.0+, these will be `interface_deps`:
     deps = [
         ":arena",
         "//src/google/protobuf/io",
@@ -80,6 +95,11 @@ cc_library(
     ],
 )
 
+# `:internal_protobuf_full` is an internal target which has the non-lite
+# portions of the protobuf runtime.
+#
+# Users of the full runtime should depend upon `:protobuf` instead, which
+# also includes the util library.
 cc_library(
     name = "protobuf",
     hdrs = glob([
@@ -92,7 +112,14 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":internal_protobuf_full",
+        # Other targets which depend on ':internal_protobuf_full':
         "//src/google/protobuf/compiler:importer",
+        "//src/google/protobuf/util:delimited_message_util",
+        "//src/google/protobuf/util:differencer",
+        "//src/google/protobuf/util:field_mask_util",
+        "//src/google/protobuf/util:json_util",
+        "//src/google/protobuf/util:time_util",
+        "//src/google/protobuf/util:type_resolver_util",
     ],
 )
 
@@ -129,26 +156,6 @@ cc_library(
         "src/google/protobuf/timestamp.pb.cc",
         "src/google/protobuf/type.pb.cc",
         "src/google/protobuf/unknown_field_set.cc",
-        "src/google/protobuf/util/delimited_message_util.cc",
-        "src/google/protobuf/util/field_comparator.cc",
-        "src/google/protobuf/util/field_mask_util.cc",
-        "src/google/protobuf/util/internal/datapiece.cc",
-        "src/google/protobuf/util/internal/default_value_objectwriter.cc",
-        "src/google/protobuf/util/internal/error_listener.cc",
-        "src/google/protobuf/util/internal/field_mask_utility.cc",
-        "src/google/protobuf/util/internal/json_escaping.cc",
-        "src/google/protobuf/util/internal/json_objectwriter.cc",
-        "src/google/protobuf/util/internal/json_stream_parser.cc",
-        "src/google/protobuf/util/internal/object_writer.cc",
-        "src/google/protobuf/util/internal/proto_writer.cc",
-        "src/google/protobuf/util/internal/protostream_objectsource.cc",
-        "src/google/protobuf/util/internal/protostream_objectwriter.cc",
-        "src/google/protobuf/util/internal/type_info.cc",
-        "src/google/protobuf/util/internal/utility.cc",
-        "src/google/protobuf/util/json_util.cc",
-        "src/google/protobuf/util/message_differencer.cc",
-        "src/google/protobuf/util/time_util.cc",
-        "src/google/protobuf/util/type_resolver_util.cc",
         "src/google/protobuf/wire_format.cc",
         "src/google/protobuf/wrappers.pb.cc",
     ],
@@ -450,20 +457,6 @@ RELATIVE_TEST_PROTOS = [
     "google/protobuf/unittest_proto3_lite.proto",
     "google/protobuf/unittest_proto3_optional.proto",
     "google/protobuf/unittest_well_known_types.proto",
-    "google/protobuf/util/internal/testdata/anys.proto",
-    "google/protobuf/util/internal/testdata/books.proto",
-    "google/protobuf/util/internal/testdata/default_value.proto",
-    "google/protobuf/util/internal/testdata/default_value_test.proto",
-    "google/protobuf/util/internal/testdata/field_mask.proto",
-    "google/protobuf/util/internal/testdata/maps.proto",
-    "google/protobuf/util/internal/testdata/oneofs.proto",
-    "google/protobuf/util/internal/testdata/proto3.proto",
-    "google/protobuf/util/internal/testdata/struct.proto",
-    "google/protobuf/util/internal/testdata/timestamp_duration.proto",
-    "google/protobuf/util/internal/testdata/wrappers.proto",
-    "google/protobuf/util/json_format.proto",
-    "google/protobuf/util/json_format_proto3.proto",
-    "google/protobuf/util/message_differencer_unittest.proto",
 ]
 
 TEST_PROTOS = ["src/" + s for s in RELATIVE_TEST_PROTOS]
@@ -631,19 +624,6 @@ cc_test(
         "src/google/protobuf/repeated_field_unittest.cc",
         "src/google/protobuf/text_format_unittest.cc",
         "src/google/protobuf/unknown_field_set_unittest.cc",
-        "src/google/protobuf/util/delimited_message_util_test.cc",
-        "src/google/protobuf/util/field_comparator_test.cc",
-        "src/google/protobuf/util/field_mask_util_test.cc",
-        "src/google/protobuf/util/internal/default_value_objectwriter_test.cc",
-        "src/google/protobuf/util/internal/json_objectwriter_test.cc",
-        "src/google/protobuf/util/internal/json_stream_parser_test.cc",
-        "src/google/protobuf/util/internal/protostream_objectsource_test.cc",
-        "src/google/protobuf/util/internal/protostream_objectwriter_test.cc",
-        "src/google/protobuf/util/internal/type_info_test_helper.cc",
-        "src/google/protobuf/util/json_util_test.cc",
-        "src/google/protobuf/util/message_differencer_unittest.cc",
-        "src/google/protobuf/util/time_util_test.cc",
-        "src/google/protobuf/util/type_resolver_util_test.cc",
         "src/google/protobuf/well_known_types_unittest.cc",
         "src/google/protobuf/wire_format_unittest.cc",
         "src/google/protobuf/wire_format_unittest.inc",

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -105,6 +105,8 @@ pkg_filegroup(
         "//src/google/protobuf/io:dist_files",
         "//src/google/protobuf/stubs:dist_files",
         "//src/google/protobuf/testing:dist_files",
+        "//src/google/protobuf/util:dist_files",
+        "//src/google/protobuf/util/internal:dist_files",
         "@com_google_protobuf_examples//:dist_files",
     ],
 )
@@ -387,6 +389,12 @@ cc_dist_library(
         "//src/google/protobuf/io:tokenizer",
         "//src/google/protobuf/stubs",
         "//src/google/protobuf/stubs:lite",
+        "//src/google/protobuf/util:delimited_message_util",
+        "//src/google/protobuf/util:differencer",
+        "//src/google/protobuf/util:field_mask_util",
+        "//src/google/protobuf/util:json_util",
+        "//src/google/protobuf/util:time_util",
+        "//src/google/protobuf/util:type_resolver_util",
     ],
 )
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -584,6 +584,8 @@ EXTRA_DIST =                                                   \
   google/protobuf/testdata/text_format_unittest_extensions_data.txt \
   google/protobuf/testdata/text_format_unittest_extensions_data_pointy.txt \
   google/protobuf/testing/BUILD.bazel                          \
+  google/protobuf/util/BUILD.bazel                             \
+  google/protobuf/util/internal/BUILD.bazel                    \
   google/protobuf/util/package_info.h                          \
   libprotobuf-lite.map                                         \
   libprotobuf.map                                              \

--- a/src/google/protobuf/util/BUILD.bazel
+++ b/src/google/protobuf/util/BUILD.bazel
@@ -1,0 +1,266 @@
+################################################################################
+# Protocol Buffers C++ Utilities
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
+cc_library(
+    name = "delimited_message_util",
+    srcs = ["delimited_message_util.cc"],
+    hdrs = ["delimited_message_util.h"],
+    strip_include_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:protobuf_lite",
+        "//src/google/protobuf/io",
+    ],
+)
+
+cc_test(
+    name = "delimited_message_util_test",
+    srcs = ["delimited_message_util_test.cc"],
+    deps = [
+        ":delimited_message_util",
+        "//:cc_test_protos",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "differencer",
+    srcs = [
+        "field_comparator.cc",
+        "message_differencer.cc",
+    ],
+    hdrs = [
+        "field_comparator.h",
+        "message_differencer.h",
+    ],
+    strip_include_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:internal_protobuf_full",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_test(
+    name = "field_comparator_test",
+    srcs = ["field_comparator_test.cc"],
+    deps = [
+        ":differencer",
+        ":message_differencer_unittest_cc_proto",
+        "//:cc_test_protos",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "message_differencer_unittest",
+    srcs = ["message_differencer_unittest.cc"],
+    copts = COPTS + [
+        "-Wno-deprecated-declarations",
+    ],
+    deps = [
+        ":differencer",
+        ":message_differencer_unittest_cc_proto",
+        "//:cc_test_protos",
+        "//:test_util",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "field_mask_util",
+    srcs = ["field_mask_util.cc"],
+    hdrs = ["field_mask_util.h"],
+    copts = COPTS,
+    strip_include_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:internal_protobuf_full",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_test(
+    name = "field_mask_util_test",
+    srcs = ["field_mask_util_test.cc"],
+    deps = [
+        ":field_mask_util",
+        "//:cc_test_protos",
+        "//:internal_protobuf_full",
+        "//:test_util",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "json_util",
+    srcs = ["json_util.cc"],
+    hdrs = ["json_util.h"],
+    copts = COPTS,
+    strip_include_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":type_resolver_util",
+        "//:internal_protobuf_full",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/util/internal:default_value",
+        "//src/google/protobuf/util/internal:json",
+        "//src/google/protobuf/util/internal:protostream",
+        "//src/google/protobuf/util/internal:utility",
+    ],
+)
+
+cc_test(
+    name = "json_util_test",
+    srcs = ["json_util_test.cc"],
+    copts = COPTS,
+    data = [
+        "//:testdata",
+    ],
+    deps = [
+        ":json_format_cc_proto",
+        ":json_format_proto3_cc_proto",
+        ":json_util",
+        "//:cc_test_protos",
+        "//:internal_protobuf_full",
+        "//:test_util",
+        "//src/google/protobuf/testing",
+        "//src/google/protobuf/util/internal:maps_cc_proto",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "time_util",
+    srcs = ["time_util.cc"],
+    hdrs = ["time_util.h"],
+    strip_include_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:internal_protobuf_full",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_test(
+    name = "time_util_test",
+    srcs = ["time_util_test.cc"],
+    deps = [
+        ":time_util",
+        "//:internal_protobuf_full",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "type_resolver_util",
+    srcs = ["type_resolver_util.cc"],
+    hdrs = [
+        "type_resolver.h",
+        "type_resolver_util.h",
+    ],
+    copts = COPTS,
+    strip_include_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:internal_protobuf_full",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/util/internal:utility",
+    ],
+)
+
+cc_test(
+    name = "type_resolver_util_test",
+    srcs = ["type_resolver_util_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":json_format_cc_proto",
+        ":json_format_proto3_cc_proto",
+        ":json_util",
+        "//:internal_protobuf_full",
+        "//:test_util",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+# Testonly protos
+
+proto_library(
+    name = "json_format_proto",
+    testonly = 1,
+    srcs = ["json_format.proto"],
+)
+
+cc_proto_library(
+    name = "json_format_cc_proto",
+    testonly = 1,
+    deps = [":json_format_proto"],
+)
+
+proto_library(
+    name = "json_format_proto3_proto",
+    testonly = 1,
+    srcs = ["json_format_proto3.proto"],
+    deps = [
+        "//:any_proto",
+        "//:cc_test_protos_lib",
+        "//:duration_proto",
+        "//:field_mask_proto",
+        "//:struct_proto",
+        "//:timestamp_proto",
+        "//:wrappers_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "json_format_proto3_cc_proto",
+    testonly = 1,
+    deps = [":json_format_proto3_proto"],
+)
+
+proto_library(
+    name = "message_differencer_unittest_proto",
+    testonly = 1,
+    srcs = ["message_differencer_unittest.proto"],
+    deps = ["//:any_proto"],
+)
+
+cc_proto_library(
+    name = "message_differencer_unittest_cc_proto",
+    testonly = 1,
+    deps = [":message_differencer_unittest_proto"],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//pkg:__pkg__"],
+)

--- a/src/google/protobuf/util/internal/BUILD.bazel
+++ b/src/google/protobuf/util/internal/BUILD.bazel
@@ -1,0 +1,446 @@
+################################################################################
+# Protocol Buffers C++ util internals.
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
+package(
+    default_visibility = ["//src/google/protobuf/util:__pkg__"],
+)
+
+cc_library(
+    name = "constants",
+    hdrs = ["constants.h"],
+    deps = [
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_library(
+    name = "datapiece",
+    srcs = ["datapiece.cc"],
+    hdrs = ["datapiece.h"],
+    copts = COPTS,
+    strip_include_prefix = "/src",
+    deps = [
+        ":constants",
+        ":utility",
+        "//:internal_protobuf_full",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_library(
+    name = "default_value",
+    srcs = ["default_value_objectwriter.cc"],
+    hdrs = ["default_value_objectwriter.h"],
+    copts = COPTS,
+    strip_include_prefix = "/src",
+    deps = [
+        ":datapiece",
+        ":object_writer",
+        ":type_info",
+        ":utility",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_test(
+    name = "default_value_objectwriter_test",
+    srcs = ["default_value_objectwriter_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":default_value",
+        ":default_value_test_cc_proto",
+        ":expecting_objectwriter",
+        ":type_info_test_helper",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "expecting_objectwriter",
+    testonly = 1,
+    hdrs = ["expecting_objectwriter.h"],
+    deps = [":object_writer"],
+)
+
+cc_library(
+    name = "field_mask_utility",
+    srcs = ["field_mask_utility.cc"],
+    hdrs = ["field_mask_utility.h"],
+    strip_include_prefix = "/src",
+    deps = [
+        ":utility",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_library(
+    name = "json",
+    srcs = [
+        "json_escaping.cc",
+        "json_objectwriter.cc",
+        "json_stream_parser.cc",
+    ],
+    hdrs = [
+        "json_escaping.h",
+        "json_objectwriter.h",
+        "json_stream_parser.h",
+    ],
+    copts = COPTS,
+    strip_include_prefix = "/src",
+    deps = [
+        ":object_writer",
+        ":utility",
+        "//:internal_protobuf_full",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_test(
+    name = "json_objectwriter_test",
+    srcs = ["json_objectwriter_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":json",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "json_stream_parser_test",
+    srcs = ["json_stream_parser_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":expecting_objectwriter",
+        ":json",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "mock_error_listener",
+    testonly = 1,
+    hdrs = ["mock_error_listener.h"],
+    deps = [":protostream"],
+)
+
+cc_library(
+    name = "object_writer",
+    srcs = ["object_writer.cc"],
+    hdrs = [
+        "object_source.h",
+        "object_writer.h",
+        "structured_objectwriter.h",
+    ],
+    strip_include_prefix = "/src",
+    deps = [
+        ":datapiece",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+cc_library(
+    name = "type_info",
+    srcs = ["type_info.cc"],
+    hdrs = ["type_info.h"],
+    strip_include_prefix = "/src",
+    deps = [
+        ":utility",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/util:type_resolver_util",
+    ],
+)
+
+cc_library(
+    name = "type_info_test_helper",
+    testonly = 1,
+    srcs = ["type_info_test_helper.cc"],
+    hdrs = ["type_info_test_helper.h"],
+    copts = COPTS,
+    deps = [
+        ":default_value",
+        ":protostream",
+        ":type_info",
+    ],
+)
+
+cc_library(
+    name = "protostream",
+    srcs = [
+        "error_listener.cc",
+        "proto_writer.cc",
+        "protostream_objectsource.cc",
+        "protostream_objectwriter.cc",
+    ],
+    hdrs = [
+        "error_listener.h",
+        "location_tracker.h",
+        "object_location_tracker.h",
+        "proto_writer.h",
+        "protostream_objectsource.h",
+        "protostream_objectwriter.h",
+    ],
+    copts = COPTS,
+    strip_include_prefix = "/src",
+    deps = [
+        ":constants",
+        ":datapiece",
+        ":field_mask_utility",
+        ":object_writer",
+        ":type_info",
+        ":utility",
+        "//:internal_protobuf_full",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs",
+        "//src/google/protobuf/util:type_resolver_util",
+    ],
+)
+
+cc_test(
+    name = "protostream_objectsource_test",
+    srcs = ["protostream_objectsource_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":anys_cc_proto",
+        ":books_cc_proto",
+        ":expecting_objectwriter",
+        ":field_mask_cc_proto",
+        ":maps_cc_proto",
+        ":oneofs_cc_proto",
+        ":proto3_cc_proto",
+        ":protostream",
+        ":struct_cc_proto",
+        ":timestamp_duration_cc_proto",
+        ":type_info_test_helper",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "protostream_objectwriter_test",
+    srcs = ["protostream_objectwriter_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":anys_cc_proto",
+        ":books_cc_proto",
+        ":field_mask_cc_proto",
+        ":maps_cc_proto",
+        ":mock_error_listener",
+        ":oneofs_cc_proto",
+        ":proto3_cc_proto",
+        ":protostream",
+        ":struct_cc_proto",
+        ":timestamp_duration_cc_proto",
+        ":type_info_test_helper",
+        ":wrappers_cc_proto",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "utility",
+    srcs = ["utility.cc"],
+    hdrs = ["utility.h"],
+    copts = COPTS,
+    strip_include_prefix = "/src",
+    deps = [
+        ":constants",
+        "//:internal_protobuf_full",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+# Testing protos:
+
+proto_library(
+    name = "anys_proto",
+    testonly = 1,
+    srcs = ["testdata/anys.proto"],
+    strip_import_prefix = "/src",
+    deps = [
+        "//:any_proto",
+        "//:duration_proto",
+        "//:empty_proto",
+        "//:struct_proto",
+        "//:timestamp_proto",
+        "//:wrappers_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "anys_cc_proto",
+    testonly = 1,
+    visibility = ["//src/google/protobuf/util:__pkg__"],
+    deps = [":anys_proto"],
+)
+
+proto_library(
+    name = "books_proto",
+    testonly = 1,
+    srcs = ["testdata/books.proto"],
+    strip_import_prefix = "/src",
+    deps = [":anys_proto"],
+)
+
+cc_proto_library(
+    name = "books_cc_proto",
+    testonly = 1,
+    deps = [":books_proto"],
+)
+
+proto_library(
+    name = "default_value_proto",
+    testonly = 1,
+    srcs = ["testdata/default_value.proto"],
+    strip_import_prefix = "/src",
+    deps = [
+        "//:any_proto",
+        "//:struct_proto",
+        "//:wrappers_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "default_value_cc_proto",
+    testonly = 1,
+    deps = [":default_value_proto"],
+)
+
+proto_library(
+    name = "default_value_test_proto",
+    testonly = 1,
+    srcs = ["testdata/default_value_test.proto"],
+    strip_import_prefix = "/src",
+)
+
+cc_proto_library(
+    name = "default_value_test_cc_proto",
+    testonly = 1,
+    deps = [":default_value_test_proto"],
+)
+
+proto_library(
+    name = "field_mask_proto",
+    testonly = 1,
+    srcs = ["testdata/field_mask.proto"],
+    strip_import_prefix = "/src",
+    deps = ["//:field_mask_proto"],
+)
+
+cc_proto_library(
+    name = "field_mask_cc_proto",
+    testonly = 1,
+    deps = [":field_mask_proto"],
+)
+
+proto_library(
+    name = "maps_proto",
+    testonly = 1,
+    srcs = ["testdata/maps.proto"],
+    strip_import_prefix = "/src",
+    deps = ["//:any_proto"],
+)
+
+cc_proto_library(
+    name = "maps_cc_proto",
+    testonly = 1,
+    deps = [":maps_proto"],
+)
+
+proto_library(
+    name = "oneofs_proto",
+    testonly = 1,
+    srcs = ["testdata/oneofs.proto"],
+    strip_import_prefix = "/src",
+    deps = [
+        "//:any_proto",
+        "//:struct_proto",
+        "//:timestamp_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "oneofs_cc_proto",
+    testonly = 1,
+    deps = [":oneofs_proto"],
+)
+
+proto_library(
+    name = "proto3_proto",
+    testonly = 1,
+    srcs = ["testdata/proto3.proto"],
+    strip_import_prefix = "/src",
+)
+
+cc_proto_library(
+    name = "proto3_cc_proto",
+    testonly = 1,
+    deps = [":proto3_proto"],
+)
+
+proto_library(
+    name = "struct_proto",
+    testonly = 1,
+    srcs = ["testdata/struct.proto"],
+    strip_import_prefix = "/src",
+    deps = ["//:struct_proto"],
+)
+
+cc_proto_library(
+    name = "struct_cc_proto",
+    testonly = 1,
+    deps = [":struct_proto"],
+)
+
+proto_library(
+    name = "timestamp_duration_proto",
+    testonly = 1,
+    srcs = ["testdata/timestamp_duration.proto"],
+    strip_import_prefix = "/src",
+    deps = [
+        "//:duration_proto",
+        "//:timestamp_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "timestamp_duration_cc_proto",
+    testonly = 1,
+    deps = [":timestamp_duration_proto"],
+)
+
+proto_library(
+    name = "wrappers_proto",
+    testonly = 1,
+    srcs = ["testdata/wrappers.proto"],
+    strip_import_prefix = "/src",
+    deps = ["//:wrappers_proto"],
+)
+
+cc_proto_library(
+    name = "wrappers_cc_proto",
+    testonly = 1,
+    deps = [":wrappers_proto"],
+)
+
+################################################################################
+# Distribution packaging
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//pkg:__pkg__"],
+)


### PR DESCRIPTION
This change creates new Bazel packages for the C++ util libraries (similar to #9980 and #9985).