### PR TITLE
[Bazel] Add back a filegroup for :well_known_protos.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -128,6 +128,22 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+# Source protos that are typically part of the protobuf runtime.
+#
+# DEPRECATED: Prefer :well_known_type_protos for the Well-Known Types
+# (https://developers.google.com/protocol-buffers/docs/reference/google.protobuf)
+# or :descriptor_proto(_srcs) for descriptor.proto (source), or
+# :compiler_plugin_proto for compiler/plugin.proto.
+filegroup(
+    name = "well_known_protos",
+    srcs = [
+        ":descriptor_proto_srcs",
+        ":well_known_type_protos",
+    ],
+    deprecation = "Prefer :well_known_type_protos instead.",
+    visibility = ["//visibility:public"],
+)
+
 ################################################################################
 # Protocol Buffers Compiler
 ################################################################################

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -139,6 +139,7 @@ filegroup(
     srcs = [
         ":descriptor_proto_srcs",
         ":well_known_type_protos",
+        "//src/google/protobuf/compiler:plugin.proto",
     ],
     deprecation = "Prefer :well_known_type_protos instead.",
     visibility = ["//visibility:public"],

--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -146,9 +146,13 @@ filegroup(
         "plugin.proto",
     ],
     visibility = [
-        "//:__pkg__",
         "//src/google/protobuf/compiler/cpp:__pkg__",
     ],
+)
+
+exports_files(
+    srcs = ["plugin.proto"],
+    visibility = ["//:__pkg__"],
 )
 
 cc_library(

--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -146,6 +146,7 @@ filegroup(
         "plugin.proto",
     ],
     visibility = [
+        "//:__pkg__",
         "//src/google/protobuf/compiler/cpp:__pkg__",
     ],
 )


### PR DESCRIPTION
This target was removed in #9915, since it is misleadingly named (the set of sources is somehow notionally "well known," but it is not the set sources for the Well-Known Types).