### PR TITLE
Upgrade upb and update CHANGES.txt

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,12 +12,16 @@
     * Lookup operations now correctly reject unhashable types as map keys.
     * We implement repr() to use the same format as dict.
   * Fix maps to use the ScalarMapContainer class when appropriate
+  * Fix bug when parsing an unknown value in a proto2 enum extension (protocolbuffers/upb#717)
 
   PHP
   * Add "readonly" as a keyword for PHP and add previous classnames to descriptor pool (#10041)
 
   Python
   * Make //:protobuf_python and //:well_known_types_py_pb2 public (#10118)
+
+  Bazel
+  * Add back a filegroup for :well_known_protos (#10061)
 
 2022-06-27 version 21.2 (C++/Java/Python/PHP/Objective-C/C#/Ruby)
   C++

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -114,6 +114,6 @@ def protobuf_deps():
         _github_archive(
             name = "upb",
             repo = "https://github.com/protocolbuffers/upb",
-            commit = "dad71550bdf01fd057c9e284fb73c5ffc8098984",
-            sha256 = "47b0c810b5830cd7fe7388b4f540d6d25fe4e511beb3412e1f92e21079b48dec"
+            commit = "672d681f196f90c890a3b2e498e89d9a40541b9d",
+            sha256 = "2fcfee985893cebc4341d708eb8c2fa01d501ed97049040b7b94b2a2e6eccd25",
         )


### PR DESCRIPTION
This commit upgrades upb to the latest commit on its 21.x branch to pull
in this fix: https://github.com/protocolbuffers/upb/pull/717 I also
updated CHANGES.txt to reflect that fix and one other Bazel change.