### PR TITLE
fix(sec): upgrade org.jetbrains.kotlin:kotlin-stdlib to 1.6.0

### DIFF
--- a/java/kotlin-lite/pom.xml
+++ b/java/kotlin-lite/pom.xml
@@ -16,7 +16,7 @@
   </description>
 
   <properties>
-    <kotlin.version>1.5.0</kotlin.version>
+    <kotlin.version>1.6.0</kotlin.version>
   </properties>
 
   <dependencies>

--- a/java/kotlin/pom.xml
+++ b/java/kotlin/pom.xml
@@ -16,7 +16,7 @@
   </description>
 
   <properties>
-    <kotlin.version>1.5.0</kotlin.version>
+    <kotlin.version>1.6.0</kotlin.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.jetbrains.kotlin:kotlin-stdlib 1.5.0
- [CVE-2022-24329](https://www.oscs1024.com/hd/CVE-2022-24329)


### What did I do？
Upgrade org.jetbrains.kotlin:kotlin-stdlib from 1.5.0 to 1.6.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS