### PR TITLE
Bugfix/issue 8101

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_generator_unittest.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_generator_unittest.cc
@@ -74,6 +74,22 @@ TEST(DescriptorProtoHelpers, IsDescriptorOptionMessage) {
   EXPECT_FALSE(IsDescriptorOptionMessage(DescriptorProto::descriptor()));
 }
 
+TEST(CSharpIdentifiers, UnderscoresToCamelCase) {
+	EXPECT_EQ("FooBar", UnderscoresToCamelCase("Foo_Bar", true));
+	EXPECT_EQ("fooBar", UnderscoresToCamelCase("FooBar", false));
+	EXPECT_EQ("foo123", UnderscoresToCamelCase("foo_123", false));
+	// remove leading underscores
+	EXPECT_EQ("Foo123", UnderscoresToCamelCase("_Foo_123", true));
+	// this one has slight unexpected output as it capitalises the first
+	// letter after consuming the underscores, but this was the existing
+	// behaviour so I have to changed it
+	EXPECT_EQ("FooBar", UnderscoresToCamelCase("___fooBar", false));
+	// leave a leading underscore for identifiers that would otherwise
+	// be invalid because they would start with a digit
+	EXPECT_EQ("_123Foo", UnderscoresToCamelCase("_123_foo", true));
+	EXPECT_EQ("_123Foo", UnderscoresToCamelCase("___123_foo", true));
+}
+
 }  // namespace
 }  // namespace csharp
 }  // namespace compiler

--- a/src/google/protobuf/compiler/csharp/csharp_generator_unittest.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_generator_unittest.cc
@@ -82,7 +82,7 @@ TEST(CSharpIdentifiers, UnderscoresToCamelCase) {
 	EXPECT_EQ("Foo123", UnderscoresToCamelCase("_Foo_123", true));
 	// this one has slight unexpected output as it capitalises the first
 	// letter after consuming the underscores, but this was the existing
-	// behaviour so I have to changed it
+	// behaviour so I have not changed it
 	EXPECT_EQ("FooBar", UnderscoresToCamelCase("___fooBar", false));
 	// leave a leading underscore for identifiers that would otherwise
 	// be invalid because they would start with a digit

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.cc
@@ -144,6 +144,7 @@ std::string UnderscoresToCamelCase(const std::string& input,
                                    bool cap_next_letter,
                                    bool preserve_period) {
   std::string result;
+
   // Note:  I distrust ctype.h due to locales.
   for (int i = 0; i < input.size(); i++) {
     if ('a' <= input[i] && input[i] <= 'z') {
@@ -176,6 +177,22 @@ std::string UnderscoresToCamelCase(const std::string& input,
   // Add a trailing "_" if the name should be altered.
   if (input.size() > 0 && input[input.size() - 1] == '#') {
     result += '_';
+  }
+
+  // https://github.com/protocolbuffers/protobuf/issues/8101
+  // To avoid generating invalid identifiers - if the input string
+  // starts with _<digit> (or multiple underscores then digit) then
+  // we need to preserve the underscore as an identifier cannot start
+  // with a digit.
+  // This check is being done after the loop rather than before
+  // to handle the case where there are multiple underscores before the
+  // first digit. We let them all be consumed so we can see if we would
+  // start with a digit.
+  // Note: not preserving leading underscores for all otherwise valid identifiers
+  // so as to not break anything that relies on the existing behaviour
+  if (result.size() > 0 && ('0' <= result[0] && result[0] <= '9') && input.size() > 0 && input[0] == '_')
+  {
+      result.insert(0, 1, '_');
   }
   return result;
 }

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.cc
@@ -190,7 +190,8 @@ std::string UnderscoresToCamelCase(const std::string& input,
   // start with a digit.
   // Note: not preserving leading underscores for all otherwise valid identifiers
   // so as to not break anything that relies on the existing behaviour
-  if (result.size() > 0 && ('0' <= result[0] && result[0] <= '9') && input.size() > 0 && input[0] == '_')
+  if (result.size() > 0 && ('0' <= result[0] && result[0] <= '9')
+      && input.size() > 0 && input[0] == '_')
   {
       result.insert(0, 1, '_');
   }


### PR DESCRIPTION
Fix for https://github.com/protocolbuffers/protobuf/issues/8101

When converting identifiers for C# camel case, handle the case where the input starts with "_&lt;digit&gt;" and preserve the underscore.

It does not alter existing behaviour for other identifiers:
- e.g. starts with "_&lt;alpha&gt;" - the underscore is consumed, so as to not break anything that relies on existing behaviour.
- e.g. input is already invalid (e.g. identifier starts with a digit) -  it does not try and fix it.

