### PR TITLE
Remove bogus IWYU pragma

### DIFF
--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -41,8 +41,6 @@
 //
 // This header covers RepeatedPtrField.
 
-// IWYU pragma: private, include "net/proto2/public/repeated_field.h"
-
 #ifndef GOOGLE_PROTOBUF_REPEATED_PTR_FIELD_H__
 #define GOOGLE_PROTOBUF_REPEATED_PTR_FIELD_H__
 


### PR DESCRIPTION
Pragma points at a directory that's not in the github repo, only internally.
It's throwing gRPC's IWYU analysis and causing it to recommend bad paths.