### PR TITLE
Add -Wundef to our Bazel build flags

### DIFF
--- a/kokoro/linux/bazel/build.sh
+++ b/kokoro/linux/bazel/build.sh
@@ -21,6 +21,7 @@ bazel_args=(
   test
   --keep_going
   --copt=-Werror
+  --copt=-Wundef
   --host_copt=-Werror
   --test_output=errors
   --


### PR DESCRIPTION
This should help prevent future warnings like the one being fixed in #10107.