### PR TITLE
Protobuf bytes field decoding allocates extra memory bytes field is …

### DIFF
--- a/src/google/protobuf/io/coded_stream.cc
+++ b/src/google/protobuf/io/coded_stream.cc
@@ -286,6 +286,8 @@ bool CodedInputStream::ReadStringFallback(std::string* buffer, int size) {
     if (bytes_to_limit > 0 && size > 0 && size <= bytes_to_limit) {
       buffer->reserve(size);
     }
+  } else {
+    buffer->reserve(size);
   }
 
   int current_buffer_size;


### PR DESCRIPTION
Protobuf decoding allocates extra memory when bytes field is decoded to c++ string