### PR TITLE
Reverting changes to ruby aarch64 build.

### DIFF
--- a/kokoro/linux/aarch64/test_ruby_aarch64.sh
+++ b/kokoro/linux/aarch64/test_ruby_aarch64.sh
@@ -24,4 +24,4 @@ kokoro/linux/aarch64/dockcross_helpers/run_dockcross_manylinux2014_aarch64.sh ko
 #   otherwise the UID would be homeless under the docker container and pip install wouldn't work. For simplicity,
 #   we just run map the user's home to a throwaway temporary directory
 
-docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work arm64v8/ruby:2.7.3-buster kokoro/linux/aarch64/ruby_build_and_run_tests_with_qemu_aarch64.sh
+docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -e "IN_DOCKER=true" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work arm64v8/ruby:2.7.3-buster kokoro/linux/aarch64/ruby_build_and_run_tests_with_qemu_aarch64.sh

--- a/kokoro/linux/aarch64/test_ruby_aarch64.sh
+++ b/kokoro/linux/aarch64/test_ruby_aarch64.sh
@@ -24,4 +24,4 @@ kokoro/linux/aarch64/dockcross_helpers/run_dockcross_manylinux2014_aarch64.sh ko
 #   otherwise the UID would be homeless under the docker container and pip install wouldn't work. For simplicity,
 #   we just run map the user's home to a throwaway temporary directory
 
-docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -e "IN_DOCKER=true" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work arm64v8/ruby:2.7.3-buster kokoro/linux/aarch64/ruby_build_and_run_tests_with_qemu_aarch64.sh
+docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -e "PROTOC=/work/protoc" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work arm64v8/ruby:2.7.3-buster kokoro/linux/aarch64/ruby_build_and_run_tests_with_qemu_aarch64.sh

--- a/kokoro/linux/ruby_aarch64/build.sh
+++ b/kokoro/linux/ruby_aarch64/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# This is the top-level script we give to Kokoro as the entry point for
+# running the "continuous" and "presubmit" jobs.
+
+set -ex
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Initialize any submodules.
+git submodule update --init --recursive
+
+kokoro/linux/aarch64/qemu_helpers/prepare_qemu.sh
+
+kokoro/linux/aarch64/test_ruby_aarch64.sh

--- a/kokoro/linux/ruby_aarch64/continuous.cfg
+++ b/kokoro/linux/ruby_aarch64/continuous.cfg
@@ -1,26 +1,11 @@
 # Config file for running tests in Kokoro
 
 # Location of the build script in repository
-build_file: "protobuf/kokoro/linux/bazel.sh"
+build_file: "protobuf/kokoro/linux/ruby_aarch64/build.sh"
 timeout_mins: 120
-
-env_vars {
-  key: "CONTAINER_IMAGE"
-  value: "gcr.io/protobuf-build/emulation/linux:aarch64-4e847d7a01c1792471b6dd985ab0bf2677332e6f"
-}
-
-env_vars {
-  key: "BAZEL_TARGETS"
-  value: "//ruby/..."
-}
-
-env_vars {
-  key: "BAZEL_EXTRA_FLAGS"
-  value: "--define=ruby_platform=c"
-}
 
 action {
   define_artifacts {
-    regex: "**/sponge_log.*"
+    regex: "**/sponge_log.xml"
   }
 }

--- a/kokoro/linux/ruby_aarch64/presubmit.cfg
+++ b/kokoro/linux/ruby_aarch64/presubmit.cfg
@@ -1,26 +1,11 @@
 # Config file for running tests in Kokoro
 
 # Location of the build script in repository
-build_file: "protobuf/kokoro/linux/bazel.sh"
+build_file: "protobuf/kokoro/linux/ruby_aarch64/build.sh"
 timeout_mins: 120
-
-env_vars {
-  key: "CONTAINER_IMAGE"
-  value: "gcr.io/protobuf-build/emulation/linux:aarch64-4e847d7a01c1792471b6dd985ab0bf2677332e6f"
-}
-
-env_vars {
-  key: "BAZEL_TARGETS"
-  value: "//ruby/..."
-}
-
-env_vars {
-  key: "BAZEL_EXTRA_FLAGS"
-  value: "--define=ruby_platform=c"
-}
 
 action {
   define_artifacts {
-    regex: "**/sponge_log.*"
+    regex: "**/sponge_log.xml"
   }
 }


### PR DESCRIPTION
Our emulation docker image doesn't have ruby installed yet, and the old version of the test should work fine in the current state of our repo.  The reason this wasn't caught in presubmits was that this test was only ever run as a continuous build.