### PR TITLE
Add a staleness test for src/file_lists.cmake

### DIFF
--- a/pkg/build_systems.bzl
+++ b/pkg/build_systems.bzl
@@ -19,6 +19,7 @@ def gen_file_lists(name, out_stem, **kwargs):
         srcs = [
             out_stem + ".cmake",
         ],
+        visibility = ["//src:__pkg__"],
     )
 
 ################################################################################

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -115,6 +115,6 @@ def protobuf_deps():
         _github_archive(
             name = "upb",
             repo = "https://github.com/protocolbuffers/upb",
-            commit = "5485645125ba3783ae2b597bd7b77679721cb1c6",
-            sha256 = "86de85c58eb3cb04b0987a7642ce84e55629f704ab4a9a0210a660a1115f1dd0",
+            commit = "ce3a28f75c8a52a5ea31f6ecf72467a9d6461cb1",
+            sha256 = "716c0c0e6b0bbafa7e64a9184b248fcd100eebb01b0e1aded61c7bc3d81d837e",
         )

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -4,6 +4,7 @@
 
 # Most rules are under google/protobuf. This package exists for convenience.
 load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
+load("@upb//cmake:build_defs.bzl", "staleness_test")
 load("//conformance:defs.bzl", "conformance_test")
 
 pkg_files(
@@ -40,4 +41,25 @@ conformance_test(
     failure_list = "//conformance:failure_list_cpp.txt",
     testee = "//conformance:conformance_cpp",
     text_format_failure_list = "//conformance:text_format_failure_list_cpp.txt",
+)
+
+# Copy the generated file_lists.cmake into a place where the staleness test
+# below can use it.
+genrule(
+    name = "copy_cmake_lists",
+    srcs = ["//pkg:gen_src_file_lists"],
+    outs = ["cmake_copy/file_lists.cmake"],
+    cmd = "cp $< $@",
+    visibility = ["//visibility:private"],
+)
+
+staleness_test(
+    name = "cmake_lists_staleness_test",
+    outs = ["file_lists.cmake"],
+    generated_pattern = "cmake_copy/%s",
+    # Only run this test if it is explicitly specified on the command line (not
+    # via //src:all or ...). This file will be automatically updated in a
+    # GitHub action, so developers should not worry about failures from this
+    # test.
+    tags = ["manual"],
 )


### PR DESCRIPTION
This test is tagged "manual", because ordinarily no one should be directly
running this test. If we were to run this test regularly during development
then we would expect it to fail occasionally, because file_lists.cmake will
sometimes be temporarily stale until it is auto-updated by our post-merge
GitHub action. We want to run this test nightly just as a safeguard to alert us
if anything ever goes wrong with the auto-update.