### PR TITLE
[ObjC] Move generation options out to their own file.

### DIFF
--- a/src/file_lists.cmake
+++ b/src/file_lists.cmake
@@ -456,6 +456,7 @@ set(libprotoc_hdrs
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/objectivec_message_field.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/objectivec_nsobject_methods.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/objectivec_oneof.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/objectivec_options.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/php/php_generator.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/plugin.h

--- a/src/google/protobuf/compiler/objectivec/BUILD.bazel
+++ b/src/google/protobuf/compiler/objectivec/BUILD.bazel
@@ -35,6 +35,7 @@ cc_library(
         "objectivec_message_field.h",
         "objectivec_nsobject_methods.h",
         "objectivec_oneof.h",
+        "objectivec_options.h",
         "objectivec_primitive_field.h",
     ],
     copts = COPTS,

--- a/src/google/protobuf/compiler/objectivec/objectivec_file.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.h
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include "google/protobuf/compiler/objectivec/objectivec_options.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/io/printer.h"
 
@@ -49,17 +50,6 @@ class MessageGenerator;
 
 class FileGenerator {
  public:
-  struct GenerationOptions {
-    GenerationOptions()
-      // TODO(thomasvl): Eventually flip this default to false for better
-      // interop with Swift if proto usages span modules made from ObjC sources.
-      : headers_use_forward_declarations(true) {}
-    std::string generate_for_named_framework;
-    std::string named_framework_to_proto_path_mappings_path;
-    std::string runtime_import_prefix;
-    bool headers_use_forward_declarations;
-  };
-
   // Wrapper for some common state that is shared between file generations to
   // improve performance when more than one file is generated at a time.
   struct CommonState {

--- a/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
@@ -103,7 +103,7 @@ bool ObjectiveCGenerator::GenerateAll(
   // e.g. protoc ... --objc_opt=expected_prefixes=file.txt,generate_for_named_framework=MyFramework
 
   Options validation_options;
-  FileGenerator::GenerationOptions generation_options;
+  GenerationOptions generation_options;
 
   std::vector<std::pair<std::string, std::string> > options;
   ParseGeneratorParameter(parameter, &options);

--- a/src/google/protobuf/compiler/objectivec/objectivec_options.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_options.h
@@ -1,0 +1,56 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_OPTIONS_H__
+#define GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_OPTIONS_H__
+
+#include <string>
+
+namespace google {
+namespace protobuf {
+namespace compiler {
+namespace objectivec {
+
+// Generation options, documented within objectivec_generator.cc.
+struct GenerationOptions {
+  std::string generate_for_named_framework;
+  std::string named_framework_to_proto_path_mappings_path;
+  std::string runtime_import_prefix;
+  // TODO(thomasvl): Eventually flip this default to false for better interop
+  // with Swift if proto usages span modules made from ObjC sources.
+  bool headers_use_forward_declarations = true;
+};
+
+}  // namespace objectivec
+}  // namespace compiler
+}  // namespace protobuf
+}  // namespace google
+
+#endif  // GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_OPTIONS_H__


### PR DESCRIPTION
This will make it easier to pass the option down in the future to the other parts (message, enum, extension, etc. generators) as needed.