### PR TITLE
Make //:protobuf_python and //:well_known_types_py_pb2 public.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -929,7 +929,7 @@ py_proto_library(
     default_runtime = "",
     protoc = ":protoc",
     srcs_version = "PY2AND3",
-    visibility = ["@upb//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(
@@ -941,6 +941,7 @@ py_library(
             ":python/google/protobuf/pyext/_message.so",
         ],
     }),
+    visibility = ["//visibility:public"],
     deps = [
         ":python_srcs",
         ":well_known_types_py_pb2",


### PR DESCRIPTION
These targets form the public interface of the Python protocol buffer support
and must always be public.  It looks like commit
a6901f057e43b3b5c8079a5dac6165c5a8e9d427 accidentally restricted their
visibility.