### PR TITLE
CMake: Check whether Abseil is already present in the current project

### DIFF
--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -2,7 +2,10 @@
 
 set(ABSL_PROPAGATE_CXX_STD ON)
 
-if(protobuf_ABSL_PROVIDER STREQUAL "module")
+if(TARGET absl::strings)
+  # If Abseil is included already, skip including it.
+  # (https://github.com/protocolbuffers/protobuf/issues/10435)
+elseif(protobuf_ABSL_PROVIDER STREQUAL "module")
   if(NOT ABSL_ROOT_DIR)
     set(ABSL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/abseil-cpp)
   endif()


### PR DESCRIPTION
If the `absl::strings` already exists at configure time, this means protobuf was likely included via `add_subdirectory()` from a parent project that also uses Abseil. Do not check `protobuf_ABSL_PROVIDER` in that case.