### PR TITLE
Use hex representation for binary data inside generated php files

### DIFF
--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -625,6 +625,30 @@ void Outdent(io::Printer* printer) {
   printer->Outdent();
 }
 
+std::string BinaryToPhpString(const std::string& src) {
+  std::string dest;
+  size_t i;
+  unsigned char symbol[16] = {
+    '0', '1', '2', '3',
+    '4', '5', '6', '7',
+    '8', '9', 'A', 'B',
+    'C', 'D', 'E', 'F',
+  };
+
+  dest.resize(src.size() * 4);
+  char* append_ptr = &dest[0];
+
+  for (i = 0; i < src.size(); i++) {
+    *append_ptr++ = '\\';
+    *append_ptr++ = 'x';
+    *append_ptr++ = symbol[(src[i] & 0xf0) >> 4];
+    *append_ptr++ = symbol[src[i] & 0x0f];
+  }
+
+  return dest;
+}
+
+
 void GenerateField(const FieldDescriptor* field, io::Printer* printer,
                    const Options& options) {
   if (field->is_repeated()) {
@@ -1037,23 +1061,7 @@ void GenerateAddFileToPool(const FileDescriptor* file, const Options& options,
 
       printer->Print("$pool->internalAddGeneratedFile(\n");
       Indent(printer);
-      printer->Print("'");
-
-      for (auto ch : files_data) {
-        switch (ch) {
-          case '\\':
-            printer->Print(R"(\\)");
-            break;
-          case '\'':
-            printer->Print(R"(\')");
-            break;
-          default:
-            printer->Print("^char^", "char", std::string(1, ch));
-            break;
-        }
-      }
-
-      printer->Print("'\n");
+      printer->Print("\"^data^\"\n", "data", BinaryToPhpString(files_data));
       Outdent(printer);
       printer->Print(
           ", true);\n\n");
@@ -1184,23 +1192,7 @@ void GenerateAddFilesToPool(const FileDescriptor* file, const Options& options,
 
   printer->Print("$pool->internalAddGeneratedFile(\n");
   Indent(printer);
-  printer->Print("'");
-
-  for (auto ch : files_data) {
-    switch (ch) {
-      case '\\':
-        printer->Print(R"(\\)");
-        break;
-      case '\'':
-        printer->Print(R"(\')");
-        break;
-      default:
-        printer->Print("^char^", "char", std::string(1, ch));
-        break;
-    }
-  }
-
-  printer->Print("'\n");
+  printer->Print("\"^data^\"\n", "data", BinaryToPhpString(files_data));
   Outdent(printer);
   printer->Print(
       ", true);\n");


### PR DESCRIPTION
For the sake of performance, the hex2bin call was removed from the generated PHP code in #8006
However, after this PR all autogenerated files contain binary data, which makes it hard or even impossible to see using common tools (git and github included (i.e. [this file](https://github.com/protocolbuffers/protobuf/blob/main/php/src/GPBMetadata/Google/Protobuf/Struct.php)), as well as some code editors) since most software considers such files as binary ones and not as code.

At the same, there is a possibility to use hex representation of binary data inside PHP files, which doesn't affect the performance (because it compiles to the same OP codes by the interpreter).

```
package ~/Desktop/proto $ cat test1.php
<?php

$str = "teststring";
echo $str;%
package ~/Desktop/proto $ phpdbg -p\* test1.php

$_main:
     ; (lines=3, args=0, vars=1, tmps=1)
     ; /Users/package/Desktop/proto/test1.php:1-4
L0003 0000 ASSIGN CV0($str) string("teststring")
L0004 0001 ECHO CV0($str)
L0004 0002 RETURN int(1)
[Script ended normally]
package ~/Desktop/proto $ cat test2.php
<?php

$str = "\x74\x65\x73\x74\x73\x74\x72\x69\x6e\x67";
echo $str;%
package ~/Desktop/proto $ phpdbg -p\* test2.php

$_main:
     ; (lines=3, args=0, vars=1, tmps=1)
     ; /Users/package/Desktop/proto/test2.php:1-4
L0003 0000 ASSIGN CV0($str) string("teststring")
L0004 0001 ECHO CV0($str)
L0004 0002 RETURN int(1)
[Script ended normally]
```

So, this PR replaces binary data with hex representation to fix issues mentioned above
