### PR TITLE
Add protoc-gen-xo to global extension registry

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -324,3 +324,7 @@ with info about your project (name and website) so we can add an entry for you.
 1. Protonium
    * Website: https://github.com/zyp/protonium
    * Extension: 1146
+
+1. Protoc-gen-xo
+   * Website: https://github.com/xo/ecosystem
+   * Extension: 1147


### PR DESCRIPTION
This PR reserves the extension number 1147 for `protoc-gen-xo`, a protoc generator related to [xo/xo](https://github.com/xo/xo).