### PR TITLE
adds setTotalBytesLimit() method

### DIFF
--- a/php/src/Google/Protobuf/Internal/CodedInputStream.php
+++ b/php/src/Google/Protobuf/Internal/CodedInputStream.php
@@ -89,6 +89,29 @@ class CodedInputStream
     {
         return substr($this->buffer, $start, $end - $start);
     }
+    
+    /**
+    * Total Bytes Limit -----------------------------------------------
+    * To prevent malicious users from sending excessively large messages
+    * and causing memory exhaustion, CodedInputStream imposes a hard limit on
+    * the total number of bytes it will read.
+    *
+    * Sets the maximum number of bytes that this CodedInputStream will read
+    * before refusing to continue.  To prevent servers from allocating enormous
+    * amounts of memory to hold parsed messages, the maximum message length
+    * should be limited to the shortest length that will not harm usability.
+    *
+    * Note: setting a limit less than the current read position is interpreted
+    * as a limit on the current position.
+    *
+    * This is unrelated to pushLimit() / popLimit().
+    *
+    * @param $total_bytes_limit
+    */
+    public function setTotalBytesLimit($total_bytes_limit) {
+        $this->total_bytes_limit = max($this->current(), $total_bytes_limit);
+        $this->recomputeBufferLimits();
+    }
 
     private function recomputeBufferLimits()
     {


### PR DESCRIPTION
fixes #9990 

Adds a method to raise total read bytes limit. Similar methods are present in code for other languages, this one was modelled after a C++ version. Without this method it is imporssible to parse large files like ONNX models as there is no way to change hardcoded read limits.

Proposed usage, instead of:
```php
$model = new \Onnx\ModelProto;
$model->mergeFromStream($data);
```

Do this (raises limit to 64MB):
```php
$model = new \Onnx\ModelProto;
$input_stream = new \Google\Protobuf\Internal\CodedInputStream($data);
$input_stream->setTotalBytesLimit(64 << 20);
$model->parseFromStream($input_stream);
```