### PR TITLE
No longer define no_threadlocal on OpenBSD

### DIFF
--- a/src/google/protobuf/stubs/platform_macros.h
+++ b/src/google/protobuf/stubs/platform_macros.h
@@ -122,11 +122,11 @@ GOOGLE_PROTOBUF_PLATFORM_ERROR
 
 #undef GOOGLE_PROTOBUF_PLATFORM_ERROR
 
-#if defined(GOOGLE_PROTOBUF_OS_ANDROID) || defined(GOOGLE_PROTOBUF_OS_IPHONE) || defined(__OpenBSD__)
+#if defined(GOOGLE_PROTOBUF_OS_ANDROID) || defined(GOOGLE_PROTOBUF_OS_IPHONE)
 // Android ndk does not support the __thread keyword very well yet. Here
 // we use pthread_key_create()/pthread_getspecific()/... methods for
 // TLS support on android.
-// iOS and OpenBSD also do not support the __thread keyword.
+// iOS also does not support the __thread keyword.
 #define GOOGLE_PROTOBUF_NO_THREADLOCAL
 #endif
 


### PR DESCRIPTION
This is no longer an issue with modern versions of OpenBSD and respective up to date compilers.