### PR TITLE
[Bazel] Extract sources from test_suite in cc_dist_library

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -308,13 +308,15 @@ gen_file_lists(
         ":protobuf": "libprotobuf",
         ":protoc": "libprotoc",
         ":protobuf_lite": "libprotobuf_lite",
+
         # Tests:
-        ":protobuf_compiler_tests": "compiler_test",
-        ":protobuf_full_tests": "protobuf_test",
-        ":protobuf_io_tests": "io_test",
-        ":protobuf_lite_tests": "lite_test",
-        ":protobuf_stubs_tests": "stubs_test",
-        ":protobuf_util_tests": "util_test",
+        "//src/google/protobuf:full_tests": "protobuf_test",
+        "//src/google/protobuf:lite_unittest": "lite_test",
+        "//src/google/protobuf:lite_arena_unittest": "lite_arena_test",
+        "//src/google/protobuf/compiler:tests": "compiler_test",
+        "//src/google/protobuf/io:tests": "io_test",
+        "//src/google/protobuf/stubs:tests": "stubs_test",
+        "//src/google/protobuf/util:tests": "util_test",
     },
 )
 
@@ -403,64 +405,6 @@ cc_dist_library(
         "//src/google/protobuf/compiler/php",
         "//src/google/protobuf/compiler/python",
         "//src/google/protobuf/compiler/ruby",
-    ],
-)
-
-################################################################################
-# Protobuf runtime tests
-################################################################################
-
-cc_dist_library(
-    name = "protobuf_full_tests",
-    testonly = 1,
-    tags = ["manual"],
-    deps = [
-        "//src/google/protobuf:full_tests",
-    ],
-)
-
-cc_dist_library(
-    name = "protobuf_lite_tests",
-    testonly = 1,
-    tags = ["manual"],
-    deps = [
-        "//src/google/protobuf:lite_tests",
-    ],
-)
-
-cc_dist_library(
-    name = "protobuf_compiler_tests",
-    testonly = 1,
-    tags = ["manual"],
-    deps = [
-        "//src/google/protobuf/compiler:tests",
-    ],
-)
-
-cc_dist_library(
-    name = "protobuf_io_tests",
-    testonly = 1,
-    tags = ["manual"],
-    deps = [
-        "//src/google/protobuf/io:tests",
-    ],
-)
-
-cc_dist_library(
-    name = "protobuf_stubs_tests",
-    testonly = 1,
-    tags = ["manual"],
-    deps = [
-        "//src/google/protobuf/stubs:tests",
-    ],
-)
-
-cc_dist_library(
-    name = "protobuf_util_tests",
-    testonly = 1,
-    tags = ["manual"],
-    deps = [
-        "//src/google/protobuf/util:tests",
     ],
 )
 

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -27,7 +27,7 @@ pkg_files(
 pkg_files(
     name = "compiler_plugin_protos_files",
     srcs = [
-      "//src/google/protobuf/compiler:compiler_plugin_protos_files",
+        "//src/google/protobuf/compiler:compiler_plugin_protos_files",
     ],
     prefix = "include/google/protobuf/compiler",
     visibility = ["//visibility:private"],
@@ -304,10 +304,17 @@ gen_file_lists(
     testonly = 1,
     out_stem = "src_file_lists",
     src_libs = {
-        # source rule: name in generated file
+        # {[source rule]: [name in generated file]}
         ":protobuf": "libprotobuf",
         ":protoc": "libprotoc",
         ":protobuf_lite": "libprotobuf_lite",
+        # Tests:
+        ":protobuf_compiler_tests": "compiler_test",
+        ":protobuf_full_tests": "protobuf_test",
+        ":protobuf_io_tests": "io_test",
+        ":protobuf_lite_tests": "lite_test",
+        ":protobuf_stubs_tests": "stubs_test",
+        ":protobuf_util_tests": "util_test",
     },
 )
 
@@ -337,6 +344,7 @@ gen_automake_file_lists(
 
 cc_dist_library(
     name = "protobuf_lite",
+    testonly = 1,
     linkopts = select({
         "//build_defs:config_msvc": [],
         "//conditions:default": ["-lpthread"],
@@ -362,15 +370,15 @@ cc_dist_library(
     }),
     tags = ["manual"],
     deps = [
+        "//src/google/protobuf",
         "//src/google/protobuf:arena",
+        "//src/google/protobuf:protobuf_lite",
         "//src/google/protobuf/compiler:importer",
         "//src/google/protobuf/io",
         "//src/google/protobuf/io:gzip_stream",
         "//src/google/protobuf/io:io_win32",
         "//src/google/protobuf/io:printer",
         "//src/google/protobuf/io:tokenizer",
-        "//src/google/protobuf:protobuf",
-        "//src/google/protobuf:protobuf_lite",
         "//src/google/protobuf/stubs",
         "//src/google/protobuf/stubs:lite",
         "//src/google/protobuf/util:delimited_message_util",
@@ -395,6 +403,64 @@ cc_dist_library(
         "//src/google/protobuf/compiler/php",
         "//src/google/protobuf/compiler/python",
         "//src/google/protobuf/compiler/ruby",
+    ],
+)
+
+################################################################################
+# Protobuf runtime tests
+################################################################################
+
+cc_dist_library(
+    name = "protobuf_full_tests",
+    testonly = 1,
+    tags = ["manual"],
+    deps = [
+        "//src/google/protobuf:full_tests",
+    ],
+)
+
+cc_dist_library(
+    name = "protobuf_lite_tests",
+    testonly = 1,
+    tags = ["manual"],
+    deps = [
+        "//src/google/protobuf:lite_tests",
+    ],
+)
+
+cc_dist_library(
+    name = "protobuf_compiler_tests",
+    testonly = 1,
+    tags = ["manual"],
+    deps = [
+        "//src/google/protobuf/compiler:tests",
+    ],
+)
+
+cc_dist_library(
+    name = "protobuf_io_tests",
+    testonly = 1,
+    tags = ["manual"],
+    deps = [
+        "//src/google/protobuf/io:tests",
+    ],
+)
+
+cc_dist_library(
+    name = "protobuf_stubs_tests",
+    testonly = 1,
+    tags = ["manual"],
+    deps = [
+        "//src/google/protobuf/stubs:tests",
+    ],
+)
+
+cc_dist_library(
+    name = "protobuf_util_tests",
+    testonly = 1,
+    tags = ["manual"],
+    deps = [
+        "//src/google/protobuf/util:tests",
     ],
 )
 

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -22,10 +22,37 @@ this isn't something we can reliably do from Bazel. To produce fully functioning
 source distributions, run `autogen.sh` before building the archives (this
 populates the necessary files directly into the source tree).
 
-## C++ runtime binary distribution
+## Build system file lists
+
+The `gen_automake_file_lists` and `gen_cmake_file_lists` rules generate files
+containing lists of files that can be included into definitions for other build
+systems.
+
+The files can come from files or `filegroup` rules, `pkg_file` or
+`pkg_filegroup` rules, `proto_library` rules, or `cc_dist_library` rules (see
+below).
+
+When a `proto_library` is used for file lists, the output will include the proto
+sources, as well as the expected generated C++ files.
+
+## C++ runtime libraries
 
 The `cc_dist_library` rule creates composite libraries from several other
-`cc_library` targets. Bazel uses a "fine-grained" library model, where each
+`cc_library`-like targets. Bazel uses a "fine-grained" library model, where each
 `cc_library` produces its own library artifacts, without transitive
 dependencies. The `cc_dist_library` rule combines several other libraries
 together, creating a single library that may be suitable for distribution.
+
+Unlike most other Bazel C++ rules, `cc_dist_library` does not consider
+transitive dependencies. This means that the resulting artifacts will contain
+exactly the objects listed in `deps`. (There is one exception, explained below.)
+
+When a `cc_dist_library` is used to generate build system file lists, the `hdrs`
+and `textual_hdrs` are listed separately in the generated output. Files in
+`srcs` are filtered, so that actual sources are emitted as `srcs`, and
+everything else as `internal_hdrs`.
+
+Tests can be passed to `cc_dist_library`, either as `cc_test` rules, or through
+`test_suite` rules. As a special-case exception, `test_suite` rules are expanded
+recursively. This allows using rules defined like `test_suite(name = "tests")`,
+which easily group all tests in a package.

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -29,30 +29,37 @@ containing lists of files that can be included into definitions for other build
 systems.
 
 The files can come from files or `filegroup` rules, `pkg_file` or
-`pkg_filegroup` rules, `proto_library` rules, or `cc_dist_library` rules (see
-below).
+`pkg_filegroup` rules, `proto_library` rules, `cc_*` rules (including
+`cc_test`), `cc_dist_library` rules (see below), and `test_suite` rules.
 
-When a `proto_library` is used for file lists, the output will include the proto
-sources, as well as the expected generated C++ files.
+Unlike most other Bazel rules, transitive dependencies are not included in the
+output. For example, if a `proto_library` is listed, only its `srcs` will be
+included in the output, but not those of any transitively-nominated
+`proto_library`s. (As an exception, `test_suite` rules are expanded recursively
+to find `cc_test` targets.)
+
+When a `proto_library` is used for file lists, the generated file will include
+the proto sources, as well as the expected generated C++ files.
 
 ## C++ runtime libraries
 
 The `cc_dist_library` rule creates composite libraries from several other
-`cc_library`-like targets. Bazel uses a "fine-grained" library model, where each
-`cc_library` produces its own library artifacts, without transitive
-dependencies. The `cc_dist_library` rule combines several other libraries
-together, creating a single library that may be suitable for distribution.
+`cc_library`-like targets. Bazel builds typically use a "fine-grained" library
+model, where each `cc_library` produces its own library artifacts, without
+transitive dependencies. The `cc_dist_library` rule combines several other
+libraries together, creating a single library that may be suitable for
+distribution.
 
 Unlike most other Bazel C++ rules, `cc_dist_library` does not consider
 transitive dependencies. This means that the resulting artifacts will contain
-exactly the objects listed in `deps`. (There is one exception, explained below.)
+exactly the objects listed in `deps`.
 
-When a `cc_dist_library` is used to generate build system file lists, the `hdrs`
-and `textual_hdrs` are listed separately in the generated output. Files in
-`srcs` are filtered, so that actual sources are emitted as `srcs`, and
-everything else as `internal_hdrs`.
+When a `cc_dist_library` is used to generate build system file lists (see
+above), it exposes the `srcs` of each of the inputs. In the generated output,
+`hdrs` and `textual_hdrs` are listed separately. Files in `srcs` are also
+filtered, so that actual sources are emitted as `srcs`, and everything else as
+`internal_hdrs`.
 
-Tests can be passed to `cc_dist_library`, either as `cc_test` rules, or through
-`test_suite` rules. As a special-case exception, `test_suite` rules are expanded
-recursively. This allows using rules defined like `test_suite(name = "tests")`,
-which easily group all tests in a package.
+Note that `cc_dist_library` uses Bazel's internal C++ build logic, but does not
+treat tests specially. Because of this, it may not be possible to build a
+`cc_test` target at the same time as a `cc_dist_library` that includes it.

--- a/pkg/build_systems.bzl
+++ b/pkg/build_systems.bzl
@@ -78,24 +78,7 @@ file_list_aspect = aspect(
     doc = """
 Aspect to provide the list of sources and headers from a rule.
 
-Output is CcFileList and/or ProtoFileList. Example:
-
-  cc_library(
-      name = "foo",
-      srcs = [
-          "foo.cc",
-          "foo_internal.h",
-      ],
-      hdrs = ["foo.h"],
-      textual_hdrs = ["foo_inl.inc"],
-  )
-  # produces:
-  # CcFileList(
-  #     hdrs = [File("foo.h")],
-  #     textual_hdrs = [File("foo_inl.inc")],
-  #     internal_hdrs = [File("foo_internal.h")],
-  #     srcs = [File("foo.cc")],
-  # )
+Output is a ProtoFileList. Example:
 
   proto_library(
       name = "bar_proto",
@@ -238,9 +221,9 @@ _source_list_common_attrs = {
     "src_libs": attr.label_keyed_string_dict(
         doc = (
             "A dict, {target: libname} of libraries to include. " +
-            "Targets can be C++ rules (like `cc_library` or `cc_test`), " +
-            "`proto_library` rules, files, `filegroup` rules, `pkg_files` " +
-            "rules, or `pkg_filegroup` rules. " +
+            "Targets can be files, `filegroup` rules, `proto_library` " +
+            "rules, `cc_dist_library` rules, `pkg_files` rules, or " +
+            "`pkg_filegroup` rules. " +
             "The libname is a string, and used to construct the variable " +
             "name in the `out` file holding the target's sources. " +
             "For generated files, the output root (like `bazel-bin/`) is not " +

--- a/pkg/cc_dist_library.bzl
+++ b/pkg/cc_dist_library.bzl
@@ -2,6 +2,12 @@
 
 load("@rules_cc//cc:action_names.bzl", cc_action_names = "ACTION_NAMES")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load(
+    ":file_list_aspects.bzl",
+    "CcFileList",
+    "cc_file_list_aspect",
+    "combine_cc_file_lists",
+)
 
 ################################################################################
 # Archive/linking support
@@ -115,147 +121,6 @@ def _create_dso_link_action(
     return outputs
 
 ################################################################################
-# Source file/header support
-################################################################################
-
-CcFileList = provider(
-    doc = "List of files to be built into a library.",
-    fields = {
-        # As a rule of thumb, `hdrs` and `textual_hdrs` are the files that
-        # would be installed along with a prebuilt library.
-        "hdrs": "public header files, including those used by generated code",
-        "textual_hdrs": "files which are included but are not self-contained",
-
-        # The `internal_hdrs` are header files which appear in `srcs`.
-        # These are only used when compiling the library.
-        "internal_hdrs": "internal header files (only used to build .cc files)",
-        "srcs": "source files",
-    },
-)
-
-def _flatten_target_files(targets):
-    return depset(transitive = [target.files for target in targets])
-
-def _extract_cc_file_list_from_cc_rule(rule_attr):
-    # CcInfo is a proxy for what we expect this rule to look like.
-    # However, some deps may expose `CcInfo` without having `srcs`,
-    # `hdrs`, etc., so we use `getattr` to handle that gracefully.
-
-    internal_hdrs = []
-    srcs = []
-
-    # Filter `srcs` so it only contains source files. Headers will go
-    # into `internal_headers`.
-    for src in _flatten_target_files(getattr(rule_attr, "srcs", [])).to_list():
-        if src.extension.lower() in ["c", "cc", "cpp", "cxx"]:
-            srcs.append(src)
-        else:
-            internal_hdrs.append(src)
-
-    return CcFileList(
-        hdrs = _flatten_target_files(getattr(rule_attr, "hdrs", [])),
-        textual_hdrs = _flatten_target_files(getattr(
-            rule_attr,
-            "textual_hdrs",
-            [],
-        )),
-        internal_hdrs = depset(internal_hdrs),
-        srcs = depset(srcs),
-    )
-
-def _collect_cc_file_lists(cc_file_lists):
-    """Combine several CcFileLists into a single one."""
-
-    # The returned CcFileList will contain depsets of the deps' file lists.
-    # These lists hold `depset()`s from each of `deps`.
-    srcs = []
-    hdrs = []
-    internal_hdrs = []
-    textual_hdrs = []
-
-    for cfl in cc_file_lists:
-        srcs.append(cfl.srcs)
-        hdrs.append(cfl.hdrs)
-        internal_hdrs.append(cfl.internal_hdrs)
-        textual_hdrs.append(cfl.textual_hdrs)
-
-    return CcFileList(
-        srcs = depset(transitive = srcs),
-        hdrs = depset(transitive = hdrs),
-        internal_hdrs = depset(transitive = internal_hdrs),
-        textual_hdrs = depset(transitive = textual_hdrs),
-    )
-
-def _extract_cc_file_list_from_test_suite(target, rule_attr):
-    transitive = []
-
-    for dep in getattr(rule_attr, "tests", []):
-        transitive.append(dep[CcFileList])
-
-    # Test suites can list tests explicitly, or they can implicitly
-    # expand to "all tests in this package." In the latter case, Bazel
-    # exposes the implicit tests via the internal attribute
-    # `_implicit_tests`.
-    #
-    # Unfortunately, these attrs are currently (as of Bazel 5) the only
-    # way to get the lists of tests, but this might change in the
-    # future (c.f.: https://github.com/bazelbuild/bazel/issues/14993).
-    for dep in getattr(rule_attr, "_implicit_tests", []):
-        transitive.append(dep[CcFileList])
-
-    if not transitive:
-        # We are reaching into Bazel-internal attributes, which have no
-        # guarantee that they won't change. If we end up with no tests,
-        # print a warning.
-        print(("WARNING: no tests were found in test_suite %s. If there " +
-               "are no tests in package %s, consider removing the " +
-               "test_suite. (Otherwise, this could be due to a bug " +
-               "in gen_file_lists.)") %
-              (target.label, target.label.package))
-
-    return _collect_cc_file_lists(transitive)
-
-def _cc_file_list_aspect_impl(target, ctx):
-    # Special case: if this is a test_suite, collect the CcFileLists from
-    # its tests.
-    if ctx.rule.kind == "test_suite":
-        return [_extract_cc_file_list_from_test_suite(target, ctx.rule.attr)]
-
-    # Extract sources from a `cc_library` (or similar):
-    if CcInfo in target:
-        return [_extract_cc_file_list_from_cc_rule(ctx.rule.attr)]
-
-    return []
-
-cc_file_list_aspect = aspect(
-    doc = """
-Aspect to provide the list of sources and headers from a rule.
-
-Output is CcFileList. Example:
-
-  cc_library(
-      name = "foo",
-      srcs = [
-          "foo.cc",
-          "foo_internal.h",
-      ],
-      hdrs = ["foo.h"],
-      textual_hdrs = ["foo_inl.inc"],
-  )
-  # produces:
-  # CcFileList(
-  #     hdrs = depset([File("foo.h")]),
-  #     textual_hdrs = depset([File("foo_inl.inc")]),
-  #     internal_hdrs = depset([File("foo_internal.h")]),
-  #     srcs = depset([File("foo.cc")]),
-  # )
-""",
-    implementation = _cc_file_list_aspect_impl,
-    # Allow propagation for test_suite rules:
-    attr_aspects = ["tests", "_implicit_tests"],
-)
-
-################################################################################
 # Rule impl
 ################################################################################
 
@@ -301,7 +166,7 @@ def _collect_inputs(deps):
     return struct(
         objects = objs,
         pic_objects = pic_objs,
-        cc_file_list = _collect_cc_file_lists(cc_file_lists),
+        cc_file_list = combine_cc_file_lists(cc_file_lists),
     )
 
 # Implementation for cc_dist_library rule.

--- a/pkg/file_list_aspects.bzl
+++ b/pkg/file_list_aspects.bzl
@@ -1,0 +1,218 @@
+# Aspect to collect srcs from rules.
+#
+# Most rule types have providers for outputs (e.g., `cc_library` ->
+# CcInfo), but not for inputs. There are cases where we want access to the
+# sources, such as generating a list of sources for other build systems.
+#
+# This file contains Starlark aspects which will collect sources from rules
+# and provide them through providers:
+#
+#   * cc_file_list_aspect (provides CcFileList)
+#   * proto_file_list_aspect (provides ProtoFileList)
+#
+# These are intended to work on direct targets, not transitive targets. (As
+# an exception, `cc_file_list_aspect` will expand `test_suite` rules
+# recursively.)
+
+def _flatten_target_files(targets):
+    return depset(transitive = [target.files for target in targets])
+
+################################################################################
+# C++ source file/header support
+################################################################################
+
+CcFileList = provider(
+    doc = "List of files to be built into a library.",
+    fields = {
+        # As a rule of thumb, `hdrs` and `textual_hdrs` are the files that
+        # would be installed along with a prebuilt library.
+        "hdrs": "public header files, including those used by generated code",
+        "textual_hdrs": "files which are included but are not self-contained",
+
+        # The `internal_hdrs` are header files which appear in `srcs`.
+        # These are only used when compiling the library.
+        "internal_hdrs": "internal header files (only used to build .cc files)",
+        "srcs": "source files",
+    },
+)
+
+def _extract_cc_file_list_from_cc_rule(rule_attr):
+    # CcInfo is a proxy for what we expect this rule to look like.
+    # However, some deps may expose `CcInfo` without having `srcs`,
+    # `hdrs`, etc., so we use `getattr` to handle that gracefully.
+
+    internal_hdrs = []
+    srcs = []
+
+    # Filter `srcs` so it only contains source files. Headers will go
+    # into `internal_headers`.
+    for src in _flatten_target_files(getattr(rule_attr, "srcs", [])).to_list():
+        if src.extension.lower() in ["c", "cc", "cpp", "cxx"]:
+            srcs.append(src)
+        else:
+            internal_hdrs.append(src)
+
+    return CcFileList(
+        hdrs = _flatten_target_files(getattr(rule_attr, "hdrs", [])),
+        textual_hdrs = _flatten_target_files(getattr(
+            rule_attr,
+            "textual_hdrs",
+            [],
+        )),
+        internal_hdrs = depset(internal_hdrs),
+        srcs = depset(srcs),
+    )
+
+def combine_cc_file_lists(cc_file_lists):
+    """Combine several CcFileLists into a single one."""
+
+    # The returned CcFileList will contain depsets of the deps' file lists.
+    # These lists hold `depset()`s from each of `deps`.
+    srcs = []
+    hdrs = []
+    internal_hdrs = []
+    textual_hdrs = []
+
+    for cfl in cc_file_lists:
+        srcs.append(cfl.srcs)
+        hdrs.append(cfl.hdrs)
+        internal_hdrs.append(cfl.internal_hdrs)
+        textual_hdrs.append(cfl.textual_hdrs)
+
+    return CcFileList(
+        srcs = depset(transitive = srcs),
+        hdrs = depset(transitive = hdrs),
+        internal_hdrs = depset(transitive = internal_hdrs),
+        textual_hdrs = depset(transitive = textual_hdrs),
+    )
+
+def _extract_cc_file_list_from_test_suite(target, rule_attr):
+    transitive = []
+
+    for dep in getattr(rule_attr, "tests", []):
+        transitive.append(dep[CcFileList])
+
+    # Test suites can list tests explicitly, or they can implicitly
+    # expand to "all tests in this package." In the latter case, Bazel
+    # exposes the implicit tests via the internal attribute
+    # `_implicit_tests`.
+    #
+    # Unfortunately, these attrs are currently (as of Bazel 5) the only
+    # way to get the lists of tests, but this might change in the
+    # future (c.f.: https://github.com/bazelbuild/bazel/issues/14993).
+    for dep in getattr(rule_attr, "_implicit_tests", []):
+        if CcFileList in dep:
+            transitive.append(dep[CcFileList])
+
+    if not transitive:
+        # We are reaching into Bazel-internal attributes, which have no
+        # guarantee that they won't change. If we end up with no tests,
+        # print a warning.
+        print(("WARNING: no tests were found in test_suite %s. If there " +
+               "are no tests in package %s, consider removing the " +
+               "test_suite. (Otherwise, this could be due to a bug " +
+               "in gen_file_lists.)") %
+              (target.label, target.label.package))
+
+    return combine_cc_file_lists(transitive)
+
+def _cc_file_list_aspect_impl(target, ctx):
+    # Special case: if this is a test_suite, collect the CcFileLists from
+    # its tests.
+    if ctx.rule.kind == "test_suite":
+        return [_extract_cc_file_list_from_test_suite(target, ctx.rule.attr)]
+
+    # Extract sources from a `cc_library` (or similar):
+    if CcInfo in target:
+        return [_extract_cc_file_list_from_cc_rule(ctx.rule.attr)]
+
+    return []
+
+cc_file_list_aspect = aspect(
+    doc = """
+Aspect to provide the list of sources and headers from a rule.
+
+Output is CcFileList. Example:
+
+  cc_library(
+      name = "foo",
+      srcs = [
+          "foo.cc",
+          "foo_internal.h",
+      ],
+      hdrs = ["foo.h"],
+      textual_hdrs = ["foo_inl.inc"],
+  )
+  # produces:
+  # CcFileList(
+  #     hdrs = depset([File("foo.h")]),
+  #     textual_hdrs = depset([File("foo_inl.inc")]),
+  #     internal_hdrs = depset([File("foo_internal.h")]),
+  #     srcs = depset([File("foo.cc")]),
+  # )
+""",
+    implementation = _cc_file_list_aspect_impl,
+
+    # Allow propagation for test_suite rules:
+    attr_aspects = ["tests", "_implicit_tests"],
+)
+
+################################################################################
+# Proto sources and generated file/header support
+################################################################################
+
+ProtoFileList = provider(
+    doc = "List of proto files and generated code to be built into a library.",
+    fields = {
+        # Proto files:
+        "proto_srcs": "proto file sources",
+
+        # Generated sources:
+        "hdrs": "header files that are expected to be generated",
+        "srcs": "source files that are expected to be generated",
+    },
+)
+
+def _proto_file_list_aspect_impl(target, ctx):
+    # We're going to reach directly into the attrs on the traversed rule.
+    rule_attr = ctx.rule.attr
+    providers = []
+
+    # Extract sources from a `proto_library`:
+    if ProtoInfo in target:
+        proto_srcs = []
+        srcs = []
+        hdrs = []
+        for src in _flatten_target_files(rule_attr.srcs):
+            proto_srcs.append(src)
+            srcs.append("%s/%s.pb.cc" % (src.dirname, src.basename))
+            hdrs.append("%s/%s.pb.h" % (src.dirname, src.basename))
+
+        providers.append(ProtoFileList(
+            proto_srcs = proto_srcs,
+            srcs = srcs,
+            hdrs = hdrs,
+        ))
+
+    return providers
+
+proto_file_list_aspect = aspect(
+    doc = """
+Aspect to provide the list of sources and headers from a rule.
+
+Output is a ProtoFileList. Example:
+
+  proto_library(
+      name = "bar_proto",
+      srcs = ["bar.proto"],
+  )
+  # produces:
+  # ProtoFileList(
+  #     proto_srcs = ["bar.proto"],
+  #     # Generated filenames are synthesized:
+  #     hdrs = ["bar.pb.h"],
+  #     srcs = ["bar.pb.cc"],
+  # )
+""",
+    implementation = _proto_file_list_aspect_impl,
+)

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -759,6 +759,7 @@ cc_test(
             "-Wno-error=sign-compare",
         ],
     }),
+    visibility = ["//pkg:__pkg__"],
     deps = [
         ":protobuf",
         ":lite_test_util",
@@ -771,6 +772,7 @@ cc_test(
 cc_test(
     name = "lite_unittest",
     srcs = ["lite_unittest.cc"],
+    visibility = ["//pkg:__pkg__"],
     deps = [
         ":cc_lite_test_protos",
         ":protobuf",
@@ -1105,11 +1107,5 @@ pkg_files(
 test_suite(
     name = "full_tests",
     tags = ["-lite"],
-    visibility = ["//pkg:__pkg__"],
-)
-
-test_suite(
-    name = "lite_tests",
-    tags = ["lite"],
     visibility = ["//pkg:__pkg__"],
 )

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -1101,3 +1101,15 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(
+    name = "full_tests",
+    tags = ["-lite"],
+    visibility = ["//pkg:__pkg__"],
+)
+
+test_suite(
+    name = "lite_tests",
+    tags = ["lite"],
+    visibility = ["//pkg:__pkg__"],
+)

--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -295,3 +295,19 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(name = "package_tests")
+
+test_suite(
+    name = "tests",
+    tests = [
+        ":package_tests",
+        "//src/google/protobuf/compiler/cpp:tests",
+        "//src/google/protobuf/compiler/csharp:tests",
+        "//src/google/protobuf/compiler/java:tests",
+        "//src/google/protobuf/compiler/objectivec:tests",
+        "//src/google/protobuf/compiler/python:tests",
+        "//src/google/protobuf/compiler/ruby:tests",
+    ],
+    visibility = ["//pkg:__pkg__"],
+)

--- a/src/google/protobuf/compiler/cpp/BUILD.bazel
+++ b/src/google/protobuf/compiler/cpp/BUILD.bazel
@@ -202,3 +202,8 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(
+    name = "tests",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/csharp/BUILD.bazel
+++ b/src/google/protobuf/compiler/csharp/BUILD.bazel
@@ -107,3 +107,8 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(
+    name = "tests",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/java/BUILD.bazel
+++ b/src/google/protobuf/compiler/java/BUILD.bazel
@@ -124,3 +124,8 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(
+    name = "tests",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/objectivec/BUILD.bazel
+++ b/src/google/protobuf/compiler/objectivec/BUILD.bazel
@@ -70,3 +70,8 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(
+    name = "tests",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/python/BUILD.bazel
+++ b/src/google/protobuf/compiler/python/BUILD.bazel
@@ -54,3 +54,8 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(
+    name = "tests",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/compiler/ruby/BUILD.bazel
+++ b/src/google/protobuf/compiler/ruby/BUILD.bazel
@@ -59,3 +59,8 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(
+    name = "tests",
+    visibility = ["//src/google/protobuf/compiler:__pkg__"],
+)

--- a/src/google/protobuf/io/BUILD.bazel
+++ b/src/google/protobuf/io/BUILD.bazel
@@ -145,3 +145,8 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(
+    name = "tests",
+    visibility = ["//pkg:__pkg__"],
+)

--- a/src/google/protobuf/stubs/BUILD.bazel
+++ b/src/google/protobuf/stubs/BUILD.bazel
@@ -136,3 +136,8 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(
+    name = "tests",
+    visibility = ["//:__subpackages__"],
+)

--- a/src/google/protobuf/util/BUILD.bazel
+++ b/src/google/protobuf/util/BUILD.bazel
@@ -281,3 +281,14 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(name = "package_tests")
+
+test_suite(
+    name = "tests",
+    tests = [
+        ":package_tests",
+        "//src/google/protobuf/util/internal:tests",
+    ],
+    visibility = ["//pkg:__pkg__"],
+)

--- a/src/google/protobuf/util/internal/BUILD.bazel
+++ b/src/google/protobuf/util/internal/BUILD.bazel
@@ -448,3 +448,8 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//src:__pkg__"],
 )
+
+test_suite(
+    name = "tests",
+    visibility = ["//src/google/protobuf/util:__pkg__"],
+)


### PR DESCRIPTION
This allows `cc_dist_library` to get the tests from a `test_suite`.
Unlike the behavior of `cc_dist_library` with `cc_library`, this is
done recursively, by propagating the aspect along the `test_suite`
structure (which is different from `deps`).

The upshot is that we can now use `cc_dist_library` to build lists of
input sources for tests, similar to how it already does this for
cc_library targets.