### PR TITLE
Fix stale descriptor files after comment change

### DIFF
--- a/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
@@ -6641,6 +6641,10 @@ namespace Google.Protobuf.Reflection {
 
     private bool mapEntry_;
     /// <summary>
+    /// NOTE: Do not set the option in .proto files. Always use the maps syntax
+    /// instead. The option should only be implicitly set by the proto compiler
+    /// parser.
+    ///
     /// Whether the message is an automatically generated map entry type for the
     /// maps field.
     ///
@@ -6658,10 +6662,6 @@ namespace Google.Protobuf.Reflection {
     /// use a native map in the target language to hold the keys and values.
     /// The reflection APIs in such implementations still need to work as
     /// if the field is a repeated message field.
-    ///
-    /// NOTE: Do not set the option in .proto files. Always use the maps syntax
-    /// instead. The option should only be implicitly set by the proto compiler
-    /// parser.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]

--- a/php/src/Google/Protobuf/Internal/MessageOptions.php
+++ b/php/src/Google/Protobuf/Internal/MessageOptions.php
@@ -53,6 +53,9 @@ class MessageOptions extends \Google\Protobuf\Internal\Message
      */
     protected $deprecated = null;
     /**
+     * NOTE: Do not set the option in .proto files. Always use the maps syntax
+     * instead. The option should only be implicitly set by the proto compiler
+     * parser.
      * Whether the message is an automatically generated map entry type for the
      * maps field.
      * For maps fields:
@@ -68,9 +71,6 @@ class MessageOptions extends \Google\Protobuf\Internal\Message
      * use a native map in the target language to hold the keys and values.
      * The reflection APIs in such implementations still need to work as
      * if the field is a repeated message field.
-     * NOTE: Do not set the option in .proto files. Always use the maps syntax
-     * instead. The option should only be implicitly set by the proto compiler
-     * parser.
      *
      * Generated from protobuf field <code>optional bool map_entry = 7;</code>
      */
@@ -114,6 +114,9 @@ class MessageOptions extends \Google\Protobuf\Internal\Message
      *           for the message, or it will be completely ignored; in the very least,
      *           this is a formalization for deprecating messages.
      *     @type bool $map_entry
+     *           NOTE: Do not set the option in .proto files. Always use the maps syntax
+     *           instead. The option should only be implicitly set by the proto compiler
+     *           parser.
      *           Whether the message is an automatically generated map entry type for the
      *           maps field.
      *           For maps fields:
@@ -129,9 +132,6 @@ class MessageOptions extends \Google\Protobuf\Internal\Message
      *           use a native map in the target language to hold the keys and values.
      *           The reflection APIs in such implementations still need to work as
      *           if the field is a repeated message field.
-     *           NOTE: Do not set the option in .proto files. Always use the maps syntax
-     *           instead. The option should only be implicitly set by the proto compiler
-     *           parser.
      *     @type array<\Google\Protobuf\Internal\UninterpretedOption>|\Google\Protobuf\Internal\RepeatedField $uninterpreted_option
      *           The parser stores options it doesn't recognize here. See above.
      * }
@@ -288,6 +288,9 @@ class MessageOptions extends \Google\Protobuf\Internal\Message
     }
 
     /**
+     * NOTE: Do not set the option in .proto files. Always use the maps syntax
+     * instead. The option should only be implicitly set by the proto compiler
+     * parser.
      * Whether the message is an automatically generated map entry type for the
      * maps field.
      * For maps fields:
@@ -303,9 +306,6 @@ class MessageOptions extends \Google\Protobuf\Internal\Message
      * use a native map in the target language to hold the keys and values.
      * The reflection APIs in such implementations still need to work as
      * if the field is a repeated message field.
-     * NOTE: Do not set the option in .proto files. Always use the maps syntax
-     * instead. The option should only be implicitly set by the proto compiler
-     * parser.
      *
      * Generated from protobuf field <code>optional bool map_entry = 7;</code>
      * @return bool
@@ -326,6 +326,9 @@ class MessageOptions extends \Google\Protobuf\Internal\Message
     }
 
     /**
+     * NOTE: Do not set the option in .proto files. Always use the maps syntax
+     * instead. The option should only be implicitly set by the proto compiler
+     * parser.
      * Whether the message is an automatically generated map entry type for the
      * maps field.
      * For maps fields:
@@ -341,9 +344,6 @@ class MessageOptions extends \Google\Protobuf\Internal\Message
      * use a native map in the target language to hold the keys and values.
      * The reflection APIs in such implementations still need to work as
      * if the field is a repeated message field.
-     * NOTE: Do not set the option in .proto files. Always use the maps syntax
-     * instead. The option should only be implicitly set by the proto compiler
-     * parser.
      *
      * Generated from protobuf field <code>optional bool map_entry = 7;</code>
      * @param bool $var


### PR DESCRIPTION
This was broken by a change in the proto comments in https://github.com/protocolbuffers/protobuf/pull/10493.  No tests were run, so it wasn't caught until later