### PR TITLE
Several Fixes for Protobuf Python Code Generation

### DIFF
--- a/python/protobuf_distutils/setup.py
+++ b/python/protobuf_distutils/setup.py
@@ -42,7 +42,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='protobuf_distutils',
-    version='1.0',
+    version='1.1.0',
     packages=find_packages(),
     maintainer='protobuf@googlegroups.com',
     maintainer_email='protobuf@googlegroups.com',
@@ -53,12 +53,10 @@ setup(
         # These Python versions should match the protobuf package:
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Code Generators",
     ],
     description=('This is a distutils extension to generate Python code for '


### PR DESCRIPTION
* Use `pathlib` instead of `glob`
* Remove deprecated `distutils` package in favour of the `setuptools` API (see PEP-632)
* fix recursive lookup of `proto` files
* Increment version to 1.1.0.