### PR TITLE
Upgrade to com.google:google:5 for protoc artifact

### DIFF
--- a/java/protoc/pom.xml
+++ b/java/protoc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google</groupId>
     <artifactId>google</artifactId>
-    <version>1</version>
+    <version>5</version>
   </parent>
   <groupId>com.google.protobuf</groupId>
   <artifactId>protoc</artifactId>

--- a/protoc-artifacts/pom.xml
+++ b/protoc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google</groupId>
     <artifactId>google</artifactId>
-    <version>1</version>
+    <version>5</version>
   </parent>
   <groupId>com.google.protobuf</groupId>
   <artifactId>protoc</artifactId>


### PR DESCRIPTION
Protoc depeneds on com.google:google:1 which is unsigned. Which means users
the validate signatures have to add it to an allow list. Upgrading makes it no longer
necessary.

Compare:
https://repo1.maven.org/maven2/com/google/google/1
vs
https://repo1.maven.org/maven2/com/google/google/5