### PR TITLE
[C++] Optimize Varint paring for c++

### DIFF
--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -35,6 +35,9 @@
 #include <cstring>
 #include <string>
 #include <type_traits>
+#include <immintrin.h>
+#include <emmintrin.h>
+#include <pmmintrin.h>
 
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream.h"
@@ -601,9 +604,81 @@ static PROTOBUF_ALWAYS_INLINE inline uint64_t Ubfx7(uint64_t data,
 }
 
 #endif  // __aarch64__
+#if defined(__SSE3__) && defined(__AVX512BW__) && defined(__AVX512VL__) && \
+    defined(__BMI2__)
+
+constexpr static const __uint64_t AvxByteMask[] = {0x0,
+                                                   0xff,
+                                                   0xffff,
+                                                   0xffffff,
+                                                   0xffffffff,
+                                                   0xffffffffff,
+                                                   0xffffffffffff,
+                                                   0xffffffffffffff,
+                                                   0xffffffffffffffff};
+static const __m128i Zero128I = _mm_setzero_si128();
 
 template <typename T>
-PROTOBUF_NODISCARD const char* VarintParse(const char* p, T* out) {
+inline const char* VarintParseAvx(const char* p, T* out) {
+  auto ptr = reinterpret_cast<const uint8_t*>(p);
+  uint32_t res = ptr[0];
+  if (!(res & 0x80)) {
+    *out = res;
+    return p + 1;
+  }
+  uint32_t byte = ptr[1];
+  res += (byte - 1) << 7;
+  if (!(byte & 0x80)) {
+    *out = res;
+    return p + 2;
+  }
+  __m128i data128i = _mm_lddqu_si128(reinterpret_cast<const __m128i*>(p));
+  const uint8* dptr = reinterpret_cast<uint8*>(&data128i);
+  //"0x3ff" = 10 bytes
+  __mmask16 msb =
+      _mm_mask_cmp_epi8_mask(0x3ff, data128i, Zero128I, _MM_CMPINT_NLT);
+  uint32_t cnt = _tzcnt_u32(msb);
+
+  if constexpr (std::is_same<T, uint32_t>::value) {
+    if (PROTOBUF_PREDICT_TRUE(cnt < 10)) {
+      uint32_t maskIndex = cnt < 5 ? cnt + 1 : 5;
+      uint64_t data64 =
+          (*(reinterpret_cast<const uint64_t*>(dptr))) & AvxByteMask[maskIndex];
+      *out = static_cast<uint32>(_pext_u64(data64, 0x7F7F7F7F7F));
+      return p + cnt + 1;
+    }
+    return nullptr;
+  }
+
+  if constexpr (std::is_same<T, uint64_t>::value) {
+    if (cnt < 8) {
+      uint32_t maskIndex = cnt + 1;
+      uint64_t data64 =
+          (*(reinterpret_cast<const uint64_t*>(dptr))) & AvxByteMask[maskIndex];
+      *out = _pext_u64(data64, 0x7F7F7F7F7F7F7F7F);
+      return p + cnt + 1;
+    }
+
+    if (cnt < 10) {
+      uint32_t maskIndex = cnt + 1 - 8;
+      uint64 tempValueLo = _pext_u64(*(reinterpret_cast<const uint64_t*>(dptr)),
+                                     0x7F7F7F7F7F7F7F7F);
+      uint64 tempValueHi =
+          _pext_u64(*(reinterpret_cast<const uint64_t*>(dptr + 8)) &
+                        AvxByteMask[maskIndex],
+                    0x7F7F);
+      *out = (tempValueHi << 56) | tempValueLo;
+      return p + cnt + 1;
+    }
+  }
+
+  return nullptr;
+}
+
+#endif  //__SSE3__ && __AVX512BW__ && __AVX512VL__ && __BMI2__
+
+template <typename T>
+PROTOBUF_NODISCARD const char* VarintParseNoneAvx(const char* p, T* out) {
 #if defined(__aarch64__) && defined(PROTOBUF_LITTLE_ENDIAN)
   // This optimization is not supported in big endian mode
   uint64_t first8;
@@ -632,6 +707,13 @@ PROTOBUF_NODISCARD const char* VarintParse(const char* p, T* out) {
   return VarintParseSlow(p, res, out);
 #endif  // __aarch64__
 }
+
+#if defined(__SSE3__) && defined(__AVX512BW__) && defined(__AVX512VL__) && \
+    defined(__BMI2__)
+#define VarintParse VarintParseAvx
+#else
+#define VarintParse VarintParseNoneAvx
+#endif  //__SSE3__ && __AVX512BW__ && __AVX512VL__ && __BMI2__
 
 // Used for tags, could read up to 5 bytes which must be available.
 // Caller must ensure its safe to call.


### PR DESCRIPTION
optimize Varint paring by avx instruction. In our funciton level benchmarking, we get about 2.7x  maximum performance boost.
Run on (112 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 48K (x56)
  L1 Instruction 32K (x56)
  L2 Unified 1280K (x56)
  L3 Unified 43008K (x2)
Load Average: 113.09, 103.01, 100.32
-----------------------------------------------------------
Benchmark                 Time             CPU   Iterations
-----------------------------------------------------------
BM_Parse32_1           5.41 ns         5.41 ns    127614707
BM_ParseAvx32_1        5.41 ns         5.41 ns    131481251
BM_Parse32_2           7.60 ns         7.60 ns    101486965
BM_ParseAvx32_2        7.21 ns         7.21 ns    100662140
BM_Parse32_3           18.6 ns         18.6 ns     37747465
BM_ParseAvx32_3        15.8 ns         15.8 ns     45671267
BM_Parse32_4           21.3 ns         21.3 ns     32821412
BM_ParseAvx32_4        15.4 ns         15.4 ns     45606688
BM_Parse32_5           24.0 ns         24.0 ns     28883162
BM_ParseAvx32_5        14.2 ns         14.2 ns     48919738
BM_Parse32_6           25.3 ns         25.3 ns     28171374
BM_ParseAvx32_6        13.1 ns         13.1 ns     53483401
BM_Parse32_7           26.9 ns         26.9 ns     25914018
BM_ParseAvx32_7        13.1 ns         13.1 ns     53334350
BM_Parse32_8           29.1 ns         29.1 ns     24179552
BM_ParseAvx32_8        13.1 ns         13.1 ns     53368440
BM_Parse32_9           32.8 ns         32.8 ns     21251833
BM_ParseAvx32_9        13.1 ns         13.1 ns     52993618
BM_Parse32_10          35.1 ns         35.1 ns     19933683
BM_ParseAvx32_10       13.1 ns         13.1 ns     52927471
BM_Parse64_1           5.96 ns         5.96 ns    114083173
BM_ParseAvx64_1        5.98 ns         5.98 ns    117008484
BM_Parse64_2           6.74 ns         6.74 ns    106423611
BM_ParseAvx64_2        6.55 ns         6.55 ns    108907164
BM_Parse64_3           18.7 ns         18.7 ns     37244811
BM_ParseAvx64_3        13.1 ns         13.1 ns     54240934
BM_Parse64_4           21.7 ns         21.7 ns     33925661
BM_ParseAvx64_4        12.8 ns         12.8 ns     53840538
BM_Parse64_5           25.2 ns         25.2 ns     28179568
BM_ParseAvx64_5        12.7 ns         12.7 ns     57454421
BM_Parse64_6           28.4 ns         28.4 ns     24626749
BM_ParseAvx64_6        13.1 ns         13.1 ns     54277091
BM_Parse64_7           32.2 ns         32.2 ns     21875611
BM_ParseAvx64_7        12.9 ns         12.9 ns     55145458
BM_Parse64_8           35.0 ns         35.0 ns     19970139
BM_ParseAvx64_8        12.5 ns         12.5 ns     52959753
BM_Parse64_9           38.3 ns         38.3 ns     18326964
BM_ParseAvx64_9        16.6 ns         16.6 ns     42330051
BM_Parse64_10          41.6 ns         41.6 ns     16794702
BM_ParseAvx64_10       16.4 ns         16.4 ns     42469314

in our object level test. End to End benchmarking for object that all are varint fields ,we can get about 20% performance boost