### PR TITLE
Fix continuous aarch64 builds

### DIFF
--- a/kokoro/linux/aarch64/protoc_crosscompile_aarch64.sh
+++ b/kokoro/linux/aarch64/protoc_crosscompile_aarch64.sh
@@ -6,3 +6,6 @@ set -ex
 
 cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_WITH_ZLIB=0 .
 make -j8
+
+# The Java build setup expects the protoc binary to be in the src/ directory.
+ln -s $PWD/protoc ./src/protoc


### PR DESCRIPTION
Some of the continuous aarch64 builds started failing yesterday because
the autotools -> CMake change caused the protoc binary to end up in an
unexpected location. This change fixes the problem by putting a symlink
in the src/ directory.