### PR TITLE
Length check accommodates NUL emitted by sprintf

### DIFF
--- a/src/google/protobuf/stubs/strutil.cc
+++ b/src/google/protobuf/stubs/strutil.cc
@@ -501,7 +501,9 @@ int CEscapeInternal(const char* src, int src_len, char* dest,
         if ((!utf8_safe || static_cast<uint8_t>(*src) < 0x80) &&
             (!isprint(*src) ||
              (last_hex_escape && isxdigit(*src)))) {
-          if (dest_len - used < 4) // need space for 4 letter escape
+          // need space for 4 letter escape and the trailing '\0' to
+          // be written by snprintf.
+          if (dest_len - used < 5)
             return -1;
           snprintf(dest + used, 5, (use_hex ? "\\x%02x" : "\\%03o"),
                   static_cast<uint8_t>(*src));


### PR DESCRIPTION
Update the length check in google::protobuf::CEscapeInternal to account
for the extra NUL character emitted by snprintf when escaping hex and
octal sequences.

That function is an internal detail, not exported via any header.
Internally, it is used in two places, and both calls make buffers
that do have space for the extra NUL.
So in the actual usage, the check is redundant.