### PR TITLE
Add header search paths to protobuf-c++ spec

### DIFF
--- a/Protobuf-C++.podspec
+++ b/Protobuf-C++.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
     # Do not let src/google/protobuf/stubs/time.h override system API
     'USE_HEADERMAP' => 'NO',
     'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+    'HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)/src"'
   }
 
 end


### PR DESCRIPTION
The Problem:
Consuming Protobuf runtime in Swift via "Protobuf-C++ podspec" fails compilation as it isn't able to resolve the header imports. 

Solution:
Adding "HEADER_SEARCH_PATHS" to the "pod_target_xcconfig" flag will help  "Protobuf-C++" pod discover the required headers. 

NOTE:- Current obj-c builds are linting "Protobuf.podspec" and not "Protobuf-C++.podspec", hence they are all green. 