### PR TITLE
Add an objc_class_prefix for the proto2 syntax file used in conformance tests

### DIFF
--- a/conformance/conformance_objc.m
+++ b/conformance/conformance_objc.m
@@ -77,7 +77,7 @@ static ConformanceResponse *DoTest(ConformanceRequest *request) {
       if ([request.messageType isEqual:@"protobuf_test_messages.proto3.TestAllTypesProto3"]) {
         msgClass = [Proto3TestAllTypesProto3 class];
       } else if ([request.messageType isEqual:@"protobuf_test_messages.proto2.TestAllTypesProto2"]) {
-        msgClass = [TestAllTypesProto2 class];
+        msgClass = [Proto2TestAllTypesProto2 class];
       } else {
         response.runtimeError =
             [NSString stringWithFormat:@"Protobuf request had an unknown message_type: %@",

--- a/src/google/protobuf/test_messages_proto2.proto
+++ b/src/google/protobuf/test_messages_proto2.proto
@@ -40,6 +40,7 @@ syntax = "proto2";
 package protobuf_test_messages.proto2;
 
 option java_package = "com.google.protobuf_test_messages.proto2";
+option objc_class_prefix = "Proto2";
 
 // This is the default, but we specify it here explicitly.
 option optimize_for = SPEED;


### PR DESCRIPTION
Not all the types have "Proto2" on the end, so for uniformity put an objc_class_prefix like was done for the proto3 syntax file.