### PR TITLE
[SUGGESTED FIX] Fix conformance tests failing due to unexpected const qualifier

### DIFF
--- a/conformance/conformance_cpp.cc
+++ b/conformance/conformance_cpp.cc
@@ -232,7 +232,7 @@ util::StatusOr<bool> Harness::ServeConformanceRequest() {
 
   std::string serialized_input;
   serialized_input.resize(in_len);
-  RETURN_IF_ERROR(ReadFd(STDIN_FILENO, serialized_input.data(), in_len));
+  RETURN_IF_ERROR(ReadFd(STDIN_FILENO, const_cast<char*>(serialized_input.data()), in_len));
 
   ConformanceRequest request;
   GOOGLE_CHECK(request.ParseFromString(serialized_input));

--- a/conformance/conformance_cpp.cc
+++ b/conformance/conformance_cpp.cc
@@ -232,7 +232,7 @@ util::StatusOr<bool> Harness::ServeConformanceRequest() {
 
   std::string serialized_input;
   serialized_input.resize(in_len);
-  RETURN_IF_ERROR(ReadFd(STDIN_FILENO, const_cast<char*>(serialized_input.data()), in_len));
+  RETURN_IF_ERROR(ReadFd(STDIN_FILENO, &serialized_input[0], in_len));
 
   ConformanceRequest request;
   GOOGLE_CHECK(request.ParseFromString(serialized_input));


### PR DESCRIPTION
# Context
Conformance tests are failing on `main` when running `cd conformance && make test_cpp`.

These tests are also failing the conformance check pipelines on Swift Protobuf (https://github.com/apple/swift-protobuf) which led me here.

# Cause
It looks like the changes made in commit a3e1de01130aa665be3d559f69bbed8a487f2f9d introduced the issue by changing the `ReadFd` function signature from taking a `void *buf` parameter to a `char *buf` ([code here](https://github.com/protocolbuffers/protobuf/commit/a3e1de01130aa665be3d559f69bbed8a487f2f9d#diff-318b3d73ef3bbddd999e3f8c7ebd2ed9c11ec720b499460afeddbcf50c1d16ddR72)).
At the same time, one of the calls to the `ReadFd` function was changed to pass the return value of a call to `std::string.data()` ([code here](https://github.com/protocolbuffers/protobuf/commit/a3e1de01130aa665be3d559f69bbed8a487f2f9d#diff-318b3d73ef3bbddd999e3f8c7ebd2ed9c11ec720b499460afeddbcf50c1d16ddR235)) which is of type `const char*` ([cpp reference](https://cplusplus.com/reference/string/string/data/)).
However, `const char*` cannot be passed as a `char *` parameter due to the loss of the const qualifier.

# Proposed fix
Since the `ReadFd` function is read-only, the proposed fix is just to use the `const_cast` operator to erase the `const` qualifier.

# Failing tests logs
```cpp
conformance_cpp.cc:235:19: error: no matching function for call to 'ReadFd'
  RETURN_IF_ERROR(ReadFd(STDIN_FILENO, serialized_input.data(), in_len));
                  ^~~~~~
../src/google/protobuf/stubs/status_macros.h:58:10: note: expanded from macro 'RETURN_IF_ERROR'
        (expr);                                                              \
         ^~~~
conformance_cpp.cc:72:14: note: candidate function not viable: 2nd argument ('const std::basic_string<char>::value_type *' (aka 'const char *')) would lose const qualifier
util::Status ReadFd(int fd, char* buf, size_t len) {
             ^
1 error generated.
make: *** [conformance_cpp-conformance_cpp.o] Error 1
```