### PR TITLE
Correct file extention of README

### DIFF
--- a/examples/AddPerson.java
+++ b/examples/AddPerson.java
@@ -1,4 +1,4 @@
-// See README.txt for information and build instructions.
+// See README.md for information and build instructions.
 
 import com.example.tutorial.protos.AddressBook;
 import com.example.tutorial.protos.Person;

--- a/examples/ListPeople.java
+++ b/examples/ListPeople.java
@@ -1,4 +1,4 @@
-// See README.txt for information and build instructions.
+// See README.md for information and build instructions.
 
 import com.example.tutorial.protos.AddressBook;
 import com.example.tutorial.protos.Person;

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-# See README.txt.
+# See README.md.
 
 .PHONY: all cpp java python clean
 

--- a/examples/add_person.cc
+++ b/examples/add_person.cc
@@ -1,4 +1,4 @@
-// See README.txt for information and build instructions.
+// See README.md for information and build instructions.
 
 #include <ctime>
 #include <fstream>

--- a/examples/add_person.py
+++ b/examples/add_person.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# See README.txt for information and build instructions.
+# See README.md for information and build instructions.
 
 import addressbook_pb2
 import sys

--- a/examples/addressbook.proto
+++ b/examples/addressbook.proto
@@ -1,4 +1,4 @@
-// See README.txt for information and build instructions.
+// See README.md for information and build instructions.
 //
 // Note: START and END tags are used in comments to define sections used in
 // tutorials.  They are not part of the syntax for Protocol Buffers.

--- a/examples/list_people.cc
+++ b/examples/list_people.cc
@@ -1,4 +1,4 @@
-// See README.txt for information and build instructions.
+// See README.md for information and build instructions.
 
 #include <fstream>
 #include <google/protobuf/util/time_util.h>

--- a/examples/list_people.py
+++ b/examples/list_people.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# See README.txt for information and build instructions.
+# See README.md for information and build instructions.
 
 from __future__ import print_function
 import addressbook_pb2


### PR DESCRIPTION
It should be `README.md` instead of `README.txt` in the `examples` directory.