### PR TITLE
Remove Tools build from csharp release script

### DIFF
--- a/csharp/build_release.sh
+++ b/csharp/build_release.sh
@@ -12,6 +12,3 @@ dotnet nuget locals all --clear
 # Builds Google.Protobuf NuGet packages
 dotnet restore src/Google.Protobuf.sln
 dotnet pack -c Release src/Google.Protobuf.sln -p:ContinuousIntegrationBuild=true
-
-# This requires built protoc executables as specified in the nusepc
-nuget pack Google.Protobuf.Tools.nuspec


### PR DESCRIPTION
Remove the packaging of Google.Protobuf.Tools since it requires protoc executables. We would like to build the other artifact before protoc executables have been built and this allows us to have more flexibility where the Tools package is built.