### PR TITLE
Fix podspecs

### DIFF
--- a/Protobuf-C++.podspec
+++ b/Protobuf-C++.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.0'
 
   s.source = { :git => 'https://github.com/google/protobuf.git',
-               :tag => "v21.0-rc2" }
+               :tag => "v#{s.version}" }
 
   s.source_files = 'src/google/protobuf/*.{h,cc,inc}',
                    'src/google/protobuf/stubs/*.{h,cc}',

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.0'
 
   s.source = { :git => 'https://github.com/protocolbuffers/protobuf.git',
-               :tag => "v21.0-rc2" }
+               :tag => "v#{s.version}" }
 
   s.source_files = 'objectivec/*.{h,m}',
                    'objectivec/google/protobuf/Any.pbobjc.h',


### PR DESCRIPTION
Change cocoapod specs to use the version as the tag number. We will be tagging each release with the protoc version number, the c++ version number and the cocoapod version number.