### PR TITLE
[Bazel/C++] Augment `cc_dist_library` to generate lists of source files

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -306,7 +306,7 @@ gen_file_lists(
     src_libs = {
         # source rule: name in generated file
         ":protobuf": "libprotobuf",
-        "//src/google/protobuf/compiler:protoc_lib": "libprotoc",
+        ":protoc": "libprotoc",
         ":protobuf_lite": "libprotobuf_lite",
     },
 )
@@ -379,6 +379,22 @@ cc_dist_library(
         "//src/google/protobuf/util:json_util",
         "//src/google/protobuf/util:time_util",
         "//src/google/protobuf/util:type_resolver_util",
+    ],
+)
+
+cc_dist_library(
+    name = "protoc",
+    tags = ["manual"],
+    deps = [
+        "//src/google/protobuf/compiler:code_generator",
+        "//src/google/protobuf/compiler:command_line_interface",
+        "//src/google/protobuf/compiler/cpp",
+        "//src/google/protobuf/compiler/csharp",
+        "//src/google/protobuf/compiler/java",
+        "//src/google/protobuf/compiler/objectivec",
+        "//src/google/protobuf/compiler/php",
+        "//src/google/protobuf/compiler/python",
+        "//src/google/protobuf/compiler/ruby",
     ],
 )
 

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -305,9 +305,9 @@ gen_file_lists(
     out_stem = "src_file_lists",
     src_libs = {
         # source rule: name in generated file
-        "//:protobuf": "libprotobuf",
+        ":protobuf": "libprotobuf",
         "//src/google/protobuf/compiler:protoc_lib": "libprotoc",
-        "//:protobuf_lite": "libprotobuf_lite",
+        ":protobuf_lite": "libprotobuf_lite",
     },
 )
 

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -343,8 +343,8 @@ cc_dist_library(
     }),
     tags = ["manual"],
     deps = [
-        "//:protobuf_lite",
         "//src/google/protobuf:arena",
+        "//src/google/protobuf:protobuf_lite",
         "//src/google/protobuf/io",
         "//src/google/protobuf/io:io_win32",
         "//src/google/protobuf/stubs:lite",
@@ -362,8 +362,6 @@ cc_dist_library(
     }),
     tags = ["manual"],
     deps = [
-        "//:protobuf",
-        "//:protobuf_lite",
         "//src/google/protobuf:arena",
         "//src/google/protobuf/compiler:importer",
         "//src/google/protobuf/io",
@@ -371,6 +369,8 @@ cc_dist_library(
         "//src/google/protobuf/io:io_win32",
         "//src/google/protobuf/io:printer",
         "//src/google/protobuf/io:tokenizer",
+        "//src/google/protobuf:protobuf",
+        "//src/google/protobuf:protobuf_lite",
         "//src/google/protobuf/stubs",
         "//src/google/protobuf/stubs:lite",
         "//src/google/protobuf/util:delimited_message_util",

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -160,6 +160,7 @@ cc_library(
     linkopts = LINK_OPTS,
     visibility = [
         "//:__pkg__",
+        "//pkg:__pkg__",
         "//src/google/protobuf:__subpackages__",
     ],
     # In Bazel 6.0+, these will be `interface_deps`:
@@ -209,6 +210,7 @@ cc_library(
     linkopts = LINK_OPTS,
     visibility = [
         "//:__pkg__",
+        "//pkg:__pkg__",
         "//src/google/protobuf:__subpackages__",
     ],
     deps = [

--- a/src/google/protobuf/compiler/cpp/BUILD.bazel
+++ b/src/google/protobuf/compiler/cpp/BUILD.bazel
@@ -48,7 +48,10 @@ cc_library(
     ],
     copts = COPTS,
     include_prefix = "google/protobuf/compiler/cpp",
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = [
+        "//pkg:__pkg__",
+        "//src/google/protobuf/compiler:__pkg__",
+    ],
     deps = [
         "//:protobuf",
         "//src/google/protobuf/compiler:code_generator",

--- a/src/google/protobuf/compiler/csharp/BUILD.bazel
+++ b/src/google/protobuf/compiler/csharp/BUILD.bazel
@@ -51,7 +51,10 @@ cc_library(
         "//conditions:default": ["-Wno-overloaded-virtual"],
     }),
     include_prefix = "google/protobuf/compiler/csharp",
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = [
+        "//pkg:__pkg__",
+        "//src/google/protobuf/compiler:__pkg__",
+    ],
     deps = [
         "//:protobuf",
         "//src/google/protobuf/compiler:code_generator",
@@ -62,11 +65,11 @@ cc_test(
     name = "bootstrap_unittest",
     srcs = ["csharp_bootstrap_unittest.cc"],
     data = [
-        "//src/google/protobuf:descriptor_proto_srcs",
         "//:well_known_type_protos",
         "//conformance:all_files",
         "//conformance:conformance_proto",
         "//csharp:wkt_cs_srcs",
+        "//src/google/protobuf:descriptor_proto_srcs",
         "//src/google/protobuf:testdata",
     ],
     deps = [

--- a/src/google/protobuf/compiler/java/BUILD.bazel
+++ b/src/google/protobuf/compiler/java/BUILD.bazel
@@ -74,7 +74,10 @@ cc_library(
     ],
     copts = COPTS,
     include_prefix = "google/protobuf/compiler/java",
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = [
+        "//pkg:__pkg__",
+        "//src/google/protobuf/compiler:__pkg__",
+    ],
     deps = [
         "//:protobuf",
         "//src/google/protobuf/compiler:code_generator",
@@ -85,9 +88,9 @@ cc_test(
     name = "doc_comment_unittest",
     srcs = ["doc_comment_unittest.cc"],
     data = [
-        "//src/google/protobuf:descriptor_proto_srcs",
         "//:well_known_type_protos",
         "//conformance:conformance_proto",
+        "//src/google/protobuf:descriptor_proto_srcs",
     ],
     deps = [
         ":java",

--- a/src/google/protobuf/compiler/objectivec/BUILD.bazel
+++ b/src/google/protobuf/compiler/objectivec/BUILD.bazel
@@ -39,7 +39,10 @@ cc_library(
     ],
     copts = COPTS,
     include_prefix = "google/protobuf/compiler/objectivec",
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = [
+        "//pkg:__pkg__",
+        "//src/google/protobuf/compiler:__pkg__",
+    ],
     deps = [
         "//:protobuf",
         "//src/google/protobuf/compiler:code_generator",

--- a/src/google/protobuf/compiler/php/BUILD.bazel
+++ b/src/google/protobuf/compiler/php/BUILD.bazel
@@ -12,7 +12,10 @@ cc_library(
     hdrs = ["php_generator.h"],
     copts = COPTS,
     include_prefix = "google/protobuf/compiler/php",
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = [
+        "//pkg:__pkg__",
+        "//src/google/protobuf/compiler:__pkg__",
+    ],
     deps = [
         "//:protobuf",
         "//src/google/protobuf/compiler:code_generator",

--- a/src/google/protobuf/compiler/python/BUILD.bazel
+++ b/src/google/protobuf/compiler/python/BUILD.bazel
@@ -20,7 +20,10 @@ cc_library(
     ],
     copts = COPTS,
     include_prefix = "google/protobuf/compiler/python",
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = [
+        "//pkg:__pkg__",
+        "//src/google/protobuf/compiler:__pkg__",
+    ],
     deps = [
         "//:protobuf",
         "//src/google/protobuf/compiler:code_generator",

--- a/src/google/protobuf/compiler/ruby/BUILD.bazel
+++ b/src/google/protobuf/compiler/ruby/BUILD.bazel
@@ -12,7 +12,10 @@ cc_library(
     hdrs = ["ruby_generator.h"],
     copts = COPTS,
     include_prefix = "google/protobuf/compiler/ruby",
-    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+    visibility = [
+        "//pkg:__pkg__",
+        "//src/google/protobuf/compiler:__pkg__",
+    ],
     deps = [
         "//:protobuf",
         "//src/google/protobuf/compiler:code_generator",


### PR DESCRIPTION
When defining a `cc_dist_library`, we generally want exactly that target to be buildable from cmake, etc. So, to simplify source file specification, this change moves the logic for producing `CcFileList` directly into the `cc_dist_library` rule. The upshot is that a `cc_dist_library` will not only produce a library, but will also expose the corresponding list of source files that would be needed to build the library outside of Bazel.

Some of this logic is simply moved from `pkg/build_systems.bzl` to `pkg/cc_dist_library.bzl`. A `cc_dist_library` rule still represents only the immediately-listed libraries, i.e., no transitive dependencies.