### PR TITLE
Fix maven pom files

### DIFF
--- a/java/protoc/pom.xml
+++ b/java/protoc/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>com.google.protobuf</groupId>
   <artifactId>protoc</artifactId>
-  <version>3.21.2-rc1</version>
+  <version>3.21.2</version>
   <packaging>pom</packaging>
   <name>Protobuf Compiler</name>
   <description>

--- a/java/util/pom_template.xml
+++ b/java/util/pom_template.xml
@@ -12,7 +12,8 @@
 
   <name>Protocol Buffers [Util]</name>
   <description>Utilities for Protocol Buffers</description>
-
-  {dependencies}
+  <dependencies>
+    {dependencies}
+  </dependencies>
 
 </project>


### PR DESCRIPTION
Add dependencies flag to pom template since java_export doesn't add the tag.

Change the new pom version to match the rest of the repository.