### PR TITLE
Update conformance/README.md for jruby

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -81,7 +81,7 @@ Ruby:
 JRuby:
 
     $ [[ $(ruby --version) == "jruby"* ]] || echo "Switch to Java Ruby!"
-    $ bazel test //ruby:conformance_test --define=ruby_platform=java \
+    $ bazel test //ruby:conformance_test_jruby --define=ruby_platform=java \
         --action_env=PATH --action_env=GEM_PATH --action_env=GEM_HOME
 
 Testing other Protocol Buffer implementations


### PR DESCRIPTION
Fix conformance test command for jruby to use conformance_test_jruby target.