### PR TITLE
Add protoc pom file to java directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -590,6 +590,7 @@ java_EXTRA_DIST=                                                                
   java/lite/src/test/java/com/google/protobuf/LiteTest.java                        \
   java/BUILD.bazel                                                                 \
   java/pom.xml                                                                     \
+  java/protoc/pom.xml                                                              \
   java/util/BUILD.bazel                                                            \
   java/util/pom.xml                                                                \
   java/util/pom_template.xml                                                       \

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -33,6 +33,7 @@ pkg_files(
         "bom/pom.xml",
         "lite.md",
         "pom.xml",
+        "protoc/pom.xml",
     ],
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//pkg:__pkg__"],

--- a/java/protoc/pom.xml
+++ b/java/protoc/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google</groupId>
+    <artifactId>google</artifactId>
+    <version>1</version>
+  </parent>
+  <groupId>com.google.protobuf</groupId>
+  <artifactId>protoc</artifactId>
+  <version>3.21.2-rc1</version>
+  <packaging>pom</packaging>
+  <name>Protobuf Compiler</name>
+  <description>
+    Protobuf Compiler (protoc) is a compiler for .proto files. It generates
+    language-specific code for Protobuf messages and RPC interfaces.
+  </description>
+  <inceptionYear>2008</inceptionYear>
+  <url>https://developers.google.com/protocol-buffers/</url>
+  <licenses>
+    <license>
+      <name>BSD-3-Clause</name>
+      <url>https://opensource.org/licenses/BSD-3-Clause</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>https://github.com/protocolbuffers/protobuf</url>
+    <connection>
+      scm:git:https://github.com/protocolbuffers/protobuf.git
+    </connection>
+  </scm>
+</project>


### PR DESCRIPTION
Add a copy of `protoc-artifacts/pom.xml` to the java folder to store all maven files inside the java directory. It no longer needs the maven build work since we will be doing those builds with bazel and uploads with gpg.

For now, `protoc-artifacts/pom.xml` will remain for a case where we need to do a point release before we have completed that shift.