### PR TITLE
Add sanitized builds to Kokoro

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,13 @@
 build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
+
+build:dbg --compilation_mode=dbg
+build:opt --compilation_mode=opt
+build:asan --copt=-fsanitize=address --linkopt=-fsanitize=address
+build:msan --copt=-fsanitize=memory --linkopt=-fsanitize=memory
+build:tsan --copt=-fsanitize=thread --linkopt=-fsanitize=thread
+build:ubsan --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+# Workaround for the fact that Bazel links with $CC, not $CXX
+# https://github.com/bazelbuild/bazel/issues/11122#issuecomment-613746748
+build:ubsan --copt=-fno-sanitize=function --copt=-fno-sanitize=vptr
+# Workaround for https://bugs.llvm.org/show_bug.cgi?id=16404
+build:ubsan --linkopt=--rtlib=compiler-rt --linkopt=-lunwind

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,10 +1,21 @@
 build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 
 build:dbg --compilation_mode=dbg
+
 build:opt --compilation_mode=opt
-build:asan --compilation_mode=dbg --copt=-fsanitize=address --linkopt=-fsanitize=address
+
+build:asan --config=dbg --copt=-fsanitize=address --linkopt=-fsanitize=address
 # ASAN hits ODR violations with shared linkage due to rules_proto.
 build:asan --dynamic_mode=off
-build:msan --compilation_mode=dbg --copt=-fsanitize=memory --linkopt=-fsanitize=memory
-build:tsan --compilation_mode=dbg --copt=-fsanitize=thread --linkopt=-fsanitize=thread
-build:ubsan --compilation_mode=dbg --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+
+build:msan --config=dbg --copt=-fsanitize=memory --linkopt=-fsanitize=memory
+build:msan --strip=never
+build:msan --copt=-O0
+build:msan --copt=-fsanitize-memory-track-origins
+build:msan --copt=-fsanitize-memory-use-after-dtor
+build:msan --copt=-fno-omit-frame-pointer
+build:msan --action_env=MSAN_OPTIONS=poison_in_dtor=1
+
+build:tsan --config=dbg --copt=-fsanitize=thread --linkopt=-fsanitize=thread
+
+build:ubsan --config=dbg --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,8 @@ build:opt --compilation_mode=opt
 build:san-common --config=dbg --strip=never --copt=-O0 --copt=-fno-omit-frame-pointer
 
 build:asan --config=san-common --copt=-fsanitize=address --linkopt=-fsanitize=address
-build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
+build:asan --action_env=ASAN_OPTIONS=detect_leaks=1
+build:asan --action_env=LSAN_OPTIONS=verbosity=1
 # ASAN hits ODR violations with shared linkage due to rules_proto.
 build:asan --dynamic_mode=off
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -4,16 +4,16 @@ build:dbg --compilation_mode=dbg
 
 build:opt --compilation_mode=opt
 
-build:asan --config=dbg --copt=-fsanitize=address --linkopt=-fsanitize=address
+build:san-common --config=dbg --strip=never --copt=-O0 --copt=-fno-omit-frame-pointer
+
+build:asan --config=san-common --copt=-fsanitize=address --linkopt=-fsanitize=address
+build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
 # ASAN hits ODR violations with shared linkage due to rules_proto.
 build:asan --dynamic_mode=off
 
-build:msan --config=dbg --copt=-fsanitize=memory --linkopt=-fsanitize=memory
-build:msan --strip=never
-build:msan --copt=-O0
+build:msan --config=san-common --copt=-fsanitize=memory --linkopt=-fsanitize=memory
 build:msan --copt=-fsanitize-memory-track-origins
 build:msan --copt=-fsanitize-memory-use-after-dtor
-build:msan --copt=-fno-omit-frame-pointer
 build:msan --action_env=MSAN_OPTIONS=poison_in_dtor=1
 
 # Use our instrumented LLVM libc++ in Kokoro.
@@ -23,6 +23,7 @@ build:kokoro-msan --linkopt=-Wl,-rpath,/opt/libcxx_msan/lib
 build:kokoro-msan --cxxopt=-stdlib=libc++ --linkopt=-stdlib=libc++
 
 
-build:tsan --config=dbg --copt=-fsanitize=thread --linkopt=-fsanitize=thread
+build:tsan --config=san-common --copt=-fsanitize=thread --linkopt=-fsanitize=thread
 
-build:ubsan --config=dbg --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+build:ubsan --config=san-common--copt=-fsanitize=undefined --linkopt=-fsanitize=undefined
+build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,8 +7,6 @@ build:opt --compilation_mode=opt
 build:san-common --config=dbg --strip=never --copt=-O0 --copt=-fno-omit-frame-pointer
 
 build:asan --config=san-common --copt=-fsanitize=address --linkopt=-fsanitize=address
-build:asan --action_env=ASAN_OPTIONS=detect_leaks=1
-build:asan --action_env=LSAN_OPTIONS=verbosity=1
 # ASAN hits ODR violations with shared linkage due to rules_proto.
 build:asan --dynamic_mode=off
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,8 +6,3 @@ build:asan --copt=-fsanitize=address --linkopt=-fsanitize=address
 build:msan --copt=-fsanitize=memory --linkopt=-fsanitize=memory
 build:tsan --copt=-fsanitize=thread --linkopt=-fsanitize=thread
 build:ubsan --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
-# Workaround for the fact that Bazel links with $CC, not $CXX
-# https://github.com/bazelbuild/bazel/issues/11122#issuecomment-613746748
-build:ubsan --copt=-fno-sanitize=function --copt=-fno-sanitize=vptr
-# Workaround for https://bugs.llvm.org/show_bug.cgi?id=16404
-build:ubsan --linkopt=--rtlib=compiler-rt --linkopt=-lunwind

--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,8 @@ build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 build:dbg --compilation_mode=dbg
 build:opt --compilation_mode=opt
 build:asan --compilation_mode=dbg --copt=-fsanitize=address --linkopt=-fsanitize=address
+# ASAN hits ODR violations with shared linkage due to rules_proto.
+build:asan --dynamic_mode=off
 build:msan --compilation_mode=dbg --copt=-fsanitize=memory --linkopt=-fsanitize=memory
 build:tsan --compilation_mode=dbg --copt=-fsanitize=thread --linkopt=-fsanitize=thread
 build:ubsan --compilation_mode=dbg --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1

--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,13 @@ build:msan --copt=-fsanitize-memory-use-after-dtor
 build:msan --copt=-fno-omit-frame-pointer
 build:msan --action_env=MSAN_OPTIONS=poison_in_dtor=1
 
+# Use our instrumented LLVM libc++ in Kokoro.
+build:kokoro-msan --config=msan
+build:kokoro-msan --linkopt=-L/opt/libcxx_msan/lib
+build:kokoro-msan --linkopt=-Wl,-rpath,/opt/libcxx_msan/lib
+build:kokoro-msan --cxxopt=-stdlib=libc++ --linkopt=-stdlib=libc++
+
+
 build:tsan --config=dbg --copt=-fsanitize=thread --linkopt=-fsanitize=thread
 
 build:ubsan --config=dbg --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1

--- a/.bazelrc
+++ b/.bazelrc
@@ -30,3 +30,6 @@ build:tsan --copt=-DTHREAD_SANITIZER=1
 build:ubsan --config=san-common --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined
 build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 build:ubsan --copt=-DUNDEFINED_SANITIZER=1
+# Workaround for the fact that Bazel links with $CC, not $CXX
+# https://github.com/bazelbuild/bazel/issues/11122#issuecomment-613746748
+build:ubsan --copt=-fno-sanitize=function --copt=-fno-sanitize=vptr

--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,7 @@ build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 
 build:dbg --compilation_mode=dbg
 build:opt --compilation_mode=opt
-build:asan --copt=-fsanitize=address --linkopt=-fsanitize=address
-build:msan --copt=-fsanitize=memory --linkopt=-fsanitize=memory
-build:tsan --copt=-fsanitize=thread --linkopt=-fsanitize=thread
-build:ubsan --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+build:asan --compilation_mode=dbg --copt=-fsanitize=address --linkopt=-fsanitize=address
+build:msan --compilation_mode=dbg --copt=-fsanitize=memory --linkopt=-fsanitize=memory
+build:tsan --compilation_mode=dbg --copt=-fsanitize=thread --linkopt=-fsanitize=thread
+build:ubsan --compilation_mode=dbg --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,7 @@ build:opt --compilation_mode=opt
 build:san-common --config=dbg --strip=never --copt=-O0 --copt=-fno-omit-frame-pointer
 
 build:asan --config=san-common --copt=-fsanitize=address --linkopt=-fsanitize=address
+build:asan --copt=-DADDRESS_SANITIZER=1
 # ASAN hits ODR violations with shared linkage due to rules_proto.
 build:asan --dynamic_mode=off
 
@@ -14,6 +15,7 @@ build:msan --config=san-common --copt=-fsanitize=memory --linkopt=-fsanitize=mem
 build:msan --copt=-fsanitize-memory-track-origins
 build:msan --copt=-fsanitize-memory-use-after-dtor
 build:msan --action_env=MSAN_OPTIONS=poison_in_dtor=1
+build:msan --copt=-DMEMORY_SANITIZER=1
 
 # Use our instrumented LLVM libc++ in Kokoro.
 build:kokoro-msan --config=msan
@@ -23,6 +25,8 @@ build:kokoro-msan --cxxopt=-stdlib=libc++ --linkopt=-stdlib=libc++
 
 
 build:tsan --config=san-common --copt=-fsanitize=thread --linkopt=-fsanitize=thread
+build:tsan --copt=-DTHREAD_SANITIZER=1
 
-build:ubsan --config=san-common--copt=-fsanitize=undefined --linkopt=-fsanitize=undefined
+build:ubsan --config=san-common --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined
 build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+build:ubsan --copt=-DUNDEFINED_SANITIZER=1

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,13 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "com_googlesource_code_re2",
+    sha256 = "906d0df8ff48f8d3a00a808827f009a840190f404559f649cb8e4d7143255ef9",
+    strip_prefix = "re2-a276a8c738735a0fe45a6ee590fe2df69bcf4502",
+    urls = ["https://github.com/google/re2/archive/a276a8c738735a0fe45a6ee590fe2df69bcf4502.zip"],  # 2022-04-08
+)
+
 # Bazel platform rules.
 http_archive(
     name = "platforms",

--- a/kokoro/linux/bazel.sh
+++ b/kokoro/linux/bazel.sh
@@ -41,7 +41,6 @@ function run {
     test \
     --keep_going \
     --test_output=streamed \
-    --verbose_failures \
     ${ENVS[@]} \
     $PLATFORM_CONFIG \
     $BAZEL_CONFIG \

--- a/kokoro/linux/bazel.sh
+++ b/kokoro/linux/bazel.sh
@@ -8,7 +8,6 @@ fi
 
 cd $(dirname $0)/../..
 GIT_REPO_ROOT=`pwd`
-rm -rf $GIT_REPO_ROOT/logs
 
 ENVS=()
 
@@ -30,6 +29,9 @@ function run {
   local BAZEL_CONFIG=$2
 
   tmpfile=$(mktemp -u)
+
+  bazel clean
+  rm -rf $GIT_REPO_ROOT/logs
 
   docker run \
     --cidfile $tmpfile \

--- a/kokoro/linux/bazel.sh
+++ b/kokoro/linux/bazel.sh
@@ -40,6 +40,7 @@ function run {
     test \
     --keep_going \
     --test_output=streamed \
+    --cap-add=SYS_PTRACE \
     ${ENVS[@]} \
     $PLATFORM_CONFIG \
     $BAZEL_CONFIG \

--- a/kokoro/linux/bazel.sh
+++ b/kokoro/linux/bazel.sh
@@ -35,12 +35,12 @@ function run {
 
   docker run \
     --cidfile $tmpfile \
+    --cap-add=SYS_PTRACE \
     -v $GIT_REPO_ROOT:/workspace \
     $CONTAINER_IMAGE \
     test \
     --keep_going \
     --test_output=streamed \
-    --cap-add=SYS_PTRACE \
     ${ENVS[@]} \
     $PLATFORM_CONFIG \
     $BAZEL_CONFIG \

--- a/kokoro/linux/bazel.sh
+++ b/kokoro/linux/bazel.sh
@@ -30,7 +30,7 @@ function run {
 
   tmpfile=$(mktemp -u)
 
-  bazel clean
+  rm -rf $GIT_REPO_ROOT/bazel-out $GIT_REPO_ROOT/bazel-bin
   rm -rf $GIT_REPO_ROOT/logs
 
   docker run \

--- a/kokoro/linux/bazel.sh
+++ b/kokoro/linux/bazel.sh
@@ -41,6 +41,7 @@ function run {
     test \
     --keep_going \
     --test_output=streamed \
+    --verbose_failures \
     ${ENVS[@]} \
     $PLATFORM_CONFIG \
     $BAZEL_CONFIG \

--- a/kokoro/linux/bazel/common.cfg
+++ b/kokoro/linux/bazel/common.cfg
@@ -2,7 +2,7 @@
 
 # Location of the build script in repository
 build_file: "protobuf/kokoro/linux/bazel.sh"
-timeout_mins: 15
+timeout_mins: 120
 
 env_vars {
   key: "BAZEL_TARGETS"

--- a/kokoro/linux/bazel/common.cfg
+++ b/kokoro/linux/bazel/common.cfg
@@ -14,14 +14,6 @@ env_vars {
   value: "opt dbg asan msan tsan ubsan"
 }
 
-env_vars {
-  key: "BAZEL_EXTRA_FLAGS"
-  # Bazel's toolchain copy of protobuf conflicts with our local version to
-  # cause ODR violations.  This problem is unique to internal tests that use
-  # cc_proto_library.
-  value: "--test_env=ASAN_OPTIONS=detect_odr_violation=0"
-}
-
 action {
   define_artifacts {
     regex: "**/sponge_log.*"

--- a/kokoro/linux/bazel/common.cfg
+++ b/kokoro/linux/bazel/common.cfg
@@ -14,6 +14,11 @@ env_vars {
   value: "opt dbg asan msan tsan ubsan"
 }
 
+env_vars {
+  key: "BAZEL_EXTRA_FLAGS"
+  value: "--distinct_host_configuration=false"
+}
+
 action {
   define_artifacts {
     regex: "**/sponge_log.*"

--- a/kokoro/linux/bazel/common.cfg
+++ b/kokoro/linux/bazel/common.cfg
@@ -5,13 +5,18 @@ build_file: "protobuf/kokoro/linux/bazel.sh"
 timeout_mins: 120
 
 env_vars {
+  key: "CONTAINER_IMAGE"
+  value: "gcr.io/protobuf-build/bazel/linux-san:b6bfa3bb505e83f062af0cb0ed23abf1e89b9edb"
+}
+
+env_vars {
   key: "BAZEL_TARGETS"
   value: "//src/... @com_google_protobuf_examples//..."
 }
 
 env_vars {
   key: "BAZEL_CONFIGS"
-  value: "opt dbg asan tsan ubsan"
+  value: "opt dbg asan tsan ubsan kokoro-msan"
 }
 
 env_vars {

--- a/kokoro/linux/bazel/common.cfg
+++ b/kokoro/linux/bazel/common.cfg
@@ -9,6 +9,19 @@ env_vars {
   value: "//src/... @com_google_protobuf_examples//..."
 }
 
+env_vars {
+  key: "BAZEL_CONFIGS"
+  value: "opt dbg asan msan tsan ubsan"
+}
+
+env_vars {
+  key: "BAZEL_EXTRA_FLAGS"
+  # Bazel's toolchain copy of protobuf conflicts with our local version to
+  # cause ODR violations.  This problem is unique to internal tests that use
+  # cc_proto_library.
+  value: "--test_env=ASAN_OPTIONS=detect_odr_violation=0"
+}
+
 action {
   define_artifacts {
     regex: "**/sponge_log.*"

--- a/kokoro/linux/bazel/common.cfg
+++ b/kokoro/linux/bazel/common.cfg
@@ -16,7 +16,7 @@ env_vars {
 
 env_vars {
   key: "BAZEL_CONFIGS"
-  value: "opt dbg asan tsan ubsan kokoro-msan"
+  value: "opt dbg kokoro-asan kokoro-msan tsan ubsan"
 }
 
 env_vars {

--- a/kokoro/linux/bazel/common.cfg
+++ b/kokoro/linux/bazel/common.cfg
@@ -11,7 +11,7 @@ env_vars {
 
 env_vars {
   key: "BAZEL_CONFIGS"
-  value: "opt dbg asan msan tsan ubsan"
+  value: "opt dbg asan tsan ubsan"
 }
 
 env_vars {

--- a/kokoro/linux/bazel/common.cfg
+++ b/kokoro/linux/bazel/common.cfg
@@ -16,7 +16,7 @@ env_vars {
 
 env_vars {
   key: "BAZEL_CONFIGS"
-  value: "opt dbg kokoro-asan kokoro-msan tsan ubsan"
+  value: "opt dbg asan kokoro-msan tsan ubsan"
 }
 
 env_vars {

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -49,9 +49,9 @@ def protobuf_deps():
         http_archive(
             name = "zlib",
             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-            sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
-            strip_prefix = "zlib-1.2.11",
-            urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
+            sha256 = "d8688496ea40fb61787500e863cc63c9afcbc524468cedeb478068924eb54932",
+            strip_prefix = "zlib-1.2.12",
+            urls = ["https://github.com/madler/zlib/archive/v1.2.12.tar.gz"],
         )
 
     if not native.existing_rule("rules_cc"):

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -189,7 +189,6 @@ cc_library(
     name = "protobuf_lite",
     srcs = [
         "any_lite.cc",
-        "arena_config.cc",
         "arenastring.cc",
         "arenaz_sampler.cc",
         "extension_set.cc",

--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -1336,19 +1336,19 @@ bool Parser::ParseDefaultAssignment(
     }
 
     case FieldDescriptorProto::TYPE_FLOAT:
-    case FieldDescriptorProto::TYPE_DOUBLE:
+    case FieldDescriptorProto::TYPE_DOUBLE: {
       // These types can be negative.
       if (TryConsume("-")) {
         default_value->append("-");
       }
       // Parse the integer because we have to convert hex integers to decimal
       // floats.
-      double value;
+      double value = 0.0;
       DO(ConsumeNumber(&value, "Expected number."));
       // And stringify it again.
       default_value->append(SimpleDtoa(value));
       break;
-
+    }
     case FieldDescriptorProto::TYPE_BOOL:
       if (TryConsume("true")) {
         default_value->assign("true");

--- a/src/google/protobuf/io/BUILD.bazel
+++ b/src/google/protobuf/io/BUILD.bazel
@@ -136,6 +136,7 @@ cc_test(
     data = [
         "//src/google/protobuf:testdata",
     ],
+    size = "large",
     deps = [
         ":gzip_stream",
         ":io",

--- a/src/google/protobuf/io/BUILD.bazel
+++ b/src/google/protobuf/io/BUILD.bazel
@@ -136,7 +136,6 @@ cc_test(
     data = [
         "//src/google/protobuf:testdata",
     ],
-    size = "large",
     deps = [
         ":gzip_stream",
         ":io",

--- a/src/google/protobuf/io/zero_copy_stream_unittest.cc
+++ b/src/google/protobuf/io/zero_copy_stream_unittest.cc
@@ -720,9 +720,9 @@ TEST_F(IoTest, StringIo) {
 
 // Verifies that outputs up to kint32max can be created.
 TEST_F(IoTest, LargeOutput) {
-  // Filter out this test on 32-bit architectures.
+  // Filter out this test on 32-bit architectures and tsan builds.
   if(sizeof(void*) < 8) return;
-
+#ifndef THREAD_SANITIZER
   std::string str;
   StringOutputStream output(&str);
   void* unused_data;
@@ -734,6 +734,7 @@ TEST_F(IoTest, LargeOutput) {
   // Further increases should be possible.
   output.Next(&unused_data, &size);
   EXPECT_GT(size, 0);
+#endif  // THREAD_SANITIZER
 }
 
 

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -901,11 +901,13 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, int size,
     nbytes = static_cast<int>(buffer_end_ + kSlopBytes - ptr);
   }
   int num = size / sizeof(T);
+  int block_size = num * sizeof(T);
+  if(num == 0) return size == block_size ? ptr : nullptr;
   int old_entries = out->size();
   out->Reserve(old_entries + num);
-  int block_size = num * sizeof(T);
   auto dst = out->AddNAlreadyReserved(num);
 #ifdef PROTOBUF_LITTLE_ENDIAN
+  GOOGLE_CHECK(dst != nullptr) << out << "," << num;
   std::memcpy(dst, ptr, block_size);
 #else
   for (int i = 0; i < num; i++) dst[i] = UnalignedLoad<T>(ptr + i * sizeof(T));

--- a/src/google/protobuf/stubs/bytestream.cc
+++ b/src/google/protobuf/stubs/bytestream.cc
@@ -116,7 +116,7 @@ char* GrowingArrayByteSink::GetBuffer(size_t* nbytes) {
   ShrinkToFit();
   char* b = buf_;
   *nbytes = size_;
-  buf_ = nullptr;
+  buf_ = new char[0];
   size_ = capacity_ = 0;
   return b;
 }
@@ -124,8 +124,10 @@ char* GrowingArrayByteSink::GetBuffer(size_t* nbytes) {
 void GrowingArrayByteSink::Expand(size_t amount) {  // Expand by at least 50%.
   size_t new_capacity = std::max(capacity_ + amount, (3 * capacity_) / 2);
   char* bigger = new char[new_capacity];
-  memcpy(bigger, buf_, size_);
-  delete[] buf_;
+  if(buf_ != nullptr) {
+    memcpy(bigger, buf_, size_);
+    delete[] buf_;
+  }
   buf_ = bigger;
   capacity_ = new_capacity;
 }

--- a/src/google/protobuf/stubs/bytestream.cc
+++ b/src/google/protobuf/stubs/bytestream.cc
@@ -116,7 +116,7 @@ char* GrowingArrayByteSink::GetBuffer(size_t* nbytes) {
   ShrinkToFit();
   char* b = buf_;
   *nbytes = size_;
-  buf_ = new char[0];
+  buf_ = nullptr;
   size_ = capacity_ = 0;
   return b;
 }


### PR DESCRIPTION
This will parametrize the Bazel kokoro presubmit, running all of optimized, debug, asan, msan, tsan, and ubsan.
