### PR TITLE
Adjust editor config to reflect cast conventions in C# libraries

### DIFF
--- a/csharp/.editorconfig
+++ b/csharp/.editorconfig
@@ -15,3 +15,6 @@ tab_width = 4
 end_of_line = lf
 insert_final_newline = false
 trim_trailing_whitespace = true
+
+[*.cs]
+csharp_space_after_cast = true


### PR DESCRIPTION
Most of our code includes a space after the cast, e.g. `(int) x`
instead of `(int)x`. This .editorconfig change means that will be
the default formatting when it's performed by the editor.

cc @erikma who encountered this in #10105.