### PR TITLE
Fixed PHP SEGV by not writing to shared memory for zend_class_entry.

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -603,10 +603,9 @@ PHP_METHOD(Message, __construct) {
   // will trigger an infinite construction loop and blow the stack.  We
   // temporarily clear create_object to break this loop (see check in
   // NameMap_GetMessage()).
-  PBPHP_ASSERT(ce->create_object == Message_create);
-  ce->create_object = NULL;
+  NameMap_EnterConstructor(ce);
   desc = Descriptor_GetFromClassEntry(ce);
-  ce->create_object = Message_create;
+  NameMap_ExitConstructor(ce);
 
   if (!desc) {
     zend_throw_exception_ex(

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -601,7 +601,7 @@ PHP_METHOD(Message, __construct) {
   //
   // However, if the user created their own class derived from Message, this
   // will trigger an infinite construction loop and blow the stack.  We
-  // temporarily clear create_object to break this loop (see check in
+  // store this `ce` in a global variable to break the cycle (see the check in
   // NameMap_GetMessage()).
   NameMap_EnterConstructor(ce);
   desc = Descriptor_GetFromClassEntry(ce);

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -155,6 +155,8 @@ void NameMap_AddMessage(const upb_MessageDef *m);
 void NameMap_AddEnum(const upb_EnumDef *m);
 const upb_MessageDef *NameMap_GetMessage(zend_class_entry *ce);
 const upb_EnumDef *NameMap_GetEnum(zend_class_entry *ce);
+void NameMap_EnterConstructor(zend_class_entry* ce);
+void NameMap_ExitConstructor(zend_class_entry* ce);
 
 // Add this descriptor object to the global list of descriptors that will be
 // kept alive for the duration of the request but destroyed when the request


### PR DESCRIPTION
Fixes: https://github.com/protocolbuffers/protobuf/issues/9446

The root cause of the SEGV was that we were mutating `zend_class_entry.create_object` As of PHP 8.1, it appears that `zend_class_entry` structs for PHP classes are shared between PHP processes when using php-fpm and opcache. This means that writes to `zend_class_entry.create_object` in one process will be visible in another process, which violated our assumption that such writes reads and writes were single-threaded.

The fix was to stop mutating `zend_class_entry.create_object`, instead mutating a member of our `PROTOBUF_G()` struct.

Unfortunately the setup to reproduce this is somewhat involved, so there is no test at the moment. I tested and verified the fix locally on my machine.