### PR TITLE
Upgrade to MSVC 2017, since 2015 is no longer supported

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,16 +3,16 @@ configuration:
 
 environment:
   matrix:
-    # Only test few combinations: "Visual Studio 2015 (14) + Win64/MinGW + Debug + DLL". We can
+    # Only test few combinations: "Visual Studio 2017 (15) + Win64/MinGW + Debug + DLL". We can
     # test more combinations but AppVeyor just takes too long to finish (each
     # combination takes ~15mins).
     - platform: MinGW
       language: cpp
-      image: Visual Studio 2015
+      image: Visual Studio 2017
 
     - platform: Win64
       language: cpp
-      image: Visual Studio 2015
+      image: Visual Studio 2017
       BUILD_DLL: ON
       UNICODE: ON
 
@@ -35,8 +35,8 @@ install:
 
 before_build:
   - if %platform%==MinGW set generator=MinGW Makefiles
-  - if %platform%==Win32 set generator=Visual Studio 14
-  - if %platform%==Win64 set generator=Visual Studio 14 Win64
+  - if %platform%==Win32 set generator=Visual Studio 15
+  - if %platform%==Win64 set generator=Visual Studio 15 Win64
   - if %platform%==Win32 set vcplatform=Win32
   - if %platform%==Win64 set vcplatform=x64
 

--- a/kokoro/release/protoc/windows/build.bat
+++ b/kokoro/release/protoc/windows/build.bat
@@ -1,6 +1,6 @@
 set PATH=C:\Program Files (x86)\MSBuild\14.0\bin\;%PATH%
-set generator32=Visual Studio 14
-set generator64=Visual Studio 14 Win64
+set generator32=Visual Studio 15
+set generator64=Visual Studio 15 Win64
 set vcplatform32=win32
 set vcplatform64=x64
 set configuration=Release
@@ -15,13 +15,13 @@ set ABSL_ROOT_DIR=%cd%\third_party\abseil-cpp
 
 mkdir build32
 cd build32
-cmake -G "%generator32%" -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_UNICODE=ON ../cmake
+cmake -G "%generator32%" -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_UNICODE=ON ..
 msbuild protobuf.sln /p:Platform=%vcplatform32% || goto error
 cd ..
 
 mkdir build64
 cd build64
-cmake -G "%generator64%" -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_UNICODE=ON ../cmake
+cmake -G "%generator64%" -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_UNICODE=ON ..
 msbuild protobuf.sln /p:Platform=%vcplatform64% || goto error
 cd ..
 


### PR DESCRIPTION
Visual Studio 2015 is no longer supported as per our [support matrix](https://developers.google.com/protocol-buffers/docs/news/2022-08-03#cpp-support-matrix).  Specifically, our dependency on Abseil breaks this old compiler.