### PR TITLE
[ObjC] Remove prefixes from test files no longer used by ObjC tests.

### DIFF
--- a/src/google/protobuf/unittest_drop_unknown_fields.proto
+++ b/src/google/protobuf/unittest_drop_unknown_fields.proto
@@ -32,7 +32,6 @@ syntax = "proto3";
 
 package unittest_drop_unknown_fields;
 
-option objc_class_prefix = "DropUnknowns";
 option csharp_namespace = "Google.Protobuf.TestProtos";
 
 message Foo {

--- a/src/google/protobuf/unittest_preserve_unknown_enum.proto
+++ b/src/google/protobuf/unittest_preserve_unknown_enum.proto
@@ -31,7 +31,6 @@
 syntax = "proto3";
 
 package proto3_preserve_unknown_enum_unittest;
-option objc_class_prefix = "UnknownEnums";
 
 option csharp_namespace = "Google.Protobuf.TestProtos";
 


### PR DESCRIPTION
The one file that isn't a WKT that still has a prefix is used by the conformance
tests, and still needs a prefix there.