### PR TITLE
Fixed PHP SEGV by not writing to shared memory for zend_class_entry.

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -603,10 +603,9 @@ PHP_METHOD(Message, __construct) {
   // will trigger an infinite construction loop and blow the stack.  We
   // temporarily clear create_object to break this loop (see check in
   // NameMap_GetMessage()).
-  PBPHP_ASSERT(ce->create_object == Message_create);
-  ce->create_object = NULL;
+  NameMap_EnterConstructor(ce);
   desc = Descriptor_GetFromClassEntry(ce);
-  ce->create_object = Message_create;
+  NameMap_ExitConstructor(ce);
 
   if (!desc) {
     zend_throw_exception_ex(

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -155,6 +155,8 @@ void NameMap_AddMessage(const upb_MessageDef *m);
 void NameMap_AddEnum(const upb_EnumDef *m);
 const upb_MessageDef *NameMap_GetMessage(zend_class_entry *ce);
 const upb_EnumDef *NameMap_GetEnum(zend_class_entry *ce);
+void NameMap_EnterConstructor(zend_class_entry* ce);
+void NameMap_ExitConstructor(zend_class_entry* ce);
 
 // Add this descriptor object to the global list of descriptors that will be
 // kept alive for the duration of the request but destroyed when the request


### PR DESCRIPTION
This is a cherry-pick of https://github.com/protocolbuffers/protobuf/pull/9995 into the 21.x release.