### PR TITLE
Create placeholders for windows cmake builds

### DIFF
--- a/kokoro/windows/cmake/build.bat
+++ b/kokoro/windows/cmake/build.bat
@@ -1,0 +1,4 @@
+@rem enter repo root
+cd /d %~dp0\..\..\..
+
+@rem TODO(mkruskal) Implement tests

--- a/kokoro/windows/cmake/continuous.cfg
+++ b/kokoro/windows/cmake/continuous.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/cmake/build.bat"
+timeout_mins: 1440

--- a/kokoro/windows/cmake/presubmit.cfg
+++ b/kokoro/windows/cmake/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/cmake/build.bat"
+timeout_mins: 1440

--- a/kokoro/windows/cmake_install/build.bat
+++ b/kokoro/windows/cmake_install/build.bat
@@ -1,0 +1,4 @@
+@rem enter repo root
+cd /d %~dp0\..\..\..
+
+@rem TODO(mkruskal) Implement tests

--- a/kokoro/windows/cmake_install/continuous.cfg
+++ b/kokoro/windows/cmake_install/continuous.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/cmake_install/build.bat"
+timeout_mins: 1440

--- a/kokoro/windows/cmake_install/presubmit.cfg
+++ b/kokoro/windows/cmake_install/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/cmake_install/build.bat"
+timeout_mins: 1440

--- a/kokoro/windows/cmake_nmake/build.bat
+++ b/kokoro/windows/cmake_nmake/build.bat
@@ -1,0 +1,4 @@
+@rem enter repo root
+cd /d %~dp0\..\..\..
+
+@rem TODO(mkruskal) Implement tests

--- a/kokoro/windows/cmake_nmake/continuous.cfg
+++ b/kokoro/windows/cmake_nmake/continuous.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/cmake_nmake/build.bat"
+timeout_mins: 1440

--- a/kokoro/windows/cmake_nmake/presubmit.cfg
+++ b/kokoro/windows/cmake_nmake/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/cmake_nmake/build.bat"
+timeout_mins: 1440


### PR DESCRIPTION
These are no-op tests for now, so that we can setup the Kokoro config.  They will be replaced with actual tests in a later PR