### PR TITLE
Remove the pre Xcode 10.2 support.

### DIFF
--- a/objectivec/DevTools/full_mac_build.sh
+++ b/objectivec/DevTools/full_mac_build.sh
@@ -224,27 +224,9 @@ if [[ "${DO_XCODE_IOS_TESTS}" == "yes" ]] ; then
   # just pick a mix of OS Versions and 32/64 bit.
   # NOTE: Different Xcode have different simulated hardware/os support.
   case "${XCODE_VERSION}" in
-    [6-8].* )
-      echo "ERROR: The unittests include Swift code that is now Swift 4.0." 1>&2
-      echo "ERROR: Xcode 9.0 or higher is required to build the test suite, but the library works with Xcode 7.x." 1>&2
+    [6-9].* )
+      echo "ERROR: Xcode 10.2 or higher is required." 1>&2
       exit 11
-      ;;
-    9.[0-2]* )
-      XCODEBUILD_TEST_BASE_IOS+=(
-          -destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" # 32bit
-          -destination "platform=iOS Simulator,name=iPhone 7,OS=latest" # 64bit
-          # 9.0-9.2 all seem to often fail running destinations in parallel
-          -disable-concurrent-testing
-      )
-      ;;
-    9.[3-4]* )
-      XCODEBUILD_TEST_BASE_IOS+=(
-          # Xcode 9.3 chokes targeting iOS 8.x - http://www.openradar.me/39335367
-          -destination "platform=iOS Simulator,name=iPhone 4s,OS=9.0" # 32bit
-          -destination "platform=iOS Simulator,name=iPhone 7,OS=latest" # 64bit
-          # 9.3 also seems to often fail running destinations in parallel
-          -disable-concurrent-testing
-      )
       ;;
     10.*)
       XCODEBUILD_TEST_BASE_IOS+=(
@@ -292,9 +274,8 @@ if [[ "${DO_XCODE_OSX_TESTS}" == "yes" ]] ; then
     XCODEBUILD_TEST_BASE_OSX+=( -quiet )
   fi
   case "${XCODE_VERSION}" in
-    [6-8].* )
-      echo "ERROR: The unittests include Swift code that is now Swift 4.0." 1>&2
-      echo "ERROR: Xcode 9.0 or higher is required to build the test suite, but the library works with Xcode 7.x." 1>&2
+    [6-9].* )
+      echo "ERROR: Xcode 10.2 or higher is required." 1>&2
       exit 11
       ;;
   esac
@@ -315,7 +296,7 @@ if [[ "${DO_XCODE_TVOS_TESTS}" == "yes" ]] ; then
   )
   case "${XCODE_VERSION}" in
     [6-9].* )
-      echo "ERROR: Xcode 10.0 or higher is required to build the test suite." 1>&2
+      echo "ERROR: Xcode 10.2 or higher is required." 1>&2
       exit 11
       ;;
     10.* | 11.* | 12.*)
@@ -323,7 +304,7 @@ if [[ "${DO_XCODE_TVOS_TESTS}" == "yes" ]] ; then
         -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=latest"
       )
       ;;
-    13.*)
+    13.* | 14.*)
       XCODEBUILD_TEST_BASE_TVOS+=(
         -destination "platform=tvOS Simulator,name=Apple TV 4K (2nd generation),OS=latest"
       )

--- a/objectivec/GPBDescriptor_PackagePrivate.h
+++ b/objectivec/GPBDescriptor_PackagePrivate.h
@@ -348,15 +348,7 @@ GPB_INLINE BOOL GPBExtensionIsWireFormat(GPBExtensionDescription *description) {
 
 // Helper for compile time assets.
 #ifndef GPBInternalCompileAssert
-#if __has_feature(c_static_assert) || __has_extension(c_static_assert)
 #define GPBInternalCompileAssert(test, msg) _Static_assert((test), #msg)
-#else
-// Pre-Xcode 7 support.
-#define GPBInternalCompileAssertSymbolInner(line, msg) GPBInternalCompileAssert##line##__##msg
-#define GPBInternalCompileAssertSymbol(line, msg) GPBInternalCompileAssertSymbolInner(line, msg)
-#define GPBInternalCompileAssert(test, msg) \
-  typedef char GPBInternalCompileAssertSymbol(__LINE__, msg)[((test) ? 1 : -1)]
-#endif  // __has_feature(c_static_assert) || __has_extension(c_static_assert)
 #endif  // GPBInternalCompileAssert
 
 // Sanity check that there isn't padding between the field description

--- a/objectivec/GPBDictionary.m
+++ b/objectivec/GPBDictionary.m
@@ -51,17 +51,6 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
 
-// Used to include code only visible to specific versions of the static
-// analyzer. Useful for wrapping code that only exists to silence the analyzer.
-// Determine the values you want to use for BEGIN_APPLE_BUILD_VERSION,
-// END_APPLE_BUILD_VERSION using:
-//   xcrun clang -dM -E -x c /dev/null | grep __apple_build_version__
-// Example usage:
-//  #if GPB_STATIC_ANALYZER_ONLY(5621, 5623) ... #endif
-#define GPB_STATIC_ANALYZER_ONLY(BEGIN_APPLE_BUILD_VERSION, END_APPLE_BUILD_VERSION)       \
-  (defined(__clang_analyzer__) && (__apple_build_version__ >= BEGIN_APPLE_BUILD_VERSION && \
-                                   __apple_build_version__ <= END_APPLE_BUILD_VERSION))
-
 enum {
   kMapKeyFieldNumber = 1,
   kMapValueFieldNumber = 2,
@@ -520,19 +509,6 @@ void GPBDictionaryReadEntry(id mapDictionary, GPBCodedInputStream *stream,
     }
 
     if ((keyDataType == GPBDataTypeString) && GPBDataTypeIsObject(valueDataType)) {
-#if GPB_STATIC_ANALYZER_ONLY(6020053, 7000181)
-      // Limited to Xcode 6.4 - 7.2, are known to fail here. The upper end can
-      // be raised as needed for new Xcodes.
-      //
-      // This is only needed on a "shallow" analyze; on a "deep" analyze, the
-      // existing code path gets this correct. In shallow, the analyzer decides
-      // GPBDataTypeIsObject(valueDataType) is both false and true on a single
-      // path through this function, allowing nil to be used for the
-      // setObject:forKey:.
-      if (value.valueString == nil) {
-        value.valueString = [@"" retain];
-      }
-#endif
       // mapDictionary is an NSMutableDictionary
       [(NSMutableDictionary *)mapDictionary setObject:value.valueString forKey:key.valueString];
     } else {

--- a/objectivec/GPBMessage.m
+++ b/objectivec/GPBMessage.m
@@ -761,9 +761,9 @@ void GPBPrepareReadOnlySemaphore(GPBMessage *self) {
       dispatch_release(worker);
     }
 #if defined(__clang_analyzer__)
-    // The Xcode 9.2 (and 9.3 beta) static analyzer thinks worker is leaked
-    // (doesn't seem to know about atomic_compare_exchange_strong); so just
-    // for the analyzer, let it think worker is also released in this case.
+    // The static analyzer thinks worker is leaked (doesn't seem to know about
+    // atomic_compare_exchange_strong); so just for the analyzer, let it think
+    // worker is also released in this case.
     else {
       dispatch_release(worker);
     }

--- a/objectivec/Tests/unittest_objc.proto
+++ b/objectivec/Tests/unittest_objc.proto
@@ -239,8 +239,7 @@ extend self {
   repeated   sint32 byref               =  3004 [packed = true];
 }
 
-// Test handing of fields that start with init* since Xcode 5's ARC support
-// doesn't like messages that look like initializers but aren't.
+// Test handing of fields that start with init*.
 message ObjCInitFoo {
   optional string init_val = 11;
   optional int32 init_size = 12;


### PR DESCRIPTION
objectivec/README.md lists Xcode 10.2 as the minimum, update things accordingly.

- Remove code paths referencing the older versions.
- Remove support from the testing script.