### PR TITLE
Run CMake file auto-generation only on the main protobuf repo

### DIFF
--- a/.github/workflows/generated_cmake.yml
+++ b/.github/workflows/generated_cmake.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   cmake:
+    if: github.repository == 'protocolbuffers/protobuf'
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
This workflow will otherwise fail on forks, so let's make sure to do it only on the main repo where we need it.