### PR TITLE
Fix Bazel 4 support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,6 +25,14 @@ http_archive(
     ],
 )
 
+# Bazel platform rules.
+http_archive(
+    name = "platforms",
+    sha256 = "a879ea428c6d56ab0ec18224f976515948822451473a80d06c2e50af0bbe5121",
+    strip_prefix = "platforms-da5541f26b7de1dc8e04c075c99df5351742a4a2",
+    urls = ["https://github.com/bazelbuild/platforms/archive/da5541f26b7de1dc8e04c075c99df5351742a4a2.zip"],  # 2022-05-27
+)
+
 # Load common dependencies.
 load("//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS", "protobuf_deps")
 protobuf_deps()

--- a/kokoro/linux/benchmark/run.sh
+++ b/kokoro/linux/benchmark/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Install Bazel 4.0.0.
-use_bazel.sh 4.0.0
+# Install Bazel 4.2.2.
+use_bazel.sh 4.2.2
 
 # Change to repo root
 cd $(dirname $0)/../../..

--- a/kokoro/linux/java_linkage_monitor/build.sh
+++ b/kokoro/linux/java_linkage_monitor/build.sh
@@ -6,7 +6,7 @@
 # This script selects a specific Dockerfile (for building a Docker image) and
 # a script to run inside that image.
 
-use_bazel.sh 5.1.1
+use_bazel.sh 4.0.0
 
 # Change to repo root
 cd $(dirname $0)/../../..

--- a/kokoro/linux/java_linkage_monitor/build.sh
+++ b/kokoro/linux/java_linkage_monitor/build.sh
@@ -6,7 +6,7 @@
 # This script selects a specific Dockerfile (for building a Docker image) and
 # a script to run inside that image.
 
-use_bazel.sh 4.0.0
+use_bazel.sh 4.2.2
 
 # Change to repo root
 cd $(dirname $0)/../../..


### PR DESCRIPTION
This fixes Bazel 4 by adding an explicit dependency on the more recent version of bazelbuild/platforms that Abseil uses