### PR TITLE
Upgrade to Kotlin 1.6

### DIFF
--- a/java/kotlin-lite/pom.xml
+++ b/java/kotlin-lite/pom.xml
@@ -16,7 +16,7 @@
   </description>
 
   <properties>
-    <kotlin.version>1.5.0</kotlin.version>
+    <kotlin.version>1.6.0</kotlin.version>
   </properties>
 
   <dependencies>

--- a/java/kotlin-lite/pom_template.xml
+++ b/java/kotlin-lite/pom_template.xml
@@ -17,6 +17,6 @@
   </description>
 
   <properties>
-    <kotlin.version>1.5.0</kotlin.version>
+    <kotlin.version>1.6.0</kotlin.version>
   </properties>
 </project>

--- a/java/kotlin/pom.xml
+++ b/java/kotlin/pom.xml
@@ -16,7 +16,7 @@
   </description>
 
   <properties>
-    <kotlin.version>1.5.0</kotlin.version>
+    <kotlin.version>1.6.0</kotlin.version>
   </properties>
 
   <dependencies>

--- a/java/kotlin/pom_template.xml
+++ b/java/kotlin/pom_template.xml
@@ -17,7 +17,7 @@
   </description>
 
   <properties>
-    <kotlin.version>1.5.0</kotlin.version>
+    <kotlin.version>1.6.0</kotlin.version>
   </properties>
 
 </project>


### PR DESCRIPTION
Upgrading Kotlin due to [this CVE](https://nvd.nist.gov/vuln/detail/CVE-2022-24329). This shouldn't affect our project, so we will not be pushing out a release immediately.