### PR TITLE
[java] Add option to JsonFormat for ignoring unresolved Any failures

### DIFF
--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -1062,6 +1062,16 @@ public class JsonFormatTest {
   }
 
   @Test
+  public void testAnyFieldsWithoutCustomAddedTypeRegistry() throws Exception {
+    TestAllTypes content = TestAllTypes.newBuilder().setOptionalInt32(1234).build();
+    TestAny message = TestAny.newBuilder().setAnyValue(Any.pack(content)).build();
+
+    JsonFormat.Printer printer = JsonFormat.printer().ignoringUnresolvedAnyTypes();
+
+    assertThat(printer.print(message)).isEqualTo("{}");
+  }
+
+  @Test
   public void testAnyFields() throws Exception {
     TestAllTypes content = TestAllTypes.newBuilder().setOptionalInt32(1234).build();
     TestAny message = TestAny.newBuilder().setAnyValue(Any.pack(content)).build();


### PR DESCRIPTION
This MR adds an additive option (`ignoringUnresolvedAnyTypes: Boolean = false`) to the `JsonFormat` class for ignoring unresolved `Any` types during serialization. Currently, JsonFormat will throw an `InvalidProtocolBufferException` whenever it attempts to serialize an `Any` type that has not been provided by a `TypeRegistry`. This is problematic because it forces consumers of `Any` types to stay updated with all of the proto definitions that upstream providers may produce. The added option allows consumers to choose to omit the serialized output altogether - instead of failing the entire serialization process. The property is set to false by default to preserve backwards compatibility.

Additionally, when set to `false`, the default behavior should, IMO, return a list of all Any fields that we were unable to serialize, so callers of the method can get an exhaustive list of failures instead of one at a time. I have not made these changes in this PR - but wanted to get the conversation started to see if there was any feedback / concerns with any of these ideas.

Thank you!