### PR TITLE
Make slight change to ordering in src/file_lists.cmake

### DIFF
--- a/src/file_lists.cmake
+++ b/src/file_lists.cmake
@@ -11,8 +11,8 @@ endif()
 
 # //pkg:protobuf
 set(libprotobuf_srcs
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/any.pb.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/api.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/any.pb.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/duration.pb.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/empty.pb.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/field_mask.pb.cc


### PR DESCRIPTION
This change does not directly do anything useful, but the goal is to confirm that the GitHub action for auto-generating file_lists.cmake will quickly rewrite the file in its canonical form.