### PR TITLE
Fully qualify git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	ignore = dirty
 [submodule "third_party/abseil-cpp"]
 	path = third_party/abseil-cpp
-	url = https://github.com/abseil/abseil-cpp
+	url = https://github.com/abseil/abseil-cpp.git
 	branch = lts_2022_06_23


### PR DESCRIPTION
In order for internal acls to work, this needs to include the '.git' suffix.