### PR TITLE
Cherry-pick composer fix

### DIFF
--- a/kokoro/linux/dockerfile/test/php_32bit/Dockerfile
+++ b/kokoro/linux/dockerfile/test/php_32bit/Dockerfile
@@ -47,8 +47,10 @@ RUN cd /var/local \
   && make install
 
 # Install composer
-RUN curl -sS https://getcomposer.org/installer | php
-RUN mv composer.phar /usr/local/bin/composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN php composer-setup.php
+RUN mv composer.phar /usr/bin/composer
+RUN php -r "unlink('composer-setup.php');"
 
 # Download php source code
 RUN git clone https://github.com/php/php-src

--- a/php/composer.json
+++ b/php/composer.json
@@ -9,7 +9,7 @@
     "php": ">=7.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=5.0.0"
+    "phpunit/phpunit": ">=5.0.0 <8.5.27"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Cherry-picking the commit from https://github.com/protocolbuffers/protobuf/pull/10222 to use the newest composer and applying the fix from https://github.com/protocolbuffers/protobuf/pull/10190/commits/8535efb3aa2b85ab691c78cd0f7769e9cb7abdc1 to cap the php unit version. This should fix the failing linux 32-bit test.