### PR TITLE
Add placeholders for further testing

### DIFF
--- a/kokoro/linux/cmake/build.sh
+++ b/kokoro/linux/cmake/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Build file to set up and run tests based on distribution archive
+# Build file to set up and run tests using CMake
 
 set -eux
 

--- a/kokoro/linux/cmake_install/build.sh
+++ b/kokoro/linux/cmake_install/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Build file to set up and run tests based on distribution archive
+# Build file to build, install, and test using CMake.
 
 set -eux
 

--- a/kokoro/linux/cmake_ninja/build.sh
+++ b/kokoro/linux/cmake_ninja/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Build file to set up and run tests based on distribution archive
+# Build file to set up and run tests using CMake with the Ninja generator.
 
 set -eux
 

--- a/kokoro/linux/cmake_shared/build.sh
+++ b/kokoro/linux/cmake_shared/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Build file to set up and run tests via CMake using shared libraries
+
+set -eux
+
+# TODO(mkruskal) Implement this.

--- a/kokoro/linux/cmake_shared/continuous.cfg
+++ b/kokoro/linux/cmake_shared/continuous.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/cmake/build.sh"
+timeout_mins: 1440
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.*"
+  }
+}

--- a/kokoro/linux/cmake_shared/presubmit.cfg
+++ b/kokoro/linux/cmake_shared/presubmit.cfg
@@ -1,0 +1,11 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/cmake/build.sh"
+timeout_mins: 1440
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.*"
+  }
+}

--- a/kokoro/windows/bazel/build.bat
+++ b/kokoro/windows/bazel/build.bat
@@ -1,0 +1,4 @@
+@rem enter repo root
+cd /d %~dp0\..\..\..
+
+@rem TODO(mkruskal) Implement tests

--- a/kokoro/windows/bazel/continuous.cfg
+++ b/kokoro/windows/bazel/continuous.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/cmake/build.bat"
+timeout_mins: 1440

--- a/kokoro/windows/bazel/presubmit.cfg
+++ b/kokoro/windows/bazel/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/cmake/build.bat"
+timeout_mins: 1440

--- a/kokoro/windows/cmake_shared/build.bat
+++ b/kokoro/windows/cmake_shared/build.bat
@@ -1,0 +1,4 @@
+@rem enter repo root
+cd /d %~dp0\..\..\..
+
+@rem TODO(mkruskal) Implement tests

--- a/kokoro/windows/cmake_shared/continuous.cfg
+++ b/kokoro/windows/cmake_shared/continuous.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/cmake/build.bat"
+timeout_mins: 1440

--- a/kokoro/windows/cmake_shared/presubmit.cfg
+++ b/kokoro/windows/cmake_shared/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/windows/cmake/build.bat"
+timeout_mins: 1440


### PR DESCRIPTION
This adds 3 new test points:
- Test CMake on windows using dlls
- Test CMake on linux using shared libraries
- Test Bazel builds on windows