### PR TITLE
Revert "Fix cmake install targets (#9822)"

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -128,20 +128,24 @@ configure_file(${protobuf_SOURCE_DIR}/cmake/protobuf-options.cmake
 if (protobuf_BUILD_PROTOC_BINARIES)
   export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
     NAMESPACE protobuf::
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/protobuf/protobuf-targets.cmake
+    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
   )
 else (protobuf_BUILD_PROTOC_BINARIES)
   export(TARGETS libprotobuf-lite libprotobuf
     NAMESPACE protobuf::
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/protobuf/protobuf-targets.cmake
+    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
   )
 endif (protobuf_BUILD_PROTOC_BINARIES)
 
 install(EXPORT protobuf-targets
-  FILE protobuf-targets.cmake
   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
   NAMESPACE protobuf::
+  COMPONENT protobuf-export)
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/
+  DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
   COMPONENT protobuf-export
+  PATTERN protobuf-targets.cmake EXCLUDE
 )
 
 option(protobuf_INSTALL_EXAMPLES "Install the examples folder" OFF)


### PR DESCRIPTION
This reverts commit c80808ce1defa4a6f02ceba8e1415b0bcdd068fd.

Thix fixes #10045. Somehow the change caused these four .cmake files to
stop being installed:

protobuf-config.cmake
protobuf-config-version.cmake
protobuf-module.cmake
protobuf-options.cmake

After reverting the change, I confirmed that the files are being
installed again.