### PR TITLE
Change phpunit version to fix error

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -9,7 +9,7 @@
     "php": ">=7.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=5.0.0"
+    "phpunit/phpunit": "8.5.26"
   },
   "autoload": {
     "psr-4": {

--- a/php/composer.json
+++ b/php/composer.json
@@ -9,7 +9,7 @@
     "php": ">=7.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "8.5.26"
+    "phpunit/phpunit": ">=5.0.0 <8.5.27"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Our Linux 32-bit test has been failing because of a PHP error. This is coming from a bug in the most recent release of phpunit: https://github.com/sebastianbergmann/phpunit/issues/4997. Changing the version numbers to ensure we use a version released before the bug was introduced.

Other failures are unrelated and partially fixed by: https://github.com/protocolbuffers/protobuf/pull/10189.