### PR TITLE
Add reserved extension number for Pigweed

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -344,3 +344,7 @@ with info about your project (name and website) so we can add an entry for you.
 1. mypy-protobuf
    * Website: https://github.com/nipunn1313/mypy-protobuf
    * Extension: 1151-1154
+
+1. Pigweed protobuf compiler
+   * Website: https://pigweed.dev/pw_protobuf
+   * Extension: 1155


### PR DESCRIPTION
The extension number will be used for providing custom options to the Pigweed protobuf compiler. Support for this is added in https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/110632.