### PR TITLE
Make abseil a public dependency of libprotobuf

### DIFF
--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -23,8 +23,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
   target_link_libraries(libprotobuf-lite PRIVATE log)
 endif()
 target_include_directories(libprotobuf-lite PUBLIC ${protobuf_SOURCE_DIR}/src)
-target_link_libraries(libprotobuf-lite PRIVATE ${protobuf_ABSL_USED_TARGETS})
-target_include_directories(libprotobuf-lite PRIVATE ${ABSL_ROOT_DIR})
+target_link_libraries(libprotobuf-lite PUBLIC ${protobuf_ABSL_USED_TARGETS})
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf-lite
     PUBLIC  PROTOBUF_USE_DLLS

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -26,8 +26,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
   target_link_libraries(libprotobuf PRIVATE log)
 endif()
 target_include_directories(libprotobuf PUBLIC ${protobuf_SOURCE_DIR}/src)
-target_link_libraries(libprotobuf PRIVATE ${protobuf_ABSL_USED_TARGETS})
-target_include_directories(libprotobuf PRIVATE ${ABSL_ROOT_DIR})
+target_link_libraries(libprotobuf PUBLIC ${protobuf_ABSL_USED_TARGETS})
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf
     PUBLIC  PROTOBUF_USE_DLLS

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -16,8 +16,7 @@ if(protobuf_HAVE_LD_VERSION_SCRIPT)
     LINK_DEPENDS ${protobuf_SOURCE_DIR}/src/libprotoc.map)
 endif()
 target_link_libraries(libprotoc PRIVATE libprotobuf)
-target_link_libraries(libprotoc PRIVATE ${protobuf_ABSL_USED_TARGETS})
-target_include_directories(libprotoc PRIVATE ${ABSL_ROOT_DIR})
+target_link_libraries(libprotoc PUBLIC ${protobuf_ABSL_USED_TARGETS})
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotoc
     PUBLIC  PROTOBUF_USE_DLLS


### PR DESCRIPTION
descriptor.h includes abseil's mutex.h directly, thus abseil is not a
private dependency any more but must be included by every user of
libprotobuf.