### PR TITLE
Adding a DEPENDENCIES option to the protobuf_generate cmake function

### DIFF
--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -12,7 +12,7 @@ function(protobuf_generate)
   include(CMakeParseArguments)
 
   set(_options APPEND_PATH)
-  set(_singleargs LANGUAGE OUT_VAR EXPORT_MACRO PROTOC_OUT_DIR PLUGIN PLUGIN_OPTIONS)
+  set(_singleargs LANGUAGE OUT_VAR EXPORT_MACRO PROTOC_OUT_DIR PLUGIN PLUGIN_OPTIONS DEPENDENCIES)
   if(COMMAND target_sources)
     list(APPEND _singleargs TARGET)
   endif()
@@ -149,7 +149,7 @@ function(protobuf_generate)
       OUTPUT ${_generated_srcs}
       COMMAND protobuf::protoc
       ARGS ${protobuf_generate_PROTOC_OPTIONS} --${protobuf_generate_LANGUAGE}_out ${_plugin_options}:${protobuf_generate_PROTOC_OUT_DIR} ${_plugin} ${_protobuf_include_path} ${_abs_file}
-      DEPENDS ${_abs_file} protobuf::protoc
+      DEPENDS ${_abs_file} protobuf::protoc ${protobuf_generate_DEPENDENCIES}
       COMMENT ${_comment}
       VERBATIM )
   endforeach()


### PR DESCRIPTION
Adds a way to pipe additional dependencies into the custom CMake code generation function. This was done to make it easier to run the generation using a custom protoc plugin within the CMake project. This allowed me to work on the plugin and cause the downstream dependencies to be regenerated.

If there's a better way to do this, please advise.