### PR TITLE
Revert "Merge pull request #10470 from jhump/jh/source-code-info-pseudo options"

### DIFF
--- a/src/google/protobuf/compiler/parser.h
+++ b/src/google/protobuf/compiler/parser.h
@@ -245,10 +245,6 @@ class PROTOBUF_EXPORT Parser {
     LocationRecorder(const LocationRecorder& parent, int path1, int path2);
 
     // Creates a recorder that generates locations into given source code info.
-    LocationRecorder(const LocationRecorder& parent,
-                     SourceCodeInfo* source_code_info);
-    // Creates a recorder that generates locations into given source code info
-    // and calls AddPath() one time.
     LocationRecorder(const LocationRecorder& parent, int path1,
                      SourceCodeInfo* source_code_info);
 

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -3606,19 +3606,18 @@ TEST_F(SourceInfoTest, FieldOptions) {
   EXPECT_TRUE(
       Parse("message Foo {"
             "  optional int32 bar = 1 "
-            "$a$[$b$default=123$c$, $d$opt1=123$e$, "
-            "$f$opt2='hi'$g$, $h$json_name='barBar'$i$]$j$;"
+            "$a$[default=$b$123$c$,$d$opt1=123$e$,"
+            "$f$opt2='hi'$g$]$h$;"
             "}\n"));
 
   const FieldDescriptorProto& field = file_.message_type(0).field(0);
   const UninterpretedOption& option1 = field.options().uninterpreted_option(0);
   const UninterpretedOption& option2 = field.options().uninterpreted_option(1);
 
-  EXPECT_TRUE(HasSpan('a', 'j', field.options()));
+  EXPECT_TRUE(HasSpan('a', 'h', field.options()));
   EXPECT_TRUE(HasSpan('b', 'c', field, "default_value"));
   EXPECT_TRUE(HasSpan('d', 'e', option1));
   EXPECT_TRUE(HasSpan('f', 'g', option2));
-  EXPECT_TRUE(HasSpan('h', 'i', field, "json_name"));
 
   // Ignore these.
   EXPECT_TRUE(HasSpan(file_));


### PR DESCRIPTION
This reverts commit dd052c9dc601f831611ef9b04d70d8210c71053d, reversing changes made to 0d3eaed6eb91f5b7702918586f730e4dd1ceccd2.

This breaks https://github.com/kythe/kythe, as well as some internal code.