### PR TITLE
Fix the crash in the ThreadLocalStorage class

### DIFF
--- a/src/google/protobuf/arena_impl.h
+++ b/src/google/protobuf/arena_impl.h
@@ -602,7 +602,11 @@ class PROTOBUF_EXPORT ThreadSafeArena {
 #ifdef _MSC_VER
 #pragma warning(disable : 4324)
 #endif
+#ifdef __cpp_aligned_new
   struct alignas(64) ThreadCache {
+#else
+  struct ThreadCache {
+#endif
 #if defined(GOOGLE_PROTOBUF_NO_THREADLOCAL)
     // If we are using the ThreadLocalStorage class to store the ThreadCache,
     // then the ThreadCache's default constructor has to be responsible for


### PR DESCRIPTION
Fix the crash that occurs due to unaligned memory access (SIGBUS) on
the aligned structure. The crash occurs on certain android devices
only in the release mode (armeabi-v7 32 bit, 23.0.7599858 ndk).

Signed-off-by: Mykhailo Kuchma <mykhailo.kuchma@gmail.com>