### PR TITLE
Use local protoc artifacts

### DIFF
--- a/protoc-artifacts/build-zip.sh
+++ b/protoc-artifacts/build-zip.sh
@@ -10,10 +10,10 @@ Example:
   $ $0 protoc 3.0.0
   $ $0 protoc-gen-javalite 3.0.0
 
-This script will download pre-built protoc or protoc plugin binaries from maven
-repository and create .zip packages suitable to be included in the github
-release page. If the target is protoc, well-known type .proto files will also be
-included. Each invocation will create 8 zip packages:
+This script will create .zip packages suitable to be included in the github
+release page. It requires all protoc executables to be present in the
+protoc-artifacts/ directory. If the target is protoc, well-known type .proto
+files will also be included. Each invocation will create 8 zip packages:
   dist/<TARGET>-<VERSION_NUMBER>-win32.zip
   dist/<TARGET>-<VERSION_NUMBER>-win64.zip
   dist/<TARGET>-<VERSION_NUMBER>-osx-x86_64.zip
@@ -98,12 +98,7 @@ for((i=0;i<${#FILE_NAMES[@]};i+=2));do
     BINARY="$TARGET"
   fi
   BINARY_NAME=${FILE_NAMES[$(($i+1))]}
-  BINARY_URL=https://repo1.maven.org/maven2/com/google/protobuf/$TARGET/${VERSION_NUMBER}/$TARGET-${VERSION_NUMBER}-${BINARY_NAME}
-  if ! wget ${BINARY_URL} -O ${DIR}/bin/$BINARY &> /dev/null; then
-    echo "[ERROR] Failed to download ${BINARY_URL}" >&2
-    echo "[ERROR] Skipped $TARGET-${VERSION_NAME}-${ZIP_NAME}" >&2
-    continue
-  fi
+  cp $BINARY_NAME ${DIR}/bin/$BINARY
   TARGET_ZIP_FILE=`pwd`/dist/$TARGET-${VERSION_NUMBER}-${ZIP_NAME}
   pushd $DIR &> /dev/null
   chmod +x bin/$BINARY


### PR DESCRIPTION
Previously, the release process downloaded protoc executables from maven. This caused a significant delay between the time that protoc executables were pushed to maven and when the github release could come out.

Instead, we will use local artifacts that are copied into the protoc-artifact directory by our release script.