### PR TITLE
Add a Kokoro release job for running staleness tests

### DIFF
--- a/kokoro/linux/staleness/release.cfg
+++ b/kokoro/linux/staleness/release.cfg
@@ -1,0 +1,18 @@
+# We run our staleness tests as release-type jobs only. They are not really
+# part of the release process, but the release job type allows us to run the
+# tests on a schedule only (not presubmit or postsubmit).
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/bazel.sh"
+timeout_mins: 15
+
+env_vars {
+  key: "BAZEL_TARGETS"
+  value: "//src:cmake_lists_staleness_test"
+}
+
+action {
+  define_artifacts {
+    regex: "**/sponge_log.*"
+  }
+}


### PR DESCRIPTION
This job is not really a "release", but it has to be a release job so that it can run on a schedule without running presubmit or postsubmit. Generated files will be quickly updated automatically after each PR is merged, but we want to run this staleness check nightly as an extra safeguard.