### PR TITLE
Upgrade python in benchmark kokoro build

### DIFF
--- a/kokoro/linux/benchmark/run.sh
+++ b/kokoro/linux/benchmark/run.sh
@@ -12,6 +12,12 @@ set -ex
 export OUTPUT_DIR=testoutput
 repo_root="$(pwd)"
 
+# Setup python virtual environment.
+apt-get update -y
+apt-get install -y --no-install-recommends python3 python3-venv
+python3 -m venv venv
+source venv/bin/activate
+
 # TODO(jtattermusch): Add back support for benchmarking with tcmalloc for C++ and python.
 # This feature was removed since it used to use tcmalloc from https://github.com/gperftools/gperftools.git
 # which is very outdated. See https://github.com/protocolbuffers/protobuf/issues/8725.

--- a/python/google/protobuf/internal/containers.py
+++ b/python/google/protobuf/internal/containers.py
@@ -346,7 +346,7 @@ class RepeatedCompositeFieldContainer(BaseContainer[_T], MutableSequence[_T]):
     # structurally compatible with typing.MutableSequence. It is
     # otherwise unsupported and will always raise an error.
     raise TypeError(
-        '%s object does not support item assignment' % self.__class__.__name__)
+        f'{self.__class__.__name__} object does not support item assignment')
 
   def __delitem__(self, key: Union[int, slice]) -> None:
     """Deletes the item at the specified position."""

--- a/python/google/protobuf/internal/containers.py
+++ b/python/google/protobuf/internal/containers.py
@@ -346,7 +346,7 @@ class RepeatedCompositeFieldContainer(BaseContainer[_T], MutableSequence[_T]):
     # structurally compatible with typing.MutableSequence. It is
     # otherwise unsupported and will always raise an error.
     raise TypeError(
-        f'{self.__class__.__name__} object does not support item assignment')
+        '%s object does not support item assignment' % self.__class__.__name__)
 
   def __delitem__(self, key: Union[int, slice]) -> None:
     """Deletes the item at the specified position."""


### PR DESCRIPTION
Kokoro is using python 3.5, which is now incompatible with our python runtime.