### PR TITLE
Revert third party/benchmark commit from Piper integrate and add ignore=dirty to submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "third_party/benchmark"]
 	path = third_party/benchmark
 	url = https://github.com/google/benchmark.git
+        ignore = dirty
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
* Reverts change updating commit for //third_party/benchmark from #10103
* Add ignore = dirty (https://git-scm.com/docs/gitmodules/2.9.5#Documentation/gitmodules.txt-submoduleltnamegtignore)