### PR TITLE
[Bazel/C++] Move core C++ implementation to //src/google/protobuf package.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,252 +6,11 @@ load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_lite_proto_library", "java_proto_library")
 load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
-load(
-    ":protobuf.bzl",
-    "adapt_proto_library",
-    "py_proto_library",
-)
+load(":protobuf.bzl", "py_proto_library")
 
 licenses(["notice"])
 
 exports_files(["LICENSE"])
-
-################################################################################
-# Protobuf Runtime Library
-################################################################################
-
-cc_library(
-    name = "port_def",
-    hdrs = ["src/google/protobuf/port.h"],
-    includes = ["src"],
-    textual_hdrs = [
-        "src/google/protobuf/port_def.inc",
-        "src/google/protobuf/port_undef.inc",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-cc_library(
-    name = "arena",
-    srcs = [
-        "src/google/protobuf/arena.cc",
-        "src/google/protobuf/arena_impl.h",
-        "src/google/protobuf/arenaz_sampler.h",
-    ],
-    hdrs = ["src/google/protobuf/arena.h"],
-    visibility = ["//:__subpackages__"],
-    deps = [
-        "//src/google/protobuf/stubs:lite",
-    ],
-)
-
-# The "lite" runtime works for .proto files that specify the option:
-#     optimize_for = LITE_RUNTIME;
-#
-# The lite runtime does not include the `Reflection` APIs (including
-# `Descriptor` and related types) or Well-Known Types.
-#
-# See also:
-#     https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#message
-#     https://developers.google.com/protocol-buffers/docs/reference/google.protobuf
-cc_library(
-    name = "protobuf_lite",
-    srcs = [
-        # AUTOGEN(protobuf_lite_srcs)
-        "src/google/protobuf/any_lite.cc",
-        "src/google/protobuf/arenastring.cc",
-        "src/google/protobuf/arenaz_sampler.cc",
-        "src/google/protobuf/extension_set.cc",
-        "src/google/protobuf/generated_enum_util.cc",
-        "src/google/protobuf/generated_message_tctable_lite.cc",
-        "src/google/protobuf/generated_message_util.cc",
-        "src/google/protobuf/implicit_weak_message.cc",
-        "src/google/protobuf/inlined_string_field.cc",
-        "src/google/protobuf/map.cc",
-        "src/google/protobuf/message_lite.cc",
-        "src/google/protobuf/parse_context.cc",
-        "src/google/protobuf/repeated_field.cc",
-        "src/google/protobuf/repeated_ptr_field.cc",
-        "src/google/protobuf/wire_format_lite.cc",
-    ],
-    hdrs = glob([
-        "src/google/protobuf/**/*.h",
-        "src/google/protobuf/**/*.inc",
-    ]),
-    copts = COPTS,
-    includes = ["src/"],
-    linkopts = LINK_OPTS,
-    visibility = ["//visibility:public"],
-    # In Bazel 6.0+, these will be `interface_deps`:
-    deps = [
-        ":arena",
-        "//src/google/protobuf/io",
-        "//src/google/protobuf/stubs:lite",
-    ],
-)
-
-cc_library(
-    name = "protobuf",
-    hdrs = glob([
-        "src/**/*.h",
-        "src/**/*.inc",
-    ]),
-    copts = COPTS,
-    includes = ["src/"],
-    linkopts = LINK_OPTS,
-    visibility = ["//visibility:public"],
-    deps = [
-        ":internal_protobuf_full",
-        # Other targets which depend on ':internal_protobuf_full':
-        "//src/google/protobuf/compiler:importer",
-        "//src/google/protobuf/util:delimited_message_util",
-        "//src/google/protobuf/util:differencer",
-        "//src/google/protobuf/util:field_mask_util",
-        "//src/google/protobuf/util:json_util",
-        "//src/google/protobuf/util:time_util",
-        "//src/google/protobuf/util:type_resolver_util",
-    ],
-)
-
-# `:internal_protobuf_full` is an internal target which has the non-lite
-# portions of the protobuf runtime.
-#
-# Users of the full runtime should depend upon `:protobuf` instead, which
-# also includes the util library.
-cc_library(
-    name = "internal_protobuf_full",
-    srcs = [
-        # AUTOGEN(protobuf_srcs)
-        "src/google/protobuf/any.cc",
-        "src/google/protobuf/any.pb.cc",
-        "src/google/protobuf/api.pb.cc",
-        "src/google/protobuf/descriptor.cc",
-        "src/google/protobuf/descriptor.pb.cc",
-        "src/google/protobuf/descriptor_database.cc",
-        "src/google/protobuf/duration.pb.cc",
-        "src/google/protobuf/dynamic_message.cc",
-        "src/google/protobuf/empty.pb.cc",
-        "src/google/protobuf/extension_set_heavy.cc",
-        "src/google/protobuf/field_mask.pb.cc",
-        "src/google/protobuf/generated_message_bases.cc",
-        "src/google/protobuf/generated_message_reflection.cc",
-        "src/google/protobuf/generated_message_tctable_full.cc",
-        "src/google/protobuf/map_field.cc",
-        "src/google/protobuf/message.cc",
-        "src/google/protobuf/reflection_ops.cc",
-        "src/google/protobuf/service.cc",
-        "src/google/protobuf/source_context.pb.cc",
-        "src/google/protobuf/struct.pb.cc",
-        "src/google/protobuf/text_format.cc",
-        "src/google/protobuf/timestamp.pb.cc",
-        "src/google/protobuf/type.pb.cc",
-        "src/google/protobuf/unknown_field_set.cc",
-        "src/google/protobuf/wire_format.cc",
-        "src/google/protobuf/wrappers.pb.cc",
-    ],
-    hdrs = glob([
-        "src/**/*.h",
-        "src/**/*.inc",
-    ]),
-    copts = COPTS,
-    includes = ["src/"],
-    linkopts = LINK_OPTS,
-    visibility = [
-        "//:__subpackages__",  # this target is only to break circular deps
-    ],
-    deps = [
-        ":protobuf_lite",
-        "//src/google/protobuf/io",
-        "//src/google/protobuf/io:gzip_stream",
-        "//src/google/protobuf/io:printer",
-        "//src/google/protobuf/io:tokenizer",
-        "//src/google/protobuf/stubs",
-    ],
-)
-
-# This provides just the header files for use in projects that need to build
-# shared libraries for dynamic loading. This target is available until Bazel
-# adds native support for such use cases.
-# TODO(keveman): Remove this target once the support gets added to Bazel.
-cc_library(
-    name = "protobuf_headers",
-    hdrs = glob([
-        "src/**/*.h",
-        "src/**/*.inc",
-    ]),
-    includes = ["src/"],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "well_known_type_protos",
-    srcs = [
-        "src/google/protobuf/any.proto",
-        "src/google/protobuf/api.proto",
-        "src/google/protobuf/duration.proto",
-        "src/google/protobuf/empty.proto",
-        "src/google/protobuf/field_mask.proto",
-        "src/google/protobuf/source_context.proto",
-        "src/google/protobuf/struct.proto",
-        "src/google/protobuf/timestamp.proto",
-        "src/google/protobuf/type.proto",
-        "src/google/protobuf/wrappers.proto",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "built_in_runtime_protos",
-    srcs = ["src/google/protobuf/descriptor.proto"],
-    visibility = ["//:__subpackages__"],
-)
-
-exports_files(
-    srcs = [
-        "src/google/protobuf/any.proto",
-        "src/google/protobuf/api.proto",
-        "src/google/protobuf/duration.proto",
-        "src/google/protobuf/empty.proto",
-        "src/google/protobuf/field_mask.proto",
-        "src/google/protobuf/source_context.proto",
-        "src/google/protobuf/struct.proto",
-        "src/google/protobuf/timestamp.proto",
-        "src/google/protobuf/type.proto",
-        "src/google/protobuf/wrappers.proto",
-    ],
-    visibility = ["//pkg:__pkg__"],
-)
-
-alias(
-    name = "lite_well_known_protos",
-    actual = ":well_known_type_protos",
-    visibility = ["//visibility:public"],
-)
-
-adapt_proto_library(
-    name = "cc_wkt_protos_genproto",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//:any_proto",
-        "//:api_proto",
-        "//:compiler_plugin_proto",
-        "//:descriptor_proto",
-        "//:duration_proto",
-        "//:empty_proto",
-        "//:field_mask_proto",
-        "//:source_context_proto",
-        "//:struct_proto",
-        "//:timestamp_proto",
-        "//:type_proto",
-        "//:wrappers_proto",
-    ],
-)
-
-cc_library(
-    name = "cc_wkt_protos",
-    deprecation = "Only for backward compatibility. Do not use.",
-    visibility = ["//visibility:public"],
-)
 
 ################################################################################
 # Well Known Types Proto Library Rules
@@ -267,96 +26,124 @@ cc_library(
 # )
 ################################################################################
 
-proto_library(
+alias(
     name = "any_proto",
-    srcs = ["src/google/protobuf/any.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:any_proto",
     visibility = ["//visibility:public"],
 )
 
-proto_library(
+alias(
     name = "api_proto",
-    srcs = ["src/google/protobuf/api.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:api_proto",
     visibility = ["//visibility:public"],
-    deps = [
-        "//:source_context_proto",
-        "//:type_proto",
-    ],
 )
 
-proto_library(
+alias(
     name = "duration_proto",
-    srcs = ["//:src/google/protobuf/duration.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:duration_proto",
     visibility = ["//visibility:public"],
 )
 
-proto_library(
+alias(
     name = "empty_proto",
-    srcs = ["src/google/protobuf/empty.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:empty_proto",
     visibility = ["//visibility:public"],
 )
 
-proto_library(
+alias(
     name = "field_mask_proto",
-    srcs = ["src/google/protobuf/field_mask.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:field_mask_proto",
     visibility = ["//visibility:public"],
 )
 
-proto_library(
+alias(
     name = "source_context_proto",
-    srcs = ["src/google/protobuf/source_context.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:source_context_proto",
     visibility = ["//visibility:public"],
 )
 
-proto_library(
+alias(
     name = "struct_proto",
-    srcs = ["src/google/protobuf/struct.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:struct_proto",
     visibility = ["//visibility:public"],
 )
 
-proto_library(
+alias(
     name = "timestamp_proto",
-    srcs = ["src/google/protobuf/timestamp.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:timestamp_proto",
     visibility = ["//visibility:public"],
 )
 
-proto_library(
+alias(
     name = "type_proto",
-    srcs = ["src/google/protobuf/type.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:type_proto",
     visibility = ["//visibility:public"],
-    deps = [
-        "//:any_proto",
-        "//:source_context_proto",
-    ],
 )
 
-proto_library(
+alias(
     name = "wrappers_proto",
-    srcs = ["src/google/protobuf/wrappers.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:wrappers_proto",
     visibility = ["//visibility:public"],
 )
 
-# Built-in runtime types
+# Source files: these are aliases to a filegroup, not a `proto_library`.
+#
+# (This is _probably_ not what you want.)
+alias(
+    name = "lite_well_known_protos",
+    actual = "//src/google/protobuf:well_known_type_protos",  # filegroup
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "well_known_type_protos",
+    actual = "//src/google/protobuf:well_known_type_protos",  # filegroup
+    visibility = ["//visibility:public"],
+)
+
+# Built-in runtime protos: these are part of protobuf's internal
+# impelementation, but are not Well-Known Types.
+
+alias(
+    name = "descriptor_proto",
+    actual = "//src/google/protobuf:descriptor_proto",  # proto_library
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "built_in_runtime_protos",
+    actual = "//src/google/protobuf:descriptor_proto_srcs",  # filegroup
+    visibility = ["//visibility:public"],
+)
 
 alias(
     name = "compiler_plugin_proto",
-    actual = "//src/google/protobuf/compiler:plugin_proto",
+    actual = "//src/google/protobuf/compiler:plugin_proto",  # proto_library
     visibility = ["//visibility:public"],
 )
 
-proto_library(
-    name = "descriptor_proto",
-    srcs = ["src/google/protobuf/descriptor.proto"],
-    strip_import_prefix = "src",
+# adapt_proto_library(
+#     name = "cc_wkt_protos_genproto",
+#     visibility = ["//visibility:public"],
+#     deps = [
+#         "//:any_proto",
+#         "//:api_proto",
+#         "//:compiler_plugin_proto",
+#         "//:descriptor_proto",
+#         "//:duration_proto",
+#         "//:empty_proto",
+#         "//:field_mask_proto",
+#         "//:source_context_proto",
+#         "//:struct_proto",
+#         "//:timestamp_proto",
+#         "//:type_proto",
+#         "//:wrappers_proto",
+#     ],
+# )
+
+cc_library(
+    name = "cc_wkt_protos",
+    deprecation = "Only for backward compatibility. Do not use.",
     visibility = ["//visibility:public"],
 )
 
@@ -372,282 +159,67 @@ cc_binary(
 )
 
 ################################################################################
-# Tests
+# C++ runtime
 ################################################################################
 
-filegroup(
-    name = "testdata",
-    srcs = glob(["src/google/protobuf/testdata/**/*"]) + [
-        "src/google/protobuf/descriptor.cc",
-    ],
-    visibility = [
-        "//:__subpackages__",
-        "@upb//:__subpackages__",
-    ],
-)
-
-RELATIVE_LITE_TEST_PROTOS = [
-    # AUTOGEN(lite_test_protos)
-    "google/protobuf/map_lite_unittest.proto",
-    "google/protobuf/unittest_import_lite.proto",
-    "google/protobuf/unittest_import_public_lite.proto",
-    "google/protobuf/unittest_lite.proto",
-]
-
-LITE_TEST_PROTOS = ["src/" + s for s in RELATIVE_LITE_TEST_PROTOS]
-
-proto_library(
-    name = "lite_test_protos",
-    srcs = LITE_TEST_PROTOS,
-    strip_import_prefix = "src",
-    visibility = ["//:__subpackages__"],
-    deps = [
-        "//:any_proto",
-        "//:api_proto",
-        "//:descriptor_proto",
-        "//:duration_proto",
-        "//:empty_proto",
-        "//:field_mask_proto",
-        "//:source_context_proto",
-        "//:struct_proto",
-        "//:timestamp_proto",
-        "//:type_proto",
-        "//:wrappers_proto",
-    ],
-)
-
-RELATIVE_TEST_PROTOS = [
-    # AUTOGEN(test_protos)
-    "google/protobuf/any_test.proto",
-    "google/protobuf/map_proto2_unittest.proto",
-    "google/protobuf/map_unittest.proto",
-    "google/protobuf/unittest.proto",
-    "google/protobuf/unittest_arena.proto",
-    "google/protobuf/unittest_custom_options.proto",
-    "google/protobuf/unittest_drop_unknown_fields.proto",
-    "google/protobuf/unittest_embed_optimize_for.proto",
-    "google/protobuf/unittest_empty.proto",
-    "google/protobuf/unittest_enormous_descriptor.proto",
-    "google/protobuf/unittest_import.proto",
-    "google/protobuf/unittest_import_public.proto",
-    "google/protobuf/unittest_lazy_dependencies.proto",
-    "google/protobuf/unittest_lazy_dependencies_custom_option.proto",
-    "google/protobuf/unittest_lazy_dependencies_enum.proto",
-    "google/protobuf/unittest_lite_imports_nonlite.proto",
-    "google/protobuf/unittest_mset.proto",
-    "google/protobuf/unittest_mset_wire_format.proto",
-    "google/protobuf/unittest_no_field_presence.proto",
-    "google/protobuf/unittest_no_generic_services.proto",
-    "google/protobuf/unittest_optimize_for.proto",
-    "google/protobuf/unittest_preserve_unknown_enum.proto",
-    "google/protobuf/unittest_preserve_unknown_enum2.proto",
-    "google/protobuf/unittest_proto3.proto",
-    "google/protobuf/unittest_proto3_arena.proto",
-    "google/protobuf/unittest_proto3_arena_lite.proto",
-    "google/protobuf/unittest_proto3_lite.proto",
-    "google/protobuf/unittest_proto3_optional.proto",
-    "google/protobuf/unittest_well_known_types.proto",
-]
-
-TEST_PROTOS = ["src/" + s for s in RELATIVE_TEST_PROTOS]
-
-filegroup(
-    name = "test_proto_srcs",
-    srcs = TEST_PROTOS,
-    visibility = ["//:__subpackages__"],
-)
-
-proto_library(
-    name = "test_protos",
-    srcs = [":test_proto_srcs"],
-    strip_import_prefix = "src",
-    visibility = ["//:__subpackages__"],
-    deps = [
-        "//:any_proto",
-        "//:api_proto",
-        "//:descriptor_proto",
-        "//:duration_proto",
-        "//:empty_proto",
-        "//:field_mask_proto",
-        "//:source_context_proto",
-        "//:struct_proto",
-        "//:timestamp_proto",
-        "//:type_proto",
-        "//:wrappers_proto",
-    ],
-)
-
-GENERIC_RELATIVE_TEST_PROTOS = [
-    "google/protobuf/map_proto2_unittest.proto",
-    "google/protobuf/map_unittest.proto",
-    "google/protobuf/unittest.proto",
-    "google/protobuf/unittest_arena.proto",
-    "google/protobuf/unittest_custom_options.proto",
-    "google/protobuf/unittest_drop_unknown_fields.proto",
-    "google/protobuf/unittest_embed_optimize_for.proto",
-    "google/protobuf/unittest_empty.proto",
-    "google/protobuf/unittest_enormous_descriptor.proto",
-    "google/protobuf/unittest_import.proto",
-    "google/protobuf/unittest_import_public.proto",
-    "google/protobuf/unittest_lazy_dependencies.proto",
-    "google/protobuf/unittest_lazy_dependencies_custom_option.proto",
-    "google/protobuf/unittest_lazy_dependencies_enum.proto",
-    "google/protobuf/unittest_lite_imports_nonlite.proto",
-    "google/protobuf/unittest_mset.proto",
-    "google/protobuf/unittest_mset_wire_format.proto",
-    "google/protobuf/unittest_no_field_presence.proto",
-    "google/protobuf/unittest_no_generic_services.proto",
-    "google/protobuf/unittest_optimize_for.proto",
-    "google/protobuf/unittest_preserve_unknown_enum.proto",
-    "google/protobuf/unittest_preserve_unknown_enum2.proto",
-    "google/protobuf/unittest_proto3.proto",
-    "google/protobuf/unittest_proto3_arena.proto",
-    "google/protobuf/unittest_proto3_arena_lite.proto",
-    "google/protobuf/unittest_proto3_lite.proto",
-    "google/protobuf/unittest_proto3_optional.proto",
-    "google/protobuf/unittest_well_known_types.proto",
-]
-
-proto_library(
-    name = "generic_test_protos",
-    srcs = ["src/" + s for s in GENERIC_RELATIVE_TEST_PROTOS],
-    strip_import_prefix = "src",
-    visibility = ["//:__subpackages__"],
-    deps = [
-        "//:any_proto",
-        "//:api_proto",
-        "//:descriptor_proto",
-        "//:duration_proto",
-        "//:empty_proto",
-        "//:field_mask_proto",
-        "//:source_context_proto",
-        "//:struct_proto",
-        "//:timestamp_proto",
-        "//:type_proto",
-        "//:wrappers_proto",
-    ],
-)
-
-cc_proto_library(
-    name = "cc_lite_test_protos",
-    deps = [":lite_test_protos"],
-)
-
-cc_proto_library(
-    name = "cc_test_protos",
-    visibility = ["//:__subpackages__"],
-    deps = [":test_protos"],
-)
-
-filegroup(
-    name = "descriptor_cc_srcs",
-    testonly = 1,
-    data = [
-        "src/google/protobuf/descriptor.pb.cc",
-        "src/google/protobuf/descriptor.pb.h",
-    ],
-    visibility = ["//src/google/protobuf/compiler/cpp:__pkg__"],
+# The "lite" runtime works for .proto files that specify the option:
+#     optimize_for = LITE_RUNTIME;
+#
+# The lite runtime does not include the `Reflection` APIs (including
+# `Descriptor` and related types) or Well-Known Types.
+#
+# See also:
+#     https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#message
+#     https://developers.google.com/protocol-buffers/docs/reference/google.protobuf
+alias(
+    name = "protobuf_lite",
+    actual = "//src/google/protobuf:protobuf_lite",
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
-    name = "test_util",
-    testonly = 1,
-    srcs = [
-        "src/google/protobuf/arena_test_util.cc",
-        "src/google/protobuf/map_lite_test_util.cc",
-        "src/google/protobuf/reflection_tester.cc",
-        "src/google/protobuf/test_util.cc",
-        "src/google/protobuf/test_util_lite.cc",
-    ],
-    hdrs = [
-        "src/google/protobuf/arena_test_util.h",
-        "src/google/protobuf/map_lite_test_util.h",
-        "src/google/protobuf/map_test_util.h",
-        "src/google/protobuf/map_test_util_impl.h",
-        "src/google/protobuf/test_util.h",
-        "src/google/protobuf/test_util2.h",
-        "src/google/protobuf/test_util_lite.h",
-    ],
+    name = "protobuf",
+    hdrs = glob([
+        "src/**/*.h",
+        "src/**/*.inc",
+    ]),
     copts = COPTS,
-    includes = ["src"],
-    textual_hdrs = [
-        "src/google/protobuf/map_test_util.inc",
-        "src/google/protobuf/test_util.inc",
-    ],
-    visibility = ["//:__subpackages__"],
+    include_prefix = "google/protobuf/io",
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
     deps = [
-        ":cc_lite_test_protos",
-        ":cc_test_protos",
-        "@com_google_googletest//:gtest",
+        "//src/google/protobuf",
+        "//src/google/protobuf/compiler:importer",
+        "//src/google/protobuf/util:delimited_message_util",
+        "//src/google/protobuf/util:differencer",
+        "//src/google/protobuf/util:field_mask_util",
+        "//src/google/protobuf/util:json_util",
+        "//src/google/protobuf/util:time_util",
+        "//src/google/protobuf/util:type_resolver_util",
     ],
 )
 
-cc_test(
-    name = "protobuf_test",
-    srcs = [
-        # AUTOGEN(test_srcs)
-        "src/google/protobuf/any_test.cc",
-        "src/google/protobuf/arena_unittest.cc",
-        "src/google/protobuf/arenastring_unittest.cc",
-        "src/google/protobuf/arenaz_sampler_test.cc",
-        "src/google/protobuf/descriptor_database_unittest.cc",
-        "src/google/protobuf/descriptor_unittest.cc",
-        "src/google/protobuf/drop_unknown_fields_test.cc",
-        "src/google/protobuf/dynamic_message_unittest.cc",
-        "src/google/protobuf/extension_set_unittest.cc",
-        "src/google/protobuf/generated_message_reflection_unittest.cc",
-        "src/google/protobuf/generated_message_tctable_lite_test.cc",
-        "src/google/protobuf/inlined_string_field_unittest.cc",
-        "src/google/protobuf/map_field_test.cc",
-        "src/google/protobuf/map_test.cc",
-        "src/google/protobuf/map_test.inc",
-        "src/google/protobuf/message_unittest.cc",
-        "src/google/protobuf/message_unittest.inc",
-        "src/google/protobuf/no_field_presence_test.cc",
-        "src/google/protobuf/preserve_unknown_enum_test.cc",
-        "src/google/protobuf/proto3_arena_lite_unittest.cc",
-        "src/google/protobuf/proto3_arena_unittest.cc",
-        "src/google/protobuf/proto3_lite_unittest.cc",
-        "src/google/protobuf/proto3_lite_unittest.inc",
-        "src/google/protobuf/reflection_ops_unittest.cc",
-        "src/google/protobuf/repeated_field_reflection_unittest.cc",
-        "src/google/protobuf/repeated_field_unittest.cc",
-        "src/google/protobuf/text_format_unittest.cc",
-        "src/google/protobuf/unknown_field_set_unittest.cc",
-        "src/google/protobuf/well_known_types_unittest.cc",
-        "src/google/protobuf/wire_format_unittest.cc",
-        "src/google/protobuf/wire_format_unittest.inc",
-    ],
-    copts = COPTS + select({
-        "//build_defs:config_msvc": [],
-        "//conditions:default": [
-            "-Wno-deprecated-declarations",
-        ],
-    }),
-    data = [
-        ":testdata",
-    ] + glob([
-        "src/google/protobuf/**/*",
-    ]) + glob(
-        [
-            # Files for csharp_bootstrap_unittest.cc.
-            "csharp/src/**/*",
-        ],
-        allow_empty = True,
-    ),
-    includes = [
-        "src/",
-    ],
-    linkopts = LINK_OPTS,
-    deps = [
-        ":cc_lite_test_protos",
-        ":cc_test_protos",
-        ":protobuf",
-        ":test_util",
-        "//src/google/protobuf/testing",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
-    ],
+# This provides just the header files for use in projects that need to build
+# shared libraries for dynamic loading. This target is available until Bazel
+# adds native support for such use cases.
+# TODO(keveman): Remove this target once the support gets added to Bazel.
+alias(
+    name = "protobuf_headers",
+    actual = "//src/google/protobuf:protobuf_headers",
+    visibility = ["//visibility:public"],
+)
+
+# TODO(dlj): remove:
+alias(
+    name = "arena",
+    actual = "//src/google/protobuf:arena",
+    visibility = [":__subpackages__"],
+)
+
+alias(
+    name = "port_def",
+    actual = "//src/google/protobuf:port_def",
+    visibility = [":__subpackages__"],
 )
 
 ################################################################################
@@ -760,24 +332,47 @@ alias(
 )
 
 ################################################################################
-# Test generated proto support
+# Test protos
 ################################################################################
+
+alias(
+    name = "lite_test_protos",
+    actual = "//src/google/protobuf:lite_test_protos",  # proto_library
+    visibility = ["//:__subpackages__"],
+)
+
+alias(
+    name = "test_proto_srcs",
+    actual = "//src/google/protobuf:test_proto_srcs",  # filegroup
+    visibility = ["//:__subpackages__"],
+)
+
+alias(
+    name = "test_protos",
+    actual = "//src/google/protobuf:test_protos",  # proto_library
+    visibility = ["//:__subpackages__"],
+)
+
+# Validate generated proto source inputs:
 
 genrule(
     name = "generated_protos",
-    srcs = ["src/google/protobuf/unittest_import.proto"],
+    testonly = 1,
+    srcs = ["//src/google/protobuf:test_proto_srcs"],
     outs = ["unittest_gen_import.proto"],
-    cmd = "cat $(SRCS) >  $(OUTS)",
+    cmd = "cat src/google/protobuf/unittest_import.proto > $@",
 )
 
 proto_library(
     name = "generated_protos_proto",
+    testonly = 1,
     srcs = [":generated_protos"],
-    deps = [":generic_test_protos"],
+    deps = ["//src/google/protobuf:generic_test_protos"],
 )
 
 py_proto_library(
     name = "generated_protos_py",
+    testonly = 1,
     srcs = [":generated_protos"],
     default_runtime = "",
     protoc = ":protoc",
@@ -794,26 +389,16 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-proto_library(
+alias(
     name = "test_messages_proto2_proto",
-    srcs = ["src/google/protobuf/test_messages_proto2.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:test_messages_proto2_proto",  # proto_library
     visibility = ["//visibility:public"],
 )
 
-proto_library(
+alias(
     name = "test_messages_proto3_proto",
-    srcs = ["src/google/protobuf/test_messages_proto3.proto"],
-    strip_import_prefix = "src",
+    actual = "//src/google/protobuf:test_messages_proto3_proto",  # proto_library
     visibility = ["//visibility:public"],
-    deps = [
-        ":any_proto",
-        ":duration_proto",
-        ":field_mask_proto",
-        ":struct_proto",
-        ":timestamp_proto",
-        ":wrappers_proto",
-    ],
 )
 
 # TODO: re-enable this test if appropriate, or replace with something that
@@ -875,46 +460,6 @@ filegroup(
     name = "bzl_srcs",
     srcs = glob(["**/*.bzl"]),
     visibility = ["//visibility:public"],
-)
-
-# Kotlin proto rules
-
-proto_library(
-    name = "kt_unittest_lite",
-    srcs = [
-        "src/google/protobuf/map_lite_unittest.proto",
-        "src/google/protobuf/unittest_import_lite.proto",
-        "src/google/protobuf/unittest_import_public_lite.proto",
-        "src/google/protobuf/unittest_lite.proto",
-    ],
-    strip_import_prefix = "src",
-    visibility = ["//java/kotlin-lite:__subpackages__"],
-)
-
-proto_library(
-    name = "kt_unittest",
-    srcs = [
-        "src/google/protobuf/map_proto2_unittest.proto",
-        "src/google/protobuf/unittest.proto",
-        "src/google/protobuf/unittest_import.proto",
-        "src/google/protobuf/unittest_import_public.proto",
-    ],
-    strip_import_prefix = "src",
-    visibility = ["//java/kotlin:__subpackages__"],
-)
-
-proto_library(
-    name = "kt_proto3_unittest",
-    srcs = [
-        "src/google/protobuf/unittest_import.proto",
-        "src/google/protobuf/unittest_import_public.proto",
-        "src/google/protobuf/unittest_proto3.proto",
-    ],
-    strip_import_prefix = "src",
-    visibility = [
-        "//java/kotlin:__subpackages__",
-        "//java/kotlin-lite:__subpackages__",
-    ],
 )
 
 ################################################################################

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -504,19 +504,6 @@ pkg_files(
     visibility = ["//pkg:__pkg__"],
 )
 
-# C++ runtime
-pkg_files(
-    name = "cpp_dist_files",
-    srcs = glob(
-        ["src/**/*"],
-        exclude = [
-            "src/google/protobuf/compiler/objectivec/method_dump.sh",  # not in autotools dist
-        ],
-    ),
-    strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//pkg:__pkg__"],
-)
-
 # Additional files for C#
 pkg_files(
     name = "csharp_dist_files",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -102,7 +102,7 @@ alias(
 )
 
 # Built-in runtime protos: these are part of protobuf's internal
-# impelementation, but are not Well-Known Types.
+# implementation, but are not Well-Known Types.
 
 alias(
     name = "descriptor_proto",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -122,25 +122,6 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-# adapt_proto_library(
-#     name = "cc_wkt_protos_genproto",
-#     visibility = ["//visibility:public"],
-#     deps = [
-#         "//:any_proto",
-#         "//:api_proto",
-#         "//:compiler_plugin_proto",
-#         "//:descriptor_proto",
-#         "//:duration_proto",
-#         "//:empty_proto",
-#         "//:field_mask_proto",
-#         "//:source_context_proto",
-#         "//:struct_proto",
-#         "//:timestamp_proto",
-#         "//:type_proto",
-#         "//:wrappers_proto",
-#     ],
-# )
-
 cc_library(
     name = "cc_wkt_protos",
     deprecation = "Only for backward compatibility. Do not use.",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -111,7 +111,7 @@ alias(
 )
 
 alias(
-    name = "built_in_runtime_protos",
+    name = "descriptor_proto_srcs",
     actual = "//src/google/protobuf:descriptor_proto_srcs",  # filegroup
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -209,19 +209,6 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-# TODO(dlj): remove:
-alias(
-    name = "arena",
-    actual = "//src/google/protobuf:arena",
-    visibility = [":__subpackages__"],
-)
-
-alias(
-    name = "port_def",
-    actual = "//src/google/protobuf:port_def",
-    visibility = [":__subpackages__"],
-)
-
 ################################################################################
 # Java support
 ################################################################################

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -191,7 +191,7 @@ java_export(
     maven_coordinates = "com.google.protobuf:protobuf-java:%s" % PROTOBUF_JAVA_VERSION,
     pom_template = "pom_template.xml",
     resources = [
-        "//:built_in_runtime_protos",
+        "//src/google/protobuf:descriptor_proto_srcs",
         "//:well_known_type_protos",
     ],
     tags = ["manual"],

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -242,9 +242,9 @@ proto_library(
     deps = [
         "//:any_proto",
         "//:descriptor_proto",
-        "//:generic_test_protos",
         "//:lite_test_protos",
         "//:wrappers_proto",
+        "//src/google/protobuf:generic_test_protos",
     ],
 )
 
@@ -253,7 +253,7 @@ java_proto_library(
     visibility = [
         "//java:__subpackages__",
     ],
-    deps = ["//:generic_test_protos"],
+    deps = ["//src/google/protobuf:generic_test_protos"],
 )
 
 java_proto_library(
@@ -279,8 +279,8 @@ java_library(
     deps = [
         ":core",
         ":generic_test_protos_java_proto",
-        ":lite_test_protos_java_proto",
         ":java_test_protos_java_proto",
+        ":lite_test_protos_java_proto",
         "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",
     ],
@@ -322,12 +322,12 @@ junit_tests(
             "src/test/java/com/google/protobuf/TestUtilLite.java",
         ],
     ),
-    data = ["//:testdata"],
+    data = ["//src/google/protobuf:testdata"],
     deps = [
         ":core",
         ":generic_test_protos_java_proto",
-        ":lite_test_protos_java_proto",
         ":java_test_protos_java_proto",
+        ":lite_test_protos_java_proto",
         ":test_util",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_truth_truth",
@@ -360,7 +360,7 @@ java_lite_proto_library(
         "//java/kotlin-lite:__pkg__",
         "//java/lite:__pkg__",
     ],
-    deps = ["//:generic_test_protos"],
+    deps = ["//src/google/protobuf:generic_test_protos"],
 )
 
 java_lite_proto_library(
@@ -402,9 +402,9 @@ java_library(
     ],
     deps = [
         ":generic_test_protos_java_proto_lite",
-        ":lite_test_protos_java_proto_lite",
         ":java_test_protos_java_proto_lite",
         ":lite_runtime_only",
+        ":lite_test_protos_java_proto_lite",
         "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",
     ],
@@ -461,13 +461,13 @@ junit_tests(
         ["src/test/java/**/*.java"],
         exclude = LITE_TEST_EXCLUSIONS,
     ),
-    data = ["//:testdata"],
+    data = ["//src/google/protobuf:testdata"],
     test_prefix = "Lite",
     deps = [
         ":generic_test_protos_java_proto_lite",
-        ":lite_test_protos_java_proto_lite",
         ":java_test_protos_java_proto_lite",
         ":lite",
+        ":lite_test_protos_java_proto_lite",
         ":test_util_lite",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",

--- a/java/kotlin-lite/BUILD.bazel
+++ b/java/kotlin-lite/BUILD.bazel
@@ -162,7 +162,7 @@ kt_jvm_library(
 internal_gen_kt_protos(
     name = "gen_kotlin_proto3_unittest_lite",
     lite = True,
-    deps = ["//:kt_proto3_unittest"],
+    deps = ["//src/google/protobuf:kt_proto3_unittest_protos"],
 )
 
 kt_jvm_library(

--- a/java/kotlin-lite/BUILD.bazel
+++ b/java/kotlin-lite/BUILD.bazel
@@ -140,7 +140,7 @@ internal_gen_kt_protos(
 internal_gen_kt_protos(
     name = "gen_kotlin_unittest_lite",
     lite = True,
-    deps = ["//:kt_unittest_lite"],
+    deps = ["//src/google/protobuf:lite_test_protos"],
 )
 
 kt_jvm_library(

--- a/java/kotlin/BUILD.bazel
+++ b/java/kotlin/BUILD.bazel
@@ -224,7 +224,7 @@ internal_gen_kt_protos(
 internal_gen_kt_protos(
     name = "gen_kotlin_unittest",
     visibility = ["//java:__subpackages__"],
-    deps = ["//src/google/protobuf:generic_test_protos"],
+    deps = ["//src/google/protobuf:kt_unittest_protos"],
 )
 
 kt_jvm_library(
@@ -246,7 +246,7 @@ kt_jvm_library(
 
 internal_gen_kt_protos(
     name = "gen_kotlin_proto3_unittest",
-    deps = ["//:kt_proto3_unittest"],
+    deps = ["//src/google/protobuf:kt_proto3_unittest_protos"],
 )
 
 kt_jvm_library(

--- a/java/kotlin/BUILD.bazel
+++ b/java/kotlin/BUILD.bazel
@@ -59,7 +59,7 @@ kt_jvm_export(
     maven_coordinates = "com.google.protobuf:protobuf-kotlin:%s" % PROTOBUF_JAVA_VERSION,
     pom_template = "//java/kotlin:pom_template.xml",
     resources = [
-        "//:built_in_runtime_protos",
+        "//src/google/protobuf:descriptor_proto_srcs",
         "//:well_known_type_protos",
     ],
     tags = ["manual"],

--- a/java/kotlin/BUILD.bazel
+++ b/java/kotlin/BUILD.bazel
@@ -224,7 +224,7 @@ internal_gen_kt_protos(
 internal_gen_kt_protos(
     name = "gen_kotlin_unittest",
     visibility = ["//java:__subpackages__"],
-    deps = ["//:kt_unittest"],
+    deps = ["//src/google/protobuf:generic_test_protos"],
 )
 
 kt_jvm_library(

--- a/java/lite/BUILD.bazel
+++ b/java/lite/BUILD.bazel
@@ -71,8 +71,8 @@ junit_tests(
     deps = [
         ":lite",
         "//java/core:generic_test_protos_java_proto_lite",
-        "//java/core:lite_test_protos_java_proto_lite",
         "//java/core:java_test_protos_java_proto_lite",
+        "//java/core:lite_test_protos_java_proto_lite",
         "//java/core:test_util_lite",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",

--- a/kokoro/linux/bazel/build.sh
+++ b/kokoro/linux/bazel/build.sh
@@ -7,16 +7,6 @@ set -ex
 use_bazel.sh 4.0.0
 bazel version
 
-# Print bazel testlogs to stdout when tests failed.
-function print_test_logs {
-  # TODO(yannic): Only print logs of failing tests.
-  testlogs_dir=$(bazel info bazel-testlogs)
-  testlogs=$(find "${testlogs_dir}" -name "*.log")
-  for log in $testlogs; do
-    cat "${log}"
-  done
-}
-
 # Change to repo root
 cd $(dirname $0)/../../..
 
@@ -25,24 +15,13 @@ git submodule update --init --recursive
 #  Disabled for now, re-enable if appropriate.
 #  //:build_files_updated_unittest \
 
-trap print_test_logs EXIT
-bazel test -k --copt=-Werror --host_copt=-Werror \
+bazel test \
+  -k --copt=-Werror --host_copt=-Werror --test_output=errors \
   //build_defs:all \
   //java:tests \
-  //:protoc \
-  //:protobuf \
+  //src/... \
   //:protobuf_python \
-  //:protobuf_test \
-  //src/google/protobuf/compiler/... \
-  //src/google/protobuf/io:all \
-  //src/google/protobuf/stubs:all \
-  //src/google/protobuf/testing:all \
-  //src/google/protobuf/util/...
-trap - EXIT
-
-pushd examples
-bazel build //...
-popd
+  @com_google_protobuf_examples//...
 
 # Verify that we can build successfully from generated tar files.
 ./autogen.sh && ./configure && make -j$(nproc) dist

--- a/kokoro/linux/bazel_distcheck/build.sh
+++ b/kokoro/linux/bazel_distcheck/build.sh
@@ -20,8 +20,7 @@ TEST_TARGETS=(
   //java:tests
   //python:all
   //src/...
-  //:protobuf_test
-  @com_google_protobuf_examples//...
+   @com_google_protobuf_examples//...
 )
 
 CONTAINER_NAME=gcr.io/protobuf-build/bazel/linux

--- a/kokoro/linux/bazel_distcheck/build.sh
+++ b/kokoro/linux/bazel_distcheck/build.sh
@@ -19,12 +19,8 @@ TEST_TARGETS=(
   //conformance:all
   //java:tests
   //python:all
+  //src/...
   //:protobuf_test
-  //src/google/protobuf/compiler/...
-  //src/google/protobuf/io:all
-  //src/google/protobuf/stubs:all
-  //src/google/protobuf/testing:all
-  //src/google/protobuf/util/...
   @com_google_protobuf_examples//...
 )
 

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -86,16 +86,10 @@ pkg_filegroup(
     srcs = [
         ":dist_files",
         "//:common_dist_files",
-        "//:cpp_dist_files",
         "//benchmarks:all_dist_files",
         "//build_defs:dist_files",
         "//conformance:all_dist_files",
-        "//src/google/protobuf/compiler:all_dist_files",
-        "//src/google/protobuf/io:dist_files",
-        "//src/google/protobuf/stubs:dist_files",
-        "//src/google/protobuf/testing:dist_files",
-        "//src/google/protobuf/util:dist_files",
-        "//src/google/protobuf/util/internal:dist_files",
+        "//src:all_dist_files",
         "@com_google_protobuf_examples//:dist_files",
     ],
 )
@@ -104,8 +98,7 @@ pkg_filegroup(
     name = "cpp_srcs",
     srcs = [
         ":dist_common",
-        "//:cpp_dist_files",
-        "//src/google/protobuf/compiler:all_dist_files",
+        "//src:all_dist_files",
     ],
 )
 

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -348,7 +348,7 @@ cc_dist_library(
     }),
     tags = ["manual"],
     deps = [
-        "//:arena",
+        "//src/google/protobuf:arena",
         "//:protobuf_lite",
         "//src/google/protobuf/io",
         "//src/google/protobuf/io:io_win32",
@@ -367,7 +367,7 @@ cc_dist_library(
     }),
     tags = ["manual"],
     deps = [
-        "//:arena",
+        "//src/google/protobuf:arena",
         "//:protobuf",
         "//:protobuf_lite",
         "//src/google/protobuf/compiler:importer",

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -348,8 +348,8 @@ cc_dist_library(
     }),
     tags = ["manual"],
     deps = [
-        "//src/google/protobuf:arena",
         "//:protobuf_lite",
+        "//src/google/protobuf:arena",
         "//src/google/protobuf/io",
         "//src/google/protobuf/io:io_win32",
         "//src/google/protobuf/stubs:lite",
@@ -367,9 +367,9 @@ cc_dist_library(
     }),
     tags = ["manual"],
     deps = [
-        "//src/google/protobuf:arena",
         "//:protobuf",
         "//:protobuf_lite",
+        "//src/google/protobuf:arena",
         "//src/google/protobuf/compiler:importer",
         "//src/google/protobuf/io",
         "//src/google/protobuf/io:gzip_stream",

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -16,18 +16,7 @@ package_naming(
 
 pkg_files(
     name = "wkt_protos_files",
-    srcs = [
-        "//:any_proto",
-        "//:api_proto",
-        "//:duration_proto",
-        "//:empty_proto",
-        "//:field_mask_proto",
-        "//:source_context_proto",
-        "//:struct_proto",
-        "//:timestamp_proto",
-        "//:type_proto",
-        "//:wrappers_proto",
-    ],
+    srcs = ["//src/google/protobuf:well_known_type_protos"],
     prefix = "include/google/protobuf",
     visibility = ["//visibility:private"],
 )

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -254,7 +254,7 @@ py_test(
     name = "message_test",
     srcs = ["google/protobuf/internal/message_test.py"],
     data = glob(["testdata/golden_pickle_*"]) + [
-        "//:testdata",
+        "//src/google/protobuf:testdata",
     ],
     imports = ["."],
     deps = [":python_test_lib"],
@@ -298,7 +298,7 @@ py_test(
 py_test(
     name = "text_format_test",
     srcs = ["google/protobuf/internal/text_format_test.py"],
-    data = ["//:testdata"],
+    data = ["//src/google/protobuf:testdata"],
     imports = ["."],
     deps = [":python_test_lib"],
 )

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -52,7 +52,7 @@ py_proto_library(
 internal_copy_files(
     name = "copied_wkt_proto_files",
     srcs = [
-        "//:built_in_runtime_protos",
+        "//src/google/protobuf:descriptor_proto_srcs",
         "//:well_known_type_protos",
     ],
     strip_prefix = "src",

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,0 +1,5 @@
+################################################################################
+# Protocol Buffers: C++ Runtime
+################################################################################
+
+# Most rules are under google/protobuf. This package exists for convenience.

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -3,3 +3,25 @@
 ################################################################################
 
 # Most rules are under google/protobuf. This package exists for convenience.
+load("@rules_pkg//:mappings.bzl", "pkg_filegroup")
+
+pkg_filegroup(
+    name = "all_dist_files",
+    srcs = [
+        "//src/google/protobuf:dist_files",
+        "//src/google/protobuf/compiler:dist_files",
+        "//src/google/protobuf/compiler/cpp:dist_files",
+        "//src/google/protobuf/compiler/csharp:dist_files",
+        "//src/google/protobuf/compiler/java:dist_files",
+        "//src/google/protobuf/compiler/objectivec:dist_files",
+        "//src/google/protobuf/compiler/php:dist_files",
+        "//src/google/protobuf/compiler/python:dist_files",
+        "//src/google/protobuf/compiler/ruby:dist_files",
+        "//src/google/protobuf/io:dist_files",
+        "//src/google/protobuf/stubs:dist_files",
+        "//src/google/protobuf/testing:dist_files",
+        "//src/google/protobuf/util:dist_files",
+        "//src/google/protobuf/util/internal:dist_files",
+    ],
+    visibility = ["//pkg:__pkg__"],
+)

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -3,11 +3,19 @@
 ################################################################################
 
 # Most rules are under google/protobuf. This package exists for convenience.
-load("@rules_pkg//:mappings.bzl", "pkg_filegroup")
+load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//src:__pkg__"],
+)
 
 pkg_filegroup(
     name = "all_dist_files",
     srcs = [
+        ":dist_files",
         "//src/google/protobuf:dist_files",
         "//src/google/protobuf/compiler:dist_files",
         "//src/google/protobuf/compiler/cpp:dist_files",

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -540,7 +540,9 @@ protoc_inputs =                                                   \
 
 EXTRA_DIST =                                                   \
   $(protoc_inputs)                                             \
+  BUILD.bazel                                                  \
   README.md                                                    \
+  google/protobuf/BUILD.bazel                                  \
   google/protobuf/compiler/BUILD.bazel                         \
   google/protobuf/compiler/cpp/BUILD.bazel                     \
   google/protobuf/compiler/csharp/BUILD.bazel                  \

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -458,7 +458,12 @@ cc_library(
         "test_util2.h",
         "test_util_lite.h",
     ],
-    copts = COPTS,
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": [
+            "-Wno-error=sign-compare",
+        ],
+    }),
     strip_include_prefix = "/src",
     textual_hdrs = [
         "map_test_util.inc",
@@ -511,6 +516,7 @@ cc_test(
         "//build_defs:config_msvc": [],
         "//conditions:default": [
             "-Wno-deprecated-declarations",
+            "-Wno-error=sign-compare",
         ],
     }),
     data = [

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -524,3 +524,31 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+# Helper targets for Kotlin tests:
+
+proto_library(
+    name = "kt_unittest_protos",
+    srcs = [
+        "map_proto2_unittest.proto",
+        "unittest.proto",
+        "unittest_import.proto",
+        "unittest_import_public.proto",
+    ],
+    strip_import_prefix = "/src",
+    visibility = ["//java/kotlin:__pkg__"],
+)
+
+proto_library(
+    name = "kt_proto3_unittest_protos",
+    srcs = [
+        "unittest_import.proto",
+        "unittest_import_public.proto",
+        "unittest_proto3.proto",
+    ],
+    strip_import_prefix = "/src",
+    visibility = [
+        "//java/kotlin:__pkg__",
+        "//java/kotlin-lite:__pkg__",
+    ],
+)

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -524,8 +524,9 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
-
-# Helper targets for Kotlin tests:
+################################################################################
+# Helper targets for Kotlin tests
+################################################################################
 
 proto_library(
     name = "kt_unittest_protos",
@@ -551,4 +552,15 @@ proto_library(
         "//java/kotlin:__pkg__",
         "//java/kotlin-lite:__pkg__",
     ],
+)
+
+################################################################################
+# Packaging rules
+################################################################################
+
+pkg_files(
+    name = "dist_files",
+    srcs = glob(["**/*"]),
+    strip_prefix = strip_prefix.from_root(""),
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -150,7 +150,12 @@ cc_library(
         "**/*.h",
         "**/*.inc",
     ]),
-    copts = COPTS,
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": [
+            "-Wno-error",
+        ],
+    }),
     include_prefix = "google/protobuf",
     linkopts = LINK_OPTS,
     visibility = [

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -560,7 +560,7 @@ proto_library(
 
 pkg_files(
     name = "dist_files",
-    srcs = glob(["**/*"]),
+    srcs = glob(["**"]),
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -1,0 +1,526 @@
+################################################################################
+# Protocol Buffers: C++ Runtime and common proto files
+################################################################################
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
+
+package(
+    default_visibility = [
+        "//:__pkg__",  # "public" targets are alias rules in //.
+    ],
+)
+
+proto_library(
+    name = "any_proto",
+    srcs = ["any.proto"],
+    strip_import_prefix = "/src",
+)
+
+proto_library(
+    name = "api_proto",
+    srcs = ["api.proto"],
+    strip_import_prefix = "/src",
+    deps = [
+        "//:source_context_proto",
+        "//:type_proto",
+    ],
+)
+
+proto_library(
+    name = "duration_proto",
+    srcs = ["duration.proto"],
+    strip_import_prefix = "/src",
+)
+
+proto_library(
+    name = "empty_proto",
+    srcs = ["empty.proto"],
+    strip_import_prefix = "/src",
+)
+
+proto_library(
+    name = "field_mask_proto",
+    srcs = ["field_mask.proto"],
+    strip_import_prefix = "/src",
+)
+
+proto_library(
+    name = "source_context_proto",
+    srcs = ["source_context.proto"],
+    strip_import_prefix = "/src",
+)
+
+proto_library(
+    name = "struct_proto",
+    srcs = ["struct.proto"],
+    strip_import_prefix = "/src",
+)
+
+proto_library(
+    name = "timestamp_proto",
+    srcs = ["timestamp.proto"],
+    strip_import_prefix = "/src",
+)
+
+proto_library(
+    name = "type_proto",
+    srcs = ["type.proto"],
+    strip_import_prefix = "/src",
+    deps = [
+        "//:any_proto",
+        "//:source_context_proto",
+    ],
+)
+
+proto_library(
+    name = "wrappers_proto",
+    srcs = ["wrappers.proto"],
+    strip_import_prefix = "/src",
+)
+
+# Built-in runtime types
+
+proto_library(
+    name = "descriptor_proto",
+    srcs = ["descriptor.proto"],
+    strip_import_prefix = "/src",
+)
+
+################################################################################
+# C++ Runtime Library
+################################################################################
+
+cc_library(
+    name = "port_def",
+    hdrs = [
+        "port.h",
+        "port_def.inc",
+        "port_undef.inc",
+    ],
+    include_prefix = "google/protobuf",
+    visibility = [
+        "//:__subpackages__",
+        "//src/google/protobuf:__subpackages__",
+    ],
+)
+
+cc_library(
+    name = "arena",
+    srcs = [
+        "arena.cc",
+    ],
+    hdrs = [
+        "arena.h",
+        "arena_impl.h",
+        "arenaz_sampler.h",
+    ],
+    include_prefix = "google/protobuf",
+    visibility = [
+        "//:__subpackages__",
+        "//src/google/protobuf:__subpackages__",
+    ],
+    deps = [
+        "//src/google/protobuf/stubs:lite",
+    ],
+)
+
+cc_library(
+    name = "protobuf_lite",
+    srcs = [
+        "any_lite.cc",
+        "arenastring.cc",
+        "arenaz_sampler.cc",
+        "extension_set.cc",
+        "generated_enum_util.cc",
+        "generated_message_tctable_lite.cc",
+        "generated_message_util.cc",
+        "implicit_weak_message.cc",
+        "inlined_string_field.cc",
+        "map.cc",
+        "message_lite.cc",
+        "parse_context.cc",
+        "repeated_field.cc",
+        "repeated_ptr_field.cc",
+        "wire_format_lite.cc",
+    ],
+    hdrs = glob([
+        "**/*.h",
+        "**/*.inc",
+    ]),
+    copts = COPTS,
+    include_prefix = "google/protobuf",
+    linkopts = LINK_OPTS,
+    visibility = [
+        "//:__pkg__",
+        "//src/google/protobuf:__subpackages__",
+    ],
+    # In Bazel 6.0+, these will be `interface_deps`:
+    deps = [
+        ":arena",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/stubs:lite",
+    ],
+)
+
+cc_library(
+    name = "protobuf",
+    srcs = [
+        "any.cc",
+        "any.pb.cc",
+        "api.pb.cc",
+        "descriptor.cc",
+        "descriptor.pb.cc",
+        "descriptor_database.cc",
+        "duration.pb.cc",
+        "dynamic_message.cc",
+        "empty.pb.cc",
+        "extension_set_heavy.cc",
+        "field_mask.pb.cc",
+        "generated_message_bases.cc",
+        "generated_message_reflection.cc",
+        "generated_message_tctable_full.cc",
+        "map_field.cc",
+        "message.cc",
+        "reflection_ops.cc",
+        "service.cc",
+        "source_context.pb.cc",
+        "struct.pb.cc",
+        "text_format.cc",
+        "timestamp.pb.cc",
+        "type.pb.cc",
+        "unknown_field_set.cc",
+        "wire_format.cc",
+        "wrappers.pb.cc",
+    ],
+    hdrs = glob([
+        "**/*.h",
+        "**/*.inc",
+    ]),
+    copts = COPTS,
+    include_prefix = "google/protobuf",
+    linkopts = LINK_OPTS,
+    visibility = [
+        "//:__pkg__",
+        "//src/google/protobuf:__subpackages__",
+    ],
+    deps = [
+        ":protobuf_lite",
+        "//src/google/protobuf/io",
+        "//src/google/protobuf/io:gzip_stream",
+        "//src/google/protobuf/io:printer",
+        "//src/google/protobuf/io:tokenizer",
+        "//src/google/protobuf/stubs",
+    ],
+)
+
+# This provides just the header files for use in projects that need to build
+# shared libraries for dynamic loading. This target is available until Bazel
+# adds native support for such use cases.
+# TODO(keveman): Remove this target once the support gets added to Bazel.
+cc_library(
+    name = "protobuf_headers",
+    hdrs = glob([
+        "**/*.h",
+        "**/*.inc",
+    ]),
+)
+
+filegroup(
+    name = "well_known_type_protos",
+    srcs = [
+        "any.proto",
+        "api.proto",
+        "duration.proto",
+        "empty.proto",
+        "field_mask.proto",
+        "source_context.proto",
+        "struct.proto",
+        "timestamp.proto",
+        "type.proto",
+        "wrappers.proto",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+filegroup(
+    name = "descriptor_proto_srcs",
+    srcs = ["descriptor.proto"],
+    visibility = ["//:__subpackages__"],
+)
+
+filegroup(
+    name = "testdata",
+    srcs = glob(["testdata/**/*"]) + [
+        "descriptor.cc",
+    ],
+    visibility = [
+        "//:__subpackages__",
+        "@upb//:__subpackages__",
+    ],
+)
+
+proto_library(
+    name = "lite_test_protos",
+    srcs = [
+        "map_lite_unittest.proto",
+        "unittest_import_lite.proto",
+        "unittest_import_public_lite.proto",
+        "unittest_lite.proto",
+    ],
+    strip_import_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":any_proto",
+        ":api_proto",
+        ":descriptor_proto",
+        ":duration_proto",
+        ":empty_proto",
+        ":field_mask_proto",
+        ":source_context_proto",
+        ":struct_proto",
+        ":timestamp_proto",
+        ":type_proto",
+        ":wrappers_proto",
+    ],
+)
+
+filegroup(
+    name = "test_proto_srcs",
+    srcs = [
+        "any_test.proto",
+        "map_proto2_unittest.proto",
+        "map_unittest.proto",
+        "unittest.proto",
+        "unittest_arena.proto",
+        "unittest_custom_options.proto",
+        "unittest_drop_unknown_fields.proto",
+        "unittest_embed_optimize_for.proto",
+        "unittest_empty.proto",
+        "unittest_enormous_descriptor.proto",
+        "unittest_import.proto",
+        "unittest_import_public.proto",
+        "unittest_lazy_dependencies.proto",
+        "unittest_lazy_dependencies_custom_option.proto",
+        "unittest_lazy_dependencies_enum.proto",
+        "unittest_lite_imports_nonlite.proto",
+        "unittest_mset.proto",
+        "unittest_mset_wire_format.proto",
+        "unittest_no_field_presence.proto",
+        "unittest_no_generic_services.proto",
+        "unittest_optimize_for.proto",
+        "unittest_preserve_unknown_enum.proto",
+        "unittest_preserve_unknown_enum2.proto",
+        "unittest_proto3.proto",
+        "unittest_proto3_arena.proto",
+        "unittest_proto3_arena_lite.proto",
+        "unittest_proto3_lite.proto",
+        "unittest_proto3_optional.proto",
+        "unittest_well_known_types.proto",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+proto_library(
+    name = "test_protos",
+    srcs = [":test_proto_srcs"],
+    strip_import_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":any_proto",
+        ":api_proto",
+        ":descriptor_proto",
+        ":duration_proto",
+        ":empty_proto",
+        ":field_mask_proto",
+        ":source_context_proto",
+        ":struct_proto",
+        ":timestamp_proto",
+        ":type_proto",
+        ":wrappers_proto",
+    ],
+)
+
+proto_library(
+    name = "generic_test_protos",
+    srcs = [
+        "map_proto2_unittest.proto",
+        "map_unittest.proto",
+        "unittest.proto",
+        "unittest_arena.proto",
+        "unittest_custom_options.proto",
+        "unittest_drop_unknown_fields.proto",
+        "unittest_embed_optimize_for.proto",
+        "unittest_empty.proto",
+        "unittest_enormous_descriptor.proto",
+        "unittest_import.proto",
+        "unittest_import_public.proto",
+        "unittest_lazy_dependencies.proto",
+        "unittest_lazy_dependencies_custom_option.proto",
+        "unittest_lazy_dependencies_enum.proto",
+        "unittest_lite_imports_nonlite.proto",
+        "unittest_mset.proto",
+        "unittest_mset_wire_format.proto",
+        "unittest_no_field_presence.proto",
+        "unittest_no_generic_services.proto",
+        "unittest_optimize_for.proto",
+        "unittest_preserve_unknown_enum.proto",
+        "unittest_preserve_unknown_enum2.proto",
+        "unittest_proto3.proto",
+        "unittest_proto3_arena.proto",
+        "unittest_proto3_arena_lite.proto",
+        "unittest_proto3_lite.proto",
+        "unittest_proto3_optional.proto",
+        "unittest_well_known_types.proto",
+    ],
+    strip_import_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":any_proto",
+        ":api_proto",
+        ":descriptor_proto",
+        ":duration_proto",
+        ":empty_proto",
+        ":field_mask_proto",
+        ":source_context_proto",
+        ":struct_proto",
+        ":timestamp_proto",
+        ":type_proto",
+        ":wrappers_proto",
+    ],
+)
+
+proto_library(
+    name = "test_messages_proto2_proto",
+    srcs = ["test_messages_proto2.proto"],
+    strip_import_prefix = "/src",
+)
+
+proto_library(
+    name = "test_messages_proto3_proto",
+    srcs = ["test_messages_proto3.proto"],
+    strip_import_prefix = "/src",
+    deps = [
+        ":any_proto",
+        ":duration_proto",
+        ":field_mask_proto",
+        ":struct_proto",
+        ":timestamp_proto",
+        ":wrappers_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "cc_lite_test_protos",
+    deps = [":lite_test_protos"],
+)
+
+cc_proto_library(
+    name = "cc_test_protos",
+    visibility = ["//src/google/protobuf:__subpackages__"],
+    deps = [":test_protos"],
+)
+
+# Filegroup for golden comparison test:
+filegroup(
+    name = "descriptor_cc_srcs",
+    testonly = 1,
+    data = [
+        "descriptor.pb.cc",
+        "descriptor.pb.h",
+    ],
+    visibility = ["//src/google/protobuf/compiler/cpp:__pkg__"],
+)
+
+cc_library(
+    name = "test_util",
+    testonly = 1,
+    srcs = [
+        "arena_test_util.cc",
+        "map_lite_test_util.cc",
+        "reflection_tester.cc",
+        "test_util.cc",
+        "test_util_lite.cc",
+    ],
+    hdrs = [
+        "arena_test_util.h",
+        "map_lite_test_util.h",
+        "map_test_util.h",
+        "map_test_util_impl.h",
+        "test_util.h",
+        "test_util2.h",
+        "test_util_lite.h",
+    ],
+    copts = COPTS,
+    strip_include_prefix = "/src",
+    textual_hdrs = [
+        "map_test_util.inc",
+        "test_util.inc",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":cc_lite_test_protos",
+        ":cc_test_protos",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "protobuf_test",
+    srcs = [
+        "any_test.cc",
+        "arena_unittest.cc",
+        "arenastring_unittest.cc",
+        "arenaz_sampler_test.cc",
+        "descriptor_database_unittest.cc",
+        "descriptor_unittest.cc",
+        "drop_unknown_fields_test.cc",
+        "dynamic_message_unittest.cc",
+        "extension_set_unittest.cc",
+        "generated_message_reflection_unittest.cc",
+        "generated_message_tctable_lite_test.cc",
+        "inlined_string_field_unittest.cc",
+        "map_field_test.cc",
+        "map_test.cc",
+        "map_test.inc",
+        "message_unittest.cc",
+        "message_unittest.inc",
+        "no_field_presence_test.cc",
+        "preserve_unknown_enum_test.cc",
+        "proto3_arena_lite_unittest.cc",
+        "proto3_arena_unittest.cc",
+        "proto3_lite_unittest.cc",
+        "proto3_lite_unittest.inc",
+        "reflection_ops_unittest.cc",
+        "repeated_field_reflection_unittest.cc",
+        "repeated_field_unittest.cc",
+        "text_format_unittest.cc",
+        "unknown_field_set_unittest.cc",
+        "well_known_types_unittest.cc",
+        "wire_format_unittest.cc",
+        "wire_format_unittest.inc",
+    ],
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": [
+            "-Wno-deprecated-declarations",
+        ],
+    }),
+    data = [
+        ":testdata",
+    ] + glob([
+        "**/*",
+    ]),
+    linkopts = LINK_OPTS,
+    deps = [
+        ":cc_lite_test_protos",
+        ":cc_test_protos",
+        ":protobuf",
+        ":test_util",
+        "//src/google/protobuf/testing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -291,20 +291,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-)
-
-# Convenience pkg_filegroup: includes all code generators.
-pkg_filegroup(
-    name = "all_dist_files",
-    srcs = [
-        ":dist_files",
-        "//src/google/protobuf/compiler/cpp:dist_files",
-        "//src/google/protobuf/compiler/csharp:dist_files",
-        "//src/google/protobuf/compiler/java:dist_files",
-        "//src/google/protobuf/compiler/objectivec:dist_files",
-        "//src/google/protobuf/compiler/php:dist_files",
-        "//src/google/protobuf/compiler/python:dist_files",
-        "//src/google/protobuf/compiler/ruby:dist_files",
-    ],
-    visibility = ["//pkg:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -33,7 +33,7 @@ cc_library(
     copts = COPTS,
     include_prefix = "google/protobuf/compiler",
     visibility = ["//visibility:public"],
-    deps = ["//:internal_protobuf_full"],
+    deps = ["//src/google/protobuf"],
 )
 
 cc_library(
@@ -122,6 +122,7 @@ cc_library(
     srcs = ["annotation_test_util.cc"],
     hdrs = ["annotation_test_util.h"],
     copts = COPTS,
+    strip_include_prefix = "/src",
     visibility = ["//visibility:public"],
     deps = [
         ":code_generator",
@@ -155,6 +156,7 @@ cc_library(
     srcs = ["mock_code_generator.cc"],
     hdrs = ["mock_code_generator.h"],
     copts = COPTS,
+    strip_include_prefix = "/src",
     deps = [
         ":code_generator",
         "//src/google/protobuf/io",
@@ -189,14 +191,14 @@ cc_test(
     data = [
         ":test_plugin",
         "//:test_proto_srcs",
-        "//:testdata",
+        "//src/google/protobuf:testdata",
     ],
     deps = [
         ":code_generator",
         ":command_line_interface",
         ":mock_code_generator",
-        "//:cc_test_protos",
         "//:protobuf",
+        "//src/google/protobuf:cc_test_protos",
         "//src/google/protobuf/io",
         "//src/google/protobuf/stubs",
         "//src/google/protobuf/testing",
@@ -232,8 +234,8 @@ cc_test(
     }),
     deps = [
         ":importer",
-        "//:cc_test_protos",
         "//:protobuf",
+        "//src/google/protobuf:cc_test_protos",
         "//src/google/protobuf/io",
         "//src/google/protobuf/stubs",
         "//src/google/protobuf/testing",

--- a/src/google/protobuf/compiler/cpp/BUILD.bazel
+++ b/src/google/protobuf/compiler/cpp/BUILD.bazel
@@ -116,7 +116,7 @@ cc_test(
     name = "bootstrap_unittest",
     srcs = ["bootstrap_unittest.cc"],
     data = [
-        "//:built_in_runtime_protos",
+        "//src/google/protobuf:descriptor_proto_srcs",
         "//:well_known_type_protos",
         "//src/google/protobuf:descriptor_cc_srcs",
         "//src/google/protobuf:testdata",

--- a/src/google/protobuf/compiler/cpp/BUILD.bazel
+++ b/src/google/protobuf/compiler/cpp/BUILD.bazel
@@ -192,5 +192,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/compiler/cpp/BUILD.bazel
+++ b/src/google/protobuf/compiler/cpp/BUILD.bazel
@@ -93,6 +93,7 @@ cc_library(
 cc_test(
     name = "unittest",
     srcs = ["unittest.cc"],
+    copts = COPTS,
     data = [
         "//:test_proto_srcs",
         "//src/google/protobuf:testdata",
@@ -116,9 +117,9 @@ cc_test(
     name = "bootstrap_unittest",
     srcs = ["bootstrap_unittest.cc"],
     data = [
-        "//src/google/protobuf:descriptor_proto_srcs",
         "//:well_known_type_protos",
         "//src/google/protobuf:descriptor_cc_srcs",
+        "//src/google/protobuf:descriptor_proto_srcs",
         "//src/google/protobuf:testdata",
         "//src/google/protobuf/compiler:plugin_proto_srcs",
     ],
@@ -160,6 +161,7 @@ cc_test(
 cc_test(
     name = "move_unittest",
     srcs = ["move_unittest.cc"],
+    copts = COPTS,
     deps = [
         "//:protobuf",
         "//src/google/protobuf:cc_test_protos",

--- a/src/google/protobuf/compiler/cpp/BUILD.bazel
+++ b/src/google/protobuf/compiler/cpp/BUILD.bazel
@@ -81,22 +81,28 @@ cc_proto_library(
     deps = [":test_large_enum_value_proto"],
 )
 
-cc_test(
-    name = "unittest",
-    srcs = [
-        "unittest.cc",
+cc_library(
+    name = "unittest_lib",
+    hdrs = [
         "unittest.h",
         "unittest.inc",
     ],
+    strip_include_prefix = "/src",
+)
+
+cc_test(
+    name = "unittest",
+    srcs = ["unittest.cc"],
     data = [
         "//:test_proto_srcs",
-        "//:testdata",
+        "//src/google/protobuf:testdata",
     ],
     deps = [
         ":cpp",
         ":test_bad_identifiers_cc_proto",
-        "//:cc_test_protos",
+        ":unittest_lib",
         "//:protobuf",
+        "//src/google/protobuf:cc_test_protos",
         "//src/google/protobuf/compiler:importer",
         "//src/google/protobuf/io",
         "//src/google/protobuf/stubs",
@@ -111,9 +117,9 @@ cc_test(
     srcs = ["bootstrap_unittest.cc"],
     data = [
         "//:built_in_runtime_protos",
-        "//:descriptor_cc_srcs",
-        "//:testdata",
         "//:well_known_type_protos",
+        "//src/google/protobuf:descriptor_cc_srcs",
+        "//src/google/protobuf:testdata",
         "//src/google/protobuf/compiler:plugin_proto_srcs",
     ],
     deps = [
@@ -132,8 +138,8 @@ cc_test(
     name = "message_size_unittest",
     srcs = ["message_size_unittest.cc"],
     deps = [
-        "//:cc_test_protos",
         "//:protobuf",
+        "//src/google/protobuf:cc_test_protos",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
@@ -155,9 +161,9 @@ cc_test(
     name = "move_unittest",
     srcs = ["move_unittest.cc"],
     deps = [
-        "//:cc_test_protos",
         "//:protobuf",
-        "//:test_util",
+        "//src/google/protobuf:cc_test_protos",
+        "//src/google/protobuf:test_util",
         "//src/google/protobuf/stubs:lite",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",

--- a/src/google/protobuf/compiler/csharp/BUILD.bazel
+++ b/src/google/protobuf/compiler/csharp/BUILD.bazel
@@ -62,12 +62,12 @@ cc_test(
     name = "bootstrap_unittest",
     srcs = ["csharp_bootstrap_unittest.cc"],
     data = [
-        "//:built_in_runtime_protos",
-        "//src/google/protobuf:testdata",
+        "//src/google/protobuf:descriptor_proto_srcs",
         "//:well_known_type_protos",
         "//conformance:all_files",
         "//conformance:conformance_proto",
         "//csharp:wkt_cs_srcs",
+        "//src/google/protobuf:testdata",
     ],
     deps = [
         ":csharp",

--- a/src/google/protobuf/compiler/csharp/BUILD.bazel
+++ b/src/google/protobuf/compiler/csharp/BUILD.bazel
@@ -102,5 +102,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/compiler/csharp/BUILD.bazel
+++ b/src/google/protobuf/compiler/csharp/BUILD.bazel
@@ -63,7 +63,7 @@ cc_test(
     srcs = ["csharp_bootstrap_unittest.cc"],
     data = [
         "//:built_in_runtime_protos",
-        "//:testdata",
+        "//src/google/protobuf:testdata",
         "//:well_known_type_protos",
         "//conformance:all_files",
         "//conformance:conformance_proto",

--- a/src/google/protobuf/compiler/java/BUILD.bazel
+++ b/src/google/protobuf/compiler/java/BUILD.bazel
@@ -119,5 +119,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/compiler/java/BUILD.bazel
+++ b/src/google/protobuf/compiler/java/BUILD.bazel
@@ -85,7 +85,7 @@ cc_test(
     name = "doc_comment_unittest",
     srcs = ["doc_comment_unittest.cc"],
     data = [
-        "//:built_in_runtime_protos",
+        "//src/google/protobuf:descriptor_proto_srcs",
         "//:well_known_type_protos",
         "//conformance:conformance_proto",
     ],

--- a/src/google/protobuf/compiler/objectivec/BUILD.bazel
+++ b/src/google/protobuf/compiler/objectivec/BUILD.bazel
@@ -65,5 +65,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/compiler/php/BUILD.bazel
+++ b/src/google/protobuf/compiler/php/BUILD.bazel
@@ -27,5 +27,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/compiler/python/BUILD.bazel
+++ b/src/google/protobuf/compiler/python/BUILD.bazel
@@ -49,5 +49,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/compiler/ruby/BUILD.bazel
+++ b/src/google/protobuf/compiler/ruby/BUILD.bazel
@@ -34,7 +34,7 @@ cc_test(
         "ruby_generated_pkg_explicit_pb.rb",
         "ruby_generated_pkg_implicit.proto",
         "ruby_generated_pkg_implicit_pb.rb",
-        "//:testdata",
+        "//src/google/protobuf:testdata",
     ],
     deps = [
         ":ruby",

--- a/src/google/protobuf/compiler/ruby/BUILD.bazel
+++ b/src/google/protobuf/compiler/ruby/BUILD.bazel
@@ -54,5 +54,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/io/BUILD.bazel
+++ b/src/google/protobuf/io/BUILD.bazel
@@ -108,7 +108,7 @@ cc_test(
         "//conditions:default": ["-Wno-maybe-uninitialized"],
     }),
     data = [
-        "//:testdata",
+        "//src/google/protobuf:testdata",
     ],
     deps = [
         ":gzip_stream",

--- a/src/google/protobuf/io/BUILD.bazel
+++ b/src/google/protobuf/io/BUILD.bazel
@@ -88,7 +88,7 @@ cc_library(
     hdrs = ["io_win32.h"],
     copts = COPTS,
     include_prefix = "google/protobuf/io",
-    visibility = ["//src:__pkg__"],
+    visibility = ["//pkg:__pkg__"],
     deps = [
         "//src/google/protobuf:arena",
         "//src/google/protobuf/stubs:lite",

--- a/src/google/protobuf/io/BUILD.bazel
+++ b/src/google/protobuf/io/BUILD.bazel
@@ -88,7 +88,7 @@ cc_library(
     hdrs = ["io_win32.h"],
     copts = COPTS,
     include_prefix = "google/protobuf/io",
-    visibility = ["//pkg:__pkg__"],
+    visibility = ["//src:__pkg__"],
     deps = [
         "//src/google/protobuf:arena",
         "//src/google/protobuf/stubs:lite",
@@ -142,5 +142,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//pkg:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/io/BUILD.bazel
+++ b/src/google/protobuf/io/BUILD.bazel
@@ -26,7 +26,7 @@ cc_library(
     include_prefix = "google/protobuf/io",
     deps = [
         ":io_win32",
-        "//:arena",
+        "//src/google/protobuf:arena",
         "//src/google/protobuf/stubs:lite",
     ],
 )
@@ -90,7 +90,7 @@ cc_library(
     include_prefix = "google/protobuf/io",
     visibility = ["//pkg:__pkg__"],
     deps = [
-        "//:arena",
+        "//src/google/protobuf:arena",
         "//src/google/protobuf/stubs:lite",
     ],
 )

--- a/src/google/protobuf/stubs/BUILD.bazel
+++ b/src/google/protobuf/stubs/BUILD.bazel
@@ -51,7 +51,7 @@ cc_library(
     copts = COPTS,
     include_prefix = "google/protobuf/stubs",
     linkopts = LINK_OPTS,
-    deps = ["//:port_def"],
+    deps = ["//src/google/protobuf:port_def"],
 )
 
 cc_library(
@@ -91,7 +91,7 @@ cc_library(
     ],
     deps = [
         ":lite",
-        "//:port_def",
+        "//src/google/protobuf:port_def",
     ],
 )
 

--- a/src/google/protobuf/stubs/BUILD.bazel
+++ b/src/google/protobuf/stubs/BUILD.bazel
@@ -134,5 +134,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//pkg:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/testing/BUILD.bazel
+++ b/src/google/protobuf/testing/BUILD.bazel
@@ -37,5 +37,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//pkg:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/util/BUILD.bazel
+++ b/src/google/protobuf/util/BUILD.bazel
@@ -275,5 +275,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//pkg:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )

--- a/src/google/protobuf/util/BUILD.bazel
+++ b/src/google/protobuf/util/BUILD.bazel
@@ -24,7 +24,7 @@ cc_test(
     srcs = ["delimited_message_util_test.cc"],
     deps = [
         ":delimited_message_util",
-        "//:cc_test_protos",
+        "//src/google/protobuf:cc_test_protos",
         "//src/google/protobuf/testing",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
@@ -44,7 +44,7 @@ cc_library(
     strip_include_prefix = "/src",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//:internal_protobuf_full",
+        "//src/google/protobuf",
         "//src/google/protobuf/io",
         "//src/google/protobuf/stubs",
     ],
@@ -56,7 +56,7 @@ cc_test(
     deps = [
         ":differencer",
         ":message_differencer_unittest_cc_proto",
-        "//:cc_test_protos",
+        "//src/google/protobuf:cc_test_protos",
         "//src/google/protobuf/testing",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
@@ -72,8 +72,8 @@ cc_test(
     deps = [
         ":differencer",
         ":message_differencer_unittest_cc_proto",
-        "//:cc_test_protos",
-        "//:test_util",
+        "//src/google/protobuf:cc_test_protos",
+        "//src/google/protobuf:test_util",
         "//src/google/protobuf/testing",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
@@ -88,7 +88,7 @@ cc_library(
     strip_include_prefix = "/src",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//:internal_protobuf_full",
+        "//src/google/protobuf",
         "//src/google/protobuf/stubs",
     ],
 )
@@ -98,9 +98,9 @@ cc_test(
     srcs = ["field_mask_util_test.cc"],
     deps = [
         ":field_mask_util",
-        "//:cc_test_protos",
-        "//:internal_protobuf_full",
-        "//:test_util",
+        "//src/google/protobuf",
+        "//src/google/protobuf:cc_test_protos",
+        "//src/google/protobuf:test_util",
         "//src/google/protobuf/stubs",
         "//src/google/protobuf/testing",
         "@com_google_googletest//:gtest",
@@ -117,7 +117,7 @@ cc_library(
     visibility = ["//:__subpackages__"],
     deps = [
         ":type_resolver_util",
-        "//:internal_protobuf_full",
+        "//src/google/protobuf",
         "//src/google/protobuf/io",
         "//src/google/protobuf/stubs",
         "//src/google/protobuf/util/internal:default_value",
@@ -132,15 +132,15 @@ cc_test(
     srcs = ["json_util_test.cc"],
     copts = COPTS,
     data = [
-        "//:testdata",
+        "//src/google/protobuf:testdata",
     ],
     deps = [
         ":json_format_cc_proto",
         ":json_format_proto3_cc_proto",
         ":json_util",
-        "//:cc_test_protos",
-        "//:internal_protobuf_full",
-        "//:test_util",
+        "//src/google/protobuf",
+        "//src/google/protobuf:cc_test_protos",
+        "//src/google/protobuf:test_util",
         "//src/google/protobuf/testing",
         "//src/google/protobuf/util/internal:maps_cc_proto",
         "@com_google_googletest//:gtest",
@@ -155,7 +155,7 @@ cc_library(
     strip_include_prefix = "/src",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//:internal_protobuf_full",
+        "//src/google/protobuf",
         "//src/google/protobuf/stubs",
     ],
 )
@@ -165,7 +165,7 @@ cc_test(
     srcs = ["time_util_test.cc"],
     deps = [
         ":time_util",
-        "//:internal_protobuf_full",
+        "//src/google/protobuf",
         "//src/google/protobuf/testing",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
@@ -183,7 +183,7 @@ cc_library(
     strip_include_prefix = "/src",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//:internal_protobuf_full",
+        "//src/google/protobuf",
         "//src/google/protobuf/io",
         "//src/google/protobuf/stubs",
         "//src/google/protobuf/util/internal:utility",
@@ -198,8 +198,8 @@ cc_test(
         ":json_format_cc_proto",
         ":json_format_proto3_cc_proto",
         ":json_util",
-        "//:internal_protobuf_full",
-        "//:test_util",
+        "//src/google/protobuf",
+        "//src/google/protobuf:test_util",
         "//src/google/protobuf/testing",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
@@ -222,6 +222,7 @@ proto_library(
     name = "json_format_proto",
     testonly = 1,
     srcs = ["json_format.proto"],
+    strip_import_prefix = "/src",
 )
 
 cc_proto_library(
@@ -234,6 +235,7 @@ proto_library(
     name = "json_format_proto3_proto",
     testonly = 1,
     srcs = ["json_format_proto3.proto"],
+    strip_import_prefix = "/src",
     deps = [
         "//:any_proto",
         "//:duration_proto",
@@ -255,6 +257,7 @@ proto_library(
     name = "message_differencer_unittest_proto",
     testonly = 1,
     srcs = ["message_differencer_unittest.proto"],
+    strip_import_prefix = "/src",
     deps = ["//:any_proto"],
 )
 

--- a/src/google/protobuf/util/BUILD.bazel
+++ b/src/google/protobuf/util/BUILD.bazel
@@ -11,6 +11,7 @@ cc_library(
     name = "delimited_message_util",
     srcs = ["delimited_message_util.cc"],
     hdrs = ["delimited_message_util.h"],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = ["//:__subpackages__"],
     deps = [
@@ -22,6 +23,7 @@ cc_library(
 cc_test(
     name = "delimited_message_util_test",
     srcs = ["delimited_message_util_test.cc"],
+    copts = COPTS,
     deps = [
         ":delimited_message_util",
         "//src/google/protobuf:cc_test_protos",
@@ -96,6 +98,7 @@ cc_library(
 cc_test(
     name = "field_mask_util_test",
     srcs = ["field_mask_util_test.cc"],
+    copts = COPTS,
     deps = [
         ":field_mask_util",
         "//src/google/protobuf",

--- a/src/google/protobuf/util/internal/BUILD.bazel
+++ b/src/google/protobuf/util/internal/BUILD.bazel
@@ -14,6 +14,7 @@ package(
 cc_library(
     name = "constants",
     hdrs = ["constants.h"],
+    strip_include_prefix = "/src",
     deps = [
         "//src/google/protobuf/stubs",
     ],
@@ -28,7 +29,7 @@ cc_library(
     deps = [
         ":constants",
         ":utility",
-        "//:internal_protobuf_full",
+        "//src/google/protobuf",
         "//src/google/protobuf/stubs",
     ],
 )
@@ -66,6 +67,7 @@ cc_library(
     name = "expecting_objectwriter",
     testonly = 1,
     hdrs = ["expecting_objectwriter.h"],
+    strip_include_prefix = "/src",
     deps = [":object_writer"],
 )
 
@@ -97,7 +99,7 @@ cc_library(
     deps = [
         ":object_writer",
         ":utility",
-        "//:internal_protobuf_full",
+        "//src/google/protobuf",
         "//src/google/protobuf/io",
         "//src/google/protobuf/stubs",
     ],
@@ -130,6 +132,7 @@ cc_library(
     name = "mock_error_listener",
     testonly = 1,
     hdrs = ["mock_error_listener.h"],
+    strip_include_prefix = "/src",
     deps = [":protostream"],
 )
 
@@ -166,6 +169,7 @@ cc_library(
     srcs = ["type_info_test_helper.cc"],
     hdrs = ["type_info_test_helper.h"],
     copts = COPTS,
+    strip_include_prefix = "/src",
     deps = [
         ":default_value",
         ":protostream",
@@ -198,7 +202,7 @@ cc_library(
         ":object_writer",
         ":type_info",
         ":utility",
-        "//:internal_protobuf_full",
+        "//src/google/protobuf",
         "//src/google/protobuf/io",
         "//src/google/protobuf/stubs",
         "//src/google/protobuf/util:type_resolver_util",
@@ -256,7 +260,7 @@ cc_library(
     strip_include_prefix = "/src",
     deps = [
         ":constants",
-        "//:internal_protobuf_full",
+        "//src/google/protobuf",
         "//src/google/protobuf/stubs",
     ],
 )

--- a/src/google/protobuf/util/internal/BUILD.bazel
+++ b/src/google/protobuf/util/internal/BUILD.bazel
@@ -446,5 +446,5 @@ pkg_files(
     name = "dist_files",
     srcs = glob(["**/*"]),
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//pkg:__pkg__"],
+    visibility = ["//src:__pkg__"],
 )


### PR DESCRIPTION
This is somewhat of a rough cut, since it doesn't split apart the lite and full targets, or unit tests.