### PR TITLE
Porting #10512 to 21.x

### DIFF
--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -7,6 +7,10 @@ set -eux
 export HOMEBREW_PREFIX=$(brew --prefix)
 
 ##
+# Remove any pre-existing protobuf installation.
+brew uninstall protobuf
+
+##
 # Select Xcode version
 
 ##

--- a/kokoro/release/python/macos/build_artifacts.sh
+++ b/kokoro/release/python/macos/build_artifacts.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+# Remove any pre-existing protobuf installation.
+brew uninstall protobuf
+
 # change to repo root
 pushd $(dirname $0)/../../../..
 


### PR DESCRIPTION
A pre-existing protobuf installation is causing CI failures (see https://github.com/protocolbuffers/protobuf/pull/10512)