### PR TITLE
Add explicit abort() at the end of AlignFail

### DIFF
--- a/src/google/protobuf/generated_message_tctable_impl.h
+++ b/src/google/protobuf/generated_message_tctable_impl.h
@@ -32,6 +32,7 @@
 #define GOOGLE_PROTOBUF_GENERATED_MESSAGE_TCTABLE_IMPL_H__
 
 #include <cstdint>
+#include <cstdlib>
 #include <type_traits>
 
 #include <google/protobuf/port.h>
@@ -262,11 +263,11 @@ enum FieldType : uint16_t {
 
 #ifndef NDEBUG
 template <size_t align>
-#ifndef _MSC_VER
-[[noreturn]]
-#endif
 void AlignFail(uintptr_t address) {
   GOOGLE_LOG(FATAL) << "Unaligned (" << align << ") access at " << address;
+
+  // Explicit abort to let compilers know this function does not return
+  abort();
 }
 
 extern template void AlignFail<4>(uintptr_t);


### PR DESCRIPTION
GCC cannot infer that `LogMessage::Finish()` (called indirectly by `GOOGLE_LOG(FAIL)` in `AlignFail`) exits program when `level_ == LOGLEVEL_FATAL`. Compilation will create a warning in projects importing the library for debug builds. The attribute cannot be individually assigned to `LogMessage::Finish()` because it does return conditionally of the log level. Tried with GCC 9.3.0 and GCC 12.1.0.

This change adds an explicit abort() for compiler to clearly understand this does not return, and enables `[[noreturn]]` for MSVC as well.

Closes #9758.