### PR TITLE
Remove osx-aarch_64

### DIFF
--- a/protoc-artifacts/build-zip.sh
+++ b/protoc-artifacts/build-zip.sh
@@ -16,7 +16,6 @@ release page. If the target is protoc, well-known type .proto files will also be
 included. Each invocation will create 8 zip packages:
   dist/<TARGET>-<VERSION_NUMBER>-win32.zip
   dist/<TARGET>-<VERSION_NUMBER>-win64.zip
-  dist/<TARGET>-<VERSION_NUMBER>-osx-aarch_64.zip
   dist/<TARGET>-<VERSION_NUMBER>-osx-x86_64.zip
   dist/<TARGET>-<VERSION_NUMBER>-linux-x86_32.zip
   dist/<TARGET>-<VERSION_NUMBER>-linux-x86_64.zip
@@ -34,7 +33,6 @@ VERSION_NUMBER=$2
 declare -a FILE_NAMES=( \
   win32.zip windows-x86_32.exe \
   win64.zip windows-x86_64.exe \
-  osx-aarch_64.zip osx-aarch_64.exe \
   osx-x86_64.zip osx-x86_64.exe \
   linux-x86_32.zip linux-x86_32.exe \
   linux-x86_64.zip linux-x86_64.exe \

--- a/protoc-artifacts/pom.xml
+++ b/protoc-artifacts/pom.xml
@@ -71,15 +71,6 @@
                   <type>exe</type>
                 </artifact>
                 <artifact>
-                  <!-- Reuse a compatible osx-x86_64 version until binary
-                       support for osx-aarch_64 is added. TODO: use
-                       <file>${basedir}/target/osx/aarch_64/protoc.exe</file>
-                       -->
-                  <file>${basedir}/target/osx/x86_64/protoc.exe</file>
-                  <classifier>osx-aarch_64</classifier>
-                  <type>exe</type>
-                </artifact>
-                <artifact>
                   <file>${basedir}/target/linux/aarch_64/protoc.exe</file>
                   <classifier>linux-aarch_64</classifier>
                   <type>exe</type>


### PR DESCRIPTION
Removing all references to aarch64 osx binaries since we don't publish them in 3.20.x