### PR TITLE
Ruby: use a valid instance variable name for `descriptor`

### DIFF
--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -1398,5 +1398,5 @@ void Message_register(VALUE protobuf) {
   // Ruby-interned string: "descriptor". We use this identifier to store an
   // instance variable on message classes we create in order to link them back
   // to their descriptors.
-  descriptor_instancevar_interned = rb_intern("descriptor");
+  descriptor_instancevar_interned = rb_intern("@descriptor");
 }


### PR DESCRIPTION
Setting an instance variable without an `@` prefix makes it unacessible from the Ruby side, which prevent introspection by various tools.

I see no reason to prevent this.