### PR TITLE
Changing windows release to VS 2017

### DIFF
--- a/kokoro/release/protoc/windows/build.bat
+++ b/kokoro/release/protoc/windows/build.bat
@@ -1,9 +1,12 @@
-set PATH=C:\Program Files (x86)\MSBuild\14.0\bin\;%PATH%
 set generator32=Visual Studio 15
 set generator64=Visual Studio 15 Win64
 set vcplatform32=win32
 set vcplatform64=x64
 set configuration=Release
+
+:: VS2017 is installed, but will not be selected by default. This command sets
+:: up the environment so that CMake will find and use it:
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 
 echo Building protoc
 cd github\protobuf

--- a/php/composer.json
+++ b/php/composer.json
@@ -30,5 +30,8 @@
     "test_valgrind": "./generate_test_protos.sh && ./tests/compile_extension.sh && ZEND_DONT_UNLOAD_MODULES=1 USE_ZEND_ALLOC=0 valgrind --leak-check=full --error-exitcode=1 php -dextension=ext/google/protobuf/modules/protobuf.so vendor/bin/phpunit --bootstrap tests/force_c_ext.php tests",
     "test": "./generate_test_protos.sh && vendor/bin/phpunit tests",
     "aggregate_metadata_test": "./generate_test_protos.sh --aggregate_metadata && vendor/bin/phpunit tests"
+  },
+  "config": {
+    "process-timeout": 1200
   }
 }


### PR DESCRIPTION
We no longer support VS 14, which was still in the path for this kokoro build