### PR TITLE
Clean up TextFormat

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,7 +7,11 @@
   * Change the Lite runtime to prefer merging from the wireformat into mutable
     messages rather than building up a new immutable object before merging. This
     way results in fewer allocations and copy operations.
-  * Make message-type extensions merge from wire-format instead of building up instances and merging afterwards. This has much better performance.
+  * Make message-type extensions merge from wire-format instead of building up
+    instances and merging afterwards. This has much better performance.
+  * Fix TextFormat parser to build up recurring (but supposedly not repeated)
+    sub-messages directly from text rather than building a new sub-message and
+    merging the fully formed message into the existing field.
 
 2022-09-13 version 3.20.2 (C++/Java/Python/PHP/Objective-C/C#/Ruby)
 


### PR DESCRIPTION
Fix TextFormat parser to build up recurring (but supposedly not repeated) sub-messages directly from text rather than building a new sub-message and merging the fully formed message into the existing field.