### PR TITLE
Keep the class forward declaration also.

### DIFF
--- a/objectivec/GPBCodedInputStream.h
+++ b/objectivec/GPBCodedInputStream.h
@@ -31,6 +31,7 @@
 #import <Foundation/Foundation.h>
 
 @class GPBMessage;
+@class GPBExtensionRegistry;
 @protocol GPBExtensionRegistry;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/objectivec/GPBMessage.h
+++ b/objectivec/GPBMessage.h
@@ -36,6 +36,7 @@
 @class GPBCodedInputStream;
 @class GPBCodedOutputStream;
 @class GPBExtensionDescriptor;
+@class GPBExtensionRegistry;
 @protocol GPBExtensionRegistry;
 @class GPBFieldDescriptor;
 @class GPBUnknownFieldSet;


### PR DESCRIPTION
Some users might be depended on these, so until everything is flipped to explicit imports, need to still provide the class declaration so the proto isn't a breaking change.