### PR TITLE
Add extension for Oclea Service Layer RPCs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -336,3 +336,7 @@ with info about your project (name and website) so we can add an entry for you.
 1. Protoc-gen-referential-integrity
    * Website: https://github.com/ComponentCorp/protoc-gen-referential-integrity
    * Extension: 1149
+
+1. Oclea Service Layer RPC
+   * Website: https://oclea.com/
+   * Extension: 1150


### PR DESCRIPTION
For the service layer we're currently building for our products we need to add some custom extensions. This will be an SDK that customers can use and extend, so it would make sense to reduce the risk of conflicting IDs by allocating one for our purposes.

Could this change be applied, please, in order to reserve our extension ID?

Thanks,
Sam