### PR TITLE
Clean up mac PHP kokoro tests

### DIFF
--- a/kokoro/macos/php7.0_mac/build.sh
+++ b/kokoro/macos/php7.0_mac/build.sh
@@ -2,10 +2,24 @@
 #
 # Build file to set up and run tests
 
+set -eux
+
 # Change to repo root
 cd $(dirname $0)/../../..
 
 # Prepare worker environment to run tests
 source kokoro/macos/prepare_build_macos_rc
+
+brew tap shivammathur/php
+
+# Install dependencies.
+brew install \
+    shivammathur/php/php@7.3 \
+    composer
+
+# "Install" valgrind
+echo "#! /bin/bash" > valgrind
+chmod ug+x valgrind
+sudo mv valgrind /usr/local/bin/valgrind
 
 ./tests.sh php7.0_mac

--- a/kokoro/macos/php7.3_mac/build.sh
+++ b/kokoro/macos/php7.3_mac/build.sh
@@ -2,10 +2,24 @@
 #
 # Build file to set up and run tests
 
+set -eux
+
 # Change to repo root
 cd $(dirname $0)/../../..
 
 # Prepare worker environment to run tests
 source kokoro/macos/prepare_build_macos_rc
+
+brew tap shivammathur/php
+
+# Install dependencies.
+brew install \
+    shivammathur/php/php@7.3 \
+    composer
+
+# "Install" valgrind
+echo "#! /bin/bash" > valgrind
+chmod ug+x valgrind
+sudo mv valgrind /usr/local/bin/valgrind
 
 ./tests.sh php7.3_mac

--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -12,6 +12,9 @@ set -eux
 # "autom4te: need GNU m4 1.4 or later: /usr/bin/m4"
 # go/kokoro/userdocs/macos/selecting_xcode.md for more information.
 export DEVELOPER_DIR=/Applications/Xcode_11.3.app/Contents/Developer
+sudo xcode-select -s /Applications/Xcode_11.3.app/Contents/Developer
+#sudo rm -rf /Library/Developer/CommandLineTools
+#sudo xcode-select --install
 
 ##
 # Select C/C++ compilers
@@ -38,3 +41,12 @@ if [[ "${KOKORO_INSTALL_RVM:-}" == "yes" ]] ; then
   # GitHub. See this issue for details: https://github.com/rvm/rvm/issues/5133
   curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s master --ruby
 fi
+
+##
+# Install Homebrew
+mkdir homebrew && curl -L https://github.com/Homebrew/brew/tarball/2.2.12 | tar xz --strip 1 -C homebrew
+eval "$(homebrew/bin/brew shellenv)"
+brew update --force --quiet
+chmod -R go-w "$(brew --prefix)/share/zsh"
+brew tap --repair
+#brew doctor

--- a/php/README.md
+++ b/php/README.md
@@ -14,10 +14,7 @@ generation functionality.
 
 ## Requirements
 
-To use PHP runtime library requires:
-
-- C extension: PHP 7.x, 8.0
-- [PHP package](http://php.net/downloads.php): PHP 5.5, 5.6, 7.x, or 8.0.
+The PHP runtime library supports PHP versions from 7.0 on Linux and 7.2 on OS X.
 
 ## Installation
 
@@ -93,7 +90,7 @@ Known Issues
 * Map fields may not be garbage-collected if there is cycle reference.
 * No debug information for messages in c extension.
 * HHVM not tested.
-* C extension not tested on windows, mac, php 7.0.
+* C extension not tested on windows, mac.
 * Message name cannot be Empty.
 
 ## Development
@@ -127,13 +124,11 @@ composer test
 
 After you have finished testing the native php, you can test the c extension:
 ```
-cd tests
-./test.sh 5.6 # The php runtime version.
-              # We provide 5.5, 5.5-zts, 5.6, 5.6-zts, 7.0, 7.0-zts, 7.1, 7.1-zts, 7.2, 7.2-zts, 7.3 and 7.3-zts
-              # ls /usr/local for more details
+composer test_c
 ```
 
 If you want to use gdb to debug the c extension, you can do:
 ```
+cd tests
 ./gdb_test.sh
 ```

--- a/tests.sh
+++ b/tests.sh
@@ -492,45 +492,11 @@ build_php_c() {
 
 build_php7.0_mac() {
   internal_build_cpp
-  # Install PHP
-  curl -s https://php-osx.liip.ch/install.sh | bash -s 7.0
-  PHP_FOLDER=`find /usr/local -type d -name "php5-7.0*"`  # The folder name may change upon time
-  test ! -z "$PHP_FOLDER"
-  export PATH="$PHP_FOLDER/bin:$PATH"
-
-  # Install Composer
-  wget https://getcomposer.org/download/2.0.13/composer.phar --progress=dot:mega -O /usr/local/bin/composer
-  chmod a+x /usr/local/bin/composer
-
-  # Install valgrind
-  echo "#! /bin/bash" > valgrind
-  chmod ug+x valgrind
-  sudo mv valgrind /usr/local/bin/valgrind
-
-  # Test
   test_php_c
 }
 
 build_php7.3_mac() {
   internal_build_cpp
-  # Install PHP
-  # We can't test PHP 7.4 with these binaries yet:
-  #   https://github.com/liip/php-osx/issues/276
-  curl -s https://php-osx.liip.ch/install.sh | bash -s 7.3
-  PHP_FOLDER=`find /usr/local -type d -name "php5-7.3*"`  # The folder name may change upon time
-  test ! -z "$PHP_FOLDER"
-  export PATH="$PHP_FOLDER/bin:$PATH"
-
-  # Install Composer
-  wget https://getcomposer.org/download/2.0.13/composer.phar --progress=dot:mega -O /usr/local/bin/composer
-  chmod a+x /usr/local/bin/composer
-
-  # Install valgrind
-  echo "#! /bin/bash" > valgrind
-  chmod ug+x valgrind
-  sudo mv valgrind /usr/local/bin/valgrind
-
-  # Test
   test_php_c
 }
 


### PR DESCRIPTION
PHP 7.0 is no longer tested or explicitly supported, and we use homebrew to install 7.3 for the remaining test.