### PR TITLE
[ObjC] Use a real import for GPBExtensionRegistry.

### DIFF
--- a/objectivec/GPBCodedInputStream.h
+++ b/objectivec/GPBCodedInputStream.h
@@ -30,9 +30,9 @@
 
 #import <Foundation/Foundation.h>
 
+#import "GPBExtensionRegistry.h"
+
 @class GPBMessage;
-@class GPBExtensionRegistry;
-@protocol GPBExtensionRegistry;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/objectivec/GPBMessage.h
+++ b/objectivec/GPBMessage.h
@@ -31,13 +31,12 @@
 #import <Foundation/Foundation.h>
 
 #import "GPBBootstrap.h"
+#import "GPBExtensionRegistry.h"
 
 @class GPBDescriptor;
 @class GPBCodedInputStream;
 @class GPBCodedOutputStream;
 @class GPBExtensionDescriptor;
-@class GPBExtensionRegistry;
-@protocol GPBExtensionRegistry;
 @class GPBFieldDescriptor;
 @class GPBUnknownFieldSet;
 


### PR DESCRIPTION
The fwd decls can lead to ambiguity for downstream users, so use a full import to avoid the potential issues.