### PR TITLE
Relocate macos protoc build

### DIFF
--- a/kokoro/release/protoc/macos/build.sh
+++ b/kokoro/release/protoc/macos/build.sh
@@ -6,6 +6,7 @@ CXXFLAGS_COMMON="-std=c++14 -DNDEBUG -mmacosx-version-min=10.9"
 cd github/protobuf
 
 bazel build //:protoc --dynamic_mode=off
+mkdir -p build64/src
 cp bazel-bin/protoc build64/src/protoc
 file bazel-bin/protoc
 otool -L bazel-bin/protoc | grep dylib

--- a/kokoro/release/protoc/macos/build.sh
+++ b/kokoro/release/protoc/macos/build.sh
@@ -6,5 +6,6 @@ CXXFLAGS_COMMON="-std=c++14 -DNDEBUG -mmacosx-version-min=10.9"
 cd github/protobuf
 
 bazel build //:protoc --dynamic_mode=off
+cp bazel-bin/protoc build64/src/protoc
 file bazel-bin/protoc
 otool -L bazel-bin/protoc | grep dylib


### PR DESCRIPTION
Builds are failing because C# can't find the macos builds. Make the directory and copy them to the correct location.