### PR TITLE
Fix some style/lint issues.

### DIFF
--- a/build_defs/cpp_opts.bzl
+++ b/build_defs/cpp_opts.bzl
@@ -1,4 +1,4 @@
-# C++ compile/link options for Protobuf.
+"""C++ compile/link options for Protobuf libraries."""
 
 COPTS = select({
     "//build_defs:config_msvc": [

--- a/conformance/defs.bzl
+++ b/conformance/defs.bzl
@@ -1,6 +1,22 @@
-# PLEASE DO NOT DEPEND ON THE CONTENTS OF THIS FILE, IT IS UNSTABLE.
+"""Starlark definitions for Protobuf conformance tests.
 
-def conformance_test(name, testee, failure_list = None, text_format_failure_list = None):
+PLEASE DO NOT DEPEND ON THE CONTENTS OF THIS FILE, IT IS UNSTABLE.
+"""
+
+def conformance_test(
+        name,
+        testee,
+        failure_list = None,
+        text_format_failure_list = None):
+    """Conformance test runner.
+
+    Args:
+      name: the name for the test.
+      testee: a conformance test client binary.
+      failure_list: a text file with known failures, one per line.
+      text_format_failure_list: a text file with known failures (one per line)
+          for the text format conformance suite.
+    """
     args = ["--testee %s" % _strip_bazel(testee)]
     failure_lists = []
     if failure_list:

--- a/python/setup.py
+++ b/python/setup.py
@@ -209,7 +209,7 @@ class TestConformanceCmd(_build_py):
     # Python 2.6 dodges these extra failures.
     os.environ['CONFORMANCE_PYTHON_EXTRA_FAILURES'] = (
         '--failure_list failure_list_python-post26.txt')
-    cmd = 'cd ../conformance && make %s' % (TestConformanceCmd.target)
+    cmd = 'cd ../conformance && make %s' % (TestConformanceCmd.target,)
     subprocess.check_call(cmd, shell=True)
 
 
@@ -227,7 +227,7 @@ def _GetFlagValues(flag_long, flag_short):
   flag_res = [re.compile(r'--?%s(=(.*))?' %
                          (flag_long[:-1] if expect_value else flag_long))]
   if flag_short:
-    flag_res.append(re.compile(r'-%s(.*)?' % (flag_short)))
+    flag_res.append(re.compile(r'-%s(.*)?' % (flag_short,)))
 
   flag_match = None
   for arg in sys.argv:


### PR DESCRIPTION
- Starlark: ensure docstrings are present.
- python/setup.py: https://refex.readthedocs.io/en/latest/guide/fixers/superfluous_parens.html