### PR TITLE
docs: add protoc-gen-bq-schema

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -203,3 +203,4 @@ There are miscellaneous other things you may find useful as a Protocol Buffers d
     * [vim-protolint: A protobuf linter for Vim](https://github.com/yoheimuta/vim-protolint)
 * [super-linter: Protocol Buffer lint as GitHub Action](https://github.com/github/super-linter)
 * [protoc-gen-fieldmask - A plugin to generate static type fieldmask paths](https://github.com/idodod/protoc-gen-fieldmask)
+* [protoc-gen-bq-schema - A protoc plugin to generate BigQuery schema files](https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema)


### PR DESCRIPTION
Add protoc-gen-bq-schema to the list of third party add-ons.