### PR TITLE
Use protoc version for --version

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -1844,7 +1844,7 @@ CommandLineInterface::InterpretArgument(const std::string& name,
     if (!version_info_.empty()) {
       std::cout << version_info_ << std::endl;
     }
-    std::cout << "libprotoc " << internal::VersionString(PROTOBUF_VERSION)
+    std::cout << "libprotoc " << internal::ProtocVersionString(PROTOBUF_VERSION)
               << PROTOBUF_VERSION_SUFFIX << std::endl;
     return PARSE_ARGUMENT_DONE_AND_EXIT;  // Exit without running compiler.
 

--- a/src/google/protobuf/stubs/common.cc
+++ b/src/google/protobuf/stubs/common.cc
@@ -92,7 +92,7 @@ void VerifyVersion(int headerVersion,
   }
 }
 
-std::string VersionString(int version) {
+std::string VersionString(int version, bool cppMajor) {
   int major = version / 1000000;
   int minor = (version / 1000) % 1000;
   int micro = version % 1000;
@@ -100,12 +100,20 @@ std::string VersionString(int version) {
   // 128 bytes should always be enough, but we use snprintf() anyway to be
   // safe.
   char buffer[128];
-  snprintf(buffer, sizeof(buffer), "%d.%d.%d", major, minor, micro);
+  if (cppMajor) {
+    snprintf(buffer, sizeof(buffer), "%d.%d.%d", major, minor, micro);
+  } else {
+    snprintf(buffer, sizeof(buffer), "%d.%d", minor, micro);
+  }
 
   // Guard against broken MSVC snprintf().
   buffer[sizeof(buffer)-1] = '\0';
 
   return buffer;
+}
+
+std::string ProtocVersionString(int version) {
+  return VersionString(version, false);
 }
 
 }  // namespace internal

--- a/src/google/protobuf/stubs/common.cc
+++ b/src/google/protobuf/stubs/common.cc
@@ -92,7 +92,7 @@ void VerifyVersion(int headerVersion,
   }
 }
 
-std::string VersionString(int version, bool cppMajor) {
+std::string VersionString(int version) {
   int major = version / 1000000;
   int minor = (version / 1000) % 1000;
   int micro = version % 1000;
@@ -100,11 +100,7 @@ std::string VersionString(int version, bool cppMajor) {
   // 128 bytes should always be enough, but we use snprintf() anyway to be
   // safe.
   char buffer[128];
-  if (cppMajor) {
-    snprintf(buffer, sizeof(buffer), "%d.%d.%d", major, minor, micro);
-  } else {
-    snprintf(buffer, sizeof(buffer), "%d.%d", minor, micro);
-  }
+  snprintf(buffer, sizeof(buffer), "%d.%d.%d", major, minor, micro);
 
   // Guard against broken MSVC snprintf().
   buffer[sizeof(buffer)-1] = '\0';
@@ -113,7 +109,19 @@ std::string VersionString(int version, bool cppMajor) {
 }
 
 std::string ProtocVersionString(int version) {
-  return VersionString(version, false);
+  int minor = (version / 1000) % 1000;
+  int micro = version % 1000;
+
+  // 128 bytes should always be enough, but we use snprintf() anyway to be
+  // safe.
+  char buffer[128];
+  snprintf(buffer, sizeof(buffer), "%d.%d", minor, micro);
+
+  // Guard against broken MSVC snprintf().
+  buffer[sizeof(buffer)-1] = '\0';
+
+  return buffer;
+
 }
 
 }  // namespace internal

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -106,7 +106,12 @@ void PROTOBUF_EXPORT VerifyVersion(int headerVersion, int minLibraryVersion,
                                    const char* filename);
 
 // Converts a numeric version number to a string.
-std::string PROTOBUF_EXPORT VersionString(int version);
+// If cppMajor is true the string will have the C++ major version, otherwise
+// the string will be the protoc version.
+std::string PROTOBUF_EXPORT VersionString(int version, bool cppMajor = true);
+
+// Prints the protoc compiler version (no major version)
+std::string PROTOBUF_EXPORT ProtocVersionString(int version);
 
 }  // namespace internal
 

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -106,9 +106,7 @@ void PROTOBUF_EXPORT VerifyVersion(int headerVersion, int minLibraryVersion,
                                    const char* filename);
 
 // Converts a numeric version number to a string.
-// If cppMajor is true the string will have the C++ major version, otherwise
-// the string will be the protoc version.
-std::string PROTOBUF_EXPORT VersionString(int version, bool cppMajor = true);
+std::string PROTOBUF_EXPORT VersionString(int version);
 
 // Prints the protoc compiler version (no major version)
 std::string PROTOBUF_EXPORT ProtocVersionString(int version);


### PR DESCRIPTION
Before `protoc --version` returned the C++ version (which includes a major version specific to C++). Changing to have no major version.