### PR TITLE
validate UTF8 during tokenization

### DIFF
--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -617,6 +617,8 @@ bool Parser::Parse(io::Tokenizer* input, FileDescriptorProto* file) {
   input_ = input;
   had_errors_ = false;
   syntax_identifier_.clear();
+  // Proto source code must be in UTF-8 encoding.
+  // TODO: make this conditional somehow: compile-time Or command-line?
   input->set_require_valid_utf8(true);
 
   // Note that |file| could be NULL at this point if

--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -617,6 +617,7 @@ bool Parser::Parse(io::Tokenizer* input, FileDescriptorProto* file) {
   input_ = input;
   had_errors_ = false;
   syntax_identifier_.clear();
+  input->set_require_valid_utf8(true);
 
   // Note that |file| could be NULL at this point if
   // stop_after_syntax_identifier_ is true.  So, we conservatively allocate

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -293,6 +293,7 @@ TEST_F(ParseMessageTest, BOMError) {
       "}\n";
   input[0] = (char)0xEF;
   ExpectHasErrors(input,
+                  "0:0: malformed UTF8 input: incomplete code point\n"
                   "0:1: Proto file starts with 0xEF but not UTF-8 BOM. "
                   "Only UTF-8 is accepted for proto file.\n"
                   "0:0: Expected top-level statement (e.g. \"message\").\n");

--- a/src/google/protobuf/io/tokenizer.cc
+++ b/src/google/protobuf/io/tokenizer.cc
@@ -292,10 +292,10 @@ void Tokenizer::NextChar() {
   } else {
     Refresh();
   }
-  CheckUtf8();
+  MaybeCheckUtf8();
 }
 
-void Tokenizer::CheckUtf8() {
+void Tokenizer::MaybeCheckUtf8() {
   if (!require_valid_utf8_) {
     return;
   }

--- a/src/google/protobuf/io/tokenizer.h
+++ b/src/google/protobuf/io/tokenizer.h
@@ -237,6 +237,15 @@ class PROTOBUF_EXPORT Tokenizer {
   // ignored.
   void set_allow_f_after_float(bool value) { allow_f_after_float_ = value; }
 
+  // Set true to require that input be valid UTF8.
+  void set_require_valid_utf8(bool value) {
+    require_valid_utf8_ = value;
+    if (value) {
+      // initialize book-keeping flags from first char of input
+      CheckUtf8();
+    }
+  }
+
   // Valid values for set_comment_style().
   enum CommentStyle {
     // Line comments begin with "//", block comments are delimited by "/*" and
@@ -307,6 +316,12 @@ class PROTOBUF_EXPORT Tokenizer {
   bool report_whitespace_ = false;
   bool report_newlines_ = false;
 
+  bool require_valid_utf8_ = false;
+  // book-keeping to implement above requirement
+  int expect_utf8_follow_ = 0;
+  int utf8_codepoint_ = 0;
+  bool at_utf8_codepoint_end_ = false;
+
   // Since we count columns we need to interpret tabs somehow.  We'll take
   // the standard 8-character definition for lack of any way to do better.
   // This must match the documentation of ColumnNumber.
@@ -320,6 +335,10 @@ class PROTOBUF_EXPORT Tokenizer {
 
   // Read a new buffer from the input.
   void Refresh();
+
+  // Check the most recent character read to verify that the input
+  // is correctly encoded UTF8. Does nothing if !require_valid_utf8_.
+  void CheckUtf8();
 
   inline void RecordTo(std::string* target);
   inline void StopRecording();

--- a/src/google/protobuf/io/tokenizer.h
+++ b/src/google/protobuf/io/tokenizer.h
@@ -242,7 +242,7 @@ class PROTOBUF_EXPORT Tokenizer {
     require_valid_utf8_ = value;
     if (value) {
       // initialize book-keeping flags from first char of input
-      CheckUtf8();
+      MaybeCheckUtf8();
     }
   }
 
@@ -338,7 +338,7 @@ class PROTOBUF_EXPORT Tokenizer {
 
   // Check the most recent character read to verify that the input
   // is correctly encoded UTF8. Does nothing if !require_valid_utf8_.
-  void CheckUtf8();
+  void MaybeCheckUtf8();
 
   inline void RecordTo(std::string* target);
   inline void StopRecording();


### PR DESCRIPTION
This enables validation inside the tokenizer only when used from the proto source parser. The tokenizer is also used by other things (including parsing the protobuf text format). This does not attempt to enable it for other contexts.

Since the parser and tokenizer are inherently byte-based, this was kind of tricky. We basically put a little state machine in the tokenizer to recognize multi-byte codepoints and to decide if it observes valid or invalid ones, as it process the bytes one at a time. The main downside to this approach is that error messages for a naked multi-byte codepoint (not in a comment or string literal, meaning they are invalid syntax) will report the wrong codepoint -- it reports the value of just the first byte, not the whole thing. I think fixing that would require far more intrusive changes, so it's less risk to leave it this way.

This addresses one part of #9175 -- about allowing illegal UTF8 in the file input. (The second part of that bug is about allowing illegal UTF8 in values for string fields, like default values and options. Not touching that at the moment.)