### PR TITLE
Add Ballerina gRPC `ballerina_package` file option to global extension registry

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -328,3 +328,7 @@ with info about your project (name and website) so we can add an entry for you.
 1. Protoc-gen-xo
    * Website: https://github.com/xo/ecosystem
    * Extension: 1147
+
+1. Ballerina gRPC
+   * Website: https://github.com/ballerina-platform/module-ballerina-grpc
+   * Extension: 1148


### PR DESCRIPTION
This PR reserves the extension number 1148
The related `FileOptions` file can be found in [here](https://github.com/ballerina-platform/module-ballerina-grpc/blob/master/native/src/main/resources/ballerina/protobuf/descriptor.proto)

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/2798