### PR TITLE
Force uninstall protobuf in python macos builds

### DIFF
--- a/kokoro/release/python/macos/build_artifacts.sh
+++ b/kokoro/release/python/macos/build_artifacts.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Remove any pre-existing protobuf installation.
-brew uninstall protobuf
+brew uninstall -f protobuf
 
 # change to repo root
 pushd $(dirname $0)/../../../..


### PR DESCRIPTION
We are seeing failures in brew uninstall protobuf due to no package. Change this to a force install to avoid the error.