### PR TITLE
Issue #10198: Utility func in FieldMaskUtil.java to clear fields specified in FieldMask

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/FieldMaskTree.java
+++ b/java/util/src/main/java/com/google/protobuf/util/FieldMaskTree.java
@@ -256,6 +256,17 @@ final class FieldMaskTree {
     merge(root, source, destination, options);
   }
 
+  /**
+   * Merges all fields from {@code source} to {@code destination} except for fields specified by this FieldMaskTree
+   */
+  void mergeClear(Message source, Message.Builder destination) {
+    if (source.getDescriptorForType() != destination.getDescriptorForType()) {
+      throw new IllegalArgumentException("Cannot merge messages of different types.");
+    }
+    destination.mergeFrom(source);
+    merge(root, source, destination, new FieldMaskUtil.MergeOptions().setClearFields(true));
+  }
+
   /** Merges all fields specified by a sub-tree from {@code source} to {@code destination}. */
   private static void merge(
       Node node, Message source, Message.Builder destination, FieldMaskUtil.MergeOptions options) {
@@ -276,6 +287,10 @@ final class FieldMaskTree {
                 + entry.getKey()
                 + "\" in message type "
                 + descriptor.getFullName());
+        continue;
+      }
+      if (options.clearFields() && entry.getValue().children.isEmpty()) {
+        destination.clearField(field);
         continue;
       }
       if (!entry.getValue().children.isEmpty()) {
@@ -331,4 +346,5 @@ final class FieldMaskTree {
       }
     }
   }
+
 }

--- a/java/util/src/main/java/com/google/protobuf/util/FieldMaskUtil.java
+++ b/java/util/src/main/java/com/google/protobuf/util/FieldMaskUtil.java
@@ -312,6 +312,7 @@ public final class FieldMaskUtil {
     // TODO(b/28277137): change the default behavior to always replace primitive fields after
     // fixing all failing TAP tests.
     private boolean replacePrimitiveFields = false;
+    private boolean clearFields = false;
 
     /**
      * Whether to replace message fields (i.e., discard existing content in
@@ -336,6 +337,14 @@ public final class FieldMaskUtil {
      */
     public boolean replacePrimitiveFields() {
       return replacePrimitiveFields;
+    }
+
+    /**
+     * Whether to clear message fields (i.e., discard content in
+     * destination message fields).
+     */
+    boolean clearFields() {
+      return clearFields;
     }
 
     /**
@@ -380,6 +389,18 @@ public final class FieldMaskUtil {
       replacePrimitiveFields = value;
       return this;
     }
+
+    /**
+     * Specify whether to clear all fields specified in the mask. Defaults to false.
+     *
+     * <p>If true, copy all values from the source to the destination except those specified
+     * in the mask.
+     */
+    @CanIgnoreReturnValue
+    MergeOptions setClearFields(boolean value) {
+      clearFields = value;
+      return this;
+    }
   }
 
   /**
@@ -403,8 +424,19 @@ public final class FieldMaskUtil {
    */
   @SuppressWarnings("unchecked")
   public static <P extends Message> P trim(FieldMask mask, P source) {
-   Message.Builder destination = source.newBuilderForType();
+    Message.Builder destination = source.newBuilderForType();
     merge(mask, source, destination);
     return (P) destination.build();
   }
+
+  /**
+   * Returns the result of clearing all the masked fields of the given proto.
+   */
+  @SuppressWarnings("unchecked")
+  public static <P extends Message> P clear(FieldMask mask, P source) {
+    Message.Builder destination = source.newBuilderForType();
+    new FieldMaskTree(mask).mergeClear(source, destination);
+    return (P) destination.build();
+  }
+
 }

--- a/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/FieldMaskUtilTest.java
@@ -312,4 +312,31 @@ public class FieldMaskUtilTest {
                     TestAllTypes.newBuilder().setOptionalInt32(1234).setOptionalString("1234"))
                 .build());
   }
+
+  @Test
+  public void testClear() {
+    // Only test a simple case here and expect
+    // {@link FieldMaskTreeTest#testClear} to cover all scenarios.
+    TestAllTypes.Builder payload = TestAllTypes.newBuilder()
+        .setOptionalInt32(1234)
+        .setOptionalString("1234")
+        .setOptionalBool(true);
+    NestedTestAllTypes.Builder nestedChild = NestedTestAllTypes.newBuilder().setPayload(payload);
+    NestedTestAllTypes.Builder sourceBuilder = NestedTestAllTypes.newBuilder()
+        .setPayload(payload)
+        .setChild(nestedChild);
+    NestedTestAllTypes source = sourceBuilder.build();
+
+    FieldMask mask =
+        FieldMaskUtil.fromStringList(
+            ImmutableList.of("payload.optional_int32", "child.payload.optional_string"));
+
+    NestedTestAllTypes actual = FieldMaskUtil.clear(mask, source);
+
+    sourceBuilder.getPayloadBuilder().clearOptionalInt32();
+    sourceBuilder.getChildBuilder().getPayloadBuilder().clearOptionalString();
+    NestedTestAllTypes expected = sourceBuilder.build();
+
+    assertThat(actual).isEqualTo(expected);
+  }
 }


### PR DESCRIPTION
Hi,

I implemented a simple function on FieldMaskUtil to _clear_ the fields specified in the mask instead of "copy only these fields", as described in Issue #10198.

For this, I extended the existing recursive `FieldMaskTree.merge()` method using a `MergeOption.clearField`. This is of course covered by tests I deemed relevant.

I'm not 100% confident about my choice of method names, nor about any performance/waste issues in `destination.mergeFrom(source)`, nor about my decision to reuse and extend `FieldMaskTree.merge()` rather than copy+pasting+editing it.

I'd love to hear your thoughts.

Thanks!