### PR TITLE
[PHP]Added missing files and fix phpext_protobuf_ptr export in pecl version

### DIFF
--- a/php/ext/google/protobuf/package.xml
+++ b/php/ext/google/protobuf/package.xml
@@ -43,6 +43,7 @@
     <file baseinstalldir="/" name="names.h" role="src"/>
     <file baseinstalldir="/" name="php-upb.c" role="src"/>
     <file baseinstalldir="/" name="php-upb.h" role="src"/>
+    <file baseinstalldir="/" name="php_protobuf.h" role="src"/>
     <file baseinstalldir="/" name="protobuf.c" role="src"/>
     <file baseinstalldir="/" name="protobuf.h" role="src"/>
     <file baseinstalldir="/" name="wkt.inc" role="src"/>


### PR DESCRIPTION
in order to compile php with protobuf from pecl.

now the pecl version of protobuf does not contain output to phpext_protobuf_ptr, causing me to manually add this code
```
extern zend_module_entry protobuf_module_entry;
#define phpext_protobuf_ptr &protobuf_module_entry
```
every time I rebuild PHP with `--enable-protobuf`

Please Add this file to PECL version.
https://pecl.php.net/package/protobuf

Thank!