### PR TITLE
Avoid -Wunused-parameter

### DIFF
--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -437,7 +437,7 @@ class PROTOBUF_EXPORT PROTOBUF_ALIGNAS(8) Arena final {
     }
 
     template <typename U>
-    static Arena* GetOwningArena(Rank1, const U* p) {
+    static Arena* GetOwningArena(Rank1, const U*) {
       return nullptr;
     }
 
@@ -467,7 +467,7 @@ class PROTOBUF_EXPORT PROTOBUF_ALIGNAS(8) Arena final {
     }
 
     template <typename U>
-    static Arena* GetArenaForAllocation(Rank2, const U* p) {
+    static Arena* GetArenaForAllocation(Rank2, const U*) {
       return nullptr;
     }
 


### PR DESCRIPTION
Two function parameters that aren't used. Removed their name to avoid the unused parameters warning Wunused-parameter in clang c++.