### PR TITLE
fix: PHP readonly legacy files for nested messages

### DIFF
--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -338,6 +338,7 @@ class GeneratedClassTest extends TestBase
     {
         $this->assertTrue(class_exists('\Upper\READONLY'));
         $this->assertTrue(class_exists('\Lower\readonly'));
+        $this->assertTrue(class_exists('\Php\Test\TestNamespace\PBEmpty\ReadOnly'));
     }
 
     public function testLegacyReadOnlyEnum()

--- a/php/tests/proto/test_php_namespace.proto
+++ b/php/tests/proto/test_php_namespace.proto
@@ -27,5 +27,7 @@ message TestNamespace {
     enum NestedEnum {
       ZERO = 0;
     };
+    // Test previously unreserved name
+    message ReadOnly {}
   }
 }


### PR DESCRIPTION
In #10041 we added escaping for PHP's `ReadOnly` keyword, but this misses writing the backwards compatibility file when the message is nested. For example, the file `Nested\ReadOnly.php` is not written for the proto `message nested { message readonly {} }`.

This fortunately should not cause any issues with existing users, as this file is only for compatibility, and without it, the previous message file remains (and works as expected). But as the previous `ReadOnly.php` throw a PHP fatal error on PHP 8.1, the result is that anyone upgrading to PHP 8.1 and still using the `ReadOnly` keyword will still receive a PHP fatal error.

This is an edge case, but still one we should fix.
