### PR TITLE
[C#] Use string literals instead of base64

### DIFF
--- a/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto2.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto2.cs
@@ -2376,7 +2376,7 @@ namespace ProtobufTestMessages.Proto2 {
 
     /// <summary>Field number for the "default_string" field.</summary>
     public const int DefaultStringFieldNumber = 254;
-    private readonly static string DefaultStringDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("Um9zZWJ1ZA=="), 0, 7);
+    private readonly static string DefaultStringDefaultValue = "Rosebud";
 
     private string defaultString_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/csharp/src/Google.Protobuf.Test.TestProtos/Unittest.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/Unittest.cs
@@ -888,7 +888,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     public static readonly pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, bool> DefaultBoolExtension =
       new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, bool>(73, pb::FieldCodec.ForBool(584, true));
     public static readonly pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string> DefaultStringExtension =
-      new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string>(74, pb::FieldCodec.ForString(594, global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("aGVsbG8="), 0, 5)));
+      new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string>(74, pb::FieldCodec.ForString(594, "hello"));
     public static readonly pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, pb::ByteString> DefaultBytesExtension =
       new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, pb::ByteString>(75, pb::FieldCodec.ForBytes(602, pb::ByteString.FromBase64("d29ybGQ=")));
     public static readonly pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedEnum> DefaultNestedEnumExtension =
@@ -898,9 +898,9 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     public static readonly pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, global::Google.Protobuf.TestProtos.Proto2.ImportEnum> DefaultImportEnumExtension =
       new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, global::Google.Protobuf.TestProtos.Proto2.ImportEnum>(83, pb::FieldCodec.ForEnum(664, x => (int) x, x => (global::Google.Protobuf.TestProtos.Proto2.ImportEnum) x, global::Google.Protobuf.TestProtos.Proto2.ImportEnum.ImportBar));
     public static readonly pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string> DefaultStringPieceExtension =
-      new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string>(84, pb::FieldCodec.ForString(674, global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("YWJj"), 0, 3)));
+      new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string>(84, pb::FieldCodec.ForString(674, "abc"));
     public static readonly pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string> DefaultCordExtension =
-      new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string>(85, pb::FieldCodec.ForString(682, global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("MTIz"), 0, 3)));
+      new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string>(85, pb::FieldCodec.ForString(682, "123"));
     /// <summary>
     /// For oneof test
     /// </summary>
@@ -2513,7 +2513,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "default_string" field.</summary>
     public const int DefaultStringFieldNumber = 74;
-    private readonly static string DefaultStringDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("aGVsbG8="), 0, 5);
+    private readonly static string DefaultStringDefaultValue = "hello";
 
     private string defaultString_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2646,7 +2646,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "default_string_piece" field.</summary>
     public const int DefaultStringPieceFieldNumber = 84;
-    private readonly static string DefaultStringPieceDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("YWJj"), 0, 3);
+    private readonly static string DefaultStringPieceDefaultValue = "abc";
 
     private string defaultStringPiece_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2672,7 +2672,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "default_cord" field.</summary>
     public const int DefaultCordFieldNumber = 85;
-    private readonly static string DefaultCordDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("MTIz"), 0, 3);
+    private readonly static string DefaultCordDefaultValue = "123";
 
     private string defaultCord_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8032,7 +8032,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       /// compile.
       /// </summary>
       public static readonly pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string> Test =
-        new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string>(1002, pb::FieldCodec.ForString(8018, global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("dGVzdA=="), 0, 4)));
+        new pb::Extension<global::Google.Protobuf.TestProtos.Proto2.TestAllExtensions, string>(1002, pb::FieldCodec.ForString(8018, "test"));
       /// <summary>
       /// Used to test if generated extension name is correct when there are
       /// underscores.
@@ -17150,7 +17150,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "utf8_string" field.</summary>
     public const int Utf8StringFieldNumber = 6;
-    private readonly static string Utf8StringDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("4Yi0"), 0, 3);
+    private readonly static string Utf8StringDefaultValue = "\u1234";
 
     private string utf8String_;
     /// <summary>
@@ -17541,7 +17541,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "cpp_trigraph" field.</summary>
     public const int CppTrigraphFieldNumber = 20;
-    private readonly static string CppTrigraphDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("PyA/ID8/ID8/ID8/PyA/Py8gPz8t"), 0, 21);
+    private readonly static string CppTrigraphDefaultValue = "\u003f\u0020\u003f\u0020\u003f\u003f\u0020\u003f\u003f\u0020\u003f\u003f\u003f\u0020\u003f\u003f\u002f\u0020\u003f\u003f\u002d";
 
     private string cppTrigraph_;
     /// <summary>
@@ -17574,7 +17574,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "string_with_zero" field.</summary>
     public const int StringWithZeroFieldNumber = 23;
-    private readonly static string StringWithZeroDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("aGVsAGxv"), 0, 6);
+    private readonly static string StringWithZeroDefaultValue = "hel\u0000lo";
 
     private string stringWithZero_;
     /// <summary>
@@ -17629,7 +17629,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "string_piece_with_zero" field.</summary>
     public const int StringPieceWithZeroFieldNumber = 25;
-    private readonly static string StringPieceWithZeroDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("YWIAYw=="), 0, 4);
+    private readonly static string StringPieceWithZeroDefaultValue = "ab\u0000c";
 
     private string stringPieceWithZero_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -17655,7 +17655,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "cord_with_zero" field.</summary>
     public const int CordWithZeroFieldNumber = 26;
-    private readonly static string CordWithZeroDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("MTIAMw=="), 0, 4);
+    private readonly static string CordWithZeroDefaultValue = "12\u00003";
 
     private string cordWithZero_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -17681,7 +17681,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "replacement_string" field.</summary>
     public const int ReplacementStringFieldNumber = 27;
-    private readonly static string ReplacementStringDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("JHt1bmtub3dufQ=="), 0, 10);
+    private readonly static string ReplacementStringDefaultValue = "\u0024\u007bunknown\u007d";
 
     private string replacementString_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -22114,7 +22114,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string BarString {
-      get { return HasBarString ? (string) bar_ : global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("U1RSSU5H"), 0, 6); }
+      get { return HasBarString ? (string) bar_ : "STRING"; }
       set {
         bar_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         barCase_ = BarOneofCase.BarString;
@@ -22140,7 +22140,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string BarCord {
-      get { return HasBarCord ? (string) bar_ : global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("Q09SRA=="), 0, 4); }
+      get { return HasBarCord ? (string) bar_ : "CORD"; }
       set {
         bar_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         barCase_ = BarOneofCase.BarCord;
@@ -22166,7 +22166,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string BarStringPiece {
-      get { return HasBarStringPiece ? (string) bar_ : global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("U1BJRUNF"), 0, 6); }
+      get { return HasBarStringPiece ? (string) bar_ : "SPIECE"; }
       set {
         bar_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         barCase_ = BarOneofCase.BarStringPiece;
@@ -22268,7 +22268,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "baz_string" field.</summary>
     public const int BazStringFieldNumber = 19;
-    private readonly static string BazStringDefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("QkFa"), 0, 3);
+    private readonly static string BazStringDefaultValue = "BAZ";
 
     private string bazString_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -28501,7 +28501,7 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     /// <summary>Field number for the "a" field.</summary>
     public const int AFieldNumber = 1;
-    private readonly static string ADefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("Ki8gPC0gTmVpdGhlciBzaG91bGQgdGhpcy4="), 0, 26);
+    private readonly static string ADefaultValue = "\u002a\u002f\u0020\u003c\u002d\u0020Neither\u0020should\u0020this\u002e";
 
     private string a_;
     /// <summary>

--- a/src/google/protobuf/compiler/csharp/csharp_field_base.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_field_base.cc
@@ -324,9 +324,7 @@ std::string FieldGeneratorBase::GetStringDefaultValueInternal(const FieldDescrip
     if (descriptor->default_value_string().empty())
         return "\"\"";
     else
-      return "global::System.Text.Encoding.UTF8.GetString(global::System."
-             "Convert.FromBase64String(\"" +
-             StringToBase64(descriptor->default_value_string()) + "\"), 0, " + absl::StrCat(descriptor->default_value_string().length()) + ")";
+        return "\"" + StringToStringLiteral(descriptor->default_value_string()) + "\"";
 }
 
 std::string FieldGeneratorBase::GetBytesDefaultValueInternal(const FieldDescriptor* descriptor) {

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.cc
@@ -35,7 +35,9 @@
 #include "google/protobuf/compiler/csharp/csharp_helpers.h"
 
 #include <algorithm>
+#include <codecvt>
 #include <limits>
+#include <locale>
 #include <sstream>
 #include <vector>
 
@@ -535,6 +537,24 @@ std::string StringToBase64(const std::string& input) {
       result += '=';
       src += 1;
       break;
+  }
+  return result;
+}
+
+static const char hex_chars[] = "0123456789abcdef";
+
+std::string StringToStringLiteral(const std::string& input) {
+  std::string result;
+  for (char16_t ch : std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{}.from_bytes(input)) {
+    if ((ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')) {
+      result += ch;
+      continue;
+    }
+    result += "\\u";
+    result += hex_chars[ch >> 12];
+    result += hex_chars[(ch >> 8) & 0xf];
+    result += hex_chars[(ch >> 4) & 0xf];
+    result += hex_chars[ch & 0xf];
   }
   return result;
 }

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.h
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.h
@@ -111,6 +111,8 @@ std::string PROTOC_EXPORT GetEnumValueName(const std::string& enum_name,
 // TODO(jtattermusch): perhaps we could move this to strutil
 std::string StringToBase64(const std::string& input);
 
+std::string StringToStringLiteral(const std::string& input);
+
 std::string FileDescriptorToBase64(const FileDescriptor* descriptor);
 
 FieldGeneratorBase* CreateFieldGenerator(const FieldDescriptor* descriptor,


### PR DESCRIPTION
Avoids runtime overheads and reduces code size.

This reduces the size of *Google.Protobuf.Test.TestProtos.dll* by 512 bytes.