### PR TITLE
json_name and default pseudo-options have source code info consistent with options

### DIFF
--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -409,6 +409,11 @@ Parser::LocationRecorder::LocationRecorder(const LocationRecorder& parent) {
 }
 
 Parser::LocationRecorder::LocationRecorder(const LocationRecorder& parent,
+                                           SourceCodeInfo* source_code_info) {
+  Init(parent, source_code_info);
+}
+
+Parser::LocationRecorder::LocationRecorder(const LocationRecorder& parent,
                                            int path1,
                                            SourceCodeInfo* source_code_info) {
   Init(parent, source_code_info);
@@ -1237,13 +1242,22 @@ bool Parser::ParseDefaultAssignment(
     field->clear_default_value();
   }
 
+  LocationRecorder location(field_location,
+                            FieldDescriptorProto::kDefaultValueFieldNumber);
+
   DO(Consume("default"));
   DO(Consume("="));
 
-  LocationRecorder location(field_location,
-                            FieldDescriptorProto::kDefaultValueFieldNumber);
-  location.RecordLegacyLocation(field,
-                                DescriptorPool::ErrorCollector::DEFAULT_VALUE);
+  // We don't need to create separate spans in source code info for name and value,
+  // since there's no way to represent them distinctly in a location path. But we will
+  // want a separate recorder for the value, just to have more precise location info
+  // in error messages. So we let it create a location in no_op, so it doesn't add a
+  // span to the file descriptor.
+  SourceCodeInfo no_op;
+  LocationRecorder value_location(location, &no_op);
+  value_location.RecordLegacyLocation(
+      field, DescriptorPool::ErrorCollector::DEFAULT_VALUE);
+
   std::string* default_value = field->mutable_default_value();
 
   if (!field->has_type()) {
@@ -1377,13 +1391,23 @@ bool Parser::ParseJsonName(FieldDescriptorProto* field,
 
   LocationRecorder location(field_location,
                             FieldDescriptorProto::kJsonNameFieldNumber);
-  location.RecordLegacyLocation(field,
-                                DescriptorPool::ErrorCollector::OPTION_NAME);
 
-  DO(Consume("json_name"));
+  // We don't need to create separate spans in source code info for name and value,
+  // since there's no way to represent them distinctly in a location path. But we will
+  // want a separate recorder for them, just to have more precise location info
+  // in error messages. So we let them create a location in no_op, so they don't
+  // add a span to the file descriptor.
+  SourceCodeInfo no_op;
+  {
+    LocationRecorder name_location(location, &no_op);
+    name_location.RecordLegacyLocation(
+        field, DescriptorPool::ErrorCollector::OPTION_NAME);
+
+    DO(Consume("json_name"));
+  }
   DO(Consume("="));
 
-  LocationRecorder value_location(location);
+  LocationRecorder value_location(location, &no_op);
   value_location.RecordLegacyLocation(
       field, DescriptorPool::ErrorCollector::OPTION_VALUE);
 

--- a/src/google/protobuf/compiler/parser.h
+++ b/src/google/protobuf/compiler/parser.h
@@ -237,6 +237,10 @@ class PROTOBUF_EXPORT Parser {
     LocationRecorder(const LocationRecorder& parent, int path1, int path2);
 
     // Creates a recorder that generates locations into given source code info.
+    LocationRecorder(const LocationRecorder& parent,
+                     SourceCodeInfo* source_code_info);
+    // Creates a recorder that generates locations into given source code info
+    // and calls AddPath() one time.
     LocationRecorder(const LocationRecorder& parent, int path1,
                      SourceCodeInfo* source_code_info);
 

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -3415,18 +3415,19 @@ TEST_F(SourceInfoTest, FieldOptions) {
   EXPECT_TRUE(
       Parse("message Foo {"
             "  optional int32 bar = 1 "
-            "$a$[default=$b$123$c$,$d$opt1=123$e$,"
-            "$f$opt2='hi'$g$]$h$;"
+            "$a$[$b$default=123$c$, $d$opt1=123$e$, "
+            "$f$opt2='hi'$g$, $h$json_name='barBar'$i$]$j$;"
             "}\n"));
 
   const FieldDescriptorProto& field = file_.message_type(0).field(0);
   const UninterpretedOption& option1 = field.options().uninterpreted_option(0);
   const UninterpretedOption& option2 = field.options().uninterpreted_option(1);
 
-  EXPECT_TRUE(HasSpan('a', 'h', field.options()));
+  EXPECT_TRUE(HasSpan('a', 'j', field.options()));
   EXPECT_TRUE(HasSpan('b', 'c', field, "default_value"));
   EXPECT_TRUE(HasSpan('d', 'e', option1));
   EXPECT_TRUE(HasSpan('f', 'g', option2));
+  EXPECT_TRUE(HasSpan('h', 'i', field, "json_name"));
 
   // Ignore these.
   EXPECT_TRUE(HasSpan(file_));


### PR DESCRIPTION
Source code locations and spans for `default` and `json_name` "pseudo-options" are not consistent with how other options look nor are they consistent with one another.
* Normal (and custom) options produce a span for the entire declaration, starting with the first character of the name and ending with the last character of the value. (For long-form option declarations, like in files, messages, enums, and services, it even includes the leading `option` keyword and trailing semicolon, so that the leading and trailing comments can be properly reported.)
* The "default" pseudo-option produces a span that includes only the value.
* The "json_name" pseudo-option produces two spans -- one that includes the entire declaration (like options) and one that includes only the value (like the default).

Fixes #10478.

Take this test file for example:
```protobuf
syntax = "proto2";

package foo.bar;

import "google/protobuf/descriptor.proto";

extend google.protobuf.FieldOptions {
  optional int64 abc = 10000;
}

message M {
  optional string name = 1 [
    default = "blahblah",
    json_name = "_NAME_",
    deprecated = false,
    (foo.bar.abc) = -99
  ];
}
```

It produces source code info for options and pseudo-options with locations like so:
```protobuf
    // entire options block, from "[" to "]"
    location {
      path: [4, 0, 2, 0, 8]
      span: [11, 27, 16, 3]
    }
    // the field's default_value, span includes only the value
    location {
      path: [4, 0, 2, 0, 7]
      span: [12, 14, 24]
    }
    // the field's json_name, span includes entire declaration
    location {
      path: [4, 0, 2, 0, 10]
      span: [13, 4, 24]
    }
    // the field's json_name (again), span includes only the value
    location {
      path: [4, 0, 2, 0, 10]
      span: [13, 16, 24]
    }
    // the deprecated option, span includes entire declaration
    location {
      path: [4, 0, 2, 0, 8, 3]
      span: [14, 4, 22]
    }
    // the (foo.bar.abc) custom option, span includes entire declaration
    location {
      path: [4, 0, 2, 0, 8, 10000]
      span: [15, 4, 23]
    }
```

This pull request makes the source code info for `json_name` and `default` pseudo-options consistent with other options:

```protobuf
    location {
      path: [4, 0, 2, 0, 8]
      span: [11, 27, 16, 3]
    }
    location {
      path: [4, 0, 2, 0, 7]
      span: [12, 4, 24]
    }
    location {
      path: [4, 0, 2, 0, 10]
      span: [13, 4, 24]
    }
    location {
      path: [4, 0, 2, 0, 8, 3]
      span: [14, 4, 22]
    }
    location {
      path: [4, 0, 2, 0, 8, 10000]
      span: [15, 4, 23]
    }
```