### PR TITLE
Sort dependency manifest

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2215,6 +2215,12 @@ bool CommandLineInterface::GenerateDependencyManifestFile(
     output_filenames.push_back(descriptor_set_out_name_);
   }
 
+  // Some consumers consider first output as the "primary output" (ninja)
+  // If this doesn't match their primary output it ignores the manifest.
+  // The unordered map for output_directories means we can't guarantee the order of files.
+  // Sorting here makes the "primary output" can be whichever is first alphabetically
+  std::sort(output_filenames.begin(), output_filenames.end());
+
   int fd;
   do {
     fd = open(dependency_out_name_.c_str(),

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -1799,7 +1799,8 @@ TEST_F(CommandLineInterfaceTest,
   ExpectNoErrors();
 
   ExpectFileContent("manifest_a",
-                    "$tmpdir/a.pb \\\n$tmpdir/bar.proto.MockCodeGenerator.test_generator: "
+                    "$tmpdir/a.pb \\\n"
+                    "$tmpdir/bar.proto.MockCodeGenerator.test_generator: "
                     "$tmpdir/foo.proto\\\n $tmpdir/bar.proto");
 
   Run("protocol_compiler --dependency_out=$tmpdir/manifest_z "
@@ -1809,7 +1810,8 @@ TEST_F(CommandLineInterfaceTest,
   ExpectNoErrors();
 
   ExpectFileContent("manifest_z",
-                    "$tmpdir/bar.proto.MockCodeGenerator.test_generator \\\n$tmpdir/z.pb: "
+                    "$tmpdir/bar.proto.MockCodeGenerator.test_generator \\\n"
+                    "$tmpdir/z.pb: "
                     "$tmpdir/foo.proto\\\n $tmpdir/bar.proto");
 }
 #endif  // !_WIN32


### PR DESCRIPTION
Currently the ordering of the files in the dependency manifest file are undefined as the directories are stored in an unordered list.

This has resulted in a bug specifically for me with the combination of `CMake`/`ninja`/`depfiles` as if the first file listed as an output by CMake is not the first file in the list for the dependency manifest file, ninja complains about a missing "primary output" and treats the entire list of dependencies as dirty and rebuilds them.

The outputs for protoc don't really have a "primary" output as outputs of python/cpp etc would all be equal.

This PR sorts the dependency output files before writing them to resolve this.
At least this way so long as both of the CMake list and depfile are sorted it will work as expected.