### PR TITLE
Don't fail for identical ExtensionInfo registration

### DIFF
--- a/src/google/protobuf/extension_set.cc
+++ b/src/google/protobuf/extension_set.cc
@@ -121,7 +121,7 @@ void Register(const ExtensionInfo& info) {
   static auto local_static_registry = OnShutdownDelete(new ExtensionRegistry);
   global_registry = local_static_registry;
   auto existing = local_static_registry->insert(info);
-  if (!existing.second && IsDifferent(existing.first, info)) {
+  if (!existing.second && IsDifferent(*existing.first, info)) {
       GOOGLE_LOG(FATAL) << "Multiple extension registrations for type \""
         << info.message->GetTypeName() << "\", field number "
         << info.number << ".";

--- a/src/google/protobuf/extension_set.cc
+++ b/src/google/protobuf/extension_set.cc
@@ -112,7 +112,7 @@ static const ExtensionRegistry* global_registry = nullptr;
 // Separate from ExtensionEq since we do a complete comparison.
 bool IsDifferent(const ExtensionInfo& a, const ExtensionInfo& b) {
   return std::tie(a.message, a.number, a.type, a.is_repeated, a.is_packed) != 
-         std::tie(b.number, b.type, b.is_repeated, b.is_packed);
+         std::tie(b.message, b.number, b.type, b.is_repeated, b.is_packed);
 }
 
 // This function is only called at startup, so there is no need for thread-


### PR DESCRIPTION
Fixes https://github.com/protocolbuffers/protobuf/issues/7826 and https://github.com/protocolbuffers/protobuf/issues/6029

Linking against a protobuf translation unit (`.pb.o`) more than once can cause this error. Currently there is no real workaround. 

See https://github.com/protocolbuffers/protobuf/issues/6029 for an example of how this problem can happen