### PR TITLE
Fix python link to install packages

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -33,7 +33,7 @@ Installation
 2) If you do not have setuptools installed, note that it will be
    downloaded and installed automatically as soon as you run `setup.py`.
    If you would rather install it manually, you may do so by following
-   the instructions on [this page](https://packaging.python.org/en/latest/installing.html#setup-for-installing-packages).
+   the instructions on [this page](https://packaging.python.org/en/latest/tutorials/installing-packages/).
 
 3) Build the C++ code, or install a binary distribution of `protoc`.  If
    you install a binary distribution, make sure that it is the same


### PR DESCRIPTION
Update old python link to new one identified by this PR: https://github.com/protocolbuffers/protobuf/pull/10177