### PR TITLE
PYI generator: print values as fields of enum

### DIFF
--- a/src/google/protobuf/compiler/python/pyi_generator.cc
+++ b/src/google/protobuf/compiler/python/pyi_generator.cc
@@ -262,6 +262,11 @@ void PyiGenerator::PrintEnum(const EnumDescriptor& enum_descriptor) const {
       "class $enum_name$(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):\n"
       "    __slots__ = []\n",
       "enum_name", enum_name);
+  printer_->Indent();
+  printer_->Indent();
+  PrintEnumValues(enum_descriptor);
+  printer_->Outdent();
+  printer_->Outdent();
 }
 
 void PyiGenerator::PrintEnumValues(
@@ -545,6 +550,7 @@ bool PyiGenerator::Generate(const FileDescriptor* file,
 
   PrintTopLevelEnums();
   // Prints top level enum values
+  printer_->Print("\n");
   for (int i = 0; i < file_->enum_type_count(); ++i) {
     PrintEnumValues(*file_->enum_type(i));
   }


### PR DESCRIPTION
When generating PYI for python, enums don't have any fields and your IDE shows errors when referring to a value of an enum using `MyEnum.Foo`

Example:
```protobuf
syntax = "proto3";
enum MyEnum {
	Abc = 0;
	Foo = 1;
	Bar = 2;
};
```
`$> protoc --pyi_out=. myenum.proto`

Current PYI Output:
```python
from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
from google.protobuf import descriptor as _descriptor
from typing import ClassVar as _ClassVar

DESCRIPTOR: _descriptor.FileDescriptor

class MyEnum(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
    __slots__ = []
Abc: MyEnum
Foo: MyEnum
Bar: MyEnum

```

With my changes:
```python
from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
from google.protobuf import descriptor as _descriptor
from typing import ClassVar as _ClassVar

DESCRIPTOR: _descriptor.FileDescriptor

class MyEnum(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
    __slots__ = []
    Abc: MyEnum
    Foo: MyEnum
    Bar: MyEnum

Abc: MyEnum
Foo: MyEnum
Bar: MyEnum
```

It's a bit ugly to have all enum values twice in the interface file, but it is an accurate representation of the generated Python interface - all the values are always in the enum class as well as the parent block. The change also works with enums nested inside of classes.