### PR TITLE
[PHP] allow dynamic properties in Message

### DIFF
--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -54,6 +54,7 @@ use Google\Protobuf\NullValue;
  * or extend this class or its child classes by their own.  See the comment of
  * specific functions for more details.
  */
+#[\AllowDynamicProperties]
 class Message
 {
 


### PR DESCRIPTION
PHP 8.2 complains about Internal\Message setting dynamic properties:

`Creation of dynamic property xxx is deprecated
/usr/src/myapp/vendor/google/protobuf/src/Google/Protobuf/Internal/Message.php:153`

Since the class uses dynamic properties a bit, enable them explicitly with an attribute.