### PR TITLE
[PHP] Run tests on PHP 8.2 too , check for startup warnings

### DIFF
--- a/.github/workflows/test_php_ext.yml
+++ b/.github/workflows/test_php_ext.yml
@@ -60,5 +60,14 @@ jobs:
           MAKE="make -j$(nproc)" pecl install $GITHUB_WORKSPACE/protobuf-*.tgz
       - name: Enable extension
         run: docker-php-ext-enable protobuf
+      - name: Check for PHP startup warnings
+        run: |
+          php -d display_errors=stderr -d display_startup_errors=1 -d error_reporting=-1 -r ';' 2>/tmp/protobuf-warnings
+          if [ -s /tmp/protobuf-warnings ]; then
+            echo 'The PHP extension was successfully installed, but PHP raised these warnings:' >&2
+            cat /tmp/protobuf-warnings >&2
+            exit 1
+          fi
+          echo "PHP didn't raise any warnings at startup."
       - name: Inspect extension
         run: php --ri protobuf

--- a/.github/workflows/test_php_ext.yml
+++ b/.github/workflows/test_php_ext.yml
@@ -45,6 +45,8 @@ jobs:
             version: "7.4.18-dbg"
           - php-image: php:8.1-cli
             version: "8.1.14"
+          - php-image: php:8.2-cli
+            version: "8.2"
     name: Build ${{ matrix.version }}
     runs-on: ubuntu-latest
     container: ${{ matrix.php-image }}


### PR DESCRIPTION
PHP 8.2 is around the corner, and they've just published 8.2.0RC2.
So, what about testing protobuf with it?

Also: even if everything compiles and the PHP extension can be used, we may have that PHP throws some warnings at startup.
For example, if we install protobuf 3.18.3 with PHP 8.1, we have these warnings:

```
$ php -r 'echo "This is just a test.\n";'

Deprecated: Return type of Google\Protobuf\Internal\RepeatedField::offsetExists($index) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

[...omissis... ]

Deprecated: Return type of Google\Protobuf\Internal\MapFieldIter::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

This is just a test.
```

So: what about letting the `php-ext.yml` GitHub Action fail in case we have such startup errors?