### PR TITLE
protoc: validate custom json_name configuration

### DIFF
--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -1972,12 +1972,14 @@ TEST_F(ParserValidationErrorTest, Proto3Default) {
 
 TEST_F(ParserValidationErrorTest, Proto3JsonConflictError) {
   ExpectHasValidationErrors(
-      "syntax = 'proto3';\n"
-      "message TestMessage {\n"
-      "  uint32 foo = 1;\n"
-      "  uint32 Foo = 2;\n"
-      "}\n",
-      "3:9: The default JSON name of field \"Foo\" (\"Foo\") conflicts "
+      R"pb(
+      syntax = 'proto3';
+      message TestMessage {
+        uint32 foo = 1;
+        uint32 Foo = 2;
+      }
+      )pb",
+      "4:15: The default JSON name of field \"Foo\" (\"Foo\") conflicts "
       "with the default JSON name of field \"foo\" (\"foo\"). "
       "This is not allowed in proto3.\n");
 }
@@ -1985,33 +1987,38 @@ TEST_F(ParserValidationErrorTest, Proto3JsonConflictError) {
 TEST_F(ParserValidationErrorTest, Proto2JsonConflictError) {
   // conflicts with default JSON names are not errors in proto2
   ExpectParsesTo(
-      "syntax = 'proto2';\n"
-      "message TestMessage {\n"
-      "  optional uint32 foo = 1;\n"
-      "  optional uint32 Foo = 2;\n"
-      "}\n",
-
-      "syntax: 'proto2'"
-      "message_type {"
-      "  name: 'TestMessage'"
-      "  field {"
-      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1"
-      "  }"
-      "  field {"
-      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'Foo' number: 2"
-      "  }"
-      "}"
+      R"pb(
+      syntax = "proto2";
+      message TestMessage {
+        optional uint32 foo = 1;
+        optional uint32 Foo = 2;
+      }
+      )pb",
+      R"pb(
+      syntax: 'proto2'
+      message_type {
+        name: 'TestMessage'
+        field {
+          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1
+        }
+        field {
+          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'Foo' number: 2
+        }
+      }
+      )pb"
       );
 }
 
 TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictWithDefaultError) {
   ExpectHasValidationErrors(
-      "syntax = 'proto3';\n"
-      "message TestMessage {\n"
-      "  uint32 foo = 1 [json_name='bar'];\n"
-      "  uint32 bar = 2;\n"
-      "}\n",
-      "3:9: The default JSON name of field \"bar\" (\"bar\") conflicts "
+      R"pb(
+      syntax = 'proto3';
+      message TestMessage {
+        uint32 foo = 1 [json_name='bar'];
+        uint32 bar = 2;
+      }
+      )pb",
+      "4:15: The default JSON name of field \"bar\" (\"bar\") conflicts "
       "with the custom JSON name of field \"foo\". "
       "This is not allowed in proto3.\n");
 }
@@ -2019,45 +2026,52 @@ TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictWithDefaultError) {
 TEST_F(ParserValidationErrorTest, Proto2CustomJsonConflictWithDefaultError) {
   // conflicts with default JSON names are not errors in proto2
   ExpectParsesTo(
-      "syntax = 'proto2';\n"
-      "message TestMessage {\n"
-      "  optional uint32 foo = 1 [json_name='bar'];\n"
-      "  optional uint32 bar = 2;\n"
-      "}\n",
-
-      "syntax: 'proto2'"
-      "message_type {"
-      "  name: 'TestMessage'"
-      "  field {"
-      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1 json_name: 'bar'"
-      "  }"
-      "  field {"
-      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'bar' number: 2"
-      "  }"
-      "}"
+      R"pb(
+      syntax = 'proto2';
+      message TestMessage {
+        optional uint32 foo = 1 [json_name='bar'];
+        optional uint32 bar = 2;
+      }
+      )pb",
+      R"pb(
+      syntax: 'proto2'
+      message_type {
+        name: 'TestMessage'
+        field {
+          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1 json_name: 'bar'
+        }
+        field {
+          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'bar' number: 2
+        }
+      }
+      )pb"
       );
 }
 
 TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictError) {
   ExpectHasValidationErrors(
-      "syntax = 'proto3';\n"
-      "message TestMessage {\n"
-      "  uint32 foo = 1 [json_name='baz'];\n"
-      "  uint32 bar = 2 [json_name='baz'];\n"
-      "}\n",
-      "3:9: The custom JSON name of field \"bar\" (\"baz\") conflicts "
+      R"pb(
+      syntax = 'proto3';
+      message TestMessage {
+        uint32 foo = 1 [json_name='baz'];
+        uint32 bar = 2 [json_name='baz'];
+      }
+      )pb",
+      "4:15: The custom JSON name of field \"bar\" (\"baz\") conflicts "
       "with the custom JSON name of field \"foo\".\n");
 }
 
 TEST_F(ParserValidationErrorTest, Proto2CustomJsonConflictError) {
   ExpectHasValidationErrors(
-      "syntax = 'proto2';\n"
-      "message TestMessage {\n"
-      "  optional uint32 foo = 1 [json_name='baz'];\n"
-      "  optional uint32 bar = 2 [json_name='baz'];\n"
-      "}\n",
+      R"pb(
+      syntax = 'proto2';
+      message TestMessage {
+        optional uint32 foo = 1 [json_name='baz'];
+        optional uint32 bar = 2 [json_name='baz'];
+      }
+      )pb",
       // fails in proto2 also: can't explicitly configure bad custom JSON names
-      "3:18: The custom JSON name of field \"bar\" (\"baz\") conflicts "
+      "4:24: The custom JSON name of field \"bar\" (\"baz\") conflicts "
       "with the custom JSON name of field \"foo\".\n");
 }
 

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -1977,8 +1977,88 @@ TEST_F(ParserValidationErrorTest, Proto3JsonConflictError) {
       "  uint32 foo = 1;\n"
       "  uint32 Foo = 2;\n"
       "}\n",
-      "3:9: The JSON camel-case name of field \"Foo\" conflicts with field "
-      "\"foo\". This is not allowed in proto3.\n");
+      "3:9: The default JSON name of field \"Foo\" (\"Foo\") conflicts "
+      "with the default JSON name of field \"foo\" (\"foo\"). "
+      "This is not allowed in proto3.\n");
+}
+
+TEST_F(ParserValidationErrorTest, Proto2JsonConflictError) {
+  // conflicts with default JSON names are not errors in proto2
+  ExpectParsesTo(
+      "syntax = 'proto2';\n"
+      "message TestMessage {\n"
+      "  optional uint32 foo = 1;\n"
+      "  optional uint32 Foo = 2;\n"
+      "}\n",
+
+      "syntax: 'proto2'"
+      "message_type {"
+      "  name: 'TestMessage'"
+      "  field {"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1"
+      "  }"
+      "  field {"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'Foo' number: 2"
+      "  }"
+      "}"
+      );
+}
+
+TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictWithDefaultError) {
+  ExpectHasValidationErrors(
+      "syntax = 'proto3';\n"
+      "message TestMessage {\n"
+      "  uint32 foo = 1 [json_name='bar'];\n"
+      "  uint32 bar = 2;\n"
+      "}\n",
+      "3:9: The default JSON name of field \"bar\" (\"bar\") conflicts "
+      "with the custom JSON name of field \"foo\". "
+      "This is not allowed in proto3.\n");
+}
+
+TEST_F(ParserValidationErrorTest, Proto2CustomJsonConflictWithDefaultError) {
+  // conflicts with default JSON names are not errors in proto2
+  ExpectParsesTo(
+      "syntax = 'proto2';\n"
+      "message TestMessage {\n"
+      "  optional uint32 foo = 1 [json_name='bar'];\n"
+      "  optional uint32 bar = 2;\n"
+      "}\n",
+
+      "syntax: 'proto2'"
+      "message_type {"
+      "  name: 'TestMessage'"
+      "  field {"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1 json_name: 'bar'"
+      "  }"
+      "  field {"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'bar' number: 2"
+      "  }"
+      "}"
+      );
+}
+
+TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictError) {
+  ExpectHasValidationErrors(
+      "syntax = 'proto3';\n"
+      "message TestMessage {\n"
+      "  uint32 foo = 1 [json_name='baz'];\n"
+      "  uint32 bar = 2 [json_name='baz'];\n"
+      "}\n",
+      "3:9: The custom JSON name of field \"bar\" (\"baz\") conflicts "
+      "with the custom JSON name of field \"foo\".\n");
+}
+
+TEST_F(ParserValidationErrorTest, Proto2CustomJsonConflictError) {
+  ExpectHasValidationErrors(
+      "syntax = 'proto2';\n"
+      "message TestMessage {\n"
+      "  optional uint32 foo = 1 [json_name='baz'];\n"
+      "  optional uint32 bar = 2 [json_name='baz'];\n"
+      "}\n",
+      // fails in proto2 also: can't explicitly configure bad custom JSON names
+      "3:18: The custom JSON name of field \"bar\" (\"baz\") conflicts "
+      "with the custom JSON name of field \"foo\".\n");
 }
 
 TEST_F(ParserValidationErrorTest, EnumNameError) {

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -5494,7 +5494,8 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     const DescriptorProto& proto, const Descriptor* result) {
   bool is_proto2 = result->file()->syntax() == FileDescriptor::SYNTAX_PROTO2;
   std::string message_name = result->full_name();
-  // two passes: one looking only at default JSON names, and one that considers custom JSON names
+  // two passes: one looking only at default JSON names, and one that considers
+  // custom JSON names
   CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, false);
   CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, true);
 }
@@ -5502,7 +5503,8 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
 namespace {
 // Helpers for function below
 
-std::string GetJsonName(const FieldDescriptorProto& field, bool use_custom, bool* was_custom) {
+std::string GetJsonName(const FieldDescriptorProto& field, bool use_custom,
+                        bool* was_custom) {
   if (use_custom && field.has_json_name()) {
     *was_custom = true;
     return field.json_name();
@@ -5520,7 +5522,8 @@ struct JsonNameDetails {
 } // namespace
 
 void DescriptorBuilder::CheckFieldJsonNameUniqueness(
-    std::string message_name,const DescriptorProto& message, bool is_proto2, bool use_custom_names) {
+    std::string message_name, const DescriptorProto& message, bool is_proto2,
+    bool use_custom_names) {
 
   absl::flat_hash_map<std::string, JsonNameDetails> name_to_field;
   for (const FieldDescriptorProto& field : message.field()) {
@@ -5532,35 +5535,38 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
       JsonNameDetails& match = existing->second;
       if (use_custom_names && !is_custom && !match.is_custom) {
         // if this pass is considering custom JSON names, but neither of the
-        // names involved in the conflict are custom, don't bother with a message.
-        // That will have been reported from other pass (non-custom JSON names).
+        // names involved in the conflict are custom, don't bother with a
+        // message. That will have been reported from other pass (non-custom
+        // JSON names).
         continue;
       }
       absl::string_view this_type = is_custom ? "custom" : "default";
       absl::string_view existing_type = match.is_custom ? "custom" : "default";
-      // If the matched name differs (which it can only differ in case), include it
-      // in the error message, for maximum clarity to user.
+      // If the matched name differs (which it can only differ in case), include
+      // it in the error message, for maximum clarity to user.
       absl::string_view name_suffix = "";
       if (name != match.orig_name) {
         name_suffix = absl::StrCat(" (\"", match.orig_name, "\")");
       }
-      std::string error_message = absl::StrFormat(
-          "The %s JSON name of field \"%s\" (\"%s\") conflicts with the %s JSON name of field \"%s\"%s.",
-          this_type, field.name(), name, existing_type, match.field->name(), name_suffix);
+      std::string error_message =
+          absl::StrFormat("The %s JSON name of field \"%s\" (\"%s\") conflicts "
+                          "with the %s JSON name of field \"%s\"%s.",
+                          this_type, field.name(), name, existing_type,
+                          match.field->name(), name_suffix);
 
       bool involves_default = !is_custom || !match.is_custom;
       if (is_proto2 && involves_default) {
-        AddWarning(message_name, field,
-                 DescriptorPool::ErrorCollector::NAME, error_message);
+        AddWarning(message_name, field, DescriptorPool::ErrorCollector::NAME,
+                   error_message);
       } else {
         if (involves_default) {
           absl::StrAppend(&error_message, " This is not allowed in proto3.");
         }
-        AddError(message_name, field,
-                 DescriptorPool::ErrorCollector::NAME, error_message);
+        AddError(message_name, field, DescriptorPool::ErrorCollector::NAME,
+                 error_message);
       }
     } else {
-      JsonNameDetails details = { &field, name, is_custom };
+      JsonNameDetails details = {&field, name, is_custom};
       name_to_field[lowercase_name] = details;
     }
   }
@@ -5974,8 +5980,7 @@ void DescriptorBuilder::CheckEnumValueUniqueness(
     const EnumValueDescriptor* value = result->value(i);
     std::string stripped =
         EnumValueToPascalCase(remover.MaybeRemove(value->name()));
-    std::pair<absl::flat_hash_map<std::string, const EnumValueDescriptor*>::iterator, bool>
-        insert_result = values.insert(std::make_pair(stripped, value));
+    auto insert_result = values.insert(std::make_pair(stripped, value));
     bool inserted = insert_result.second;
 
     // We don't throw the error if the two conflicting symbols are identical, or

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -5982,9 +5982,8 @@ void DescriptorBuilder::CheckEnumValueUniqueness(
           "Enum name " + value->name() + " has the same name as " +
           values[stripped]->name() +
           " if you ignore case and strip out the enum name prefix (if any). "
-          "This is error-prone and can lead to undefined behavior. "
-          "Please avoid doing this. If you are using allow_alias, please "
-          "assign the same numeric value to both enums.";
+          "(If you are using allow_alias, please assign the same numeric "
+          "value to both enums.)";
       // There are proto2 enums out there with conflicting names, so to preserve
       // compatibility we issue only a warning for proto2.
       if (result->file()->syntax() == FileDescriptor::SYNTAX_PROTO2) {

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -5504,21 +5504,19 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
 namespace {
 // Helpers for function below
 
-std::string GetJsonName(const FieldDescriptorProto& field, bool use_custom,
-                        bool* was_custom) {
-  if (use_custom && field.has_json_name()) {
-    *was_custom = true;
-    return field.json_name();
-  }
-  *was_custom = false;
-  return ToJsonName(field.name());
-}
-
 struct JsonNameDetails {
   const FieldDescriptorProto* field;
   std::string orig_name;
   bool is_custom;
 };
+
+JsonNameDetails GetJsonNameDetails(const FieldDescriptorProto* field, bool use_custom) {
+  if (use_custom && field->has_json_name()) {
+    return {field, field->json_name(), true};
+  }
+  return {field, ToJsonName(field->name()), false};
+}
+
 
 } // namespace
 
@@ -5528,38 +5526,36 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
 
   absl::flat_hash_map<std::string, JsonNameDetails> name_to_field;
   for (const FieldDescriptorProto& field : message.field()) {
-    bool is_custom;
-    std::string name = GetJsonName(field, use_custom_names, &is_custom);
-    std::string lowercase_name = absl::AsciiStrToLower(name);
+    JsonNameDetails details = GetJsonNameDetails(&field, use_custom_names);
+    std::string lowercase_name = absl::AsciiStrToLower(details.orig_name);
     auto existing = name_to_field.find(lowercase_name);
     if (existing == name_to_field.end()) {
-      JsonNameDetails details = {&field, name, is_custom};
       name_to_field[lowercase_name] = details;
       continue;
     }
     JsonNameDetails& match = existing->second;
-    if (use_custom_names && !is_custom && !match.is_custom) {
+    if (use_custom_names && !details.is_custom && !match.is_custom) {
       // if this pass is considering custom JSON names, but neither of the
       // names involved in the conflict are custom, don't bother with a
       // message. That will have been reported from other pass (non-custom
       // JSON names).
       continue;
     }
-    absl::string_view this_type = is_custom ? "custom" : "default";
+    absl::string_view this_type = details.is_custom ? "custom" : "default";
     absl::string_view existing_type = match.is_custom ? "custom" : "default";
     // If the matched name differs (which it can only differ in case), include
     // it in the error message, for maximum clarity to user.
     absl::string_view name_suffix = "";
-    if (name != match.orig_name) {
+    if (details.orig_name != match.orig_name) {
       name_suffix = absl::StrCat(" (\"", match.orig_name, "\")");
     }
     std::string error_message =
         absl::StrFormat("The %s JSON name of field \"%s\" (\"%s\") conflicts "
                         "with the %s JSON name of field \"%s\"%s.",
-                        this_type, field.name(), name, existing_type,
+                        this_type, field.name(), details.orig_name, existing_type,
                         match.field->name(), name_suffix);
 
-    bool involves_default = !is_custom || !match.is_custom;
+    bool involves_default = !details.is_custom || !match.is_custom;
     if (syntax == FileDescriptor::SYNTAX_PROTO2 && involves_default) {
       AddWarning(message_name, field, DescriptorPool::ErrorCollector::NAME,
                  error_message);

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -3858,9 +3858,9 @@ class DescriptorBuilder {
                    const ServiceDescriptor* parent, MethodDescriptor* result,
                    internal::FlatAllocator& alloc);
 
-  void CheckFieldJSONNameUniqueness(const DescriptorProto& proto,
+  void CheckFieldJsonNameUniqueness(const DescriptorProto& proto,
                                     const Descriptor* result);
-  void CheckFieldJSONNameUniqueness(std::string message_name,
+  void CheckFieldJsonNameUniqueness(std::string message_name,
                                     const DescriptorProto& message,
                                     bool is_proto2, bool use_custom_names);
   void CheckEnumValueUniqueness(const EnumDescriptorProto& proto,
@@ -5421,7 +5421,7 @@ void DescriptorBuilder::BuildMessage(const DescriptorProto& proto,
     }
   }
 
-  CheckFieldJSONNameUniqueness(proto, result);
+  CheckFieldJsonNameUniqueness(proto, result);
 
   // Check that fields aren't using reserved names or numbers and that they
   // aren't using extension numbers.
@@ -5489,7 +5489,7 @@ void DescriptorBuilder::BuildMessage(const DescriptorProto& proto,
   }
 }
 
-std::string GetJSONName(const FieldDescriptorProto& field, bool use_custom, bool* was_custom) {
+std::string GetJsonName(const FieldDescriptorProto& field, bool use_custom, bool* was_custom) {
   if (use_custom && field.has_json_name()) {
     *was_custom = true;
     return field.json_name();
@@ -5498,28 +5498,28 @@ std::string GetJSONName(const FieldDescriptorProto& field, bool use_custom, bool
   return ToJsonName(field.name());
 }
 
-void DescriptorBuilder::CheckFieldJSONNameUniqueness(
+void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     const DescriptorProto& proto, const Descriptor* result) {
   bool is_proto2 = result->file()->syntax() == FileDescriptor::SYNTAX_PROTO2;
   std::string message_name = result->full_name();
   // two passes: one looking only at default JSON names, and one that considers custom JSON names
-  CheckFieldJSONNameUniqueness(message_name, proto, is_proto2, false);
-  CheckFieldJSONNameUniqueness(message_name, proto, is_proto2, true);
+  CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, false);
+  CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, true);
 }
 
-struct JSONNameDetails {
+struct JsonNameDetails {
   const FieldDescriptorProto* field;
   std::string orig_name;
   bool is_custom;
 };
 
-void DescriptorBuilder::CheckFieldJSONNameUniqueness(
+void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     std::string message_name,const DescriptorProto& message, bool is_proto2, bool use_custom_names) {
 
-  std::map<std::string, struct JSONNameDetails> name_to_field;
+  std::map<std::string, JsonNameDetails> name_to_field;
   for (int i = 0; i < message.field_size(); ++i) {
     bool is_custom;
-    std::string name = GetJSONName(message.field(i), use_custom_names, &is_custom);
+    std::string name = GetJsonName(message.field(i), use_custom_names, &is_custom);
     std::string lowercase_name = absl::AsciiStrToLower(name);
     auto existing = name_to_field.find(lowercase_name);
     if (existing != name_to_field.end()) {
@@ -5552,7 +5552,7 @@ void DescriptorBuilder::CheckFieldJSONNameUniqueness(
                  DescriptorPool::ErrorCollector::NAME, error_message);
       }
     } else {
-      struct JSONNameDetails details = { &message.field(i), name, is_custom };
+      JsonNameDetails details = { &message.field(i), name, is_custom };
       name_to_field[lowercase_name] = details;
     }
   }

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -6411,9 +6411,8 @@ TEST_F(ValidationErrorTest, EnumValuesConflictWithDifferentCasing) {
       "}",
       "foo.proto: bar: NAME: Enum name bar has the same name as BAR "
       "if you ignore case and strip out the enum name prefix (if any). "
-      "This is error-prone and can lead to undefined behavior. "
-      "Please avoid doing this. If you are using allow_alias, please assign "
-      "the same numeric value to both enums.\n");
+      "(If you are using allow_alias, please assign the same numeric "
+      "value to both enums.) This is not allowed in proto3.\n");
 
   // Not an error because both enums are mapped to the same value.
   BuildFile(
@@ -6439,9 +6438,8 @@ TEST_F(ValidationErrorTest, EnumValuesConflictWhenPrefixesStripped) {
       "}",
       "foo.proto: BAZ: NAME: Enum name BAZ has the same name as FOO_ENUM_BAZ "
       "if you ignore case and strip out the enum name prefix (if any). "
-      "This is error-prone and can lead to undefined behavior. "
-      "Please avoid doing this. If you are using allow_alias, please assign "
-      "the same numeric value to both enums.\n");
+      "(If you are using allow_alias, please assign the same numeric value "
+      "to both enums.) This is not allowed in proto3.\n");
 
   BuildFileWithErrors(
       "syntax: 'proto3'"
@@ -6453,9 +6451,8 @@ TEST_F(ValidationErrorTest, EnumValuesConflictWhenPrefixesStripped) {
       "}",
       "foo.proto: BAZ: NAME: Enum name BAZ has the same name as FOOENUM_BAZ "
       "if you ignore case and strip out the enum name prefix (if any). "
-      "This is error-prone and can lead to undefined behavior. "
-      "Please avoid doing this. If you are using allow_alias, please assign "
-      "the same numeric value to both enums.\n");
+      "(If you are using allow_alias, please assign the same numeric value "
+      "to both enums.) This is not allowed in proto3.\n");
 
   BuildFileWithErrors(
       "syntax: 'proto3'"
@@ -6467,9 +6464,8 @@ TEST_F(ValidationErrorTest, EnumValuesConflictWhenPrefixesStripped) {
       "}",
       "foo.proto: BAR__BAZ: NAME: Enum name BAR__BAZ has the same name as "
       "FOO_ENUM_BAR_BAZ if you ignore case and strip out the enum name prefix "
-      "(if any). This is error-prone and can lead to undefined behavior. "
-      "Please avoid doing this. If you are using allow_alias, please assign "
-      "the same numeric value to both enums.\n");
+      "(if any). (If you are using allow_alias, please assign the same numeric "
+      "value to both enums.) This is not allowed in proto3.\n");
 
   BuildFileWithErrors(
       "syntax: 'proto3'"
@@ -6481,9 +6477,8 @@ TEST_F(ValidationErrorTest, EnumValuesConflictWhenPrefixesStripped) {
       "}",
       "foo.proto: BAR_BAZ: NAME: Enum name BAR_BAZ has the same name as "
       "FOO_ENUM__BAR_BAZ if you ignore case and strip out the enum name prefix "
-      "(if any). This is error-prone and can lead to undefined behavior. "
-      "Please avoid doing this. If you are using allow_alias, please assign "
-      "the same numeric value to both enums.\n");
+      "(if any). (If you are using allow_alias, please assign the same numeric "
+      "value to both enums.) This is not allowed in proto3.\n");
 
   // This isn't an error because the underscore will cause the PascalCase to
   // differ by case (BarBaz vs. Barbaz).
@@ -6828,8 +6823,9 @@ TEST_F(ValidationErrorTest, ValidateProto3JsonName) {
       "  field { name:'name' number:1 label:LABEL_OPTIONAL type:TYPE_INT32 }"
       "  field { name:'Name' number:2 label:LABEL_OPTIONAL type:TYPE_INT32 }"
       "}",
-      "foo.proto: Foo: NAME: The JSON camel-case name of field \"Name\" "
-      "conflicts with field \"name\". This is not allowed in proto3.\n");
+      "foo.proto: Foo: NAME: The default JSON name of field \"Name\" (\"Name\") "
+      "conflicts with the default JSON name of field \"name\" (\"name\"). This is "
+      "not allowed in proto3.\n");
   // Underscores are ignored.
   BuildFileWithErrors(
       "name: 'foo.proto' "
@@ -6839,8 +6835,9 @@ TEST_F(ValidationErrorTest, ValidateProto3JsonName) {
       "  field { name:'ab' number:1 label:LABEL_OPTIONAL type:TYPE_INT32 }"
       "  field { name:'_a__b_' number:2 label:LABEL_OPTIONAL type:TYPE_INT32 }"
       "}",
-      "foo.proto: Foo: NAME: The JSON camel-case name of field \"_a__b_\" "
-      "conflicts with field \"ab\". This is not allowed in proto3.\n");
+      "foo.proto: Foo: NAME: The default JSON name of field \"_a__b_\" (\"AB\") "
+      "conflicts with the default JSON name of field \"ab\" (\"ab\"). This is not "
+      "allowed in proto3.\n");
 }
 
 


### PR DESCRIPTION
This makes a few other related changes, for consistency:
* Adds the existing checks, for default JSON names, to run even for proto2 files, but only as warnings (symmetry with similar check for enum value names).
* Tweaks the similar check for enum value names to include "This is not allowed in proto3", for clarity, since it's only a warning in proto2.

When checking custom JSON names, this considers it an error even in proto2 if two `json_name` options conflict. However, if a `json_name` option conflicts with a _default_ JSON name, it is just a warning in proto2 (aligns with the existing check and the similar check for enum value names).

Fixes #5063.