### PR TITLE
Update CMake configuration to add a dependency on Abseil

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,4 +1,5 @@
 # These are fetched as external repositories.
+third_party/abseil-cpp
 third_party/benchmark
 third_party/googletest
 _build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git
 	ignore = dirty
+[submodule "third_party/abseil-cpp"]
+	path = third_party/abseil-cpp
+	url = https://github.com/abseil/abseil-cpp
+	branch = lts_2021_11_02

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,14 @@ file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/cmaketest.map)
 
 find_package(Threads REQUIRED)
 
+# We can install dependencies from submodules if we're running
+# CMake v3.13 or newer.
+if(CMAKE_VERSION VERSION_LESS 3.13)
+  set(_protobuf_INSTALL_SUPPORTED_FROM_MODULE OFF)
+else()
+  set(_protobuf_INSTALL_SUPPORTED_FROM_MODULE ON)
+endif()
+
 set(_protobuf_FIND_ZLIB)
 if (protobuf_WITH_ZLIB)
   find_package(ZLIB)
@@ -289,6 +297,11 @@ include_directories(
 if (protobuf_UNICODE)
   add_definitions(-DUNICODE -D_UNICODE)
 endif (protobuf_UNICODE)
+
+set(protobuf_ABSL_PROVIDER "module" CACHE STRING "Provider of absl library")
+set_property(CACHE protobuf_ABSL_PROVIDER PROPERTY STRINGS "module" "package")
+
+include(${protobuf_SOURCE_DIR}/cmake/abseil-cpp.cmake)
 
 if (protobuf_BUILD_PROTOBUF_BINARIES)
   include(${protobuf_SOURCE_DIR}/cmake/libprotobuf-lite.cmake)

--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -1,0 +1,30 @@
+set(ABSL_PROPAGATE_CXX_STD ON)
+
+if(protobuf_ABSL_PROVIDER STREQUAL "module")
+  if(NOT ABSL_ROOT_DIR)
+    set(ABSL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/abseil-cpp)
+  endif()
+  if(EXISTS "${ABSL_ROOT_DIR}/CMakeLists.txt")
+    if(protobuf_INSTALL)
+      # When protobuf_INSTALL is enabled and Abseil will be built as a module,
+      # Abseil will be installed along with protobuf for convenience.
+      set(ABSL_ENABLE_INSTALL ON)
+    endif()
+    add_subdirectory(${ABSL_ROOT_DIR} third_party/abseil-cpp)
+  else()
+    message(WARNING "protobuf_ABSL_PROVIDER is \"module\" but ABSL_ROOT_DIR is wrong")
+  endif()
+  if(protobuf_INSTALL AND NOT _protobuf_INSTALL_SUPPORTED_FROM_MODULE)
+    message(WARNING "protobuf_INSTALL will be forced to FALSE because protobuf_ABSL_PROVIDER is \"module\" and CMake version (${CMAKE_VERSION}) is less than 3.13.")
+    set(protobuf_INSTALL FALSE)
+  endif()
+elseif(protobuf_ABSL_PROVIDER STREQUAL "package")
+  # Use "CONFIG" as there is no built-in cmake module for absl.
+  find_package(absl REQUIRED CONFIG)
+endif()
+set(_protobuf_FIND_ABSL "if(NOT TARGET absl::strings)\n  find_package(absl CONFIG)\nendif()")
+
+set(protobuf_ABSL_USED_TARGETS
+  absl::strings
+  absl::strings_internal
+)

--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -1,3 +1,5 @@
+# Setup our dependency on Abseil.
+
 set(ABSL_PROPAGATE_CXX_STD ON)
 
 if(protobuf_ABSL_PROVIDER STREQUAL "module")

--- a/cmake/conformance.cmake
+++ b/cmake/conformance.cmake
@@ -52,7 +52,7 @@ target_include_directories(conformance_cpp PRIVATE ${ABSL_ROOT_DIR})
 
 target_link_libraries(conformance_test_runner ${protobuf_LIB_PROTOBUF})
 target_link_libraries(conformance_cpp ${protobuf_LIB_PROTOBUF})
-target_link_libraries(conformance_cpp PRIVATE ${protobuf_ABSL_USED_TARGETS})
+target_link_libraries(conformance_cpp ${protobuf_ABSL_USED_TARGETS})
 
 add_test(NAME conformance_cpp_test
   COMMAND ${CMAKE_CURRENT_BINARY_DIR}/conformance_test_runner

--- a/cmake/conformance.cmake
+++ b/cmake/conformance.cmake
@@ -48,8 +48,11 @@ target_include_directories(
   conformance_cpp
   PUBLIC ${protobuf_SOURCE_DIR})
 
+target_include_directories(conformance_cpp PRIVATE ${ABSL_ROOT_DIR})
+
 target_link_libraries(conformance_test_runner ${protobuf_LIB_PROTOBUF})
 target_link_libraries(conformance_cpp ${protobuf_LIB_PROTOBUF})
+target_link_libraries(conformance_cpp PRIVATE ${protobuf_ABSL_USED_TARGETS})
 
 add_test(NAME conformance_cpp_test
   COMMAND ${CMAKE_CURRENT_BINARY_DIR}/conformance_test_runner

--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -23,6 +23,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
   target_link_libraries(libprotobuf-lite PRIVATE log)
 endif()
 target_include_directories(libprotobuf-lite PUBLIC ${protobuf_SOURCE_DIR}/src)
+target_include_directories(libprotobuf-lite PRIVATE ${ABSL_ROOT_DIR})
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf-lite
     PUBLIC  PROTOBUF_USE_DLLS

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -26,6 +26,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
   target_link_libraries(libprotobuf PRIVATE log)
 endif()
 target_include_directories(libprotobuf PUBLIC ${protobuf_SOURCE_DIR}/src)
+target_include_directories(libprotobuf PRIVATE ${ABSL_ROOT_DIR})
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf
     PUBLIC  PROTOBUF_USE_DLLS

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -16,6 +16,7 @@ if(protobuf_HAVE_LD_VERSION_SCRIPT)
     LINK_DEPENDS ${protobuf_SOURCE_DIR}/src/libprotoc.map)
 endif()
 target_link_libraries(libprotoc PRIVATE libprotobuf)
+target_include_directories(libprotoc PRIVATE ${ABSL_ROOT_DIR})
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotoc
     PUBLIC  PROTOBUF_USE_DLLS

--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -3,6 +3,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/protobuf-options.cmake")
 
 # Depend packages
 @_protobuf_FIND_ZLIB@
+@_protobuf_FIND_ABSL@
 
 # Imported targets
 include("${CMAKE_CURRENT_LIST_DIR}/protobuf-targets.cmake")

--- a/cmake/protoc.cmake
+++ b/cmake/protoc.cmake
@@ -6,6 +6,7 @@ add_executable(protoc ${protoc_files} ${protobuf_version_rc_file})
 target_link_libraries(protoc
   libprotoc
   libprotobuf
+  ${protobuf_ABSL_USED_TARGETS}
 )
 add_executable(protobuf::protoc ALIAS protoc)
 

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -78,7 +78,9 @@ endforeach(proto_file)
 
 add_library(protobuf-lite-test-common STATIC
   ${lite_test_util_srcs} ${lite_test_proto_files})
-target_link_libraries(protobuf-lite-test-common ${protobuf_LIB_PROTOBUF_LITE} GTest::gmock)
+target_include_directories(protobuf-lite-test-common PRIVATE ${ABSL_ROOT_DIR})
+target_link_libraries(protobuf-lite-test-common
+  ${protobuf_LIB_PROTOBUF_LITE} ${protobuf_ABSL_USED_TARGETS} GTest::gmock)
 
 set(common_test_files
   ${test_util_hdrs}
@@ -89,7 +91,9 @@ set(common_test_files
 
 add_library(protobuf-test-common STATIC
   ${common_test_files} ${tests_proto_files})
-target_link_libraries(protobuf-test-common ${protobuf_LIB_PROTOBUF} GTest::gmock)
+target_include_directories(protobuf-test-common PRIVATE ${ABSL_ROOT_DIR})
+target_link_libraries(protobuf-test-common
+  ${protobuf_LIB_PROTOBUF} ${protobuf_ABSL_USED_TARGETS} GTest::gmock)
 
 set(tests_files
   ${protobuf_test_files}


### PR DESCRIPTION
This is the most recent Abseil LTS branch, from November 2021. We do not yet use Abseil for anything, but this change will make it possible to start using it in CMake when we're ready. This PR was tested by confirming that using absl::string_view from protobuf::Message doesn't break anything (under CMake builds only).

Note: this is a roll-forward of https://github.com/protocolbuffers/protobuf/pull/9793 after we've put more CMake test coverage in place.