### PR TITLE
[Bazel] Make the protobuf workspace (nearly) wildcard-buildable

### DIFF
--- a/benchmarks/BUILD.bazel
+++ b/benchmarks/BUILD.bazel
@@ -87,7 +87,7 @@ pkg_filegroup(
     srcs = [
         ":dist_files",
         "//benchmarks/cpp:dist_files",
-        # "//benchmarks/datasets:dist_files",  # not in autotools dist
+        "//benchmarks/datasets:dist_files",  # not in autotools dist
         "//benchmarks/datasets/google_message1/proto2:dist_files",
         "//benchmarks/datasets/google_message1/proto3:dist_files",
         "//benchmarks/datasets/google_message2:dist_files",


### PR DESCRIPTION
- Add back benchmarks/datasets/BUILD.bazel to dist archive
- Change dist/build_systems.bzl to be compatible with Bazel 4.0.0.

After this, most builds can use `//...`, with one exception: non-Mac environments must also exclude objectivec:
`bazel build -- //... -//objectivec/...`