### PR TITLE
Re-add aliases for test protos

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -348,6 +348,18 @@ alias(
     visibility = ["//:__subpackages__"],
 )
 
+alias(
+    name = "test_messages_proto2_proto",
+    actual = "//src/google/protobuf:test_messages_proto2_proto",  # proto_library
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "test_messages_proto3_proto",
+    actual = "//src/google/protobuf:test_messages_proto3_proto",  # proto_library
+    visibility = ["//visibility:public"],
+)
+
 # Validate generated proto source inputs:
 
 genrule(
@@ -471,7 +483,8 @@ internal_php_proto_library(
         "Protobuf_test_messages/Proto3/ForeignMessage.php",
         "Protobuf_test_messages/Proto3/NullHypothesisProto3.php",
         "Protobuf_test_messages/Proto3/TestAllTypesProto3.php",
-        "Protobuf_test_messages/Proto3/TestAllTypesProto3/AliasedEnum.php",
+        "Protobuf_test_messages/Proto3/TestAllTypesProto3/
+        edEnum.php",
         "Protobuf_test_messages/Proto3/TestAllTypesProto3/NestedEnum.php",
         "Protobuf_test_messages/Proto3/TestAllTypesProto3/NestedMessage.php",
     ],


### PR DESCRIPTION
Re-add aliases for test_messages_proto3_proto and test_messages_proto2_proto, removed by https://github.com/protocolbuffers/protobuf/commit/ed5c57a574aa24bc49432baced51aa6d01fbf38a

These are used by upb, and when upgrading upb to point at protobuf main HEAD failed with 
```
ERROR: /home/runner/work/upb/upb/BUILD:823:29: no such target '@com_google_protobuf//:test_messages_proto3_proto': target 'test_messages_proto3_proto' not declared in package '' (did you mean 'test_messages_proto3_cc_proto'?) defined by /home/runner/.cache/bazel/_bazel_runner/9d5ab857a4215216a12f2077d5365ae9/external/com_google_protobuf/BUILD.bazel and referenced by '//:test_messages_proto3_upbdefs'
```
https://github.com/protocolbuffers/upb/actions/runs/3192939059/jobs/5210976696