### PR TITLE
[cleanup] MSVC Warnings - Fix Type Conversions (4244 and 4267), Enable Warnings as Errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,10 +257,9 @@ if (MSVC)
   add_definitions(/utf-8)
   # MSVC warning suppressions
   add_definitions(
+    /WX # Warnings as errors
     /wd4065 # switch statement contains 'default' but no 'case' labels
-    /wd4244 # 'conversion' conversion from 'type1' to 'type2', possible loss of data
     /wd4251 # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
-    /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
     /wd4305 # 'identifier' : truncation from 'type1' to 'type2'
     /wd4307 # 'operator' : integral constant overflow
     /wd4309 # 'conversion' : truncation of constant value

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ if (MSVC)
   # MSVC warning suppressions
   add_definitions(
     /WX # Warnings as errors
+    /wd4018 # 'token' : signed/unsigned mismatch
     /wd4065 # switch statement contains 'default' but no 'case' labels
     /wd4251 # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
     /wd4305 # 'identifier' : truncation from 'type1' to 'type2'

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -6,6 +6,10 @@ option(protobuf_ABSOLUTE_TEST_PLUGIN_PATH
   "Using absolute test_plugin path in tests" ON)
 mark_as_advanced(protobuf_ABSOLUTE_TEST_PLUGIN_PATH)
 
+# The compile_proto_file macro places files in the source tree, so this option
+# must be turned off.
+set(CMAKE_DISABLE_SOURCE_CHANGES OFF)
+
 if (protobuf_USE_EXTERNAL_GTEST)
   find_package(GTest REQUIRED)
 else()

--- a/src/google/protobuf/arena_test_util.h
+++ b/src/google/protobuf/arena_test_util.h
@@ -53,7 +53,7 @@ void TestParseCorruptedString(const T& message) {
     message.SerializePartialToCodedStream(&out);
   }
   const int kMaxIters = 900;
-  const int stride = s.size() <= kMaxIters ? 1 : s.size() / kMaxIters;
+  const int stride = s.size() <= kMaxIters ? 1 : static_cast<int>(s.size() / kMaxIters);
   const int start = stride == 1 || use_arena ? 0 : (stride + 1) / 2;
   for (int i = start; i < s.size(); i += stride) {
     for (int c = 1 + (i % 17); c < 256; c += 2 * c + (i & 3)) {

--- a/src/google/protobuf/compiler/annotation_test_util.cc
+++ b/src/google/protobuf/compiler/annotation_test_util.cc
@@ -95,7 +95,7 @@ bool RunProtoCompiler(const std::string& filename,
 bool DecodeMetadata(const std::string& path, GeneratedCodeInfo* info) {
   std::string data;
   GOOGLE_CHECK_OK(File::GetContents(path, &data, true));
-  io::ArrayInputStream input(data.data(), data.size());
+  io::ArrayInputStream input(data.data(), static_cast<int>(data.size()));
   return info->ParseFromZeroCopyStream(&input);
 }
 

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -499,7 +499,7 @@ bool CommandLineInterface::GeneratorContextImpl::WriteAllToDisk(
   for (const auto& pair : files_) {
     const std::string& relative_filename = pair.first;
     const char* data = pair.second.data();
-    int size = pair.second.size();
+    int size = static_cast<int>(pair.second.size());
 
     if (!TryCreateParentDirectory(prefix, relative_filename)) {
       return false;
@@ -683,7 +683,7 @@ void CommandLineInterface::MemoryOutputStream::InsertShiftedInfo(
   insertion_offset += indent_length;
   for (const auto& source_annotation : info_to_insert_.annotation()) {
     GeneratedCodeInfo::Annotation* annotation = target_info.add_annotation();
-    int inner_indent = 0;
+    size_t inner_indent = 0;
     // insertion_content is guaranteed to end in an endline. This last endline
     // has no effect on indentation.
     for (; pos < source_annotation.end() && pos < insertion_content.size() - 1;
@@ -699,9 +699,9 @@ void CommandLineInterface::MemoryOutputStream::InsertShiftedInfo(
       }
     }
     *annotation = source_annotation;
-    annotation->set_begin(annotation->begin() + insertion_offset);
+    annotation->set_begin(static_cast<int32_t>(annotation->begin() + insertion_offset));
     insertion_offset += inner_indent;
-    annotation->set_end(annotation->end() + insertion_offset);
+    annotation->set_end(static_cast<int32_t>(annotation->end() + insertion_offset));
   }
 }
 
@@ -756,8 +756,8 @@ void CommandLineInterface::MemoryOutputStream::UpdateMetadata(
     }
     GeneratedCodeInfo::Annotation* annotation = new_metadata.add_annotation();
     *annotation = source_annotation;
-    annotation->set_begin(annotation->begin() + to_add);
-    annotation->set_end(annotation->end() + to_add);
+    annotation->set_begin(static_cast<int32_t>(annotation->begin() + to_add));
+    annotation->set_end(static_cast<int32_t>(annotation->end() + to_add));
   }
   // If there were never any annotations at or after the insertion point,
   // make sure to still insert the new metadata from info_to_insert_.
@@ -854,7 +854,7 @@ CommandLineInterface::MemoryOutputStream::~MemoryOutputStream() {
       UpdateMetadata(data_, pos, data_.size(), 0);
     } else {
       // Calculate how much space we need.
-      int indent_size = 0;
+      size_t indent_size = 0;
       for (int i = 0; i < data_.size(); i++) {
         if (data_[i] == '\n') indent_size += indent_.size();
       }

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -380,7 +380,7 @@ void CommandLineInterfaceTest::RunWithArgs(std::vector<std::string> args) {
 #endif
   CaptureTestStderr();
 
-  return_code_ = cli_.Run(args.size(), argv.get());
+  return_code_ = cli_.Run(static_cast<int>(args.size()), argv.get());
 
   error_text_ = GetCapturedTestStderr();
 #if !defined(__CYGWIN__)
@@ -2614,7 +2614,7 @@ class EncodeDecodeTest : public testing::TestWithParam<EncodeDecodeTestMode> {
     CaptureTestStdout();
     CaptureTestStderr();
 
-    int result = cli.Run(args.size(), argv.get());
+    int result = cli.Run(static_cast<int>(args.size()), argv.get());
 
     captured_stdout_ = GetCapturedTestStdout();
     captured_stderr_ = GetCapturedTestStderr();

--- a/src/google/protobuf/compiler/cpp/enum.cc
+++ b/src/google/protobuf/compiler/cpp/enum.cc
@@ -69,7 +69,7 @@ int CountUniqueValues(const EnumDescriptor* descriptor) {
   for (int i = 0; i < descriptor->value_count(); ++i) {
     values.insert(descriptor->value(i)->number());
   }
-  return values.size();
+  return static_cast<int>(values.size());
 }
 
 }  // namespace
@@ -357,7 +357,7 @@ void EnumGenerator::GenerateMethods(int idx, io::Printer* printer) {
         number_to_index.emplace(p.second, i);
       }
       ++i;
-      data_index += p.first.size();
+      data_index += static_cast<int>(p.first.size());
     }
 
     format(

--- a/src/google/protobuf/compiler/cpp/file.cc
+++ b/src/google/protobuf/compiler/cpp/file.cc
@@ -826,8 +826,8 @@ void FileGenerator::GenerateReflectionInitializationCode(io::Printer* printer) {
       int offset = 0;
       for (int i = 0; i < message_generators_.size(); i++) {
         message_generators_[i]->GenerateSchema(printer, offset,
-                                               pairs[i].second);
-        offset += pairs[i].first;
+                                               static_cast<int>(pairs[i].second));
+        offset += static_cast<int>(pairs[i].first);
       }
     }
     format.Outdent();
@@ -901,7 +901,7 @@ void FileGenerator::GenerateReflectionInitializationCode(io::Printer* printer) {
   CrossFileReferences refs;
   GetCrossFileReferencesForFile(file_, &refs);
   int num_deps =
-      refs.strong_reflection_files.size() + refs.weak_reflection_files.size();
+      static_cast<int>(refs.strong_reflection_files.size() + refs.weak_reflection_files.size());
 
   // Build array of DescriptorTable deps.
   if (num_deps > 0) {

--- a/src/google/protobuf/compiler/cpp/file.h
+++ b/src/google/protobuf/compiler/cpp/file.h
@@ -89,8 +89,8 @@ class FileGenerator {
   // one .cc file per message, one .cc file per extension, and a main pb.cc file
   // containing everything else.
 
-  int NumMessages() const { return message_generators_.size(); }
-  int NumExtensions() const { return extension_generators_.size(); }
+  int NumMessages() const { return static_cast<int>(message_generators_.size()); }
+  int NumExtensions() const { return static_cast<int>(extension_generators_.size()); }
   // Generates the source file for one message.
   void GenerateSourceForMessage(int idx, io::Printer* printer);
   // Generates the source file for one extension.

--- a/src/google/protobuf/compiler/cpp/message.cc
+++ b/src/google/protobuf/compiler/cpp/message.cc
@@ -2034,7 +2034,7 @@ void MessageGenerator::GenerateSchema(io::Printer* printer, int offset,
   } else {
     GOOGLE_DCHECK_NE(has_offset, -1);
     GOOGLE_DCHECK(!IsMapEntryMessage(descriptor_));
-    inlined_string_indices_offset = has_offset + has_bit_indices_.size();
+    inlined_string_indices_offset = static_cast<int>(has_offset + has_bit_indices_.size());
   }
 
   format("{ $1$, $2$, $3$, sizeof($classtype$)},\n", offset, has_offset,
@@ -4021,7 +4021,7 @@ void MessageGenerator::GenerateSerializeWithCachedSizesBodyShuffled(
   std::sort(sorted_extensions.begin(), sorted_extensions.end(),
             ExtensionRangeSorter());
 
-  int num_fields = ordered_fields.size() + sorted_extensions.size();
+  int num_fields = static_cast<int>(ordered_fields.size() + sorted_extensions.size());
   constexpr int kLargePrime = 1000003;
   GOOGLE_CHECK_LT(num_fields, kLargePrime)
       << "Prime offset must be greater than the number of fields to ensure "
@@ -4093,7 +4093,7 @@ void MessageGenerator::GenerateSerializeWithCachedSizesBodyShuffled(
 }
 
 std::vector<uint32_t> MessageGenerator::RequiredFieldsBitMask() const {
-  const int array_size = HasBitsSize();
+  const int array_size = static_cast<int>(HasBitsSize());
   std::vector<uint32_t> masks(array_size, 0);
 
   for (auto field : FieldRange(descriptor_)) {

--- a/src/google/protobuf/compiler/cpp/unittest.inc
+++ b/src/google/protobuf/compiler/cpp/unittest.inc
@@ -661,7 +661,7 @@ TEST(GENERATED_MESSAGE_TEST_NAME, SerializationToArray) {
   UNITTEST::TestAllTypes message1, message2;
   std::string data;
   TestUtil::SetAllFields(&message1);
-  int size = message1.ByteSizeLong();
+  int size = static_cast<int>(message1.ByteSizeLong());
   data.resize(size);
   uint8_t* start = reinterpret_cast<uint8_t*>(::google::protobuf::string_as_array(&data));
   uint8_t* end = message1.SerializeWithCachedSizesToArray(start);
@@ -675,7 +675,7 @@ TEST(GENERATED_MESSAGE_TEST_NAME, PackedFieldsSerializationToArray) {
   UNITTEST::TestPackedTypes packed_message1, packed_message2;
   std::string packed_data;
   TestUtil::SetPackedFields(&packed_message1);
-  int packed_size = packed_message1.ByteSizeLong();
+  int packed_size = static_cast<int>(packed_message1.ByteSizeLong());
   packed_data.resize(packed_size);
   uint8_t* start =
       reinterpret_cast<uint8_t*>(::google::protobuf::string_as_array(&packed_data));
@@ -690,7 +690,7 @@ TEST(GENERATED_MESSAGE_TEST_NAME, PackedFieldsSerializationToArray) {
 TEST(GENERATED_MESSAGE_TEST_NAME, SerializationToStream) {
   UNITTEST::TestAllTypes message1, message2;
   TestUtil::SetAllFields(&message1);
-  int size = message1.ByteSizeLong();
+  int size = static_cast<int>(message1.ByteSizeLong());
   std::string data;
   data.resize(size);
   {
@@ -709,7 +709,7 @@ TEST(GENERATED_MESSAGE_TEST_NAME, SerializationToStream) {
 TEST(GENERATED_MESSAGE_TEST_NAME, PackedFieldsSerializationToStream) {
   UNITTEST::TestPackedTypes message1, message2;
   TestUtil::SetPackedFields(&message1);
-  int size = message1.ByteSizeLong();
+  int size = static_cast<int>(message1.ByteSizeLong());
   std::string data;
   data.resize(size);
   {
@@ -892,7 +892,7 @@ TEST(GENERATED_MESSAGE_TEST_NAME, TestSpaceUsed) {
   // Setting a string to a value larger than the string object itself should
   // increase SpaceUsedLong(), because it cannot store the value internally.
   message1->set_optional_string(std::string(sizeof(std::string) + 1, 'x'));
-  int min_expected_increase = message1->optional_string().capacity();
+  int min_expected_increase = static_cast<int>(message1->optional_string().capacity());
   EXPECT_LE(empty_message_size + min_expected_increase,
             message1->SpaceUsedLong());
 
@@ -930,7 +930,7 @@ TEST(GENERATED_MESSAGE_TEST_NAME, TestOneofSpaceUsed) {
   // internally.
   message1->set_foo_string(std::string(sizeof(std::string) + 1, 'x'));
   int min_expected_increase =
-      message1->foo_string().capacity() + sizeof(std::string);
+      static_cast<int>(message1->foo_string().capacity() + sizeof(std::string));
   EXPECT_LE(empty_message_size + min_expected_increase,
             message1->SpaceUsedLong());
 
@@ -1838,7 +1838,7 @@ TEST_F(OneofTest, SerializationToArray) {
     UNITTEST::TestOneof2 message1, message2;
 std::string data;
 message1.set_foo_int(123);
-int size = message1.ByteSizeLong();
+int size = static_cast<int>(message1.ByteSizeLong());
 data.resize(size);
 uint8_t* start = reinterpret_cast<uint8_t*>(::google::protobuf::string_as_array(&data));
 uint8_t* end = message1.SerializeWithCachedSizesToArray(start);
@@ -1852,7 +1852,7 @@ EXPECT_EQ(message2.foo_int(), 123);
     UNITTEST::TestOneof2 message1, message2;
     std::string data;
     message1.set_foo_string("foo");
-    int size = message1.ByteSizeLong();
+    int size = static_cast<int>(message1.ByteSizeLong());
     data.resize(size);
     uint8_t* start = reinterpret_cast<uint8_t*>(::google::protobuf::string_as_array(&data));
     uint8_t* end = message1.SerializeWithCachedSizesToArray(start);
@@ -1867,7 +1867,7 @@ EXPECT_EQ(message2.foo_int(), 123);
     UNITTEST::TestOneof2 message1, message2;
     std::string data;
     message1.set_foo_bytes("moo");
-    int size = message1.ByteSizeLong();
+    int size = static_cast<int>(message1.ByteSizeLong());
     data.resize(size);
     uint8_t* start = reinterpret_cast<uint8_t*>(::google::protobuf::string_as_array(&data));
     uint8_t* end = message1.SerializeWithCachedSizesToArray(start);
@@ -1881,7 +1881,7 @@ EXPECT_EQ(message2.foo_int(), 123);
     UNITTEST::TestOneof2 message1, message2;
     std::string data;
     message1.set_foo_enum(UNITTEST::TestOneof2::FOO);
-    int size = message1.ByteSizeLong();
+    int size = static_cast<int>(message1.ByteSizeLong());
     data.resize(size);
     uint8_t* start = reinterpret_cast<uint8_t*>(::google::protobuf::string_as_array(&data));
     uint8_t* end = message1.SerializeWithCachedSizesToArray(start);
@@ -1895,7 +1895,7 @@ EXPECT_EQ(message2.foo_int(), 123);
     UNITTEST::TestOneof2 message1, message2;
     std::string data;
     message1.mutable_foo_message()->set_moo_int(234);
-    int size = message1.ByteSizeLong();
+    int size = static_cast<int>(message1.ByteSizeLong());
     data.resize(size);
     uint8_t* start = reinterpret_cast<uint8_t*>(::google::protobuf::string_as_array(&data));
     uint8_t* end = message1.SerializeWithCachedSizesToArray(start);
@@ -1909,7 +1909,7 @@ EXPECT_EQ(message2.foo_int(), 123);
     UNITTEST::TestOneof2 message1, message2;
     std::string data;
     message1.mutable_foogroup()->set_a(345);
-    int size = message1.ByteSizeLong();
+    int size = static_cast<int>(message1.ByteSizeLong());
     data.resize(size);
     uint8_t* start = reinterpret_cast<uint8_t*>(::google::protobuf::string_as_array(&data));
     uint8_t* end = message1.SerializeWithCachedSizesToArray(start);
@@ -1931,7 +1931,7 @@ TEST_F(OneofTest, SerializationToStream) {
     UNITTEST::TestOneof2 message1, message2;
 std::string data;
 message1.set_foo_int(123);
-int size = message1.ByteSizeLong();
+int size = static_cast<int>(message1.ByteSizeLong());
 data.resize(size);
 
 {
@@ -1952,7 +1952,7 @@ data.resize(size);
     UNITTEST::TestOneof2 message1, message2;
     std::string data;
     message1.set_foo_string("foo");
-    int size = message1.ByteSizeLong();
+    int size = static_cast<int>(message1.ByteSizeLong());
     data.resize(size);
 
     {
@@ -1974,7 +1974,7 @@ data.resize(size);
     UNITTEST::TestOneof2 message1, message2;
     std::string data;
     message1.set_foo_bytes("moo");
-    int size = message1.ByteSizeLong();
+    int size = static_cast<int>(message1.ByteSizeLong());
     data.resize(size);
 
     {
@@ -1995,7 +1995,7 @@ data.resize(size);
     UNITTEST::TestOneof2 message1, message2;
     std::string data;
     message1.set_foo_enum(UNITTEST::TestOneof2::FOO);
-    int size = message1.ByteSizeLong();
+    int size = static_cast<int>(message1.ByteSizeLong());
     data.resize(size);
 
     {
@@ -2016,7 +2016,7 @@ data.resize(size);
     UNITTEST::TestOneof2 message1, message2;
     std::string data;
     message1.mutable_foo_message()->set_moo_int(234);
-    int size = message1.ByteSizeLong();
+    int size = static_cast<int>(message1.ByteSizeLong());
     data.resize(size);
 
     {
@@ -2037,7 +2037,7 @@ data.resize(size);
     UNITTEST::TestOneof2 message1, message2;
     std::string data;
     message1.mutable_foogroup()->set_a(345);
-    int size = message1.ByteSizeLong();
+    int size = static_cast<int>(message1.ByteSizeLong());
     data.resize(size);
 
     {

--- a/src/google/protobuf/compiler/csharp/csharp_field_base.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_field_base.cc
@@ -55,7 +55,7 @@ void FieldGeneratorBase::SetCommonFieldVariables(
   // Note: this will be valid even though the tag emitted for packed and unpacked versions of
   // repeated fields varies by wire format. The wire format is encoded in the bottom 3 bits, which
   // never effects the tag size.
-  int tag_size = internal::WireFormat::TagSize(descriptor_->number(), descriptor_->type());
+  int tag_size = static_cast<int>(internal::WireFormat::TagSize(descriptor_->number(), descriptor_->type()));
   int part_tag_size = tag_size;
   if (descriptor_->type() == FieldDescriptor::TYPE_GROUP) {
     part_tag_size /= 2;

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.cc
@@ -107,7 +107,7 @@ CSharpType GetCSharpType(FieldDescriptor::Type type) {
 }
 
 std::string StripDotProto(const std::string& proto_file) {
-  int lastindex = proto_file.find_last_of(".");
+  int lastindex = static_cast<int>(proto_file.find_last_of("."));
   return proto_file.substr(0, lastindex);
 }
 
@@ -122,7 +122,7 @@ std::string GetFileNamespace(const FileDescriptor* descriptor) {
 // input of "google/protobuf/foo_bar.proto" would result in "FooBar".
 std::string GetFileNameBase(const FileDescriptor* descriptor) {
     std::string proto_file = descriptor->name();
-    int lastslash = proto_file.find_last_of("/");
+    int lastslash = static_cast<int>(proto_file.find_last_of("/"));
     std::string base = proto_file.substr(lastslash + 1);
     return UnderscoresToPascalCase(StripDotProto(base));
 }

--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -361,11 +361,11 @@ static bool ApplyMapping(const std::string& filename,
       // does not match the filename "foo/barbaz".
       int after_prefix_start = -1;
       if (filename[old_prefix.size()] == '/') {
-        after_prefix_start = old_prefix.size() + 1;
+        after_prefix_start = static_cast<int>(old_prefix.size() + 1);
       } else if (filename[old_prefix.size() - 1] == '/') {
         // old_prefix is never empty, and canonicalized paths never have
         // consecutive '/' characters.
-        after_prefix_start = old_prefix.size();
+        after_prefix_start = static_cast<int>(old_prefix.size());
       }
       if (after_prefix_start != -1) {
         // Yep.  So the prefixes are directories and the filename is a file

--- a/src/google/protobuf/compiler/importer_unittest.cc
+++ b/src/google/protobuf/compiler/importer_unittest.cc
@@ -103,7 +103,7 @@ class MockSourceTree : public SourceTree {
     if (contents == nullptr) {
       return nullptr;
     } else {
-      return new io::ArrayInputStream(contents, strlen(contents));
+      return new io::ArrayInputStream(contents, static_cast<int>(strlen(contents)));
     }
   }
 

--- a/src/google/protobuf/compiler/java/message_lite.cc
+++ b/src/google/protobuf/compiler/java/message_lite.cc
@@ -495,7 +495,7 @@ void ImmutableMessageLiteGenerator::GenerateDynamicMethodNewBuildMessageInfo(
     printer->Indent();
 
     // Record the number of oneofs.
-    WriteIntToUtf16CharSequence(oneofs_.size(), &chars);
+    WriteIntToUtf16CharSequence(static_cast<int>(oneofs_.size()), &chars);
     for (auto oneof : oneofs_) {
       printer->Print(
           "\"$oneof_name$_\",\n"
@@ -544,7 +544,7 @@ void ImmutableMessageLiteGenerator::GenerateDynamicMethodNewBuildMessageInfo(
         fields_for_is_initialized_check.push_back(descriptor_->field(i));
       }
     }
-    WriteIntToUtf16CharSequence(fields_for_is_initialized_check.size(), &chars);
+    WriteIntToUtf16CharSequence(static_cast<int>(fields_for_is_initialized_check.size()), &chars);
 
     for (int i = 0; i < descriptor_->field_count(); i++) {
       const FieldDescriptor* field = sorted_fields[i];

--- a/src/google/protobuf/compiler/mock_code_generator.cc
+++ b/src/google/protobuf/compiler/mock_code_generator.cc
@@ -267,7 +267,7 @@ bool MockCodeGenerator::Generate(const FileDescriptor* file,
         if (annotate) {
           auto* annotation = info.add_annotation();
           annotation->set_begin(0);
-          annotation->set_end(content.size());
+          annotation->set_end(static_cast<int32_t>(content.size()));
           annotation->set_source_file("first_path");
         }
         std::unique_ptr<io::ZeroCopyOutputStream> output(
@@ -292,7 +292,7 @@ bool MockCodeGenerator::Generate(const FileDescriptor* file,
         if (annotate) {
           auto* annotation = info.add_annotation();
           annotation->set_begin(0);
-          annotation->set_end(content.size());
+          annotation->set_end(static_cast<int32_t>(content.size()));
           annotation->set_source_file("second_path");
         }
         std::unique_ptr<io::ZeroCopyOutputStream> output(

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -1090,7 +1090,7 @@ std::string DefaultValue(const FieldDescriptor* field) {
 
         // Must convert to a standard byte order for packing length into
         // a cstring.
-        uint32_t length = ghtonl(default_string.length());
+        uint32_t length = ghtonl(static_cast<uint32_t>(default_string.length()));
         std::string bytes((const char*)&length, sizeof(length));
         bytes.append(default_string);
         return "(NSData*)\"" + EscapeTrigraphs(CEscape(bytes)) + "\"";
@@ -1272,7 +1272,7 @@ bool ReadLine(StringPiece* input, StringPiece* line) {
 }
 
 void RemoveComment(StringPiece* input) {
-  int offset = input->find('#');
+  int offset = static_cast<int>(input->find('#'));
   if (offset != StringPiece::npos) {
     input->remove_suffix(input->length() - offset);
   }
@@ -1282,7 +1282,7 @@ namespace {
 
 bool PackageToPrefixesCollector::ConsumeLine(
     const StringPiece& line, std::string* out_error) {
-  int offset = line.find('=');
+  int offset = static_cast<int>(line.find('='));
   if (offset == StringPiece::npos) {
     *out_error = usage_ + " file line without equal sign: '" + StrCat(line) + "'.";
     return false;
@@ -1532,7 +1532,7 @@ std::string TextFormatDecodeData::Data() const {
     io::OstreamOutputStream data_outputstream(&data_stringstream);
     io::CodedOutputStream output_stream(&data_outputstream);
 
-    output_stream.WriteVarint32(num_entries());
+    output_stream.WriteVarint32(static_cast<uint32_t>(num_entries()));
     for (std::vector<DataEntry>::const_iterator i = entries_.begin();
          i != entries_.end(); ++i) {
       output_stream.WriteVarint32(i->first);
@@ -1990,7 +1990,7 @@ void ImportWriter::ParseFrameworkMappings() {
 
 bool ImportWriter::ProtoFrameworkCollector::ConsumeLine(
     const StringPiece& line, std::string* out_error) {
-  int offset = line.find(':');
+  int offset = static_cast<int>(line.find(':'));
   if (offset == StringPiece::npos) {
     *out_error =
         std::string("Framework/proto file mapping line without colon sign: '") +
@@ -2003,9 +2003,9 @@ bool ImportWriter::ProtoFrameworkCollector::ConsumeLine(
 
   int start = 0;
   while (start < proto_file_list.length()) {
-    offset = proto_file_list.find(',', start);
+    offset = static_cast<int>(proto_file_list.find(',', start));
     if (offset == StringPiece::npos) {
-      offset = proto_file_list.length();
+      offset = static_cast<int>(proto_file_list.length());
     }
 
     StringPiece proto_file = proto_file_list.substr(start, offset - start);

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers_unittest.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers_unittest.cc
@@ -285,7 +285,7 @@ TEST(ObjCHelper, ParseSimple_BasicsSuccess) {
 
   for (const auto& test : tests) {
     for (int i = 0; i < kBlockSizeCount; i++) {
-      io::ArrayInputStream input(test.first.data(), test.first.size(), kBlockSizes[i]);
+      io::ArrayInputStream input(test.first.data(), static_cast<int>(test.first.size()), kBlockSizes[i]);
       std::string err_str;
       std::vector<std::string> lines;
       TestLineCollector collector(&lines);
@@ -313,7 +313,7 @@ TEST(ObjCHelper, ParseSimple_DropsComments) {
 
   for (const auto& test : tests) {
     for (int i = 0; i < kBlockSizeCount; i++) {
-      io::ArrayInputStream input(test.first.data(), test.first.size(), kBlockSizes[i]);
+      io::ArrayInputStream input(test.first.data(), static_cast<int>(test.first.size()), kBlockSizes[i]);
       std::string err_str;
       std::vector<std::string> lines;
       TestLineCollector collector(&lines);
@@ -334,7 +334,7 @@ TEST(ObjCHelper, ParseSimple_RejectLines) {
 
   for (const auto& test : tests) {
     for (int i = 0; i < kBlockSizeCount; i++) {
-      io::ArrayInputStream input(std::get<0>(test).data(), std::get<0>(test).size(),
+      io::ArrayInputStream input(std::get<0>(test).data(), static_cast<int>(std::get<0>(test).size()),
                                  kBlockSizes[i]);
       std::string err_str;
       TestLineCollector collector(nullptr, &std::get<1>(test));
@@ -356,7 +356,7 @@ TEST(ObjCHelper, ParseSimple_RejectLinesNoMessage) {
 
   for (const auto& test : tests) {
     for (int i = 0; i < kBlockSizeCount; i++) {
-      io::ArrayInputStream input(std::get<0>(test).data(), std::get<0>(test).size(),
+      io::ArrayInputStream input(std::get<0>(test).data(), static_cast<int>(std::get<0>(test).size()),
                                  kBlockSizes[i]);
       std::string err_str;
       TestLineCollector collector(nullptr, &std::get<1>(test), true /* skip msg */);

--- a/src/google/protobuf/compiler/objectivec/objectivec_message.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message.cc
@@ -437,9 +437,9 @@ void MessageGenerator::GenerateSource(io::Printer* printer) {
     }
     // Tell all the fields the oneof base.
     for (const auto& generator : oneof_generators_) {
-      generator->SetOneofIndexBase(sizeof_has_storage);
+      generator->SetOneofIndexBase(static_cast<int>(sizeof_has_storage));
     }
-    field_generators_.SetOneofIndexBase(sizeof_has_storage);
+    field_generators_.SetOneofIndexBase(static_cast<int>(sizeof_has_storage));
     // sizeof_has_storage needs enough bits for the single fields that aren't in
     // any oneof, and then one int32 for each oneof (to store the field number).
     sizeof_has_storage += oneof_generators_.size();

--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -246,7 +246,7 @@ bool Parser::ConsumeInteger(int* output, const char* error) {
       AddError("Integer out of range.");
       // We still return true because we did, in fact, parse an integer.
     }
-    *output = value;
+    *output = static_cast<int>(value);
     input_->Next();
     return true;
   } else {
@@ -265,7 +265,7 @@ bool Parser::ConsumeSignedInteger(int* output, const char* error) {
   uint64_t value = 0;
   DO(ConsumeInteger64(max_value, &value, error));
   if (is_negative) value *= -1;
-  *output = value;
+  *output = static_cast<int>(value);
   return true;
 }
 
@@ -300,7 +300,7 @@ bool Parser::ConsumeNumber(double* output, const char* error) {
       AddError("Integer out of range.");
       // We still return true because we did, in fact, parse a number.
     }
-    *output = value;
+    *output = static_cast<double>(value);
     input_->Next();
     return true;
   } else if (LookingAt("inf")) {

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -109,7 +109,7 @@ class ParserTest : public testing::Test {
 
   // Set up the parser to parse the given text.
   void SetupParser(const char* text) {
-    raw_input_.reset(new io::ArrayInputStream(text, strlen(text)));
+    raw_input_.reset(new io::ArrayInputStream(text, static_cast<int>(strlen(text))));
     input_.reset(new io::Tokenizer(raw_input_.get(), &error_collector_));
     parser_.reset(new Parser());
     parser_->RecordErrorsTo(&error_collector_);

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -334,7 +334,7 @@ std::string GeneratedMetadataFileName(const FileDescriptor* file,
                                       const Options& options) {
   const std::string& proto_file = file->name();
   int start_index = 0;
-  int first_index = proto_file.find_first_of("/", start_index);
+  int first_index = static_cast<int>(proto_file.find_first_of("/", start_index));
   std::string result = "";
   std::string segment = "";
 
@@ -347,7 +347,7 @@ std::string GeneratedMetadataFileName(const FileDescriptor* file,
 
   // Append directory name.
   std::string file_no_suffix;
-  int lastindex = proto_file.find_last_of(".");
+  int lastindex = static_cast<int>(proto_file.find_last_of("."));
   if (proto_file == kEmptyFile) {
     return kEmptyMetadataFile;
   } else {
@@ -371,12 +371,12 @@ std::string GeneratedMetadataFileName(const FileDescriptor* file,
           file_no_suffix.substr(start_index, first_index - start_index), true);
       result += ReservedNamePrefix(segment, file) + segment + "/";
       start_index = first_index + 1;
-      first_index = file_no_suffix.find_first_of("/", start_index);
+      first_index = static_cast<int>(file_no_suffix.find_first_of("/", start_index));
     }
   }
 
   // Append file name.
-  int file_name_start = file_no_suffix.find_last_of("/");
+  int file_name_start = static_cast<int>(file_no_suffix.find_last_of("/"));
   if (file_name_start == std::string::npos) {
     file_name_start = 0;
   } else {
@@ -1217,7 +1217,7 @@ void GenerateHead(const FileDescriptor* file, io::Printer* printer) {
 }
 
 std::string FilenameToClassname(const std::string& filename) {
-  int lastindex = filename.find_last_of(".");
+  int lastindex = static_cast<int>(filename.find_last_of("."));
   std::string result = filename.substr(0, lastindex);
   for (int i = 0; i < result.size(); i++) {
     if (result[i] == '/') {
@@ -1237,7 +1237,7 @@ void GenerateMetadataFile(const FileDescriptor* file, const Options& options,
   GenerateHead(file, &printer);
 
   std::string fullname = FilenameToClassname(filename);
-  int lastindex = fullname.find_last_of("\\");
+  size_t lastindex = fullname.find_last_of("\\");
 
   if (lastindex != std::string::npos) {
     printer.Print(
@@ -1299,7 +1299,7 @@ void GenerateEnumFile(const FileDescriptor* file, const EnumDescriptor* en,
   GenerateHead(file, &printer);
 
   std::string fullname = FilenameToClassname(filename);
-  int lastindex = fullname.find_last_of("\\");
+  size_t lastindex = fullname.find_last_of("\\");
 
   if (lastindex != std::string::npos) {
     printer.Print(
@@ -1440,7 +1440,7 @@ void GenerateMessageFile(const FileDescriptor* file, const Descriptor* message,
   GenerateHead(file, &printer);
 
   std::string fullname = FilenameToClassname(filename);
-  int lastindex = fullname.find_last_of("\\");
+  size_t lastindex = fullname.find_last_of("\\");
 
   if (lastindex != std::string::npos) {
     printer.Print(
@@ -1570,7 +1570,7 @@ void GenerateServiceFile(
   GenerateHead(file, &printer);
 
   std::string fullname = FilenameToClassname(filename);
-  int lastindex = fullname.find_last_of("\\");
+  size_t lastindex = fullname.find_last_of("\\");
 
   if (!file->options().php_namespace().empty() ||
       (!file->options().has_php_namespace() && !file->package().empty()) ||

--- a/src/google/protobuf/compiler/python/generator.cc
+++ b/src/google/protobuf/compiler/python/generator.cc
@@ -339,7 +339,7 @@ void Generator::PrintImports() const {
       printer_->Print("$alias$ = importlib.import_module('$name$')\n", "alias",
                       module_alias, "name", module_name);
     } else {
-      int last_dot_pos = module_name.rfind('.');
+      int last_dot_pos = static_cast<int>(module_name.rfind('.'));
       std::string import_statement;
       if (last_dot_pos == std::string::npos) {
         // NOTE(petya): this is not tested as it would require a protocol buffer
@@ -1159,7 +1159,7 @@ void Generator::PrintSerializedPbInterval(const DescriptorT& descriptor,
   descriptor.CopyTo(&proto);
   std::string sp;
   proto.SerializeToString(&sp);
-  int offset = file_descriptor_serialized_.find(sp);
+  int offset = static_cast<int>(file_descriptor_serialized_.find(sp));
   GOOGLE_CHECK_GE(offset, 0);
 
   printer_->Print(

--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -68,7 +68,7 @@ std::string NumberToString(numeric_type value) {
 }
 
 std::string GetRequireName(const std::string& proto_file) {
-  int lastindex = proto_file.find_last_of(".");
+  int lastindex = static_cast<int>(proto_file.find_last_of("."));
   return proto_file.substr(0, lastindex) + "_pb";
 }
 

--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -205,10 +205,10 @@ bool Subprocess::Communicate(const Message& input, Message* output,
     if (signaled_handle == child_stdin_) {
       DWORD n;
       if (!WriteFile(child_stdin_, input_data.data() + input_pos,
-                     input_data.size() - input_pos, &n, nullptr)) {
+                     static_cast<DWORD>(input_data.size() - input_pos), &n, nullptr)) {
         // Child closed pipe.  Presumably it will report an error later.
         // Pretend we're done for now.
-        input_pos = input_data.size();
+        input_pos = static_cast<int>(input_data.size());
       } else {
         input_pos += n;
       }

--- a/src/google/protobuf/compiler/zip_writer.cc
+++ b/src/google/protobuf/compiler/zip_writer.cc
@@ -117,9 +117,9 @@ bool ZipWriter::Write(const std::string& filename,
   FileInfo info;
 
   info.name = filename;
-  uint16_t filename_size = filename.size();
-  info.offset = raw_output_->ByteCount();
-  info.size = contents.size();
+  uint16_t filename_size = static_cast<uint16_t>(filename.size());
+  info.offset = static_cast<uint32_t>(raw_output_->ByteCount());
+  info.size = static_cast<uint32_t>(contents.size());
   info.crc32 = ComputeCRC32(contents);
 
   files_.push_back(info);
@@ -144,14 +144,14 @@ bool ZipWriter::Write(const std::string& filename,
 }
 
 bool ZipWriter::WriteDirectory() {
-  uint16_t num_entries = files_.size();
-  uint32_t dir_ofs = raw_output_->ByteCount();
+  uint16_t num_entries = static_cast<uint16_t>(files_.size());
+  uint32_t dir_ofs = static_cast<uint32_t>(raw_output_->ByteCount());
 
   // write central directory
   io::CodedOutputStream output(raw_output_);
   for (int i = 0; i < num_entries; ++i) {
     const std::string& filename = files_[i].name;
-    uint16_t filename_size = filename.size();
+    uint16_t filename_size = static_cast<uint16_t>(filename.size());
     uint32_t crc32 = files_[i].crc32;
     uint32_t size = files_[i].size;
     uint32_t offset = files_[i].offset;

--- a/src/google/protobuf/descriptor.pb.cc
+++ b/src/google/protobuf/descriptor.pb.cc
@@ -3780,7 +3780,7 @@ const char* FieldDescriptorProto::_InternalParse(const char* ptr, ::_pbi::ParseC
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 32)) {
           uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
-          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::FieldDescriptorProto_Label_IsValid(val))) {
+          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::FieldDescriptorProto_Label_IsValid(static_cast<int>(val)))) {
             _internal_set_label(static_cast<::PROTOBUF_NAMESPACE_ID::FieldDescriptorProto_Label>(val));
           } else {
             ::PROTOBUF_NAMESPACE_ID::internal::WriteVarint(4, val, mutable_unknown_fields());
@@ -3793,7 +3793,7 @@ const char* FieldDescriptorProto::_InternalParse(const char* ptr, ::_pbi::ParseC
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 40)) {
           uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
-          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::FieldDescriptorProto_Type_IsValid(val))) {
+          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::FieldDescriptorProto_Type_IsValid(static_cast<int>(val)))) {
             _internal_set_type(static_cast<::PROTOBUF_NAMESPACE_ID::FieldDescriptorProto_Type>(val));
           } else {
             ::PROTOBUF_NAMESPACE_ID::internal::WriteVarint(5, val, mutable_unknown_fields());
@@ -6568,7 +6568,7 @@ const char* FileOptions::_InternalParse(const char* ptr, ::_pbi::ParseContext* c
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 72)) {
           uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
-          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::FileOptions_OptimizeMode_IsValid(val))) {
+          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::FileOptions_OptimizeMode_IsValid(static_cast<int>(val)))) {
             _internal_set_optimize_for(static_cast<::PROTOBUF_NAMESPACE_ID::FileOptions_OptimizeMode>(val));
           } else {
             ::PROTOBUF_NAMESPACE_ID::internal::WriteVarint(9, val, mutable_unknown_fields());
@@ -7779,7 +7779,7 @@ const char* FieldOptions::_InternalParse(const char* ptr, ::_pbi::ParseContext* 
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
           uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
-          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::FieldOptions_CType_IsValid(val))) {
+          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::FieldOptions_CType_IsValid(static_cast<int>(val)))) {
             _internal_set_ctype(static_cast<::PROTOBUF_NAMESPACE_ID::FieldOptions_CType>(val));
           } else {
             ::PROTOBUF_NAMESPACE_ID::internal::WriteVarint(1, val, mutable_unknown_fields());
@@ -7819,7 +7819,7 @@ const char* FieldOptions::_InternalParse(const char* ptr, ::_pbi::ParseContext* 
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 48)) {
           uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
-          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::FieldOptions_JSType_IsValid(val))) {
+          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::FieldOptions_JSType_IsValid(static_cast<int>(val)))) {
             _internal_set_jstype(static_cast<::PROTOBUF_NAMESPACE_ID::FieldOptions_JSType>(val));
           } else {
             ::PROTOBUF_NAMESPACE_ID::internal::WriteVarint(6, val, mutable_unknown_fields());
@@ -9217,7 +9217,7 @@ const char* MethodOptions::_InternalParse(const char* ptr, ::_pbi::ParseContext*
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
           uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
-          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::MethodOptions_IdempotencyLevel_IsValid(val))) {
+          if (PROTOBUF_PREDICT_TRUE(::PROTOBUF_NAMESPACE_ID::MethodOptions_IdempotencyLevel_IsValid(static_cast<int>(val)))) {
             _internal_set_idempotency_level(static_cast<::PROTOBUF_NAMESPACE_ID::MethodOptions_IdempotencyLevel>(val));
           } else {
             ::PROTOBUF_NAMESPACE_ID::internal::WriteVarint(34, val, mutable_unknown_fields());

--- a/src/google/protobuf/descriptor_database_unittest.cc
+++ b/src/google/protobuf/descriptor_database_unittest.cc
@@ -501,8 +501,8 @@ TEST(EncodedDescriptorDatabaseExtraTest, FindNameOfFileContainingSymbol) {
 
   // Create EncodedDescriptorDatabase containing both files.
   EncodedDescriptorDatabase db;
-  db.Add(data1.data(), data1.size());
-  db.Add(data2.data(), data2.size());
+  db.Add(data1.data(), static_cast<int>(data1.size()));
+  db.Add(data2.data(), static_cast<int>(data2.size()));
 
   // Test!
   std::string filename;

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -595,7 +595,7 @@ TEST_F(FileDescriptorTest, DebugStringRoundTrip) {
   for (int i = 0; i < debug_strings.size(); ++i) {
     const std::string& name = debug_strings[i].first;
     const std::string& content = debug_strings[i].second;
-    io::ArrayInputStream input_stream(content.data(), content.size());
+    io::ArrayInputStream input_stream(content.data(), static_cast<int>(content.size()));
     SimpleErrorCollector error_collector;
     io::Tokenizer tokenizer(&input_stream, &error_collector);
     compiler::Parser parser;
@@ -7325,8 +7325,8 @@ class ExponentialErrorDatabase : public DescriptorDatabase {
  private:
   void FullMatch(const std::string& name, const std::string& begin_with,
                  const std::string& end_with, int* file_num) {
-    int begin_size = begin_with.size();
-    int end_size = end_with.size();
+    int begin_size = static_cast<int>(begin_with.size());
+    int end_size = static_cast<int>(end_with.size());
     if (name.substr(0, begin_size) != begin_with ||
         name.substr(name.size() - end_size, end_size) != end_with) {
       return;
@@ -7420,7 +7420,7 @@ class SingletonSourceTree : public compiler::SourceTree {
 
   io::ZeroCopyInputStream* Open(const std::string& filename) override {
     return filename == filename_
-               ? new io::ArrayInputStream(contents_.data(), contents_.size())
+               ? new io::ArrayInputStream(contents_.data(), static_cast<int>(contents_.size()))
                : nullptr;
   }
 

--- a/src/google/protobuf/extension_set.cc
+++ b/src/google/protobuf/extension_set.cc
@@ -1232,13 +1232,13 @@ const char* ExtensionSet::ParseField(uint64_t tag, const char* ptr,
                                      internal::InternalMetadata* metadata,
                                      internal::ParseContext* ctx) {
   GeneratedExtensionFinder finder(extendee);
-  int number = tag >> 3;
+  int number = static_cast<int>(tag >> 3);
   bool was_packed_on_wire;
   ExtensionInfo extension;
   if (!FindExtensionInfoFromFieldNumber(tag & 7, number, &finder, &extension,
                                         &was_packed_on_wire)) {
     return UnknownFieldParse(
-        tag, metadata->mutable_unknown_fields<std::string>(), ptr, ctx);
+        static_cast<uint32_t>(tag), metadata->mutable_unknown_fields<std::string>(), ptr, ctx);
   }
   return ParseFieldWithExtensionInfo<std::string>(
       number, was_packed_on_wire, extension, metadata, ptr, ctx);
@@ -1401,7 +1401,7 @@ size_t ExtensionSet::Extension::ByteSize(int number) const {
 
       cached_size = ToCachedSize(result);
       if (result > 0) {
-        result += io::CodedOutputStream::VarintSize32(result);
+        result += io::CodedOutputStream::VarintSize32(static_cast<uint32_t>(result));
         result += io::CodedOutputStream::VarintSize32(WireFormatLite::MakeTag(
             number, WireFormatLite::WIRETYPE_LENGTH_DELIMITED));
       }
@@ -1469,7 +1469,7 @@ size_t ExtensionSet::Extension::ByteSize(int number) const {
       case WireFormatLite::TYPE_MESSAGE: {
         if (is_lazy) {
           size_t size = lazymessage_value->ByteSizeLong();
-          result += io::CodedOutputStream::VarintSize32(size) + size;
+          result += io::CodedOutputStream::VarintSize32(static_cast<uint32_t>(size)) + size;
         } else {
           result += WireFormatLite::MessageSize(*message_value);
         }
@@ -1936,7 +1936,7 @@ size_t ExtensionSet::Extension::MessageSetItemByteSize(int number) const {
     message_size = message_value->ByteSizeLong();
   }
 
-  our_size += io::CodedOutputStream::VarintSize32(message_size);
+  our_size += io::CodedOutputStream::VarintSize32(static_cast<uint32_t>(message_size));
   our_size += message_size;
 
   return our_size;

--- a/src/google/protobuf/extension_set_heavy.cc
+++ b/src/google/protobuf/extension_set_heavy.cc
@@ -328,7 +328,7 @@ const char* ExtensionSet::ParseField(uint64_t tag, const char* ptr,
                                      const Message* containing_type,
                                      internal::InternalMetadata* metadata,
                                      internal::ParseContext* ctx) {
-  int number = tag >> 3;
+  int number = static_cast<int>(tag >> 3);
   bool was_packed_on_wire;
   ExtensionInfo extension;
   if (!FindExtension(tag & 7, number, containing_type, ctx, &extension,
@@ -354,7 +354,7 @@ const char* ExtensionSet::ParseMessageSetItem(
 }
 
 int ExtensionSet::SpaceUsedExcludingSelf() const {
-  return internal::FromIntSize(SpaceUsedExcludingSelfLong());
+  return internal::ToIntSize(SpaceUsedExcludingSelfLong());
 }
 
 size_t ExtensionSet::SpaceUsedExcludingSelfLong() const {
@@ -427,7 +427,7 @@ size_t ExtensionSet::Extension::SpaceUsedExcludingSelfLong() const {
 uint8_t* ExtensionSet::SerializeMessageSetWithCachedSizesToArray(
     const MessageLite* extendee, uint8_t* target) const {
   io::EpsCopyOutputStream stream(
-      target, MessageSetByteSize(),
+      target, static_cast<int>(MessageSetByteSize()),
       io::CodedOutputStream::IsDefaultSerializationDeterministic());
   return InternalSerializeMessageSetWithCachedSizesToArray(extendee, target,
                                                            &stream);

--- a/src/google/protobuf/extension_set_unittest.cc
+++ b/src/google/protobuf/extension_set_unittest.cc
@@ -569,7 +569,7 @@ TEST(ExtensionSetTest, SerializationToStream) {
   std::string data;
   data.resize(size);
   {
-    io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&data), size, 1);
+    io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&data), static_cast<int>(size), 1);
     io::CodedOutputStream output_stream(&array_stream);
     source.SerializeWithCachedSizes(&output_stream);
     ASSERT_FALSE(output_stream.HadError());
@@ -613,7 +613,7 @@ TEST(ExtensionSetTest, PackedSerializationToStream) {
   std::string data;
   data.resize(size);
   {
-    io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&data), size, 1);
+    io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&data), static_cast<int>(size), 1);
     io::CodedOutputStream output_stream(&array_stream);
     source.SerializeWithCachedSizes(&output_stream);
     ASSERT_FALSE(output_stream.HadError());
@@ -769,7 +769,7 @@ TEST(ExtensionSetTest, SpaceUsedExcludingSelf) {
 #define TEST_SCALAR_EXTENSIONS_SPACE_USED(type, value)                       \
   do {                                                                       \
     unittest::TestAllExtensions message;                                     \
-    const int base_size = message.SpaceUsedLong();                           \
+    const int base_size = static_cast<int>(message.SpaceUsedLong());         \
     message.SetExtension(unittest::optional_##type##_extension, value);      \
     int min_expected_size =                                                  \
         base_size +                                                          \
@@ -793,7 +793,7 @@ TEST(ExtensionSetTest, SpaceUsedExcludingSelf) {
 #undef TEST_SCALAR_EXTENSIONS_SPACE_USED
   {
     unittest::TestAllExtensions message;
-    const int base_size = message.SpaceUsedLong();
+    const int base_size = static_cast<int>(message.SpaceUsedLong());
     message.SetExtension(unittest::optional_nested_enum_extension,
                          unittest::TestAllTypes::FOO);
     int min_expected_size =
@@ -805,23 +805,23 @@ TEST(ExtensionSetTest, SpaceUsedExcludingSelf) {
     // Strings may cause extra allocations depending on their length; ensure
     // that gets included as well.
     unittest::TestAllExtensions message;
-    const int base_size = message.SpaceUsedLong();
+    const int base_size = static_cast<int>(message.SpaceUsedLong());
     const std::string s(
         "this is a fairly large string that will cause some "
         "allocation in order to store it in the extension");
     message.SetExtension(unittest::optional_string_extension, s);
-    int min_expected_size = base_size + s.length();
+    int min_expected_size = base_size + static_cast<int>(s.length());
     EXPECT_LE(min_expected_size, message.SpaceUsedLong());
   }
   {
     // Messages also have additional allocation that need to be counted.
     unittest::TestAllExtensions message;
-    const int base_size = message.SpaceUsedLong();
+    const int base_size = static_cast<int>(message.SpaceUsedLong());
     unittest::ForeignMessage foreign;
     foreign.set_c(42);
     message.MutableExtension(unittest::optional_foreign_message_extension)
         ->CopyFrom(foreign);
-    int min_expected_size = base_size + foreign.SpaceUsedLong();
+    int min_expected_size = base_size + static_cast<int>(foreign.SpaceUsedLong());
     EXPECT_LE(min_expected_size, message.SpaceUsedLong());
   }
 
@@ -857,7 +857,7 @@ TEST(ExtensionSetTest, SpaceUsedExcludingSelf) {
     for (int i = 0; i < 16; ++i) {                                             \
       message->AddExtension(unittest::repeated_##type##_extension, value);     \
     }                                                                          \
-    int expected_size =                                                        \
+    size_t expected_size =                                                        \
         sizeof(cpptype) *                                                      \
             (message                                                           \
                  ->GetRepeatedExtension(unittest::repeated_##type##_extension) \
@@ -1278,7 +1278,7 @@ TEST(ExtensionSetTest, DynamicExtensions) {
   // Now we can parse this using our dynamic extension definitions...
   unittest::TestAllExtensions message;
   {
-    io::ArrayInputStream raw_input(data.data(), data.size());
+    io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
     io::CodedInputStream input(&raw_input);
     input.SetExtensionRegistry(&dynamic_pool, &dynamic_factory);
     ASSERT_TRUE(message.ParseFromCodedStream(&input));
@@ -1315,7 +1315,7 @@ TEST(ExtensionSetTest, DynamicExtensions) {
   // What if we parse using the reflection-based parser?
   {
     unittest::TestAllExtensions message2;
-    io::ArrayInputStream raw_input(data.data(), data.size());
+    io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
     io::CodedInputStream input(&raw_input);
     input.SetExtensionRegistry(&dynamic_pool, &dynamic_factory);
     ASSERT_TRUE(WireFormat::ParseAndMergePartial(&input, &message2));

--- a/src/google/protobuf/generated_enum_util.cc
+++ b/src/google/protobuf/generated_enum_util.cc
@@ -75,7 +75,7 @@ int LookUpEnumName(const EnumEntry* enums, const int* sorted_indices,
   auto it =
       std::lower_bound(sorted_indices, sorted_indices + size, -1, comparator);
   if (it != sorted_indices + size && enums[*it].value == value) {
-    return it - sorted_indices;
+    return static_cast<int>(it - sorted_indices);
   }
   return -1;
 }

--- a/src/google/protobuf/generated_message_reflection.cc
+++ b/src/google/protobuf/generated_message_reflection.cc
@@ -286,7 +286,7 @@ size_t Reflection::SpaceUsedLong(const Message& message) const {
   auto* arena = Arena::InternalGetArenaForAllocation(&message);
   if (arena != nullptr && Arena::InternalGetOwningArena(&message) == nullptr &&
       arena->InternalIsMessageOwnedArena()) {
-    total_size += arena->SpaceAllocated() - arena->SpaceUsed();
+    total_size += static_cast<size_t>(arena->SpaceAllocated() - arena->SpaceUsed());
   }
 
   if (schema_.HasExtensionSet()) {

--- a/src/google/protobuf/generated_message_tctable_lite.cc
+++ b/src/google/protobuf/generated_message_tctable_lite.cc
@@ -775,7 +775,7 @@ inline FieldType ZigZagDecodeHelper(uint64_t value) {
 
 template <>
 inline int32_t ZigZagDecodeHelper<int32_t, true>(uint64_t value) {
-  return WireFormatLite::ZigZagDecode32(value);
+  return WireFormatLite::ZigZagDecode32(static_cast<uint32_t>(value));
 }
 
 template <>
@@ -982,12 +982,12 @@ const char* TcParser::PackedVarint(PROTOBUF_TC_PARAM_DECL) {
     FieldType val;
     if (zigzag) {
       if (sizeof(FieldType) == 8) {
-        val = WireFormatLite::ZigZagDecode64(varint);
+        val = static_cast<FieldType>(WireFormatLite::ZigZagDecode64(varint));
       } else {
-        val = WireFormatLite::ZigZagDecode32(varint);
+        val = static_cast<FieldType>(WireFormatLite::ZigZagDecode32(static_cast<uint32_t>(varint)));
       }
     } else {
-      val = varint;
+      val = static_cast<FieldType>(varint);
     }
     field->Add(val);
   });
@@ -1071,7 +1071,7 @@ PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularEnum(
     PROTOBUF_MUSTTAIL return FastUnknownEnumFallback(PROTOBUF_TC_PARAM_PASS);
   }
   hasbits |= (uint64_t{1} << data.hasbit_idx());
-  RefAt<int32_t>(msg, data.offset()) = tmp;
+  RefAt<int32_t>(msg, data.offset()) = static_cast<int32_t>(tmp);
   PROTOBUF_MUSTTAIL return ToTagDispatch(PROTOBUF_TC_PARAM_PASS);
 }
 
@@ -1541,7 +1541,7 @@ const char* TcParser::MpVarint(PROTOBUF_TC_PARAM_DECL) {
     }
   } else if (rep == field_layout::kRep32Bits) {
     if (is_validated_enum) {
-      if (!EnumIsValidAux(tmp, xform_val, *table->field_aux(&entry))) {
+      if (!EnumIsValidAux(static_cast<int32_t>(tmp), xform_val, *table->field_aux(&entry))) {
         ptr = ptr2;
         PROTOBUF_MUSTTAIL return table->fallback(PROTOBUF_TC_PARAM_PASS);
       }
@@ -1610,14 +1610,14 @@ const char* TcParser::MpRepeatedVarint(PROTOBUF_TC_PARAM_DECL) {
       ptr = ParseVarint(ptr2, &tmp);
       if (ptr == nullptr) return Error(PROTOBUF_TC_PARAM_PASS);
       if (is_validated_enum) {
-        if (!EnumIsValidAux(tmp, xform_val, *table->field_aux(&entry))) {
+        if (!EnumIsValidAux(static_cast<int32_t>(tmp), xform_val, *table->field_aux(&entry))) {
           ptr = ptr2;
           PROTOBUF_MUSTTAIL return table->fallback(PROTOBUF_TC_PARAM_PASS);
         }
       } else if (is_zigzag) {
-        tmp = WireFormatLite::ZigZagDecode32(tmp);
+        tmp = WireFormatLite::ZigZagDecode32(static_cast<uint32_t>(tmp));
       }
-      field.Add(tmp);
+      field.Add(static_cast<uint32_t>(tmp));
       if (!ctx->DataAvailable(ptr)) break;
       ptr2 = ReadTag(ptr, &next_tag);
     } while (next_tag == decoded_tag);
@@ -1669,9 +1669,9 @@ const char* TcParser::MpPackedVarint(PROTOBUF_TC_PARAM_DECL) {
   } else if (rep == field_layout::kRep32Bits) {
     auto* field = &RefAt<RepeatedField<uint32_t>>(msg, entry.offset);
     return ctx->ReadPackedVarint(ptr, [field, is_zigzag](uint64_t value) {
-      field->Add(is_zigzag ? WireFormatLite::ZigZagDecode32(
+      field->Add(static_cast<uint32_t>(is_zigzag ? WireFormatLite::ZigZagDecode32(
                                  static_cast<uint32_t>(value))
-                           : value);
+                           : value));
     });
   } else {
     GOOGLE_DCHECK_EQ(rep, static_cast<uint16_t>(field_layout::kRep8Bits));

--- a/src/google/protobuf/generated_message_util.cc
+++ b/src/google/protobuf/generated_message_util.cc
@@ -239,8 +239,8 @@ struct PrimitiveTypeHelper<WireFormatLite::TYPE_STRING> {
   typedef std::string Type;
   static void Serialize(const void* ptr, io::CodedOutputStream* output) {
     const Type& value = *static_cast<const Type*>(ptr);
-    output->WriteVarint32(value.size());
-    output->WriteRawMaybeAliased(value.data(), value.size());
+    output->WriteVarint32(static_cast<uint32_t>(value.size()));
+    output->WriteRawMaybeAliased(value.data(), static_cast<int>(value.size()));
   }
   static uint8_t* SerializeToArray(const void* ptr, uint8_t* buffer) {
     const Type& value = *static_cast<const Type*>(ptr);

--- a/src/google/protobuf/has_bits.h
+++ b/src/google/protobuf/has_bits.h
@@ -71,7 +71,7 @@ class HasBits {
   }
 
   void Or(const HasBits<doublewords>& rhs) {
-    for (size_t i = 0; i < doublewords; i++) has_bits_[i] |= rhs[i];
+    for (size_t i = 0; i < doublewords; i++) has_bits_[i] |= rhs[static_cast<int>(i)];
   }
 
   bool empty() const;

--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -782,7 +782,7 @@ class PROTOBUF_EXPORT EpsCopyOutputStream {
     ptr = EnsureSpace(ptr);
     constexpr auto element_size = sizeof(typename T::value_type);
     auto size = r.size() * element_size;
-    ptr = WriteLengthDelim(num, size, ptr);
+    ptr = WriteLengthDelim(num, static_cast<uint32_t>(size), ptr);
     return WriteRawLittleEndian<element_size>(r.data(), static_cast<int>(size),
                                               ptr);
   }

--- a/src/google/protobuf/io/coded_stream_unittest.cc
+++ b/src/google/protobuf/io/coded_stream_unittest.cc
@@ -702,7 +702,7 @@ TEST_1D(CodedStreamTest, ReadString, kBlockSizes) {
     CodedInputStream coded_input(&input);
 
     std::string str;
-    EXPECT_TRUE(coded_input.ReadString(&str, strlen(kRawBytes)));
+    EXPECT_TRUE(coded_input.ReadString(&str, static_cast<int>(strlen(kRawBytes))));
     EXPECT_EQ(kRawBytes, str);
   }
 
@@ -748,7 +748,7 @@ TEST_1D(CodedStreamTest, ReadStringReservesMemoryOnTotalLimit, kBlockSizes) {
     EXPECT_EQ(sizeof(kRawBytes), coded_input.BytesUntilTotalBytesLimit());
 
     std::string str;
-    EXPECT_TRUE(coded_input.ReadString(&str, strlen(kRawBytes)));
+    EXPECT_TRUE(coded_input.ReadString(&str, static_cast<int>(strlen(kRawBytes))));
     EXPECT_EQ(sizeof(kRawBytes) - strlen(kRawBytes),
               coded_input.BytesUntilTotalBytesLimit());
     EXPECT_EQ(kRawBytes, str);
@@ -768,7 +768,7 @@ TEST_1D(CodedStreamTest, ReadStringReservesMemoryOnPushedLimit, kBlockSizes) {
     coded_input.PushLimit(sizeof(buffer_));
 
     std::string str;
-    EXPECT_TRUE(coded_input.ReadString(&str, strlen(kRawBytes)));
+    EXPECT_TRUE(coded_input.ReadString(&str, static_cast<int>(strlen(kRawBytes))));
     EXPECT_EQ(kRawBytes, str);
     // TODO(liujisi): Replace with a more meaningful test (see cl/60966023).
     EXPECT_GE(str.capacity(), strlen(kRawBytes));
@@ -788,7 +788,7 @@ TEST_F(CodedStreamTest, ReadStringNoReservationIfLimitsNotSet) {
     CodedInputStream coded_input(&input);
 
     std::string str;
-    EXPECT_TRUE(coded_input.ReadString(&str, strlen(kRawBytes)));
+    EXPECT_TRUE(coded_input.ReadString(&str, static_cast<int>(strlen(kRawBytes))));
     EXPECT_EQ(kRawBytes, str);
     // Note: this check depends on string class implementation. It
     // expects that string will allocate more than strlen(kRawBytes)
@@ -850,7 +850,7 @@ TEST_F(CodedStreamTest, ReadStringNoReservationSizeIsOverTheLimit) {
     coded_input.PushLimit(16);
 
     std::string str;
-    EXPECT_FALSE(coded_input.ReadString(&str, strlen(kRawBytes)));
+    EXPECT_FALSE(coded_input.ReadString(&str, static_cast<int>(strlen(kRawBytes))));
     // Note: this check depends on string class implementation. It
     // expects that string will allocate less than strlen(kRawBytes)
     // for an empty string.
@@ -870,7 +870,7 @@ TEST_F(CodedStreamTest, ReadStringNoReservationSizeIsOverTheTotalBytesLimit) {
     coded_input.SetTotalBytesLimit(16);
 
     std::string str;
-    EXPECT_FALSE(coded_input.ReadString(&str, strlen(kRawBytes)));
+    EXPECT_FALSE(coded_input.ReadString(&str, static_cast<int>(strlen(kRawBytes))));
     // Note: this check depends on string class implementation. It
     // expects that string will allocate less than strlen(kRawBytes)
     // for an empty string.
@@ -892,7 +892,7 @@ TEST_F(CodedStreamTest,
     coded_input.SetTotalBytesLimit(16);
 
     std::string str;
-    EXPECT_FALSE(coded_input.ReadString(&str, strlen(kRawBytes)));
+    EXPECT_FALSE(coded_input.ReadString(&str, static_cast<int>(strlen(kRawBytes))));
     // Note: this check depends on string class implementation. It
     // expects that string will allocate less than strlen(kRawBytes)
     // for an empty string.
@@ -915,7 +915,7 @@ TEST_F(CodedStreamTest,
     EXPECT_EQ(sizeof(buffer_), coded_input.BytesUntilTotalBytesLimit());
 
     std::string str;
-    EXPECT_FALSE(coded_input.ReadString(&str, strlen(kRawBytes)));
+    EXPECT_FALSE(coded_input.ReadString(&str, static_cast<int>(strlen(kRawBytes))));
     // Note: this check depends on string class implementation. It
     // expects that string will allocate less than strlen(kRawBytes)
     // for an empty string.
@@ -938,10 +938,10 @@ TEST_1D(CodedStreamTest, SkipInput, kBlockSizes) {
     CodedInputStream coded_input(&input);
 
     std::string str;
-    EXPECT_TRUE(coded_input.ReadString(&str, strlen("<Before skipping>")));
+    EXPECT_TRUE(coded_input.ReadString(&str, static_cast<int>(strlen("<Before skipping>"))));
     EXPECT_EQ("<Before skipping>", str);
-    EXPECT_TRUE(coded_input.Skip(strlen("<To be skipped>")));
-    EXPECT_TRUE(coded_input.ReadString(&str, strlen("<After skipping>")));
+    EXPECT_TRUE(coded_input.Skip(static_cast<int>(strlen("<To be skipped>"))));
+    EXPECT_TRUE(coded_input.ReadString(&str, static_cast<int>(strlen("<After skipping>"))));
     EXPECT_EQ("<After skipping>", str);
   }
 

--- a/src/google/protobuf/io/io_win32.cc
+++ b/src/google/protobuf/io/io_win32.cc
@@ -347,13 +347,13 @@ int dup(int fd) { return ::_dup(fd); }
 int dup2(int fd1, int fd2) { return ::_dup2(fd1, fd2); }
 
 int read(int fd, void* buffer, size_t size) {
-  return ::_read(fd, buffer, size);
+  return ::_read(fd, buffer, static_cast<unsigned int>(size));
 }
 
 int setmode(int fd, int mode) { return ::_setmode(fd, mode); }
 
 int write(int fd, const void* buffer, size_t size) {
-  return ::_write(fd, buffer, size);
+  return ::_write(fd, buffer, static_cast<unsigned int>(size));
 }
 
 wstring testonly_utf8_to_winpath(const char* path) {

--- a/src/google/protobuf/io/io_win32_unittest.cc
+++ b/src/google/protobuf/io/io_win32_unittest.cc
@@ -111,7 +111,7 @@ class IoWin32Test : public ::testing::Test {
 
 namespace {
 void StripTrailingSlashes(string* str) {
-  int i = str->size() - 1;
+  int i = static_cast<int>(str->size() - 1);
   for (; i >= 0 && ((*str)[i] == '/' || (*str)[i] == '\\'); --i) {}
   str->resize(i+1);
 }

--- a/src/google/protobuf/io/printer.cc
+++ b/src/google/protobuf/io/printer.cc
@@ -115,7 +115,7 @@ void Printer::Annotate(const char* begin_varname, const char* end_varname,
 
 void Printer::Print(const std::map<std::string, std::string>& variables,
                     const char* text) {
-  int size = strlen(text);
+  int size = static_cast<int>(strlen(text));
   int pos = 0;  // The number of bytes we've written so far.
   substitutions_.clear();
   line_start_variables_.clear();
@@ -145,7 +145,7 @@ void Printer::Print(const std::map<std::string, std::string>& variables,
         GOOGLE_LOG(DFATAL) << " Unclosed variable name.";
         end = text + pos;
       }
-      int endpos = end - text;
+      int endpos = static_cast<int>(end - text);
 
       std::string varname(text + pos, endpos - pos);
       if (varname.empty()) {
@@ -161,7 +161,7 @@ void Printer::Print(const std::map<std::string, std::string>& variables,
           if (at_start_of_line_ && iter->second.empty()) {
             line_start_variables_.push_back(varname);
           }
-          WriteRaw(iter->second.data(), iter->second.size());
+          WriteRaw(iter->second.data(), static_cast<int>(iter->second.size()));
           std::pair<std::map<std::string, std::pair<size_t, size_t> >::iterator,
                     bool>
               inserted = substitutions_.insert(std::make_pair(
@@ -198,12 +198,12 @@ void Printer::Outdent() {
 }
 
 void Printer::PrintRaw(const std::string& data) {
-  WriteRaw(data.data(), data.size());
+  WriteRaw(data.data(), static_cast<int>(data.size()));
 }
 
 void Printer::PrintRaw(const char* data) {
   if (failed_) return;
-  WriteRaw(data, strlen(data));
+  WriteRaw(data, static_cast<int>(strlen(data)));
 }
 
 void Printer::WriteRaw(const char* data, int size) {
@@ -213,7 +213,7 @@ void Printer::WriteRaw(const char* data, int size) {
   if (at_start_of_line_ && (size > 0) && (data[0] != '\n')) {
     // Insert an indent.
     at_start_of_line_ = false;
-    CopyToBuffer(indent_.data(), indent_.size());
+    CopyToBuffer(indent_.data(), static_cast<int>(indent_.size()));
     if (failed_) return;
     // Fix up empty variables (e.g., "{") that should be annotated as
     // coming after the indent.
@@ -272,7 +272,7 @@ void Printer::CopyToBuffer(const char* data, int size) {
 
 void Printer::IndentIfAtStart() {
   if (at_start_of_line_) {
-    CopyToBuffer(indent_.data(), indent_.size());
+    CopyToBuffer(indent_.data(), static_cast<int>(indent_.size()));
     at_start_of_line_ = false;
   }
 }
@@ -390,11 +390,11 @@ const char* Printer::WriteVariable(
   IndentIfAtStart();
 
   // Write the possible spaces in front.
-  CopyToBuffer(start, start_var - start);
+  CopyToBuffer(start, static_cast<int>(start_var - start));
   // Write a non-empty substituted variable.
-  CopyToBuffer(sub.c_str(), sub.size());
+  CopyToBuffer(sub.c_str(), static_cast<int>(sub.size()));
   // Finish off with writing possible trailing spaces.
-  CopyToBuffer(end_var, end - end_var);
+  CopyToBuffer(end_var, static_cast<int>(end - end_var));
   return format;
 }
 

--- a/src/google/protobuf/io/printer.h
+++ b/src/google/protobuf/io/printer.h
@@ -92,15 +92,15 @@ class AnnotationProtoCollector : public AnnotationCollector {
       annotation->add_path(path[i]);
     }
     annotation->set_source_file(file_path);
-    annotation->set_begin(begin_offset);
-    annotation->set_end(end_offset);
+    annotation->set_begin(static_cast<int32_t>(begin_offset));
+    annotation->set_end(static_cast<int32_t>(end_offset));
   }
   // Override for AnnotationCollector::AddAnnotation.
   void AddAnnotationNew(Annotation& a) override {
     auto* annotation = annotation_proto_->add_annotation();
     annotation->ParseFromString(a.second);
-    annotation->set_begin(a.first.first);
-    annotation->set_end(a.first.second);
+    annotation->set_begin(static_cast<int32_t>(a.first.first));
+    annotation->set_end(static_cast<int32_t>(a.first.second));
   }
 
  private:

--- a/src/google/protobuf/io/tokenizer_unittest.cc
+++ b/src/google/protobuf/io/tokenizer_unittest.cc
@@ -249,7 +249,7 @@ SimpleTokenCase kSimpleTokenCases[] = {
 TEST_2D(TokenizerTest, SimpleTokens, kSimpleTokenCases, kBlockSizes) {
   // Set up the tokenizer.
   TestInputStream input(kSimpleTokenCases_case.input.data(),
-                        kSimpleTokenCases_case.input.size(), kBlockSizes_case);
+                        static_cast<int>(kSimpleTokenCases_case.input.size()), kBlockSizes_case);
   TestErrorCollector error_collector;
   Tokenizer tokenizer(&input, &error_collector);
 
@@ -293,7 +293,7 @@ TEST_1D(TokenizerTest, FloatSuffix, kBlockSizes) {
 
   // Set up the tokenizer.
   const char* text = "1f 2.5f 6e3f 7F";
-  TestInputStream input(text, strlen(text), kBlockSizes_case);
+  TestInputStream input(text, static_cast<int>(strlen(text)), kBlockSizes_case);
   TestErrorCollector error_collector;
   Tokenizer tokenizer(&input, &error_collector);
   tokenizer.set_allow_f_after_float(true);
@@ -333,7 +333,7 @@ SimpleTokenCase kWhitespaceTokenCases[] = {
 TEST_2D(TokenizerTest, Whitespace, kWhitespaceTokenCases, kBlockSizes) {
   {
     TestInputStream input(kWhitespaceTokenCases_case.input.data(),
-                          kWhitespaceTokenCases_case.input.size(),
+                          static_cast<int>(kWhitespaceTokenCases_case.input.size()),
                           kBlockSizes_case);
     TestErrorCollector error_collector;
     Tokenizer tokenizer(&input, &error_collector);
@@ -342,7 +342,7 @@ TEST_2D(TokenizerTest, Whitespace, kWhitespaceTokenCases, kBlockSizes) {
   }
   {
     TestInputStream input(kWhitespaceTokenCases_case.input.data(),
-                          kWhitespaceTokenCases_case.input.size(),
+                          static_cast<int>(kWhitespaceTokenCases_case.input.size()),
                           kBlockSizes_case);
     TestErrorCollector error_collector;
     Tokenizer tokenizer(&input, &error_collector);
@@ -468,7 +468,7 @@ MultiTokenCase kMultiTokenCases[] = {
 TEST_2D(TokenizerTest, MultipleTokens, kMultiTokenCases, kBlockSizes) {
   // Set up the tokenizer.
   TestInputStream input(kMultiTokenCases_case.input.data(),
-                        kMultiTokenCases_case.input.size(), kBlockSizes_case);
+                        static_cast<int>(kMultiTokenCases_case.input.size()), kBlockSizes_case);
   TestErrorCollector error_collector;
   Tokenizer tokenizer(&input, &error_collector);
 
@@ -540,7 +540,7 @@ TEST_2D(TokenizerTest, MultipleWhitespaceTokens, kMultiWhitespaceTokenCases,
         kBlockSizes) {
   // Set up the tokenizer.
   TestInputStream input(kMultiWhitespaceTokenCases_case.input.data(),
-                        kMultiWhitespaceTokenCases_case.input.size(),
+                        static_cast<int>(kMultiWhitespaceTokenCases_case.input.size()),
                         kBlockSizes_case);
   TestErrorCollector error_collector;
   Tokenizer tokenizer(&input, &error_collector);
@@ -608,7 +608,7 @@ TEST_1D(TokenizerTest, ShCommentStyle, kBlockSizes) {
                                  "*",   "grault", "*", "/",   "garply"};
 
   // Set up the tokenizer.
-  TestInputStream input(text, strlen(text), kBlockSizes_case);
+  TestInputStream input(text, static_cast<int>(strlen(text)), kBlockSizes_case);
   TestErrorCollector error_collector;
   Tokenizer tokenizer(&input, &error_collector);
   tokenizer.set_comment_style(Tokenizer::SH_COMMENT_STYLE);
@@ -768,13 +768,13 @@ DocCommentCase kDocCommentCases[] = {
 TEST_2D(TokenizerTest, DocComments, kDocCommentCases, kBlockSizes) {
   // Set up the tokenizer.
   TestInputStream input(kDocCommentCases_case.input.data(),
-                        kDocCommentCases_case.input.size(), kBlockSizes_case);
+                        static_cast<int>(kDocCommentCases_case.input.size()), kBlockSizes_case);
   TestErrorCollector error_collector;
   Tokenizer tokenizer(&input, &error_collector);
 
   // Set up a second tokenizer where we'll pass all NULLs to NextWithComments().
   TestInputStream input2(kDocCommentCases_case.input.data(),
-                         kDocCommentCases_case.input.size(), kBlockSizes_case);
+                         static_cast<int>(kDocCommentCases_case.input.size()), kBlockSizes_case);
   Tokenizer tokenizer2(&input2, &error_collector);
 
   tokenizer.Next();
@@ -1131,7 +1131,7 @@ ErrorCase kErrorCases[] = {
 TEST_2D(TokenizerTest, Errors, kErrorCases, kBlockSizes) {
   // Set up the tokenizer.
   TestInputStream input(kErrorCases_case.input.data(),
-                        kErrorCases_case.input.size(), kBlockSizes_case);
+                        static_cast<int>(kErrorCases_case.input.size()), kBlockSizes_case);
   TestErrorCollector error_collector;
   Tokenizer tokenizer(&input, &error_collector);
 
@@ -1154,7 +1154,7 @@ TEST_2D(TokenizerTest, Errors, kErrorCases, kBlockSizes) {
 
 TEST_1D(TokenizerTest, BackUpOnDestruction, kBlockSizes) {
   std::string text = "foo bar";
-  TestInputStream input(text.data(), text.size(), kBlockSizes_case);
+  TestInputStream input(text.data(), static_cast<int>(text.size()), kBlockSizes_case);
 
   // Create a tokenizer, read one token, then destroy it.
   {

--- a/src/google/protobuf/io/zero_copy_stream_impl.cc
+++ b/src/google/protobuf/io/zero_copy_stream_impl.cc
@@ -270,7 +270,7 @@ IstreamInputStream::CopyingIstreamInputStream::~CopyingIstreamInputStream() {}
 int IstreamInputStream::CopyingIstreamInputStream::Read(void* buffer,
                                                         int size) {
   input_->read(reinterpret_cast<char*>(buffer), size);
-  int result = input_->gcount();
+  int result = static_cast<int>(input_->gcount());
   if (result == 0 && input_->fail() && !input_->eof()) {
     return -1;
   }
@@ -345,7 +345,7 @@ bool ConcatenatingInputStream::Skip(int count) {
     // to skip.
     int64_t final_byte_count = streams_[0]->ByteCount();
     GOOGLE_DCHECK_LT(final_byte_count, target_byte_count);
-    count = target_byte_count - final_byte_count;
+    count = static_cast<int>(target_byte_count - final_byte_count);
 
     // That stream is done.  Advance to the next one.
     bytes_retired_ += final_byte_count;

--- a/src/google/protobuf/io/zero_copy_stream_impl_lite.cc
+++ b/src/google/protobuf/io/zero_copy_stream_impl_lite.cc
@@ -164,7 +164,7 @@ bool StringOutputStream::Next(void** data, int* size) {
                kMinimumSize + 0));  // "+ 0" works around GCC4 weirdness.
 
   *data = mutable_string_data(target_) + old_size;
-  *size = target_->size() - old_size;
+  *size = static_cast<int>(target_->size() - old_size);
   return true;
 }
 
@@ -187,7 +187,7 @@ int CopyingInputStream::Skip(int count) {
   int skipped = 0;
   while (skipped < count) {
     int bytes = Read(junk, std::min(count - skipped,
-                                    implicit_cast<int>(sizeof(junk))));
+                                    static_cast<int>(sizeof(junk))));
     if (bytes <= 0) {
       // EOF or read error.
       return skipped;
@@ -420,7 +420,7 @@ LimitingInputStream::LimitingInputStream(ZeroCopyInputStream* input,
 
 LimitingInputStream::~LimitingInputStream() {
   // If we overshot the limit, back up.
-  if (limit_ < 0) input_->BackUp(-limit_);
+  if (limit_ < 0) input_->BackUp(static_cast<int>(-limit_));
 }
 
 bool LimitingInputStream::Next(const void** data, int* size) {
@@ -430,14 +430,14 @@ bool LimitingInputStream::Next(const void** data, int* size) {
   limit_ -= *size;
   if (limit_ < 0) {
     // We overshot the limit.  Reduce *size to hide the rest of the buffer.
-    *size += limit_;
+    *size += static_cast<int>(limit_);
   }
   return true;
 }
 
 void LimitingInputStream::BackUp(int count) {
   if (limit_ < 0) {
-    input_->BackUp(count - limit_);
+    input_->BackUp(static_cast<int>(count - limit_));
     limit_ = count;
   } else {
     input_->BackUp(count);
@@ -448,7 +448,7 @@ void LimitingInputStream::BackUp(int count) {
 bool LimitingInputStream::Skip(int count) {
   if (count > limit_) {
     if (limit_ < 0) return false;
-    input_->Skip(limit_);
+    input_->Skip(static_cast<int>(limit_));
     limit_ = 0;
     return false;
   } else {

--- a/src/google/protobuf/io/zero_copy_stream_unittest.cc
+++ b/src/google/protobuf/io/zero_copy_stream_unittest.cc
@@ -206,13 +206,13 @@ int IoTest::ReadFromInput(ZeroCopyInputStream* input, void* data, int size) {
 }
 
 void IoTest::WriteString(ZeroCopyOutputStream* output, const std::string& str) {
-  EXPECT_TRUE(WriteToOutput(output, str.c_str(), str.size()));
+  EXPECT_TRUE(WriteToOutput(output, str.c_str(), static_cast<int>(str.size())));
 }
 
 void IoTest::ReadString(ZeroCopyInputStream* input, const std::string& str) {
   std::unique_ptr<char[]> buffer(new char[str.size() + 1]);
   buffer[str.size()] = '\0';
-  EXPECT_EQ(ReadFromInput(input, buffer.get(), str.size()), str.size());
+  EXPECT_EQ(ReadFromInput(input, buffer.get(), static_cast<int>(str.size())), str.size());
   EXPECT_STREQ(str.c_str(), buffer.get());
 }
 
@@ -226,7 +226,7 @@ int IoTest::WriteStuff(ZeroCopyOutputStream* output) {
 
   EXPECT_EQ(output->ByteCount(), 68);
 
-  int result = output->ByteCount();
+  int result = static_cast<int>(output->ByteCount());
   return result;
 }
 
@@ -260,7 +260,7 @@ int IoTest::WriteStuffLarge(ZeroCopyOutputStream* output) {
 
   EXPECT_EQ(output->ByteCount(), 200055);
 
-  int result = output->ByteCount();
+  int result = static_cast<int>(output->ByteCount());
   return result;
 }
 
@@ -316,22 +316,22 @@ TEST_F(IoTest, TwoSessionWrite) {
       ArrayOutputStream* output =
           new ArrayOutputStream(buffer, kBufferSize, kBlockSizes[i]);
       CodedOutputStream* coded_output = new CodedOutputStream(output);
-      coded_output->WriteVarint32(strlen(strA));
-      coded_output->WriteRaw(strA, strlen(strA));
+      coded_output->WriteVarint32(static_cast<uint32_t>(strlen(strA)));
+      coded_output->WriteRaw(strA, static_cast<int>(strlen(strA)));
       delete coded_output;  // flush
       int64 pos = output->ByteCount();
       delete output;
-      output = new ArrayOutputStream(buffer + pos, kBufferSize - pos,
+      output = new ArrayOutputStream(buffer + pos, static_cast<int>(kBufferSize - pos),
                                      kBlockSizes[i]);
       coded_output = new CodedOutputStream(output);
-      coded_output->WriteVarint32(strlen(strB));
-      coded_output->WriteRaw(strB, strlen(strB));
+      coded_output->WriteVarint32(static_cast<uint32_t>(strlen(strB)));
+      coded_output->WriteRaw(strB, static_cast<int>(strlen(strB)));
       delete coded_output;  // flush
       int64 size = pos + output->ByteCount();
       delete output;
 
       ArrayInputStream* input =
-          new ArrayInputStream(buffer, size, kBlockSizes[j]);
+          new ArrayInputStream(buffer, static_cast<int>(size), kBlockSizes[j]);
       CodedInputStream* coded_input = new CodedInputStream(input);
       uint32 insize;
       EXPECT_TRUE(coded_input->ReadVarint32(&insize));
@@ -713,7 +713,7 @@ TEST_F(IoTest, StringIo) {
     WriteStuff(&output);
   }
   {
-    ArrayInputStream input(str.data(), str.size());
+    ArrayInputStream input(str.data(), static_cast<int>(str.size()));
     ReadStuff(&input);
   }
 }

--- a/src/google/protobuf/lite_arena_unittest.cc
+++ b/src/google/protobuf/lite_arena_unittest.cc
@@ -77,11 +77,11 @@ TEST_F(LiteArenaTest, UnknownFieldMemLeak) {
       Arena::CreateMessage<protobuf_unittest::ForeignMessageArenaLite>(
           arena_.get());
   std::string data = "\012\000";
-  int original_capacity = data.capacity();
+  int original_capacity = static_cast<int>(data.capacity());
   while (data.capacity() <= original_capacity) {
     data.append("a");
   }
-  data[1] = data.size() - 2;
+  data[1] = static_cast<char>(data.size() - 2);
   message->ParseFromString(data);
 }
 

--- a/src/google/protobuf/lite_unittest.cc
+++ b/src/google/protobuf/lite_unittest.cc
@@ -695,7 +695,7 @@ TEST(Lite, AllLite29) {
     data.resize(size);
     {
       // Allow the output stream to buffer only one byte at a time.
-      io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&data), size, 1);
+      io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&data), static_cast<int>(size), 1);
       io::CodedOutputStream output_stream(&array_stream);
       message1.SerializeWithCachedSizes(&output_stream);
       EXPECT_FALSE(output_stream.HadError());
@@ -936,7 +936,7 @@ TEST(Lite, AllLite43) {
     message2.mutable_oneof_submessage();
     io::CodedInputStream input_stream(
         reinterpret_cast<const ::uint8_t*>(serialized.data()),
-        serialized.size());
+        static_cast<int>(serialized.size()));
     EXPECT_TRUE(message2.MergeFromCodedStream(&input_stream));
     EXPECT_EQ(17, message2.oneof_int32());
   }
@@ -947,7 +947,7 @@ TEST(Lite, AllLite43) {
     message2.set_oneof_string("string");
     io::CodedInputStream input_stream(
         reinterpret_cast<const ::uint8_t*>(serialized.data()),
-        serialized.size());
+        static_cast<int>(serialized.size()));
     EXPECT_TRUE(message2.MergeFromCodedStream(&input_stream));
     EXPECT_EQ(17, message2.oneof_int32());
   }
@@ -958,7 +958,7 @@ TEST(Lite, AllLite43) {
     message2.set_oneof_bytes("bytes");
     io::CodedInputStream input_stream(
         reinterpret_cast<const ::uint8_t*>(serialized.data()),
-        serialized.size());
+        static_cast<int>(serialized.size()));
     EXPECT_TRUE(message2.MergeFromCodedStream(&input_stream));
     EXPECT_EQ(17, message2.oneof_int32());
   }
@@ -978,7 +978,7 @@ TEST(Lite, AllLite44) {
     for (int i = 0; i < 2; ++i) {
       io::CodedInputStream input_stream(
           reinterpret_cast<const ::uint8_t*>(serialized.data()),
-          serialized.size());
+          static_cast<int>(serialized.size()));
       EXPECT_TRUE(parsed.MergeFromCodedStream(&input_stream));
       EXPECT_EQ(17, parsed.oneof_int32());
     }
@@ -994,7 +994,7 @@ TEST(Lite, AllLite44) {
     for (int i = 0; i < 2; ++i) {
       io::CodedInputStream input_stream(
           reinterpret_cast<const ::uint8_t*>(serialized.data()),
-          serialized.size());
+          static_cast<int>(serialized.size()));
       EXPECT_TRUE(parsed.MergeFromCodedStream(&input_stream));
       EXPECT_EQ(5, parsed.oneof_submessage().optional_int32());
     }
@@ -1010,7 +1010,7 @@ TEST(Lite, AllLite44) {
     for (int i = 0; i < 2; ++i) {
       io::CodedInputStream input_stream(
           reinterpret_cast<const ::uint8_t*>(serialized.data()),
-          serialized.size());
+          static_cast<int>(serialized.size()));
       EXPECT_TRUE(parsed.MergeFromCodedStream(&input_stream));
       EXPECT_EQ("string", parsed.oneof_string());
     }
@@ -1026,7 +1026,7 @@ TEST(Lite, AllLite44) {
     for (int i = 0; i < 2; ++i) {
       io::CodedInputStream input_stream(
           reinterpret_cast<const ::uint8_t*>(serialized.data()),
-          serialized.size());
+          static_cast<int>(serialized.size()));
       EXPECT_TRUE(parsed.MergeFromCodedStream(&input_stream));
       EXPECT_EQ("bytes", parsed.oneof_bytes());
     }
@@ -1042,7 +1042,7 @@ TEST(Lite, AllLite44) {
     for (int i = 0; i < 2; ++i) {
       io::CodedInputStream input_stream(
           reinterpret_cast<const ::uint8_t*>(serialized.data()),
-          serialized.size());
+          static_cast<int>(serialized.size()));
       EXPECT_TRUE(parsed.MergeFromCodedStream(&input_stream));
       EXPECT_EQ(protobuf_unittest::V2_SECOND, parsed.oneof_enum());
     }
@@ -1058,7 +1058,7 @@ TEST(Lite, AllLite45) {
   protobuf_unittest::ForeignMessageLite a;
   EXPECT_TRUE(a.ParseFromString(data));
   io::CodedInputStream input_stream(
-      reinterpret_cast<const ::uint8_t*>(data.data()), data.size());
+      reinterpret_cast<const ::uint8_t*>(data.data()), static_cast<int>(data.size()));
   EXPECT_TRUE(a.MergePartialFromCodedStream(&input_stream));
 
   std::string serialized = a.SerializeAsString();
@@ -1258,8 +1258,8 @@ TEST(Lite, CodedInputStreamRollback) {
     std::string serialized = m.SerializeAsString();
     serialized += '\014';
     serialized += std::string(3, ' ');
-    io::ArrayInputStream is(serialized.data(), serialized.size(),
-                            serialized.size() - 6);
+    io::ArrayInputStream is(serialized.data(), static_cast<int>(serialized.size()),
+                            static_cast<int>(serialized.size() - 6));
     {
       io::CodedInputStream cis(&is);
       m.Clear();
@@ -1282,8 +1282,8 @@ TEST(Lite, CodedInputStreamRollback) {
     serialized += '\014';
     serialized += std::string(3, ' ');
     // Buffer breaks in middle of a fixed32.
-    io::ArrayInputStream is(serialized.data(), serialized.size(),
-                            serialized.size() - 7);
+    io::ArrayInputStream is(serialized.data(), static_cast<int>(serialized.size()),
+                            static_cast<int>(serialized.size() - 7));
     {
       io::CodedInputStream cis(&is);
       m.Clear();
@@ -1309,8 +1309,8 @@ TEST(Lite, CodedInputStreamRollback) {
     serialized += '\014';
     serialized += std::string(3, ' ');
     // Buffer breaks in middle of a 2 byte varint.
-    io::ArrayInputStream is(serialized.data(), serialized.size(),
-                            serialized.size() - 5);
+    io::ArrayInputStream is(serialized.data(), static_cast<int>(serialized.size()),
+                            static_cast<int>(serialized.size() - 5));
     {
       io::CodedInputStream cis(&is);
       m.Clear();

--- a/src/google/protobuf/map_field.cc
+++ b/src/google/protobuf/map_field.cc
@@ -235,7 +235,7 @@ DynamicMapField::~DynamicMapField() {
   Destruct();
 }
 
-int DynamicMapField::size() const { return GetMap().size(); }
+int DynamicMapField::size() const { return static_cast<int>(GetMap().size()); }
 
 void DynamicMapField::Clear() {
   Map<MapKey, MapValueRef>* map = &const_cast<DynamicMapField*>(this)->map_;

--- a/src/google/protobuf/map_test.inc
+++ b/src/google/protobuf/map_test.inc
@@ -470,7 +470,7 @@ TEST_F(MapImplTest, HashFlood) {
 
 TEST_F(MapImplTest, CopyIteratorStressTest) {
   std::vector<Map<int32_t, int32_t>::iterator> v;
-  const int kIters = 1e5;
+  const int kIters = static_cast<int>(1e5);
   for (uint32_t i = 0; i < kIters; i++) {
     int32_t key = (3 + i * (5 + i * (-8 + i * (62 + i)))) & 0x77777777;
     map_[key] = i;
@@ -516,7 +516,7 @@ static void TestEqualIterators(Iter i0, Iter i1, Iter end) {
 
 template <typename IteratorType>
 static void TestOldVersusNewIterator(int skip, Map<int, int>* m) {
-  const int initial_size = m->size();
+  const int initial_size = static_cast<int>(m->size());
   IteratorType it = m->begin();
   for (int i = 0; i < skip && it != m->end(); it++, i++) {
   }
@@ -596,7 +596,7 @@ static void StressTestIterators(int n) {
   int position_of_last_key = 0;
   for (Map<int, int>::iterator it = m.begin(); it != m.end(); ++it) {
     if (it->first == last_key) {
-      position_of_last_key = v.size();
+      position_of_last_key = static_cast<int>(v.size());
     }
     v.push_back(it);
   }
@@ -640,7 +640,7 @@ TEST_F(MapImplTest, IteratorInvalidation) {
 // Test that erase() revalidates iterators.
 TEST_F(MapImplTest, EraseRevalidates) {
   map_[3] = map_[13] = map_[20] = 0;
-  const int initial_size = map_.size();
+  const int initial_size = static_cast<int>(map_.size());
   EXPECT_EQ(3, initial_size);
   std::vector<Map<int, int>::iterator> v;
   for (Map<int, int>::iterator it = map_.begin(); it != map_.end(); ++it) {
@@ -650,7 +650,7 @@ TEST_F(MapImplTest, EraseRevalidates) {
   for (int i = 0; map_.size() <= initial_size * 20; i++) {
     map_[i] = 0;
   }
-  const int larger_size = map_.size();
+  const int larger_size = static_cast<int>(map_.size());
   // We've greatly increased the size of the map, so it is highly likely that
   // the following will corrupt m if erase() doesn't properly revalidate
   // iterators passed to it.  Finishing this routine without crashing indicates
@@ -2613,7 +2613,7 @@ TEST(GeneratedMapFieldTest, SerializationToStream) {
   data.resize(size);
   {
     // Allow the output stream to buffer only one byte at a time.
-    io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&data), size, 1);
+    io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&data), static_cast<int>(size), 1);
     io::CodedOutputStream output_stream(&array_stream);
     message1.SerializeWithCachedSizes(&output_stream);
     EXPECT_FALSE(output_stream.HadError());
@@ -2924,7 +2924,7 @@ TEST(GeneratedMapFieldTest, MessagesMustMerge) {
   // (*) http://google3/net/proto2/internal/map_test.cc?l=2433&rcl=310012028
   std::string dummy4_s = with_dummy4.SerializePartialAsString();
   std::string dummy5_s = with_dummy5.SerializePartialAsString();
-  int payload_size = dummy4_s.size() + dummy5_s.size();
+  int payload_size = static_cast<int>(dummy4_s.size() + dummy5_s.size());
   // Makes sure the payload size fits into one byte.
   ASSERT_LT(payload_size, 128);
 
@@ -3265,7 +3265,7 @@ TEST_F(MapFieldInDynamicMessageTest, MapSpaceUsed) {
   std::unique_ptr<Message> message(map_prototype_->New());
   MapReflectionTester reflection_tester(map_descriptor_);
 
-  int initial_space_used = message->SpaceUsedLong();
+  int initial_space_used = static_cast<int>(message->SpaceUsedLong());
 
   reflection_tester.SetMapFieldsViaReflection(message.get());
   EXPECT_LT(initial_space_used, message->SpaceUsedLong());
@@ -3430,7 +3430,7 @@ TEST(WireFormatForMapFieldTest, ParseMap) {
   source.SerializeToString(&data);
 
   // Parse using WireFormat.
-  io::ArrayInputStream raw_input(data.data(), data.size());
+  io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
   io::CodedInputStream input(&raw_input);
   WireFormat::ParseAndMergePartial(&input, &dest);
 
@@ -3469,7 +3469,7 @@ TEST(WireFormatForMapFieldTest, SerializeMap) {
     io::StringOutputStream raw_output(&dynamic_data);
     io::CodedOutputStream output(&raw_output);
     size_t size = WireFormat::ByteSize(message);
-    WireFormat::SerializeWithCachedSizes(message, size, &output);
+    WireFormat::SerializeWithCachedSizes(message, static_cast<int>(size), &output);
     ASSERT_FALSE(output.HadError());
   }
 
@@ -3514,7 +3514,7 @@ TEST(WireFormatForMapFieldTest, MapByteSizeDynamicMessage) {
   reflection_tester.ExpectMapFieldsSetViaReflection(*dynamic_message);
   std::string expected_serialized_data;
   dynamic_message->SerializeToString(&expected_serialized_data);
-  int expected_size = expected_serialized_data.size();
+  int expected_size = static_cast<int>(expected_serialized_data.size());
   EXPECT_EQ(dynamic_message->ByteSizeLong(), expected_size);
   TestMap expected_message;
   expected_message.ParseFromString(expected_serialized_data);
@@ -3577,7 +3577,7 @@ TEST(WireFormatForMapFieldTest, MapByteSizeDynamicMessage) {
   EXPECT_EQ(reflection_tester.MapSize(*dynamic_message, "map_int32_foreign_message"), 2);
   // The map field is marked as CLEAN, ByteSizeLong() will use map which do not
   // have duplicate keys to calculate.
-  int size = dynamic_message->ByteSizeLong();
+  int size = static_cast<int>(dynamic_message->ByteSizeLong());
   EXPECT_EQ(expected_size, size);
 
   // Protobuf used to have a bug for serialize when map it marked CLEAN. It used
@@ -3621,19 +3621,19 @@ TEST(WireFormatForMapFieldTest, MapParseHelpers) {
     // Test ParseFromBoundedZeroCopyStream.
     std::string data_with_junk(data);
     data_with_junk.append("some junk on the end");
-    io::ArrayInputStream stream(data_with_junk.data(), data_with_junk.size());
+    io::ArrayInputStream stream(data_with_junk.data(), static_cast<int>(data_with_junk.size()));
     UNITTEST::TestMap message;
-    EXPECT_TRUE(message.ParseFromBoundedZeroCopyStream(&stream, data.size()));
+    EXPECT_TRUE(message.ParseFromBoundedZeroCopyStream(&stream, static_cast<int>(data.size())));
     MapTestUtil::ExpectMapFieldsSet(message);
   }
 
   {
     // Test that ParseFromBoundedZeroCopyStream fails (but doesn't crash) if
     // EOF is reached before the expected number of bytes.
-    io::ArrayInputStream stream(data.data(), data.size());
+    io::ArrayInputStream stream(data.data(), static_cast<int>(data.size()));
     UNITTEST::TestAllTypes message;
     EXPECT_FALSE(
-        message.ParseFromBoundedZeroCopyStream(&stream, data.size() + 1));
+        message.ParseFromBoundedZeroCopyStream(&stream, static_cast<int>(data.size() + 1)));
   }
 }
 
@@ -3644,7 +3644,7 @@ static std::string DeterministicSerializationWithSerializePartialToCodedStream(
     const T& t) {
   const size_t size = t.ByteSizeLong();
   std::string result(size, '\0');
-  io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&result), size);
+  io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&result), static_cast<int>(size));
   io::CodedOutputStream output_stream(&array_stream);
   output_stream.SetSerializationDeterministic(true);
   t.SerializePartialToCodedStream(&output_stream);
@@ -3658,7 +3658,7 @@ static std::string DeterministicSerializationWithSerializeToCodedStream(
     const T& t) {
   const size_t size = t.ByteSizeLong();
   std::string result(size, '\0');
-  io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&result), size);
+  io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&result), static_cast<int>(size));
   io::CodedOutputStream output_stream(&array_stream);
   output_stream.SetSerializationDeterministic(true);
   t.SerializeToCodedStream(&output_stream);
@@ -3671,7 +3671,7 @@ template <typename T>
 static std::string DeterministicSerialization(const T& t) {
   const size_t size = t.ByteSizeLong();
   std::string result(size, '\0');
-  io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&result), size);
+  io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&result), static_cast<int>(size));
   {
     io::CodedOutputStream output_stream(&array_stream);
     output_stream.SetSerializationDeterministic(true);
@@ -3972,7 +3972,7 @@ TEST(ArenaTest, StringMapNoLeak) {
       Arena::CreateMessage<UNITTEST::TestArenaMap>(&arena);
   std::string data;
   // String with length less than 16 will not be allocated from heap.
-  int original_capacity = data.capacity();
+  int original_capacity = static_cast<int>(data.capacity());
   while (data.capacity() <= original_capacity) {
     data.append("a");
   }

--- a/src/google/protobuf/message_lite.cc
+++ b/src/google/protobuf/message_lite.cc
@@ -455,7 +455,7 @@ bool MessageLite::AppendPartialToString(std::string* output) const {
   STLStringResizeUninitializedAmortized(output, old_size + byte_size);
   uint8_t* start =
       reinterpret_cast<uint8_t*>(io::mutable_string_data(output) + old_size);
-  SerializeToArrayImpl(*this, start, byte_size);
+  SerializeToArrayImpl(*this, start, static_cast<int>(byte_size));
   return true;
 }
 
@@ -483,7 +483,7 @@ bool MessageLite::SerializePartialToArray(void* data, int size) const {
   }
   if (size < static_cast<int64_t>(byte_size)) return false;
   uint8_t* start = reinterpret_cast<uint8_t*>(data);
-  SerializeToArrayImpl(*this, start, byte_size);
+  SerializeToArrayImpl(*this, start, static_cast<int>(byte_size));
   return true;
 }
 

--- a/src/google/protobuf/message_unittest.inc
+++ b/src/google/protobuf/message_unittest.inc
@@ -180,19 +180,19 @@ TEST(MESSAGE_TEST_NAME, ParseHelpers) {
     // Test ParseFromBoundedZeroCopyStream.
     std::string data_with_junk(data);
     data_with_junk.append("some junk on the end");
-    io::ArrayInputStream stream(data_with_junk.data(), data_with_junk.size());
+    io::ArrayInputStream stream(data_with_junk.data(), static_cast<int>(data_with_junk.size()));
     UNITTEST::TestAllTypes message;
-    EXPECT_TRUE(message.ParseFromBoundedZeroCopyStream(&stream, data.size()));
+    EXPECT_TRUE(message.ParseFromBoundedZeroCopyStream(&stream, static_cast<int>(data.size())));
     TestUtil::ExpectAllFieldsSet(message);
   }
 
   {
     // Test that ParseFromBoundedZeroCopyStream fails (but doesn't crash) if
     // EOF is reached before the expected number of bytes.
-    io::ArrayInputStream stream(data.data(), data.size());
+    io::ArrayInputStream stream(data.data(), static_cast<int>(data.size()));
     UNITTEST::TestAllTypes message;
     EXPECT_FALSE(
-        message.ParseFromBoundedZeroCopyStream(&stream, data.size() + 1));
+        message.ParseFromBoundedZeroCopyStream(&stream, static_cast<int>(data.size() + 1)));
   }
 }
 
@@ -297,7 +297,7 @@ TEST(MESSAGE_TEST_NAME, ExplicitLazyExceedRecursionLimit) {
 
   // User annotated LazyField ([lazy = true]) is eagerly verified and should
   // catch the recursion limit violation.
-  io::ArrayInputStream array_stream(serialized.data(), serialized.size());
+  io::ArrayInputStream array_stream(serialized.data(), static_cast<int>(serialized.size()));
   io::CodedInputStream input_stream(&array_stream);
   input_stream.SetRecursionLimit(2);
   EXPECT_FALSE(parsed.ParseFromCodedStream(&input_stream));
@@ -321,7 +321,7 @@ TEST(MESSAGE_TEST_NAME, NestedExplicitLazyExceedRecursionLimit) {
 
   // User annotated LazyField ([lazy = true]) is eagerly verified and should
   // catch the recursion limit violation.
-  io::ArrayInputStream array_stream(serialized.data(), serialized.size());
+  io::ArrayInputStream array_stream(serialized.data(), static_cast<int>(serialized.size()));
   io::CodedInputStream input_stream(&array_stream);
   input_stream.SetRecursionLimit(4);
   EXPECT_FALSE(parsed.ParseFromCodedStream(&input_stream));
@@ -464,8 +464,8 @@ TEST(MESSAGE_TEST_NAME, ParseStrictlyBoundedStream) {
   std::string data;
   EXPECT_TRUE(o.SerializeToString(&data));
 
-  TestUtil::BoundedArrayInputStream stream(data.data(), data.size());
-  EXPECT_TRUE(p.ParseFromBoundedZeroCopyStream(&stream, data.size()));
+  TestUtil::BoundedArrayInputStream stream(data.data(), static_cast<int>(data.size()));
+  EXPECT_TRUE(p.ParseFromBoundedZeroCopyStream(&stream, static_cast<int>(data.size())));
   TestUtil::ExpectAllFieldsSet(p.child().payload());
 }
 
@@ -529,7 +529,7 @@ TEST(MESSAGE_TEST_NAME, SupportCustomRecursionLimitRead) {
   EXPECT_TRUE(o.SerializeToString(&serialized));
 
   // Should pass with custom limit + reads.
-  io::ArrayInputStream raw_input(serialized.data(), serialized.size());
+  io::ArrayInputStream raw_input(serialized.data(), static_cast<int>(serialized.size()));
   io::CodedInputStream input(&raw_input);
   input.SetRecursionLimit(kDepth + 10);
   EXPECT_TRUE(p.ParseFromCodedStream(&input));
@@ -550,7 +550,7 @@ TEST(MESSAGE_TEST_NAME, SupportCustomRecursionLimitWrite) {
   EXPECT_TRUE(o.SerializeToString(&serialized));
 
   // Should pass with custom limit + writes.
-  io::ArrayInputStream raw_input(serialized.data(), serialized.size());
+  io::ArrayInputStream raw_input(serialized.data(), static_cast<int>(serialized.size()));
   io::CodedInputStream input(&raw_input);
   input.SetRecursionLimit(kDepth + 10);
   EXPECT_TRUE(p.ParseFromCodedStream(&input));
@@ -575,7 +575,7 @@ TEST(MESSAGE_TEST_NAME, SupportDeepRecursionLimit) {
   std::string serialized;
   EXPECT_TRUE(o.SerializeToString(&serialized));
 
-  io::ArrayInputStream raw_input(serialized.data(), serialized.size());
+  io::ArrayInputStream raw_input(serialized.data(), static_cast<int>(serialized.size()));
   io::CodedInputStream input(&raw_input);
   input.SetRecursionLimit(1100);
   EXPECT_TRUE(p.ParseFromCodedStream(&input));
@@ -1029,7 +1029,7 @@ TEST(MESSAGE_TEST_NAME, MOMIParserEdgeCases) {
     // followed by the rest of the stream
     // space is ascii 32 so no end group
     data += std::string(30, ' ');
-    io::ArrayInputStream zcis(data.data(), data.size(), 17);
+    io::ArrayInputStream zcis(data.data(), static_cast<int>(data.size()), 17);
     io::CodedInputStream cis(&zcis);
     EXPECT_TRUE(msg.MergePartialFromCodedStream(&cis));
     EXPECT_EQ(cis.CurrentPosition(), 3 * 4 + 1);
@@ -1043,7 +1043,7 @@ TEST(MESSAGE_TEST_NAME, MOMIParserEdgeCases) {
     for (int i = 0; i < 3; i++) data += "\370\1\1";
     data += '\14';  // Octal end-group tag 12 (1 * 8 + 4(
     data += std::string(30, ' ');
-    io::ArrayInputStream zcis(data.data(), data.size(), 17);
+    io::ArrayInputStream zcis(data.data(), static_cast<int>(data.size()), 17);
     io::CodedInputStream cis(&zcis);
     EXPECT_TRUE(msg.MergePartialFromCodedStream(&cis));
     EXPECT_EQ(cis.CurrentPosition(), 3 * 3 + 1);
@@ -1058,7 +1058,7 @@ TEST(MESSAGE_TEST_NAME, MOMIParserEdgeCases) {
     data += "\22\3foo";
     data += '\14';  // Octal end-group tag 12 (1 * 8 + 4(
     data += std::string(30, ' ');
-    io::ArrayInputStream zcis(data.data(), data.size(), 17);
+    io::ArrayInputStream zcis(data.data(), static_cast<int>(data.size()), 17);
     io::CodedInputStream cis(&zcis);
     EXPECT_TRUE(msg.MergePartialFromCodedStream(&cis));
     EXPECT_EQ(cis.CurrentPosition(), 6);
@@ -1073,7 +1073,7 @@ TEST(MESSAGE_TEST_NAME, MOMIParserEdgeCases) {
     // 13 byte is terminator
     data += '\0';  // Terminator
     data += std::string(30, ' ');
-    io::ArrayInputStream zcis(data.data(), data.size(), 17);
+    io::ArrayInputStream zcis(data.data(), static_cast<int>(data.size()), 17);
     EXPECT_FALSE(msg.ParsePartialFromZeroCopyStream(&zcis));
   }
 }

--- a/src/google/protobuf/parse_context.cc
+++ b/src/google/protobuf/parse_context.cc
@@ -164,7 +164,7 @@ const char* EpsCopyInputStream::Next() {
     SetEndOfStream();
     return nullptr;
   }
-  limit_ -= buffer_end_ - p;  // Adjust limit_ relative to new anchor
+  limit_ -= static_cast<int>(buffer_end_ - p);  // Adjust limit_ relative to new anchor
   limit_end_ = buffer_end_ + std::min(0, limit_);
   return p;
 }
@@ -197,9 +197,9 @@ std::pair<const char*, bool> EpsCopyInputStream::DoneFallback(int overrun,
       SetEndOfStream();
       return {buffer_end_, true};
     }
-    limit_ -= buffer_end_ - p;  // Adjust limit_ relative to new anchor
+    limit_ -= static_cast<int>(buffer_end_ - p);  // Adjust limit_ relative to new anchor
     p += overrun;
-    overrun = p - buffer_end_;
+    overrun = static_cast<int>(p - buffer_end_);
   } while (overrun >= 0);
   limit_end_ = buffer_end_ + std::min(0, limit_);
   return {p, false};
@@ -288,11 +288,11 @@ const char* ParseContext::ParseMessage(MessageLite* msg, const char* ptr) {
 
 inline void WriteVarint(uint64_t val, std::string* s) {
   while (val >= 128) {
-    uint8_t c = val | 0x80;
+    uint8_t c = static_cast<uint8_t>(val | 0x80);
     s->push_back(c);
     val >>= 7;
   }
-  s->push_back(val);
+  s->push_back(static_cast<char>(val));
 }
 
 void WriteVarint(uint32_t num, uint64_t val, std::string* s) {
@@ -403,12 +403,12 @@ const char* VarintParser(void* object, const char* ptr, ParseContext* ctx) {
     T val;
     if (sign) {
       if (sizeof(T) == 8) {
-        val = WireFormatLite::ZigZagDecode64(varint);
+        val = static_cast<T>(WireFormatLite::ZigZagDecode64(varint));
       } else {
-        val = WireFormatLite::ZigZagDecode32(varint);
+        val = static_cast<T>(WireFormatLite::ZigZagDecode32(static_cast<uint32_t>(varint)));
       }
     } else {
-      val = varint;
+      val = static_cast<T>(varint);
     }
     static_cast<RepeatedField<T>*>(object)->Add(val);
   });

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -796,9 +796,9 @@ inline typename RepeatedField<Element>::iterator RepeatedField<Element>::erase(
 template <typename Element>
 inline typename RepeatedField<Element>::iterator RepeatedField<Element>::erase(
     const_iterator first, const_iterator last) {
-  size_type first_offset = first - cbegin();
+  size_type first_offset = static_cast<size_type>(first - cbegin());
   if (first != last) {
-    Truncate(std::copy(last, cend(), begin() + first_offset) - cbegin());
+    Truncate(static_cast<int>(std::copy(last, cend(), begin() + first_offset) - cbegin()));
   }
   return begin() + first_offset;
 }

--- a/src/google/protobuf/repeated_field_unittest.cc
+++ b/src/google/protobuf/repeated_field_unittest.cc
@@ -331,7 +331,7 @@ TEST(RepeatedField, ReserveLessThanDouble) {
   RepeatedField<int> field;
   field.Reserve(20);
   int capacity = field.Capacity();
-  field.Reserve(capacity * 1.5);
+  field.Reserve(static_cast<int>(capacity * 1.5));
 
   EXPECT_LE(2 * capacity, ReservedSpace(&field));
 }

--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -1285,7 +1285,7 @@ inline void RepeatedPtrField<Element>::Add(Iter begin, Iter end) {
   if (std::is_base_of<
           std::forward_iterator_tag,
           typename std::iterator_traits<Iter>::iterator_category>::value) {
-    int reserve = std::distance(begin, end);
+    int reserve = static_cast<int>(std::distance(begin, end));
     Reserve(size() + reserve);
   }
   for (; begin != end; ++begin) {
@@ -1430,8 +1430,8 @@ RepeatedPtrField<Element>::erase(const_iterator position) {
 template <typename Element>
 inline typename RepeatedPtrField<Element>::iterator
 RepeatedPtrField<Element>::erase(const_iterator first, const_iterator last) {
-  size_type pos_offset = std::distance(cbegin(), first);
-  size_type last_offset = std::distance(cbegin(), last);
+  size_type pos_offset = static_cast<size_type>(std::distance(cbegin(), first));
+  size_type last_offset = static_cast<size_type>(std::distance(cbegin(), last));
   DeleteSubrange(pos_offset, last_offset - pos_offset);
   return begin() + pos_offset;
 }

--- a/src/google/protobuf/stubs/int128.cc
+++ b/src/google/protobuf/stubs/int128.cc
@@ -61,7 +61,7 @@ static inline int Fls64(uint64_t n) {
   GOOGLE_DCHECK_NE(0, n);
   int pos = 0;
   STEP(uint64_t, n, pos, 0x20);
-  uint32_t n32 = n;
+  uint32_t n32 = static_cast<uint32_t>(n);
   STEP(uint32_t, n32, pos, 0x10);
   STEP(uint32_t, n32, pos, 0x08);
   STEP(uint32_t, n32, pos, 0x04);
@@ -175,10 +175,11 @@ std::ostream& operator<<(std::ostream& o, const uint128& b) {
   std::streamsize width = o.width(0);
   auto repSize = static_cast<std::streamsize>(rep.size());
   if (width > repSize) {
+    const size_t padding = static_cast<size_t>(width - repSize);
     if ((flags & std::ios::adjustfield) == std::ios::left) {
-      rep.append(width - repSize, o.fill());
+      rep.append(padding, o.fill());
     } else {
-      rep.insert(static_cast<std::string::size_type>(0), width - repSize,
+      rep.insert(static_cast<std::string::size_type>(0), padding,
                  o.fill());
     }
   }

--- a/src/google/protobuf/stubs/mathutil.h
+++ b/src/google/protobuf/stubs/mathutil.h
@@ -84,7 +84,7 @@ class MathUtil {
     if (value == T(0) || internal::IsNan(value)) {
       return value;
     }
-    return value > T(0) ? 1 : -1;
+    return value > T(0) ? static_cast<T>(1) : static_cast<T>(-1);
   }
 
   template <typename T>

--- a/src/google/protobuf/stubs/stringprintf.cc
+++ b/src/google/protobuf/stubs/stringprintf.cc
@@ -152,7 +152,7 @@ std::string StringPrintfVector(const char* format,
   for (int i = 0; i < v.size(); ++i) {
     cstr[i] = v[i].c_str();
   }
-  for (int i = v.size(); i < GOOGLE_ARRAYSIZE(cstr); ++i) {
+  for (int i = static_cast<int>(v.size()); i < GOOGLE_ARRAYSIZE(cstr); ++i) {
     cstr[i] = &string_printf_empty_block[0];
   }
 

--- a/src/google/protobuf/stubs/structurally_valid.cc
+++ b/src/google/protobuf/stubs/structurally_valid.cc
@@ -491,7 +491,7 @@ int UTF8GenericScan(const UTF8ScanObj* st,
     goto DoAgain;
   }
 
-  *bytes_consumed = src - isrc;
+  *bytes_consumed = static_cast<int>(src - isrc);
   return e;
 }
 
@@ -527,12 +527,12 @@ int UTF8GenericScanFastAscii(const UTF8ScanObj* st,
       src++;
     }
     // Run state table on the rest
-    n = src - isrc;
+    n = static_cast<int>(src - isrc);
     exit_reason = UTF8GenericScan(st, str + n, str_length - n, &rest_consumed);
     src += rest_consumed;
   } while ( exit_reason == kExitDoAgain );
 
-  *bytes_consumed = src - isrc;
+  *bytes_consumed = static_cast<int>(src - isrc);
   return exit_reason;
 }
 
@@ -564,11 +564,11 @@ bool IsStructurallyValidUTF8(const char* buf, int len) {
 }
 
 int UTF8SpnStructurallyValid(StringPiece str) {
-  if (!module_initialized_) return str.size();
+  if (!module_initialized_) return static_cast<int>(str.size());
 
   int bytes_consumed = 0;
   UTF8GenericScanFastAscii(&utf8acceptnonsurrogates_obj,
-                           str.data(), str.size(), &bytes_consumed);
+                           str.data(), static_cast<int>(str.size()), &bytes_consumed);
   return bytes_consumed;
 }
 
@@ -587,7 +587,7 @@ int UTF8SpnStructurallyValid(StringPiece str) {
 char* UTF8CoerceToStructurallyValid(StringPiece src_str, char* idst,
                                     const char replace_char) {
   const char* isrc = src_str.data();
-  const int len = src_str.length();
+  const int len = static_cast<int>(src_str.length());
   int n = UTF8SpnStructurallyValid(src_str);
   if (n == len) {               // Normal case -- all is cool, return
     return const_cast<char*>(isrc);

--- a/src/google/protobuf/stubs/structurally_valid_unittest.cc
+++ b/src/google/protobuf/stubs/structurally_valid_unittest.cc
@@ -46,22 +46,22 @@ TEST(StructurallyValidTest, ValidUTF8String) {
   std::string valid_str(
       "abcd 1234 - \342\200\224\342\200\223\342\210\222 - xyz789");
   EXPECT_TRUE(IsStructurallyValidUTF8(valid_str.data(),
-                                      valid_str.size()));
+                                      static_cast<int>(valid_str.size())));
   // Additional check for pointer alignment
   for (int i = 1; i < 8; ++i) {
     EXPECT_TRUE(IsStructurallyValidUTF8(valid_str.data() + i,
-                                        valid_str.size() - i));
+                                        static_cast<int>(valid_str.size() - i)));
   }
 }
 
 TEST(StructurallyValidTest, InvalidUTF8String) {
   const std::string invalid_str("abcd\xA0\xB0\xA0\xB0\xA0\xB0 - xyz789");
   EXPECT_FALSE(IsStructurallyValidUTF8(invalid_str.data(),
-                                       invalid_str.size()));
+                                       static_cast<int>(invalid_str.size())));
   // Additional check for pointer alignment
   for (int i = 1; i < 8; ++i) {
     EXPECT_FALSE(IsStructurallyValidUTF8(invalid_str.data() + i,
-                                         invalid_str.size() - i));
+                                         static_cast<int>(invalid_str.size() - i)));
   }
 }
 

--- a/src/google/protobuf/stubs/strutil.cc
+++ b/src/google/protobuf/stubs/strutil.cc
@@ -95,7 +95,7 @@ void ReplaceCharacters(std::string *s, const char *remove, char replacewith) {
 }
 
 void StripWhitespace(std::string *str) {
-  int str_length = str->length();
+  int str_length = static_cast<int>(str->length());
 
   // Strip off leading whitespace.
   int first = 0;
@@ -263,7 +263,7 @@ static void JoinStringsIterator(const ITERATOR &start, const ITERATOR &end,
                                 const char *delim, std::string *result) {
   GOOGLE_CHECK(result != nullptr);
   result->clear();
-  int delim_length = strlen(delim);
+  int delim_length = static_cast<int>(strlen(delim));
 
   // Precompute resulting length so we can reserve() memory in one shot.
   int length = 0;
@@ -271,7 +271,7 @@ static void JoinStringsIterator(const ITERATOR &start, const ITERATOR &end,
     if (iter != start) {
       length += delim_length;
     }
-    length += iter->size();
+    length += static_cast<int>(iter->size());
   }
   result->reserve(length);
 
@@ -330,7 +330,7 @@ int UnescapeCEscapeSequences(const char *source, char *dest,
         case '\0':
           LOG_STRING(ERROR, errors) << "String cannot end with \\";
           *d = '\0';
-          return d - dest;   // we're done with p
+          return static_cast<int>(d - dest);   // we're done with p
         case 'a':  *d++ = '\a';  break;
         case 'b':  *d++ = '\b';  break;
         case 'f':  *d++ = '\f';  break;
@@ -428,7 +428,7 @@ int UnescapeCEscapeSequences(const char *source, char *dest,
     }
   }
   *d = '\0';
-  return d - dest;
+  return static_cast<int>(d - dest);
 }
 
 // ----------------------------------------------------------------------
@@ -601,18 +601,18 @@ std::string CEscape(const std::string &src) {
 namespace strings {
 
 std::string Utf8SafeCEscape(const std::string &src) {
-  const int dest_length = src.size() * 4 + 1; // Maximum possible expansion
+  const int dest_length = static_cast<int>(src.size() * 4 + 1); // Maximum possible expansion
   std::unique_ptr<char[]> dest(new char[dest_length]);
-  const int len = CEscapeInternal(src.data(), src.size(),
+  const int len = CEscapeInternal(src.data(), static_cast<int>(src.size()),
                                   dest.get(), dest_length, false, true);
   GOOGLE_DCHECK_GE(len, 0);
   return std::string(dest.get(), len);
 }
 
 std::string CHexEscape(const std::string &src) {
-  const int dest_length = src.size() * 4 + 1; // Maximum possible expansion
+  const int dest_length = static_cast<int>(src.size() * 4 + 1); // Maximum possible expansion
   std::unique_ptr<char[]> dest(new char[dest_length]);
-  const int len = CEscapeInternal(src.data(), src.size(),
+  const int len = CEscapeInternal(src.data(), static_cast<int>(src.size()),
                                   dest.get(), dest_length, true, false);
   GOOGLE_DCHECK_GE(len, 0);
   return std::string(dest.get(), len);
@@ -818,7 +818,7 @@ char *FastInt64ToBuffer(int64_t i, char* buffer) {
     // we don't divide negative numbers.
     if (i > -10) {
       i = -i;
-      *p-- = '0' + i;
+      *p-- = static_cast<char>('0' + i);
       *p = '-';
       return p;
     } else {
@@ -1062,7 +1062,7 @@ char* FastUInt64ToBufferLeft(uint64_t u64, char* buffer) {
 
   uint64_t top_11_digits = u64 / 1000000000;
   buffer = FastUInt64ToBufferLeft(top_11_digits, buffer);
-  u = u64 - (top_11_digits * 1000000000);
+  u = static_cast<uint32_t>(u64 - (top_11_digits * 1000000000));
 
   digits = u / 10000000;  // 10,000,000
   GOOGLE_DCHECK_LT(digits, 100);
@@ -1144,14 +1144,14 @@ std::string SimpleItoa(unsigned long i) {
 std::string SimpleItoa(long long i) {
   char buffer[kFastToBufferSize];
   return (sizeof(i) == 4) ?
-    FastInt32ToBuffer(i, buffer) :
+    FastInt32ToBuffer(static_cast<int32_t>(i), buffer) :
     FastInt64ToBuffer(i, buffer);
 }
 
 std::string SimpleItoa(unsigned long long i) {
   char buffer[kFastToBufferSize];
   return std::string(buffer, (sizeof(i) == 4)
-                                 ? FastUInt32ToBufferLeft(i, buffer)
+                                 ? FastUInt32ToBufferLeft(static_cast<uint32_t>(i), buffer)
                                  : FastUInt64ToBufferLeft(i, buffer));
 }
 
@@ -1322,7 +1322,7 @@ bool safe_strtof(const char* str, float* value) {
   char* endptr;
   errno = 0;  // errno only gets set on errors
 #if defined(_WIN32) || defined (__hpux)  // has no strtof()
-  *value = internal::NoLocaleStrtod(str, &endptr);
+  *value = static_cast<float>(internal::NoLocaleStrtod(str, &endptr));
 #else
   *value = strtof(str, &endptr);
 #endif
@@ -1621,7 +1621,7 @@ int GlobalReplaceSubstring(const std::string &substring,
   int pos = 0;
   for (StringPiece::size_type match_pos =
            s->find(substring.data(), pos, substring.length());
-       match_pos != std::string::npos; pos = match_pos + substring.length(),
+       match_pos != std::string::npos; pos = static_cast<int>(match_pos + substring.length()),
                               match_pos = s->find(substring.data(), pos,
                                                   substring.length())) {
     ++num_replacements;
@@ -2079,11 +2079,11 @@ static bool Base64UnescapeInternal(const char *src, int slen, std::string *dest,
 }
 
 bool Base64Unescape(StringPiece src, std::string *dest) {
-  return Base64UnescapeInternal(src.data(), src.size(), dest, kUnBase64);
+  return Base64UnescapeInternal(src.data(), static_cast<int>(src.size()), dest, kUnBase64);
 }
 
 bool WebSafeBase64Unescape(StringPiece src, std::string *dest) {
-  return Base64UnescapeInternal(src.data(), src.size(), dest, kUnWebSafeBase64);
+  return Base64UnescapeInternal(src.data(), static_cast<int>(src.size()), dest, kUnWebSafeBase64);
 }
 
 int Base64EscapeInternal(const unsigned char *src, int szsrc,
@@ -2118,8 +2118,8 @@ int Base64EscapeInternal(const unsigned char *src, int szsrc,
     cur_src += 3;
   }
   // To save time, we didn't update szdest or szsrc in the loop.  So do it now.
-  szdest = limit_dest - cur_dest;
-  szsrc = limit_src - cur_src;
+  szdest = static_cast<int>(limit_dest - cur_dest);
+  szsrc = static_cast<int>(limit_src - cur_src);
 
   /* now deal with the tail (<=3 bytes) */
   switch (szsrc) {
@@ -2183,7 +2183,7 @@ int Base64EscapeInternal(const unsigned char *src, int szsrc,
       GOOGLE_LOG(FATAL) << "Logic problem? szsrc = " << szsrc;
       break;
   }
-  return (cur_dest - dest);
+  return static_cast<int>(cur_dest - dest);
 }
 
 static const char kBase64Chars[] =
@@ -2209,7 +2209,7 @@ void Base64EscapeInternal(const unsigned char *src, int szsrc,
   dest->resize(calc_escaped_size);
   const int escaped_len = Base64EscapeInternal(src, szsrc,
                                                string_as_array(dest),
-                                               dest->size(),
+                                               static_cast<int>(dest->size()),
                                                base64_chars,
                                                do_padding);
   GOOGLE_DCHECK_EQ(calc_escaped_size, escaped_len);
@@ -2228,17 +2228,17 @@ void WebSafeBase64Escape(const unsigned char *src, int szsrc, std::string *dest,
 
 void Base64Escape(StringPiece src, std::string *dest) {
   Base64Escape(reinterpret_cast<const unsigned char*>(src.data()),
-               src.size(), dest, true);
+               static_cast<int>(src.size()), dest, true);
 }
 
 void WebSafeBase64Escape(StringPiece src, std::string *dest) {
   WebSafeBase64Escape(reinterpret_cast<const unsigned char*>(src.data()),
-                      src.size(), dest, false);
+                      static_cast<int>(src.size()), dest, false);
 }
 
 void WebSafeBase64EscapeWithPadding(StringPiece src, std::string *dest) {
   WebSafeBase64Escape(reinterpret_cast<const unsigned char*>(src.data()),
-                      src.size(), dest, true);
+                      static_cast<int>(src.size()), dest, true);
 }
 
 // Helper to append a Unicode code point to a string as UTF8, without bringing
@@ -2463,7 +2463,7 @@ double NoLocaleStrtod(const char *str, char **endptr) {
     // Update endptr to point at the right location.
     if (endptr != NULL) {
       // size_diff is non-zero if the localized radix has multiple bytes.
-      int size_diff = localized.size() - strlen(str);
+      int size_diff = static_cast<int>(localized.size() - strlen(str));
       // const_cast is necessary to match the strtod() interface.
       *endptr = const_cast<char *>(
           str + (localized_endptr - localized_cstr - size_diff));

--- a/src/google/protobuf/stubs/strutil_unittest.cc
+++ b/src/google/protobuf/stubs/strutil_unittest.cc
@@ -454,7 +454,7 @@ TEST(Base64, EscapeAndUnescape) {
     StringPiece plaintext(base64_tests[i].plaintext,
                           base64_tests[i].plain_length);
 
-    cipher_length = strlen(base64_tests[i].ciphertext);
+    cipher_length = static_cast<int>(strlen(base64_tests[i].ciphertext));
 
     // The basic escape function:
     memset(encode_buffer, 0, sizeof(encode_buffer));
@@ -551,10 +551,10 @@ TEST(Base64, EscapeAndUnescape) {
       // decoder should accept this.
       if (equals == 2) {
         snprintf(first_equals, 6, " = = ");
-        len = first_equals - encode_buffer + 5;
+        len = static_cast<int>(first_equals - encode_buffer + 5);
       } else {
         snprintf(first_equals, 6, " = ");
-        len = first_equals - encode_buffer + 3;
+        len = static_cast<int>(first_equals - encode_buffer + 3);
       }
       decoded2.assign("this junk should be ignored");
       EXPECT_TRUE(
@@ -567,10 +567,10 @@ TEST(Base64, EscapeAndUnescape) {
       // refuse these strings.
       if (equals == 1) {
         snprintf(first_equals, 6, " = = ");
-        len = first_equals - encode_buffer + 5;
+        len = static_cast<int>(first_equals - encode_buffer + 5);
       } else {
         snprintf(first_equals, 6, " = ");
-        len = first_equals - encode_buffer + 3;
+        len = static_cast<int>(first_equals - encode_buffer + 3);
       }
       EXPECT_TRUE(
           !Base64Unescape(StringPiece(encode_buffer, len), &decoded2));
@@ -767,13 +767,13 @@ TEST(Base64, EscapeAndUnescape) {
        ++i) {
     const unsigned char* unsigned_plaintext =
       reinterpret_cast<const unsigned char*>(base64_strings[i].plaintext);
-    int plain_length = strlen(base64_strings[i].plaintext);
-    int cipher_length = strlen(base64_strings[i].ciphertext);
+    int plain_length = static_cast<int>(strlen(base64_strings[i].plaintext));
+    int cipher_length = static_cast<int>(strlen(base64_strings[i].ciphertext));
     std::vector<char> buffer(cipher_length + 1);
     int encode_length = WebSafeBase64Escape(unsigned_plaintext,
                                                      plain_length,
                                                      &buffer[0],
-                                                     buffer.size(),
+                                                     static_cast<int>(buffer.size()),
                                                      false);
     EXPECT_EQ(cipher_length, encode_length);
     EXPECT_EQ(

--- a/src/google/protobuf/stubs/substitute.cc
+++ b/src/google/protobuf/stubs/substitute.cc
@@ -107,7 +107,7 @@ void SubstituteAndAppend(std::string* output, const char* format,
   if (size == 0) return;
 
   // Build the string.
-  int original_size = output->size();
+  int original_size = static_cast<int>(output->size());
   STLStringResizeUninitialized(output, original_size + size);
   char* target = string_as_array(output) + original_size;
   for (int i = 0; format[i] != '\0'; i++) {

--- a/src/google/protobuf/stubs/substitute.h
+++ b/src/google/protobuf/stubs/substitute.h
@@ -91,11 +91,11 @@ namespace internal {  // Implementation details.
 class SubstituteArg {
  public:
   inline SubstituteArg(const char* value)
-    : text_(value), size_(strlen(text_)) {}
+    : text_(value), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(const std::string& value)
-      : text_(value.data()), size_(value.size()) {}
+      : text_(value.data()), size_(static_cast<int>(value.size())) {}
   inline SubstituteArg(const StringPiece value)
-      : text_(value.data()), size_(value.size()) {}
+      : text_(value.data()), size_(static_cast<int>(value.size())) {}
 
   // Indicates that no argument was given.
   inline explicit SubstituteArg()
@@ -110,27 +110,27 @@ class SubstituteArg {
   inline SubstituteArg(char value)
     : text_(scratch_), size_(1) { scratch_[0] = value; }
   inline SubstituteArg(short value)
-    : text_(FastInt32ToBuffer(value, scratch_)), size_(strlen(text_)) {}
+    : text_(FastInt32ToBuffer(value, scratch_)), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(unsigned short value)
-    : text_(FastUInt32ToBuffer(value, scratch_)), size_(strlen(text_)) {}
+    : text_(FastUInt32ToBuffer(value, scratch_)), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(int value)
-    : text_(FastInt32ToBuffer(value, scratch_)), size_(strlen(text_)) {}
+    : text_(FastInt32ToBuffer(value, scratch_)), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(unsigned int value)
-    : text_(FastUInt32ToBuffer(value, scratch_)), size_(strlen(text_)) {}
+    : text_(FastUInt32ToBuffer(value, scratch_)), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(long value)
-    : text_(FastLongToBuffer(value, scratch_)), size_(strlen(text_)) {}
+    : text_(FastLongToBuffer(value, scratch_)), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(unsigned long value)
-    : text_(FastULongToBuffer(value, scratch_)), size_(strlen(text_)) {}
+    : text_(FastULongToBuffer(value, scratch_)), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(long long value)
-    : text_(FastInt64ToBuffer(value, scratch_)), size_(strlen(text_)) {}
+    : text_(FastInt64ToBuffer(value, scratch_)), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(unsigned long long value)
-    : text_(FastUInt64ToBuffer(value, scratch_)), size_(strlen(text_)) {}
+    : text_(FastUInt64ToBuffer(value, scratch_)), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(float value)
-    : text_(FloatToBuffer(value, scratch_)), size_(strlen(text_)) {}
+    : text_(FloatToBuffer(value, scratch_)), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(double value)
-    : text_(DoubleToBuffer(value, scratch_)), size_(strlen(text_)) {}
+    : text_(DoubleToBuffer(value, scratch_)), size_(static_cast<int>(strlen(text_))) {}
   inline SubstituteArg(bool value)
-    : text_(value ? "true" : "false"), size_(strlen(text_)) {}
+    : text_(value ? "true" : "false"), size_(static_cast<int>(strlen(text_))) {}
 
   inline const char* data() const { return text_; }
   inline int size() const { return size_; }

--- a/src/google/protobuf/stubs/time.cc
+++ b/src/google/protobuf/stubs/time.cc
@@ -216,7 +216,7 @@ bool SecondsToDateTime(int64_t seconds, DateTime* time) {
   seconds = seconds + kSecondsFromEraToEpoch;
   int year = 1;
   if (seconds >= kSecondsPer400Years) {
-    int count_400years = seconds / kSecondsPer400Years;
+    int count_400years = static_cast<int>(seconds / kSecondsPer400Years);
     year += 400 * count_400years;
     seconds %= kSecondsPer400Years;
   }
@@ -238,11 +238,11 @@ bool SecondsToDateTime(int64_t seconds, DateTime* time) {
     seconds -= SecondsPerMonth(month, leap);
     ++month;
   }
-  int day = 1 + seconds / kSecondsPerDay;
+  int day = static_cast<int>(1 + seconds / kSecondsPerDay);
   seconds %= kSecondsPerDay;
-  int hour = seconds / kSecondsPerHour;
+  int hour = static_cast<int>(seconds / kSecondsPerHour);
   seconds %= kSecondsPerHour;
-  int minute = seconds / kSecondsPerMinute;
+  int minute = static_cast<int>(seconds / kSecondsPerMinute);
   seconds %= kSecondsPerMinute;
   time->year = year;
   time->month = month;

--- a/src/google/protobuf/testing/googletest.cc
+++ b/src/google/protobuf/testing/googletest.cc
@@ -81,6 +81,12 @@ std::string TestSourceDir() {
   if (result != NULL) {
     return result;
   }
+#else
+  // Allow the user to set a "PROTOSRC" environment variable.
+  char* result = std::getenv("PROTOSRC");
+  if (result != NULL) {
+    return result;
+  }
 #endif  // _MSC_VER
 
   // Look for the "src" directory.
@@ -119,10 +125,15 @@ std::string GetTemporaryDirectoryName() {
   // testing.  We cannot use tmpfile() or mkstemp() since we're creating a
   // directory.
   char b[L_tmpnam + 1];     // HPUX multithread return 0 if s is 0
+#ifndef _MSC_VER // MSVC warns about '#pragma GCC'
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif  // _MSC_VER
   std::string result = tmpnam(b);
+#ifndef _MSC_VER
 #pragma GCC diagnostic pop
+#endif  // _MSC_VER
+
 #ifdef _WIN32
   // Avoid a trailing dot by changing it to an underscore. On Win32 the names of
   // files and directories can, but should not, end with dot.

--- a/src/google/protobuf/text_format.cc
+++ b/src/google/protobuf/text_format.cc
@@ -846,7 +846,7 @@ class TextFormat::Parser::ParserImpl {
                    LookingAtType(io::Tokenizer::TYPE_INTEGER)) {
           DO(ConsumeSignedInteger(&int_value, kint32max));
           value = StrCat(int_value);  // for error reporting
-          enum_value = enum_type->FindValueByNumber(int_value);
+          enum_value = enum_type->FindValueByNumber(static_cast<int>(int_value));
         } else {
           ReportError("Expected integer or identifier, got: " +
                       tokenizer_.current().text);
@@ -856,7 +856,7 @@ class TextFormat::Parser::ParserImpl {
         if (enum_value == nullptr) {
           if (int_value != kint64max &&
               reflection->SupportsUnknownEnumValues()) {
-            SET_FIELD(EnumValue, int_value);
+            SET_FIELD(EnumValue, static_cast<int>(int_value));
             return true;
           } else if (!allow_unknown_enum_) {
             ReportError("Unknown enumeration value of \"" + value +
@@ -1470,7 +1470,7 @@ class TextFormat::Printer::TextGenerator
     // Buffer is big enough to receive the data; copy it.
     memcpy(buffer_, data, size);
     buffer_ += size;
-    buffer_size_ -= size;
+    buffer_size_ -= static_cast<int>(size);
   }
 
   void WriteIndent() {
@@ -1478,7 +1478,7 @@ class TextFormat::Printer::TextGenerator
       return;
     }
     GOOGLE_DCHECK(!failed_);
-    int size = GetCurrentIndentationSize();
+    int size = static_cast<int>(GetCurrentIndentationSize());
 
     while (size > buffer_size_) {
       // Data exceeds space in the buffer. Write what we can and request a new
@@ -1640,7 +1640,7 @@ bool TextFormat::Parser::Parse(io::ZeroCopyInputStream* input,
 bool TextFormat::Parser::ParseFromString(ConstStringParam input,
                                          Message* output) {
   DO(CheckParseInputSize(input, error_collector_));
-  io::ArrayInputStream input_stream(input.data(), input.size());
+  io::ArrayInputStream input_stream(input.data(), static_cast<int>(input.size()));
   return Parse(&input_stream, output);
 }
 
@@ -1658,7 +1658,7 @@ bool TextFormat::Parser::Merge(io::ZeroCopyInputStream* input,
 bool TextFormat::Parser::MergeFromString(ConstStringParam input,
                                          Message* output) {
   DO(CheckParseInputSize(input, error_collector_));
-  io::ArrayInputStream input_stream(input.data(), input.size());
+  io::ArrayInputStream input_stream(input.data(), static_cast<int>(input.size()));
   return Merge(&input_stream, output);
 }
 
@@ -1680,7 +1680,7 @@ bool TextFormat::Parser::MergeUsingImpl(io::ZeroCopyInputStream* /* input */,
 bool TextFormat::Parser::ParseFieldValueFromString(const std::string& input,
                                                    const FieldDescriptor* field,
                                                    Message* output) {
-  io::ArrayInputStream input_stream(input.data(), input.size());
+  io::ArrayInputStream input_stream(input.data(), static_cast<int>(input.size()));
   ParserImpl parser(
       output->GetDescriptor(), &input_stream, error_collector_, finder_,
       parse_info_tree_, ParserImpl::ALLOW_SINGULAR_OVERWRITES,
@@ -2189,7 +2189,7 @@ void TextFormat::Printer::Print(const Message& message,
     UnknownFieldSet unknown_fields;
     {
       std::string serialized = message.SerializeAsString();
-      io::ArrayInputStream input(serialized.data(), serialized.size());
+      io::ArrayInputStream input(serialized.data(), static_cast<int>(serialized.size()));
       unknown_fields.ParseFromZeroCopyStream(&input);
     }
     PrintUnknownFields(unknown_fields, generator, kUnknownFieldRecursionLimit);
@@ -2562,7 +2562,7 @@ void TextFormat::Printer::PrintFieldValue(const Message& message,
       if (truncate_string_field_longer_than_ > 0 &&
           static_cast<size_t>(truncate_string_field_longer_than_) <
               value.size()) {
-        truncated_value = value.substr(0, truncate_string_field_longer_than_) +
+        truncated_value = value.substr(0, static_cast<size_t>(truncate_string_field_longer_than_)) +
                           "...<truncated>...";
         value_to_print = &truncated_value;
       }
@@ -2685,7 +2685,7 @@ void TextFormat::Printer::PrintUnknownFields(
         // budget when we attempt to parse the data. UnknownFieldSet parsing is
         // recursive because of groups.
         io::CodedInputStream input_stream(
-            reinterpret_cast<const uint8_t*>(value.data()), value.size());
+            reinterpret_cast<const uint8_t*>(value.data()), static_cast<int>(value.size()));
         input_stream.SetRecursionLimit(recursion_budget);
         UnknownFieldSet embedded_unknown_fields;
         if (!value.empty() && recursion_budget > 0 &&

--- a/src/google/protobuf/text_format_unittest.cc
+++ b/src/google/protobuf/text_format_unittest.cc
@@ -374,9 +374,9 @@ TEST_F(TextFormatTest, PrintDeeplyNestedUnknownMessage) {
   lengths.push_back(0);
   for (int i = 0; i < kNestingDepth - 1; ++i) {
     lengths.push_back(
-        internal::WireFormatLite::TagSize(
+        static_cast<int>(internal::WireFormatLite::TagSize(
             kUnknownFieldNumber, internal::WireFormatLite::TYPE_BYTES) +
-        internal::WireFormatLite::LengthDelimitedSize(lengths.back()));
+        internal::WireFormatLite::LengthDelimitedSize(lengths.back())));
   }
   std::string serialized;
   {
@@ -735,13 +735,13 @@ class MultilineStringPrinter : public TextFormat::FastFieldValuePrinter {
                    TextFormat::BaseTextGenerator* generator) const override {
     generator->Indent();
     int last_pos = 0;
-    int newline_pos = val.find('\n');
+    int newline_pos = static_cast<int>(val.find('\n'));
     while (newline_pos != std::string::npos) {
       generator->PrintLiteral("\n");
       TextFormat::FastFieldValuePrinter::PrintString(
           val.substr(last_pos, newline_pos + 1 - last_pos), generator);
       last_pos = newline_pos + 1;
-      newline_pos = val.find('\n', last_pos);
+      newline_pos = static_cast<int>(val.find('\n', last_pos));
     }
     if (last_pos < val.size()) {
       generator->PrintLiteral("\n");
@@ -802,14 +802,14 @@ TEST_F(TextFormatTest, CustomMessagePrinter) {
 
 TEST_F(TextFormatTest, ParseBasic) {
   io::ArrayInputStream input_stream(proto_text_format_.data(),
-                                    proto_text_format_.size());
+                                    static_cast<int>(proto_text_format_.size()));
   TextFormat::Parse(&input_stream, &proto_);
   TestUtil::ExpectAllFieldsSet(proto_);
 }
 
 TEST_F(TextFormatExtensionsTest, ParseExtensions) {
   io::ArrayInputStream input_stream(proto_text_format_.data(),
-                                    proto_text_format_.size());
+                                    static_cast<int>(proto_text_format_.size()));
   TextFormat::Parse(&input_stream, &proto_);
   TestUtil::ExpectAllExtensionsSet(proto_);
 }
@@ -870,7 +870,7 @@ TEST_F(TextFormatTest, ParseStringEscape) {
   std::string parse_string =
       "optional_string: " + kEscapeTestStringEscaped + "\n";
 
-  io::ArrayInputStream input_stream(parse_string.data(), parse_string.size());
+  io::ArrayInputStream input_stream(parse_string.data(), static_cast<int>(parse_string.size()));
   TextFormat::Parse(&input_stream, &proto_);
 
   // Compare.
@@ -881,7 +881,7 @@ TEST_F(TextFormatTest, ParseConcatenatedString) {
   // Create a parse string with multiple parts on one line.
   std::string parse_string = "optional_string: \"foo\" \"bar\"\n";
 
-  io::ArrayInputStream input_stream1(parse_string.data(), parse_string.size());
+  io::ArrayInputStream input_stream1(parse_string.data(), static_cast<int>(parse_string.size()));
   TextFormat::Parse(&input_stream1, &proto_);
 
   // Compare.
@@ -892,7 +892,7 @@ TEST_F(TextFormatTest, ParseConcatenatedString) {
       "optional_string: \"foo\"\n"
       "\"bar\"\n";
 
-  io::ArrayInputStream input_stream2(parse_string.data(), parse_string.size());
+  io::ArrayInputStream input_stream2(parse_string.data(), static_cast<int>(parse_string.size()));
   TextFormat::Parse(&input_stream2, &proto_);
 
   // Compare.
@@ -906,7 +906,7 @@ TEST_F(TextFormatTest, ParseFloatWithSuffix) {
   // Have it parse a float with the 'f' suffix.
   std::string parse_string = "optional_float: 1.0f\n";
 
-  io::ArrayInputStream input_stream(parse_string.data(), parse_string.size());
+  io::ArrayInputStream input_stream(parse_string.data(), static_cast<int>(parse_string.size()));
 
   TextFormat::Parse(&input_stream, &proto_);
 
@@ -1056,7 +1056,7 @@ TEST_F(TextFormatTest, Comments) {
       "optional_int32: 1  # a comment\n"
       "optional_int64: 2  # another comment";
 
-  io::ArrayInputStream input_stream(parse_string.data(), parse_string.size());
+  io::ArrayInputStream input_stream(parse_string.data(), static_cast<int>(parse_string.size()));
 
   TextFormat::Parse(&input_stream, &proto_);
 
@@ -1071,7 +1071,7 @@ TEST_F(TextFormatTest, OptionalColon) {
 
   std::string parse_string = "optional_nested_message: { bb: 1}\n";
 
-  io::ArrayInputStream input_stream(parse_string.data(), parse_string.size());
+  io::ArrayInputStream input_stream(parse_string.data(), static_cast<int>(parse_string.size()));
 
   TextFormat::Parse(&input_stream, &proto_);
 

--- a/src/google/protobuf/unknown_field_set.cc
+++ b/src/google/protobuf/unknown_field_set.cc
@@ -61,7 +61,7 @@ const UnknownFieldSet& UnknownFieldSet::default_instance() {
 
 void UnknownFieldSet::ClearFallback() {
   GOOGLE_DCHECK(!fields_.empty());
-  int n = fields_.size();
+  int n = static_cast<int>(fields_.size());
   do {
     (fields_)[--n].Delete();
   } while (n > 0);
@@ -290,8 +290,8 @@ uint8_t* UnknownField::InternalSerializeLengthDelimitedNoTag(
     uint8_t* target, io::EpsCopyOutputStream* stream) const {
   GOOGLE_DCHECK_EQ(TYPE_LENGTH_DELIMITED, type());
   const std::string& data = *data_.length_delimited_.string_value;
-  target = io::CodedOutputStream::WriteVarint32ToArray(data.size(), target);
-  target = stream->WriteRaw(data.data(), data.size(), target);
+  target = io::CodedOutputStream::WriteVarint32ToArray(static_cast<uint32_t>(data.size()), target);
+  target = stream->WriteRaw(data.data(), static_cast<int>(data.size()), target);
   return target;
 }
 

--- a/src/google/protobuf/unknown_field_set.h
+++ b/src/google/protobuf/unknown_field_set.h
@@ -203,7 +203,7 @@ class PROTOBUF_EXPORT UnknownFieldSet {
   bool InternalMergeFromMessage(const MessageType& message) {
     const auto& unknown_fields = message.unknown_fields();
     io::ArrayInputStream array_stream(unknown_fields.data(),
-                                      unknown_fields.size());
+                                      static_cast<int>(unknown_fields.size()));
     io::CodedInputStream coded_stream(&array_stream);
     return MergeFromCodedStream(&coded_stream);
   }

--- a/src/google/protobuf/unknown_field_set_unittest.cc
+++ b/src/google/protobuf/unknown_field_set_unittest.cc
@@ -198,7 +198,7 @@ TEST_F(UnknownFieldSetTest, Group) {
 
 TEST_F(UnknownFieldSetTest, SerializeFastAndSlowAreEquivalent) {
   int size =
-      WireFormat::ComputeUnknownFieldsSize(empty_message_.unknown_fields());
+      static_cast<int>(WireFormat::ComputeUnknownFieldsSize(empty_message_.unknown_fields()));
   std::string slow_buffer;
   std::string fast_buffer;
   slow_buffer.resize(size);
@@ -239,7 +239,7 @@ TEST_F(UnknownFieldSetTest, ParseViaReflection) {
 
   unittest::TestEmptyMessage message;
   io::ArrayInputStream raw_input(all_fields_data_.data(),
-                                 all_fields_data_.size());
+                                 static_cast<int>(all_fields_data_.size()));
   io::CodedInputStream input(&raw_input);
   ASSERT_TRUE(WireFormat::ParseAndMergePartial(&input, &message));
 
@@ -256,7 +256,7 @@ TEST_F(UnknownFieldSetTest, SerializeViaReflection) {
     io::StringOutputStream raw_output(&data);
     io::CodedOutputStream output(&raw_output);
     size_t size = WireFormat::ByteSize(empty_message_);
-    WireFormat::SerializeWithCachedSizes(empty_message_, size, &output);
+    WireFormat::SerializeWithCachedSizes(empty_message_, static_cast<int>(size), &output);
     ASSERT_FALSE(output.HadError());
   }
 
@@ -411,7 +411,7 @@ TEST_F(UnknownFieldSetTest, WrongTypeTreatedAsUnknownViaReflection) {
   unittest::TestAllTypes all_types_message;
   unittest::TestEmptyMessage empty_message;
   std::string bizarro_data = GetBizarroData();
-  io::ArrayInputStream raw_input(bizarro_data.data(), bizarro_data.size());
+  io::ArrayInputStream raw_input(bizarro_data.data(), static_cast<int>(bizarro_data.size()));
   io::CodedInputStream input(&raw_input);
   ASSERT_TRUE(WireFormat::ParseAndMergePartial(&input, &all_types_message));
   ASSERT_TRUE(empty_message.ParseFromString(bizarro_data));
@@ -434,7 +434,7 @@ TEST_F(UnknownFieldSetTest, UnknownExtensionsReflection) {
 
   unittest::TestEmptyMessageWithExtensions message;
   io::ArrayInputStream raw_input(all_fields_data_.data(),
-                                 all_fields_data_.size());
+                                 static_cast<int>(all_fields_data_.size()));
   io::CodedInputStream input(&raw_input);
   ASSERT_TRUE(WireFormat::ParseAndMergePartial(&input, &message));
 

--- a/src/google/protobuf/util/field_mask_util.cc
+++ b/src/google/protobuf/util/field_mask_util.cc
@@ -400,7 +400,7 @@ void FieldMaskTree::RemovePath(const std::string& path,
     }
   }
   // Remove path.
-  for (int i = parts.size() - 1; i >= 0; i--) {
+  for (int i = static_cast<int>(parts.size() - 1); i >= 0; i--) {
     delete nodes[i]->children[parts[i]];
     nodes[i]->children.erase(parts[i]);
     if (!nodes[i]->children.empty()) {

--- a/src/google/protobuf/util/field_mask_util.h
+++ b/src/google/protobuf/util/field_mask_util.h
@@ -63,7 +63,7 @@ class PROTOBUF_EXPORT FieldMaskUtil {
                                FieldMask* out) {
     for (const auto field_number : field_numbers) {
       const FieldDescriptor* field_desc =
-          T::descriptor()->FindFieldByNumber(field_number);
+          T::descriptor()->FindFieldByNumber(static_cast<int>(field_number));
       GOOGLE_CHECK(field_desc != nullptr)
           << "Invalid field number for " << T::descriptor()->full_name() << ": "
           << field_number;

--- a/src/google/protobuf/util/internal/default_value_objectwriter.h
+++ b/src/google/protobuf/util/internal/default_value_objectwriter.h
@@ -186,7 +186,7 @@ class PROTOBUF_EXPORT DefaultValueObjectWriter : public ObjectWriter {
 
     NodeKind kind() const { return kind_; }
 
-    int number_of_children() const { return children_.size(); }
+    int number_of_children() const { return static_cast<int>(children_.size()); }
 
     void set_data(const DataPiece& data) { data_ = data; }
 

--- a/src/google/protobuf/util/internal/field_mask_utility.cc
+++ b/src/google/protobuf/util/internal/field_mask_utility.cc
@@ -86,7 +86,7 @@ std::string ConvertFieldMaskPath(const StringPiece path,
       } else if (path[i] == '\\') {
         is_escaping = true;
       } else if (path[i] == '\"') {
-        current_segment_start = i + 1;
+        current_segment_start = static_cast<int>(i + 1);
         is_quoted = false;
       }
       continue;
@@ -98,7 +98,7 @@ std::string ConvertFieldMaskPath(const StringPiece path,
       if (i < path.size()) {
         result.push_back(path[i]);
       }
-      current_segment_start = i + 1;
+      current_segment_start = static_cast<int>(i + 1);
     }
     if (i < path.size() && path[i] == '\"') {
       is_quoted = true;
@@ -110,7 +110,7 @@ std::string ConvertFieldMaskPath(const StringPiece path,
 util::Status DecodeCompactFieldMaskPaths(StringPiece paths,
                                          PathSinkCallback path_sink) {
   std::stack<std::string> prefix;
-  int length = paths.length();
+  int length = static_cast<int>(paths.length());
   int previous_position = 0;
   bool in_map_key = false;
   bool is_escaping = false;

--- a/src/google/protobuf/util/internal/json_objectwriter.cc
+++ b/src/google/protobuf/util/internal/json_objectwriter.cc
@@ -157,7 +157,7 @@ JsonObjectWriter* JsonObjectWriter::RenderBytes(StringPiece name,
   // TODO(wpoon): Consider a ByteSink solution that writes the base64 bytes
   //              directly to the stream, rather than first putting them
   //              into a string and then writing them to the stream.
-  stream_->WriteRaw(base64.data(), base64.size());
+  stream_->WriteRaw(base64.data(), static_cast<int>(base64.size()));
   WriteChar('"');
   return this;
 }

--- a/src/google/protobuf/util/internal/json_objectwriter.h
+++ b/src/google/protobuf/util/internal/json_objectwriter.h
@@ -101,7 +101,7 @@ class PROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
     // See if we have a trivial sequence of indent characters.
     if (!indent_string.empty()) {
       indent_char_ = indent_string[0];
-      indent_count_ = indent_string.length();
+      indent_count_ = static_cast<int>(indent_string.length());
       for (int i = 1; i < indent_string.length(); i++) {
         if (indent_char_ != indent_string_[i]) {
           indent_char_ = '\0';
@@ -176,7 +176,7 @@ class PROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
 
     // ByteSink methods.
     void Append(const char* bytes, size_t n) override {
-      stream_->WriteRaw(bytes, n);
+      stream_->WriteRaw(bytes, static_cast<int>(n));
     }
 
    private:
@@ -223,7 +223,7 @@ class PROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
       // us from using memset.
       uint8_t* out = nullptr;
       if (indent_count_ > 0) {
-        out = stream_->GetDirectBufferForNBytesAndAdvance(len);
+        out = stream_->GetDirectBufferForNBytesAndAdvance(static_cast<int>(len));
       }
 
       if (out != nullptr) {
@@ -233,7 +233,7 @@ class PROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
         // Slow path, no contiguous output buffer available.
         WriteChar('\n');
         for (int i = 0; i < element()->level(); i++) {
-          stream_->WriteRaw(indent_string_.c_str(), indent_string_.length());
+          stream_->WriteRaw(indent_string_.c_str(), static_cast<int>(indent_string_.length()));
         }
       }
     }
@@ -249,7 +249,7 @@ class PROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
 
   // Writes a string to the output.
   void WriteRawString(StringPiece s) {
-    stream_->WriteRaw(s.data(), s.length());
+    stream_->WriteRaw(s.data(), static_cast<int>(s.length()));
   }
 
   std::unique_ptr<Element> element_;

--- a/src/google/protobuf/util/internal/json_stream_parser.cc
+++ b/src/google/protobuf/util/internal/json_stream_parser.cc
@@ -586,7 +586,7 @@ util::Status JsonStreamParser::ParseDoubleHelper(const std::string& number,
 
 util::Status JsonStreamParser::ParseNumberHelper(NumberResult* result) {
   const char* data = p_.data();
-  int length = p_.length();
+  int length = static_cast<int>(p_.length());
 
   // Look for the first non-numeric character, or the end of the string.
   int index = 0;
@@ -914,7 +914,7 @@ void JsonStreamParser::Advance() {
   // Advance by moving one UTF8 character while making sure we don't go beyond
   // the length of StringPiece.
   p_.remove_prefix(std::min<int>(
-      p_.length(), UTF8FirstLetterNumBytes(p_.data(), p_.length())));
+      static_cast<int>(p_.length()), UTF8FirstLetterNumBytes(p_.data(), static_cast<int>(p_.length()))));
 }
 
 util::Status JsonStreamParser::ParseKey() {
@@ -946,7 +946,7 @@ util::Status JsonStreamParser::ParseKey() {
 JsonStreamParser::TokenType JsonStreamParser::GetNextTokenType() {
   SkipWhitespace();
 
-  int size = p_.size();
+  int size = static_cast<int>(p_.size());
   if (size == 0) {
     // If we ran out of data, report unknown and we'll place the previous parse
     // type onto the stack and try again when we have more data.

--- a/src/google/protobuf/util/internal/proto_writer.cc
+++ b/src/google/protobuf/util/internal/proto_writer.cc
@@ -315,7 +315,7 @@ ProtoWriter::ProtoElement::ProtoElement(ProtoWriter::ProtoElement* parent,
       type_(type),
       size_index_(!is_list &&
                           field->kind() == google::protobuf::Field::TYPE_MESSAGE
-                      ? ow_->size_insert_.size()
+                      ? static_cast<int>(ow_->size_insert_.size())
                       : -1),
       array_index_(is_list ? 0 : -1),
       // oneof_indices_ values are 1-indexed (0 means not present).
@@ -369,7 +369,7 @@ ProtoWriter::ProtoElement* ProtoWriter::ProtoElement::pop() {
     // message, and propagate this additional size information upward to
     // all enclosing messages.
     int size = ow_->size_insert_[size_index_].size;
-    int length = CodedOutputStream::VarintSize32(size);
+    int length = static_cast<int>(CodedOutputStream::VarintSize32(size));
     for (ProtoElement* e = parent(); e != nullptr; e = e->parent()) {
       // Only nested messages have size field, lists do not have size field.
       if (e->size_index_ >= 0) {
@@ -777,7 +777,7 @@ void ProtoWriter::WriteRootMessage() {
   stream_.reset(nullptr);
   const void* data;
   int length;
-  io::ArrayInputStream input_stream(buffer_.data(), buffer_.size());
+  io::ArrayInputStream input_stream(buffer_.data(), static_cast<int>(buffer_.size()));
   while (input_stream.Next(&data, &length)) {
     if (length == 0) continue;
     int num_bytes = length;

--- a/src/google/protobuf/util/internal/protostream_objectsource.cc
+++ b/src/google/protobuf/util/internal/protostream_objectsource.cc
@@ -620,7 +620,7 @@ util::Status ProtoStreamObjectSource::RenderAny(
   // nested_type cannot be null at this time.
   const google::protobuf::Type* nested_type = resolved_type.value();
 
-  io::ArrayInputStream zero_copy_stream(value.data(), value.size());
+  io::ArrayInputStream zero_copy_stream(value.data(), static_cast<int>(value.size()));
   io::CodedInputStream in_stream(&zero_copy_stream);
   // We know the type so we can render it. Recursively parse the nested stream
   // using a nested ProtoStreamObjectSource using our nested type information.

--- a/src/google/protobuf/util/internal/protostream_objectsource_test.cc
+++ b/src/google/protobuf/util/internal/protostream_objectsource_test.cc
@@ -114,7 +114,7 @@ class ProtostreamObjectSourceTest
     std::ostringstream oss;
     msg.SerializePartialToOstream(&oss);
     std::string proto = oss.str();
-    ArrayInputStream arr_stream(proto.data(), proto.size());
+    ArrayInputStream arr_stream(proto.data(), static_cast<int>(proto.size()));
     CodedInputStream in_stream(&arr_stream);
 
     ProtoStreamObjectSource::RenderOptions render_options;

--- a/src/google/protobuf/util/internal/protostream_objectwriter.cc
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.cc
@@ -157,7 +157,7 @@ Status GetNanosFromStringPiece(StringPiece s_nanos,
   if (i_nanos > 0) {
     // 'scale' is the number of digits to the right of the decimal
     // point in "0." + s_nanos.ToString()
-    int32_t scale = num_leading_zeros + s_nanos.size();
+    int32_t scale = static_cast<int32_t>(num_leading_zeros + s_nanos.size());
     // 'conversion' converts i_nanos into nanoseconds.
     // conversion = kNanosPerSecond / static_cast<int32_t>(std::pow(10, scale))
     // For efficiency, we precompute the conversion factor.

--- a/src/google/protobuf/util/json_util.cc
+++ b/src/google/protobuf/util/json_util.cc
@@ -67,7 +67,7 @@ void ZeroCopyStreamByteSink::Append(const char* bytes, size_t len) {
     if (len <= buffer_size_) {  // NOLINT
       memcpy(buffer_, bytes, len);
       buffer_ = static_cast<char*>(buffer_) + len;
-      buffer_size_ -= len;
+      buffer_size_ -= static_cast<int>(len);
       return;
     }
     if (buffer_size_ > 0) {
@@ -119,7 +119,7 @@ util::Status BinaryToJsonString(TypeResolver* resolver,
                                 const std::string& binary_input,
                                 std::string* json_output,
                                 const JsonPrintOptions& options) {
-  io::ArrayInputStream input_stream(binary_input.data(), binary_input.size());
+  io::ArrayInputStream input_stream(binary_input.data(), static_cast<int>(binary_input.size()));
   io::StringOutputStream output_stream(json_output);
   return BinaryToJsonStream(resolver, type_url, &input_stream, &output_stream,
                             options);
@@ -210,7 +210,7 @@ util::Status JsonToBinaryString(TypeResolver* resolver,
                                 StringPiece json_input,
                                 std::string* binary_output,
                                 const JsonParseOptions& options) {
-  io::ArrayInputStream input_stream(json_input.data(), json_input.size());
+  io::ArrayInputStream input_stream(json_input.data(), static_cast<int>(json_input.size()));
   io::StringOutputStream output_stream(binary_output);
   return JsonToBinaryStream(resolver, type_url, &input_stream, &output_stream,
                             options);

--- a/src/google/protobuf/util/json_util_test.cc
+++ b/src/google/protobuf/util/json_util_test.cc
@@ -643,7 +643,7 @@ TEST(ZeroCopyStreamByteSinkTest, TestAllInputOutputPatterns) {
 
 TEST_F(JsonUtilTest, TestWrongJsonInput) {
   const char json[] = "{\"unknown_field\":\"some_value\"}";
-  io::ArrayInputStream input_stream(json, strlen(json));
+  io::ArrayInputStream input_stream(json, static_cast<int>(strlen(json)));
   char proto_buffer[10000];
   io::ArrayOutputStream output_stream(proto_buffer, sizeof(proto_buffer));
   std::string message_type = "type.googleapis.com/proto3.TestMessage";

--- a/src/google/protobuf/util/message_differencer.cc
+++ b/src/google/protobuf/util/message_differencer.cc
@@ -1573,8 +1573,8 @@ bool MessageDifferencer::CompareUnknownFields(
         focus_field->type() != current_repeated->type()) {
       // We've started a new repeated field.
       current_repeated = focus_field;
-      current_repeated_start1 = index1;
-      current_repeated_start2 = index2;
+      current_repeated_start1 = static_cast<int>(index1);
+      current_repeated_start2 = static_cast<int>(index2);
     }
 
     if (change_type == NO_CHANGE && reporter_ == NULL) {
@@ -1601,11 +1601,11 @@ bool MessageDifferencer::CompareUnknownFields(
 
     // Calculate the field index.
     if (change_type == ADDITION) {
-      specific_field.index = index2 - current_repeated_start2;
-      specific_field.new_index = index2 - current_repeated_start2;
+      specific_field.index = static_cast<int>(index2 - current_repeated_start2);
+      specific_field.new_index = static_cast<int>(index2 - current_repeated_start2);
     } else {
-      specific_field.index = index1 - current_repeated_start1;
-      specific_field.new_index = index2 - current_repeated_start2;
+      specific_field.index = static_cast<int>(index1 - current_repeated_start1);
+      specific_field.new_index = static_cast<int>(index2 - current_repeated_start2);
     }
 
     if (IsUnknownFieldIgnored(message1, message2, specific_field,

--- a/src/google/protobuf/util/time_util.cc
+++ b/src/google/protobuf/util/time_util.cc
@@ -383,8 +383,8 @@ Timestamp TimeUtil::TimevalToTimestamp(const timeval& value) {
 
 timeval TimeUtil::TimestampToTimeval(const Timestamp& value) {
   timeval result;
-  result.tv_sec = value.seconds();
-  result.tv_usec = RoundTowardZero(value.nanos(), kNanosPerMicrosecond);
+  result.tv_sec = static_cast<long>(value.seconds());
+  result.tv_usec = static_cast<long>(RoundTowardZero(value.nanos(), kNanosPerMicrosecond));
   return result;
 }
 
@@ -395,8 +395,8 @@ Duration TimeUtil::TimevalToDuration(const timeval& value) {
 
 timeval TimeUtil::DurationToTimeval(const Duration& value) {
   timeval result;
-  result.tv_sec = value.seconds();
-  result.tv_usec = RoundTowardZero(value.nanos(), kNanosPerMicrosecond);
+  result.tv_sec = static_cast<long>(value.seconds());
+  result.tv_usec = static_cast<long>(RoundTowardZero(value.nanos(), kNanosPerMicrosecond));
   // timeval.tv_usec's range is [0, 1000000)
   if (result.tv_usec < 0) {
     result.tv_sec -= 1;

--- a/src/google/protobuf/wire_format_lite.cc
+++ b/src/google/protobuf/wire_format_lite.cc
@@ -484,7 +484,7 @@ void WireFormatLite::WriteString(int field_number, const std::string& value,
   // String is for UTF-8 text only
   WriteTag(field_number, WIRETYPE_LENGTH_DELIMITED, output);
   GOOGLE_CHECK_LE(value.size(), kInt32MaxSize);
-  output->WriteVarint32(value.size());
+  output->WriteVarint32(static_cast<uint32_t>(value.size()));
   output->WriteString(value);
 }
 void WireFormatLite::WriteStringMaybeAliased(int field_number,
@@ -493,14 +493,14 @@ void WireFormatLite::WriteStringMaybeAliased(int field_number,
   // String is for UTF-8 text only
   WriteTag(field_number, WIRETYPE_LENGTH_DELIMITED, output);
   GOOGLE_CHECK_LE(value.size(), kInt32MaxSize);
-  output->WriteVarint32(value.size());
-  output->WriteRawMaybeAliased(value.data(), value.size());
+  output->WriteVarint32(static_cast<uint32_t>(value.size()));
+  output->WriteRawMaybeAliased(value.data(), static_cast<int>(value.size()));
 }
 void WireFormatLite::WriteBytes(int field_number, const std::string& value,
                                 io::CodedOutputStream* output) {
   WriteTag(field_number, WIRETYPE_LENGTH_DELIMITED, output);
   GOOGLE_CHECK_LE(value.size(), kInt32MaxSize);
-  output->WriteVarint32(value.size());
+  output->WriteVarint32(static_cast<uint32_t>(value.size()));
   output->WriteString(value);
 }
 void WireFormatLite::WriteBytesMaybeAliased(int field_number,
@@ -508,8 +508,8 @@ void WireFormatLite::WriteBytesMaybeAliased(int field_number,
                                             io::CodedOutputStream* output) {
   WriteTag(field_number, WIRETYPE_LENGTH_DELIMITED, output);
   GOOGLE_CHECK_LE(value.size(), kInt32MaxSize);
-  output->WriteVarint32(value.size());
-  output->WriteRawMaybeAliased(value.data(), value.size());
+  output->WriteVarint32(static_cast<uint32_t>(value.size()));
+  output->WriteRawMaybeAliased(value.data(), static_cast<int>(value.size()));
 }
 
 

--- a/src/google/protobuf/wire_format_unittest.inc
+++ b/src/google/protobuf/wire_format_unittest.inc
@@ -91,7 +91,7 @@ TEST(WireFormatTest, Parse) {
   source.SerializeToString(&data);
 
   // Parse using WireFormat.
-  io::ArrayInputStream raw_input(data.data(), data.size());
+  io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
   io::CodedInputStream input(&raw_input);
   WireFormat::ParseAndMergePartial(&input, &dest);
 
@@ -108,7 +108,7 @@ TEST(WireFormatTest, ParseExtensions) {
   source.SerializeToString(&data);
 
   // Parse using WireFormat.
-  io::ArrayInputStream raw_input(data.data(), data.size());
+  io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
   io::CodedInputStream input(&raw_input);
   WireFormat::ParseAndMergePartial(&input, &dest);
 
@@ -125,7 +125,7 @@ TEST(WireFormatTest, ParsePacked) {
   source.SerializeToString(&data);
 
   // Parse using WireFormat.
-  io::ArrayInputStream raw_input(data.data(), data.size());
+  io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
   io::CodedInputStream input(&raw_input);
   WireFormat::ParseAndMergePartial(&input, &dest);
 
@@ -141,7 +141,7 @@ TEST(WireFormatTest, ParsePackedFromUnpacked) {
 
   // Parse using WireFormat.
   UNITTEST::TestPackedTypes dest;
-  io::ArrayInputStream raw_input(data.data(), data.size());
+  io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
   io::CodedInputStream input(&raw_input);
   WireFormat::ParseAndMergePartial(&input, &dest);
 
@@ -157,7 +157,7 @@ TEST(WireFormatTest, ParseUnpackedFromPacked) {
 
   // Parse using WireFormat.
   UNITTEST::TestUnpackedTypes dest;
-  io::ArrayInputStream raw_input(data.data(), data.size());
+  io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
   io::CodedInputStream input(&raw_input);
   WireFormat::ParseAndMergePartial(&input, &dest);
 
@@ -174,7 +174,7 @@ TEST(WireFormatTest, ParsePackedExtensions) {
   source.SerializeToString(&data);
 
   // Parse using WireFormat.
-  io::ArrayInputStream raw_input(data.data(), data.size());
+  io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
   io::CodedInputStream input(&raw_input);
   WireFormat::ParseAndMergePartial(&input, &dest);
 
@@ -191,7 +191,7 @@ TEST(WireFormatTest, ParseOneof) {
   source.SerializeToString(&data);
 
   // Parse using WireFormat.
-  io::ArrayInputStream raw_input(data.data(), data.size());
+  io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
   io::CodedInputStream input(&raw_input);
   WireFormat::ParseAndMergePartial(&input, &dest);
 
@@ -214,11 +214,11 @@ TEST(WireFormatTest, OneofOnlySetLast) {
   {
     io::StringOutputStream raw_output(&data);
     io::CodedOutputStream output(&raw_output);
-    WireFormat::SerializeWithCachedSizes(source, source.ByteSizeLong(),
+    WireFormat::SerializeWithCachedSizes(source, static_cast<int>(source.ByteSizeLong()),
                                          &output);
     ASSERT_FALSE(output.HadError());
   }
-  io::ArrayInputStream raw_input(data.data(), data.size());
+  io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
   io::CodedInputStream input(&raw_input);
   WireFormat::ParseAndMergePartial(&input, &oneof_dest);
 
@@ -298,7 +298,7 @@ TEST(WireFormatTest, Serialize) {
   {
     io::StringOutputStream raw_output(&dynamic_data);
     io::CodedOutputStream output(&raw_output);
-    WireFormat::SerializeWithCachedSizes(message, size, &output);
+    WireFormat::SerializeWithCachedSizes(message, static_cast<int>(size), &output);
     ASSERT_FALSE(output.HadError());
   }
 
@@ -327,7 +327,7 @@ TEST(WireFormatTest, SerializeExtensions) {
   {
     io::StringOutputStream raw_output(&dynamic_data);
     io::CodedOutputStream output(&raw_output);
-    WireFormat::SerializeWithCachedSizes(message, size, &output);
+    WireFormat::SerializeWithCachedSizes(message, static_cast<int>(size), &output);
     ASSERT_FALSE(output.HadError());
   }
 
@@ -356,7 +356,7 @@ TEST(WireFormatTest, SerializeFieldsAndExtensions) {
   {
     io::StringOutputStream raw_output(&dynamic_data);
     io::CodedOutputStream output(&raw_output);
-    WireFormat::SerializeWithCachedSizes(message, size, &output);
+    WireFormat::SerializeWithCachedSizes(message, static_cast<int>(size), &output);
     ASSERT_FALSE(output.HadError());
   }
 
@@ -385,7 +385,7 @@ TEST(WireFormatTest, SerializeOneof) {
   {
     io::StringOutputStream raw_output(&dynamic_data);
     io::CodedOutputStream output(&raw_output);
-    WireFormat::SerializeWithCachedSizes(message, size, &output);
+    WireFormat::SerializeWithCachedSizes(message, static_cast<int>(size), &output);
     ASSERT_FALSE(output.HadError());
   }
 
@@ -411,7 +411,7 @@ TEST(WireFormatTest, ParseMultipleExtensionRanges) {
   // Also test using reflection-based parsing.
   {
     UNITTEST::TestFieldOrderings dest;
-    io::ArrayInputStream raw_input(data.data(), data.size());
+    io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
     io::CodedInputStream coded_input(&raw_input);
     EXPECT_TRUE(WireFormat::ParseAndMergePartial(&coded_input, &dest));
     EXPECT_EQ(source.DebugString(), dest.DebugString());
@@ -501,7 +501,7 @@ TEST(WireFormatTest, SerializeMessageSetVariousWaysAreEqual) {
 
   // Serialize to buffer
   {
-    io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&stream_data), size,
+    io::ArrayOutputStream array_stream(::google::protobuf::string_as_array(&stream_data), static_cast<int>(size),
                                        1);
     io::CodedOutputStream output_stream(&array_stream);
     message_set.SerializeWithCachedSizes(&output_stream);
@@ -512,7 +512,7 @@ TEST(WireFormatTest, SerializeMessageSetVariousWaysAreEqual) {
   {
     io::StringOutputStream string_stream(&dynamic_data);
     io::CodedOutputStream output_stream(&string_stream);
-    WireFormat::SerializeWithCachedSizes(message_set, size, &output_stream);
+    WireFormat::SerializeWithCachedSizes(message_set, static_cast<int>(size), &output_stream);
     ASSERT_FALSE(output_stream.HadError());
   }
 
@@ -576,7 +576,7 @@ TEST(WireFormatTest, ParseMessageSet) {
   // Also parse using WireFormat.
   PROTO2_WIREFORMAT_UNITTEST::TestMessageSet dynamic_message_set;
   io::CodedInputStream input(reinterpret_cast<const uint8_t*>(data.data()),
-                             data.size());
+                             static_cast<int>(data.size()));
   ASSERT_TRUE(WireFormat::ParseAndMergePartial(&input, &dynamic_message_set));
   EXPECT_EQ(message_set.DebugString(), dynamic_message_set.DebugString());
 }
@@ -595,7 +595,7 @@ TEST(WireFormatTest, ParseMessageSetWithReverseTagOrder) {
     WireFormatLite::WriteTag(WireFormatLite::kMessageSetMessageNumber,
                              WireFormatLite::WIRETYPE_LENGTH_DELIMITED,
                              &coded_output);
-    coded_output.WriteVarint32(message.ByteSizeLong());
+    coded_output.WriteVarint32(static_cast<uint32_t>(message.ByteSizeLong()));
     message.SerializeWithCachedSizes(&coded_output);
     // Write the type id.
     uint32_t type_id = message.GetDescriptor()->extension(0)->number();
@@ -617,7 +617,7 @@ TEST(WireFormatTest, ParseMessageSetWithReverseTagOrder) {
     // Test parse the message via Reflection.
     PROTO2_WIREFORMAT_UNITTEST::TestMessageSet message_set;
     io::CodedInputStream input(reinterpret_cast<const uint8_t*>(data.data()),
-                               data.size());
+                               static_cast<int>(data.size()));
     EXPECT_TRUE(WireFormat::ParseAndMergePartial(&input, &message_set));
     EXPECT_TRUE(input.ConsumedEntireMessage());
 
@@ -761,7 +761,7 @@ TEST(WireFormatTest, RecursionLimit) {
   message.SerializeToString(&data);
 
   {
-    io::ArrayInputStream raw_input(data.data(), data.size());
+    io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
     io::CodedInputStream input(&raw_input);
     input.SetRecursionLimit(4);
     UNITTEST::TestRecursiveMessage message2;
@@ -769,7 +769,7 @@ TEST(WireFormatTest, RecursionLimit) {
   }
 
   {
-    io::ArrayInputStream raw_input(data.data(), data.size());
+    io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
     io::CodedInputStream input(&raw_input);
     input.SetRecursionLimit(3);
     UNITTEST::TestRecursiveMessage message2;
@@ -789,14 +789,14 @@ TEST(WireFormatTest, LargeRecursionLimit) {
   std::string data = src.SerializeAsString();
   {
     // Parse with default recursion limit. Should fail.
-    io::ArrayInputStream raw_input(data.data(), data.size());
+    io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
     io::CodedInputStream input(&raw_input);
     ASSERT_FALSE(dst.ParseFromCodedStream(&input));
   }
 
   {
     // Parse with custom recursion limit. Should pass.
-    io::ArrayInputStream raw_input(data.data(), data.size());
+    io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
     io::CodedInputStream input(&raw_input);
     input.SetRecursionLimit(kLargeLimit);
     ASSERT_TRUE(dst.ParseFromCodedStream(&input));
@@ -826,7 +826,7 @@ TEST(WireFormatTest, UnknownFieldRecursionLimit) {
   message.SerializeToString(&data);
 
   {
-    io::ArrayInputStream raw_input(data.data(), data.size());
+    io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
     io::CodedInputStream input(&raw_input);
     input.SetRecursionLimit(4);
     UNITTEST::TestEmptyMessage message2;
@@ -834,7 +834,7 @@ TEST(WireFormatTest, UnknownFieldRecursionLimit) {
   }
 
   {
-    io::ArrayInputStream raw_input(data.data(), data.size());
+    io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
     io::CodedInputStream input(&raw_input);
     input.SetRecursionLimit(3);
     UNITTEST::TestEmptyMessage message2;
@@ -920,7 +920,7 @@ TEST(WireFormatTest, RepeatedScalarsDifferentTagSizes) {
     msg1.add_repeated_int32(i);
     msg1.add_repeated_fixed64(i);
     msg1.add_repeated_int64(i);
-    msg1.add_repeated_float(i);
+    msg1.add_repeated_float(static_cast<float>(i));
     msg1.add_repeated_uint64(i);
   }
 
@@ -1103,7 +1103,7 @@ class Proto3PrimitiveRepeatedWireFormatTest : public ::testing::Test {
     {
       io::StringOutputStream raw_output(&dynamic_data);
       io::CodedOutputStream output(&raw_output);
-      WireFormat::SerializeWithCachedSizes(*message, size, &output);
+      WireFormat::SerializeWithCachedSizes(*message, static_cast<int>(size), &output);
       ASSERT_FALSE(output.HadError());
     }
     EXPECT_TRUE(expected == dynamic_data);
@@ -1118,7 +1118,7 @@ class Proto3PrimitiveRepeatedWireFormatTest : public ::testing::Test {
     message->Clear();
     io::CodedInputStream input(
         reinterpret_cast<const uint8_t*>(compatible_data.data()),
-        compatible_data.size());
+        static_cast<int>(compatible_data.size()));
     WireFormat::ParseAndMergePartial(&input, message);
     ExpectProto3PrimitiveRepeatedFieldsSet(*message);
   }
@@ -1221,7 +1221,7 @@ TEST_F(WireFormatInvalidInputTest, InvalidMessageWithExtraZero) {
 
   // Control case.
   {
-    io::ArrayInputStream ais(data.data(), data.size());
+    io::ArrayInputStream ais(data.data(), static_cast<int>(data.size()));
     io::CodedInputStream is(&ais);
     UNITTEST::TestAllTypes message;
     // It should fail but currently passes.
@@ -1291,7 +1291,7 @@ TEST_F(WireFormatInvalidInputTest, InvalidStringInUnknownGroup) {
 
   // Try to skip it.  Note that the bug was only present when parsing to an
   // UnknownFieldSet.
-  io::ArrayInputStream raw_input(data.data(), data.size());
+  io::ArrayInputStream raw_input(data.data(), static_cast<int>(data.size()));
   io::CodedInputStream coded_input(&raw_input);
   UnknownFieldSet unknown_fields;
   EXPECT_FALSE(WireFormat::SkipMessage(&coded_input, &unknown_fields));
@@ -1321,7 +1321,7 @@ bool WriteMessage(const char* value, T* message, std::string* wire_buffer) {
 
 template <typename T>
 bool ReadMessage(const std::string& wire_buffer, T* message) {
-  return message->ParseFromArray(wire_buffer.data(), wire_buffer.size());
+  return message->ParseFromArray(wire_buffer.data(), static_cast<int>(wire_buffer.size()));
 }
 
 class Utf8ValidationTest : public ::testing::Test {
@@ -1467,7 +1467,7 @@ TEST_F(Utf8ValidationTest, OldVerifyUTF8String) {
   std::vector<std::string> errors;
   {
     ScopedMemoryLog log;
-    WireFormat::VerifyUTF8String(data.data(), data.size(),
+    WireFormat::VerifyUTF8String(data.data(), static_cast<int>(data.size()),
                                  WireFormat::SERIALIZE);
     errors = log.GetMessages(ERROR);
   }


### PR DESCRIPTION
This change fixes the following MSVC warnings:
- [C4244 – 'conversion' conversion from 'type1' to 'type2', possible loss of data](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244?view=msvc-170)
- [C4267 – 'var' : conversion from 'size_t' to 'type', possible loss of data](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267?view=msvc-170)

To prevent further instances from making it into the codebase, the change also adds the [`/WX` flag](https://docs.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level?view=msvc-170) to treat all compiler warnings as errors.

This change also disables the following MSVC warning (to be addressed in a follow-up PR):
- [C4018 - 'token' : signed/unsigned mismatch](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018?view=msvc-170)

For more context on these changes, please see #9263 and the discussion there.