### PR TITLE
Clean up some warnings

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_file.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.cc
@@ -145,9 +145,9 @@ FileGenerator::CommonState::CollectMinimalFileDepsContainingExtensionsInternal(
     return it->second;
   }
 
-  std::set<const FileDescriptor*> min_deps_collector;
-  std::set<const FileDescriptor*> covered_deps_collector;
-  std::set<const FileDescriptor*> to_prune;
+  std::unordered_set<const FileDescriptor*> min_deps_collector;
+  std::unordered_set<const FileDescriptor*> covered_deps_collector;
+  std::unordered_set<const FileDescriptor*> to_prune;
   for (int i = 0; i < file->dependency_count(); i++) {
     const FileDescriptor* dep = file->dependency(i);
     MinDepsEntry dep_info =
@@ -180,7 +180,7 @@ FileGenerator::CommonState::CollectMinimalFileDepsContainingExtensionsInternal(
         {file, {file_has_exts, min_deps_collector, covered_deps_collector}}).first->second;
   }
 
-  std::set<const FileDescriptor*> min_deps;
+  std::unordered_set<const FileDescriptor*> min_deps;
   std::copy_if(min_deps_collector.begin(), min_deps_collector.end(),
                std::inserter(min_deps, min_deps.end()),
                [&](const FileDescriptor* value){
@@ -202,7 +202,7 @@ FileGenerator::CommonState::CollectMinimalFileDepsContainingExtensionsInternal(
 const std::vector<const FileDescriptor*>
 FileGenerator::CommonState::CollectMinimalFileDepsContainingExtensions(
     const FileDescriptor* file) {
-  std::set<const FileDescriptor*> min_deps =
+  std::unordered_set<const FileDescriptor*> min_deps =
     CollectMinimalFileDepsContainingExtensionsInternal(file).min_deps;
   // Sort the list since pointer order isn't stable across runs.
   std::vector<const FileDescriptor*> result(min_deps.begin(), min_deps.end());

--- a/src/google/protobuf/compiler/objectivec/objectivec_file.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.h
@@ -71,13 +71,13 @@ class FileGenerator {
    private:
     struct MinDepsEntry {
       bool has_extensions;
-      std::set<const FileDescriptor*> min_deps;
+      std::unordered_set<const FileDescriptor*> min_deps;
       // `covered_deps` are the transtive deps of `min_deps_w_exts` that also
       // have extensions.
-      std::set<const FileDescriptor*> covered_deps;
+      std::unordered_set<const FileDescriptor*> covered_deps;
     };
     const MinDepsEntry& CollectMinimalFileDepsContainingExtensionsInternal(const FileDescriptor* file);
-    std::map<const FileDescriptor*, MinDepsEntry> deps_info_cache_;
+    std::unordered_map<const FileDescriptor*, MinDepsEntry> deps_info_cache_;
   };
 
   FileGenerator(const FileDescriptor* file,

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -83,7 +83,7 @@ bool BoolFromEnvVar(const char* env_var, bool default_value) {
 
 class SimpleLineCollector : public LineConsumer {
  public:
-  SimpleLineCollector(std::unordered_set<std::string>* inout_set)
+  explicit SimpleLineCollector(std::unordered_set<std::string>* inout_set)
       : set_(inout_set) {}
 
   virtual bool ConsumeLine(const StringPiece& line, std::string* out_error) override {

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers_unittest.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers_unittest.cc
@@ -244,7 +244,7 @@ TEST(ObjCHelperDeathTest, TextFormatDecodeData_Failures) {
 
 class TestLineCollector : public LineConsumer {
  public:
-  TestLineCollector(std::vector<std::string>* inout_lines,
+  explicit TestLineCollector(std::vector<std::string>* inout_lines,
                     const std::string* reject_line = nullptr,
                     bool skip_msg = false)
     : lines_(inout_lines), reject_(reject_line), skip_msg_(skip_msg) {}


### PR DESCRIPTION
Move to explicit on single arg c'tors.
Move to unordered container types when working with pointers as order is likely unnecessary and just a performance issue.