### PR TITLE
protoc: validate custom json_name configuration (take 2)

### DIFF
--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -2074,8 +2074,88 @@ TEST_F(ParserValidationErrorTest, Proto3JsonConflictError) {
       "  uint32 foo = 1;\n"
       "  uint32 Foo = 2;\n"
       "}\n",
-      "3:9: The JSON camel-case name of field \"Foo\" conflicts with field "
-      "\"foo\". This is not allowed in proto3.\n");
+      "3:9: The default JSON name of field \"Foo\" (\"Foo\") conflicts "
+      "with the default JSON name of field \"foo\" (\"foo\"). "
+      "This is not allowed in proto3.\n");
+}
+
+TEST_F(ParserValidationErrorTest, Proto2JsonConflictError) {
+  // conflicts with default JSON names are not errors in proto2
+  ExpectParsesTo(
+      "syntax = 'proto2';\n"
+      "message TestMessage {\n"
+      "  optional uint32 foo = 1;\n"
+      "  optional uint32 Foo = 2;\n"
+      "}\n",
+
+      "syntax: 'proto2'"
+      "message_type {"
+      "  name: 'TestMessage'"
+      "  field {"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1"
+      "  }"
+      "  field {"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'Foo' number: 2"
+      "  }"
+      "}"
+      );
+}
+
+TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictWithDefaultError) {
+  ExpectHasValidationErrors(
+      "syntax = 'proto3';\n"
+      "message TestMessage {\n"
+      "  uint32 foo = 1 [json_name='bar'];\n"
+      "  uint32 bar = 2;\n"
+      "}\n",
+      "3:9: The default JSON name of field \"bar\" (\"bar\") conflicts "
+      "with the custom JSON name of field \"foo\". "
+      "This is not allowed in proto3.\n");
+}
+
+TEST_F(ParserValidationErrorTest, Proto2CustomJsonConflictWithDefaultError) {
+  // conflicts with default JSON names are not errors in proto2
+  ExpectParsesTo(
+      "syntax = 'proto2';\n"
+      "message TestMessage {\n"
+      "  optional uint32 foo = 1 [json_name='bar'];\n"
+      "  optional uint32 bar = 2;\n"
+      "}\n",
+
+      "syntax: 'proto2'"
+      "message_type {"
+      "  name: 'TestMessage'"
+      "  field {"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1 json_name: 'bar'"
+      "  }"
+      "  field {"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'bar' number: 2"
+      "  }"
+      "}"
+      );
+}
+
+TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictError) {
+  ExpectHasValidationErrors(
+      "syntax = 'proto3';\n"
+      "message TestMessage {\n"
+      "  uint32 foo = 1 [json_name='baz'];\n"
+      "  uint32 bar = 2 [json_name='baz'];\n"
+      "}\n",
+      "3:9: The custom JSON name of field \"bar\" (\"baz\") conflicts "
+      "with the custom JSON name of field \"foo\".\n");
+}
+
+TEST_F(ParserValidationErrorTest, Proto2CustomJsonConflictError) {
+  ExpectHasValidationErrors(
+      "syntax = 'proto2';\n"
+      "message TestMessage {\n"
+      "  optional uint32 foo = 1 [json_name='baz'];\n"
+      "  optional uint32 bar = 2 [json_name='baz'];\n"
+      "}\n",
+      // fails in proto2 also: can't explicitly configure bad custom JSON names
+      "3:18: The custom JSON name of field \"bar\" (\"baz\") conflicts "
+      "with the custom JSON name of field \"foo\".\n");
 }
 
 TEST_F(ParserValidationErrorTest, EnumNameError) {

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -2069,12 +2069,14 @@ TEST_F(ParserValidationErrorTest, Proto3Default) {
 
 TEST_F(ParserValidationErrorTest, Proto3JsonConflictError) {
   ExpectHasValidationErrors(
-      "syntax = 'proto3';\n"
-      "message TestMessage {\n"
-      "  uint32 foo = 1;\n"
-      "  uint32 Foo = 2;\n"
-      "}\n",
-      "3:9: The default JSON name of field \"Foo\" (\"Foo\") conflicts "
+      R"pb(
+      syntax = 'proto3';
+      message TestMessage {
+        uint32 foo = 1;
+        uint32 Foo = 2;
+      }
+      )pb",
+      "4:15: The default JSON name of field \"Foo\" (\"Foo\") conflicts "
       "with the default JSON name of field \"foo\" (\"foo\"). "
       "This is not allowed in proto3.\n");
 }
@@ -2082,33 +2084,38 @@ TEST_F(ParserValidationErrorTest, Proto3JsonConflictError) {
 TEST_F(ParserValidationErrorTest, Proto2JsonConflictError) {
   // conflicts with default JSON names are not errors in proto2
   ExpectParsesTo(
-      "syntax = 'proto2';\n"
-      "message TestMessage {\n"
-      "  optional uint32 foo = 1;\n"
-      "  optional uint32 Foo = 2;\n"
-      "}\n",
-
-      "syntax: 'proto2'"
-      "message_type {"
-      "  name: 'TestMessage'"
-      "  field {"
-      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1"
-      "  }"
-      "  field {"
-      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'Foo' number: 2"
-      "  }"
-      "}"
+      R"pb(
+      syntax = "proto2";
+      message TestMessage {
+        optional uint32 foo = 1;
+        optional uint32 Foo = 2;
+      }
+      )pb",
+      R"pb(
+      syntax: 'proto2'
+      message_type {
+        name: 'TestMessage'
+        field {
+          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1
+        }
+        field {
+          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'Foo' number: 2
+        }
+      }
+      )pb"
       );
 }
 
 TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictWithDefaultError) {
   ExpectHasValidationErrors(
-      "syntax = 'proto3';\n"
-      "message TestMessage {\n"
-      "  uint32 foo = 1 [json_name='bar'];\n"
-      "  uint32 bar = 2;\n"
-      "}\n",
-      "3:9: The default JSON name of field \"bar\" (\"bar\") conflicts "
+      R"pb(
+      syntax = 'proto3';
+      message TestMessage {
+        uint32 foo = 1 [json_name='bar'];
+        uint32 bar = 2;
+      }
+      )pb",
+      "4:15: The default JSON name of field \"bar\" (\"bar\") conflicts "
       "with the custom JSON name of field \"foo\". "
       "This is not allowed in proto3.\n");
 }
@@ -2116,45 +2123,52 @@ TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictWithDefaultError) {
 TEST_F(ParserValidationErrorTest, Proto2CustomJsonConflictWithDefaultError) {
   // conflicts with default JSON names are not errors in proto2
   ExpectParsesTo(
-      "syntax = 'proto2';\n"
-      "message TestMessage {\n"
-      "  optional uint32 foo = 1 [json_name='bar'];\n"
-      "  optional uint32 bar = 2;\n"
-      "}\n",
-
-      "syntax: 'proto2'"
-      "message_type {"
-      "  name: 'TestMessage'"
-      "  field {"
-      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1 json_name: 'bar'"
-      "  }"
-      "  field {"
-      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'bar' number: 2"
-      "  }"
-      "}"
+      R"pb(
+      syntax = 'proto2';
+      message TestMessage {
+        optional uint32 foo = 1 [json_name='bar'];
+        optional uint32 bar = 2;
+      }
+      )pb",
+      R"pb(
+      syntax: 'proto2'
+      message_type {
+        name: 'TestMessage'
+        field {
+          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1 json_name: 'bar'
+        }
+        field {
+          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'bar' number: 2
+        }
+      }
+      )pb"
       );
 }
 
 TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictError) {
   ExpectHasValidationErrors(
-      "syntax = 'proto3';\n"
-      "message TestMessage {\n"
-      "  uint32 foo = 1 [json_name='baz'];\n"
-      "  uint32 bar = 2 [json_name='baz'];\n"
-      "}\n",
-      "3:9: The custom JSON name of field \"bar\" (\"baz\") conflicts "
+      R"pb(
+      syntax = 'proto3';
+      message TestMessage {
+        uint32 foo = 1 [json_name='baz'];
+        uint32 bar = 2 [json_name='baz'];
+      }
+      )pb",
+      "4:15: The custom JSON name of field \"bar\" (\"baz\") conflicts "
       "with the custom JSON name of field \"foo\".\n");
 }
 
 TEST_F(ParserValidationErrorTest, Proto2CustomJsonConflictError) {
   ExpectHasValidationErrors(
-      "syntax = 'proto2';\n"
-      "message TestMessage {\n"
-      "  optional uint32 foo = 1 [json_name='baz'];\n"
-      "  optional uint32 bar = 2 [json_name='baz'];\n"
-      "}\n",
+      R"pb(
+      syntax = 'proto2';
+      message TestMessage {
+        optional uint32 foo = 1 [json_name='baz'];
+        optional uint32 bar = 2 [json_name='baz'];
+      }
+      )pb",
       // fails in proto2 also: can't explicitly configure bad custom JSON names
-      "3:18: The custom JSON name of field \"bar\" (\"baz\") conflicts "
+      "4:24: The custom JSON name of field \"bar\" (\"baz\") conflicts "
       "with the custom JSON name of field \"foo\".\n");
 }
 

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -2069,14 +2069,12 @@ TEST_F(ParserValidationErrorTest, Proto3Default) {
 
 TEST_F(ParserValidationErrorTest, Proto3JsonConflictError) {
   ExpectHasValidationErrors(
-      R"pb(
-      syntax = 'proto3';
-      message TestMessage {
-        uint32 foo = 1;
-        uint32 Foo = 2;
-      }
-      )pb",
-      "4:15: The default JSON name of field \"Foo\" (\"Foo\") conflicts "
+      "syntax = 'proto3';\n"
+      "message TestMessage {\n"
+      "  uint32 foo = 1;\n"
+      "  uint32 Foo = 2;\n"
+      "}\n",
+      "3:9: The default JSON name of field \"Foo\" (\"Foo\") conflicts "
       "with the default JSON name of field \"foo\" (\"foo\"). "
       "This is not allowed in proto3.\n");
 }
@@ -2084,38 +2082,31 @@ TEST_F(ParserValidationErrorTest, Proto3JsonConflictError) {
 TEST_F(ParserValidationErrorTest, Proto2JsonConflictError) {
   // conflicts with default JSON names are not errors in proto2
   ExpectParsesTo(
-      R"pb(
-      syntax = "proto2";
-      message TestMessage {
-        optional uint32 foo = 1;
-        optional uint32 Foo = 2;
-      }
-      )pb",
-      R"pb(
-      syntax: 'proto2'
-      message_type {
-        name: 'TestMessage'
-        field {
-          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1
-        }
-        field {
-          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'Foo' number: 2
-        }
-      }
-      )pb"
-      );
+      "syntax = 'proto2';\n"
+      "message TestMessage {\n"
+      "  optional uint32 foo = 1;\n"
+      "  optional uint32 Foo = 2;\n"
+      "}\n",
+      "syntax: 'proto2'\n"
+      "message_type {\n"
+      "  name: 'TestMessage'\n"
+      "  field {\n"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1\n"
+      "  }\n"
+      "  field {\n"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'Foo' number: 2\n"
+      "  }\n"
+      "}\n");
 }
 
 TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictWithDefaultError) {
   ExpectHasValidationErrors(
-      R"pb(
-      syntax = 'proto3';
-      message TestMessage {
-        uint32 foo = 1 [json_name='bar'];
-        uint32 bar = 2;
-      }
-      )pb",
-      "4:15: The default JSON name of field \"bar\" (\"bar\") conflicts "
+      "syntax = 'proto3';\n"
+      "message TestMessage {\n"
+      "  uint32 foo = 1 [json_name='bar'];\n"
+      "  uint32 bar = 2;\n"
+      "}\n",
+      "3:9: The default JSON name of field \"bar\" (\"bar\") conflicts "
       "with the custom JSON name of field \"foo\". "
       "This is not allowed in proto3.\n");
 }
@@ -2123,52 +2114,44 @@ TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictWithDefaultError) {
 TEST_F(ParserValidationErrorTest, Proto2CustomJsonConflictWithDefaultError) {
   // conflicts with default JSON names are not errors in proto2
   ExpectParsesTo(
-      R"pb(
-      syntax = 'proto2';
-      message TestMessage {
-        optional uint32 foo = 1 [json_name='bar'];
-        optional uint32 bar = 2;
-      }
-      )pb",
-      R"pb(
-      syntax: 'proto2'
-      message_type {
-        name: 'TestMessage'
-        field {
-          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1 json_name: 'bar'
-        }
-        field {
-          label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'bar' number: 2
-        }
-      }
-      )pb"
-      );
+      "syntax = 'proto2';\n"
+      "message TestMessage {\n"
+      "  optional uint32 foo = 1 [json_name='bar'];\n"
+      "  optional uint32 bar = 2;\n"
+      "}\n",
+      "syntax: 'proto2'\n"
+      "message_type {\n"
+      "  name: 'TestMessage'\n"
+      "  field {\n"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'foo' number: 1 "
+      "json_name: 'bar'\n"
+      "  }\n"
+      "  field {\n"
+      "    label: LABEL_OPTIONAL type: TYPE_UINT32 name: 'bar' number: 2\n"
+      "  }\n"
+      "}\n");
 }
 
 TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictError) {
   ExpectHasValidationErrors(
-      R"pb(
-      syntax = 'proto3';
-      message TestMessage {
-        uint32 foo = 1 [json_name='baz'];
-        uint32 bar = 2 [json_name='baz'];
-      }
-      )pb",
-      "4:15: The custom JSON name of field \"bar\" (\"baz\") conflicts "
+      "syntax = 'proto3';\n"
+      "message TestMessage {\n"
+      "  uint32 foo = 1 [json_name='baz'];\n"
+      "  uint32 bar = 2 [json_name='baz'];\n"
+      "}\n",
+      "3:9: The custom JSON name of field \"bar\" (\"baz\") conflicts "
       "with the custom JSON name of field \"foo\".\n");
 }
 
 TEST_F(ParserValidationErrorTest, Proto2CustomJsonConflictError) {
   ExpectHasValidationErrors(
-      R"pb(
-      syntax = 'proto2';
-      message TestMessage {
-        optional uint32 foo = 1 [json_name='baz'];
-        optional uint32 bar = 2 [json_name='baz'];
-      }
-      )pb",
+      "syntax = 'proto2';\n"
+      "message TestMessage {\n"
+      "  optional uint32 foo = 1 [json_name='baz'];\n"
+      "  optional uint32 bar = 2 [json_name='baz'];\n"
+      "}\n",
       // fails in proto2 also: can't explicitly configure bad custom JSON names
-      "4:24: The custom JSON name of field \"bar\" (\"baz\") conflicts "
+      "3:18: The custom JSON name of field \"bar\" (\"baz\") conflicts "
       "with the custom JSON name of field \"foo\".\n");
 }
 

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -2122,8 +2122,8 @@ TEST_F(ParserValidationErrorTest, Proto2JsonConflictError) {
       "  optional uint32 foo = 1;\n"
       "  optional uint32 _foo = 2;\n"
       "}\n",
-      "3:18: The default JSON name of field \"_foo\" (\"Foo\") conflicts "
-      "with the default JSON name of field \"foo\" (\"foo\").\n");
+      // expect no warnings for this in proto2
+      "");
 }
 
 TEST_F(ParserValidationErrorTest, Proto3CustomJsonConflictWithDefaultError) {

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -5500,7 +5500,8 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     const DescriptorProto& proto, const Descriptor* result) {
   bool is_proto2 = result->file()->syntax() == FileDescriptor::SYNTAX_PROTO2;
   std::string message_name = result->full_name();
-  // two passes: one looking only at default JSON names, and one that considers custom JSON names
+  // two passes: one looking only at default JSON names, and one that considers
+  // custom JSON names
   CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, false);
   CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, true);
 }
@@ -5508,7 +5509,8 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
 namespace {
 // Helpers for function below
 
-std::string GetJsonName(const FieldDescriptorProto& field, bool use_custom, bool* was_custom) {
+std::string GetJsonName(const FieldDescriptorProto& field, bool use_custom,
+                        bool* was_custom) {
   if (use_custom && field.has_json_name()) {
     *was_custom = true;
     return field.json_name();
@@ -5526,7 +5528,8 @@ struct JsonNameDetails {
 } // namespace
 
 void DescriptorBuilder::CheckFieldJsonNameUniqueness(
-    std::string message_name,const DescriptorProto& message, bool is_proto2, bool use_custom_names) {
+    std::string message_name, const DescriptorProto& message, bool is_proto2,
+    bool use_custom_names) {
 
   absl::flat_hash_map<std::string, JsonNameDetails> name_to_field;
   for (const FieldDescriptorProto& field : message.field()) {
@@ -5538,35 +5541,38 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
       JsonNameDetails& match = existing->second;
       if (use_custom_names && !is_custom && !match.is_custom) {
         // if this pass is considering custom JSON names, but neither of the
-        // names involved in the conflict are custom, don't bother with a message.
-        // That will have been reported from other pass (non-custom JSON names).
+        // names involved in the conflict are custom, don't bother with a
+        // message. That will have been reported from other pass (non-custom
+        // JSON names).
         continue;
       }
       absl::string_view this_type = is_custom ? "custom" : "default";
       absl::string_view existing_type = match.is_custom ? "custom" : "default";
-      // If the matched name differs (which it can only differ in case), include it
-      // in the error message, for maximum clarity to user.
+      // If the matched name differs (which it can only differ in case), include
+      // it in the error message, for maximum clarity to user.
       absl::string_view name_suffix = "";
       if (name != match.orig_name) {
         name_suffix = absl::StrCat(" (\"", match.orig_name, "\")");
       }
-      std::string error_message = absl::StrFormat(
-          "The %s JSON name of field \"%s\" (\"%s\") conflicts with the %s JSON name of field \"%s\"%s.",
-          this_type, field.name(), name, existing_type, match.field->name(), name_suffix);
+      std::string error_message =
+          absl::StrFormat("The %s JSON name of field \"%s\" (\"%s\") conflicts "
+                          "with the %s JSON name of field \"%s\"%s.",
+                          this_type, field.name(), name, existing_type,
+                          match.field->name(), name_suffix);
 
       bool involves_default = !is_custom || !match.is_custom;
       if (is_proto2 && involves_default) {
-        AddWarning(message_name, field,
-                 DescriptorPool::ErrorCollector::NAME, error_message);
+        AddWarning(message_name, field, DescriptorPool::ErrorCollector::NAME,
+                   error_message);
       } else {
         if (involves_default) {
           absl::StrAppend(&error_message, " This is not allowed in proto3.");
         }
-        AddError(message_name, field,
-                 DescriptorPool::ErrorCollector::NAME, error_message);
+        AddError(message_name, field, DescriptorPool::ErrorCollector::NAME,
+                 error_message);
       }
     } else {
-      JsonNameDetails details = { &field, name, is_custom };
+      JsonNameDetails details = {&field, name, is_custom};
       name_to_field[lowercase_name] = details;
     }
   }
@@ -5984,8 +5990,7 @@ void DescriptorBuilder::CheckEnumValueUniqueness(
     const EnumValueDescriptor* value = result->value(i);
     std::string stripped =
         EnumValueToPascalCase(remover.MaybeRemove(value->name()));
-    std::pair<absl::flat_hash_map<std::string, const EnumValueDescriptor*>::iterator, bool>
-        insert_result = values.insert(std::make_pair(stripped, value));
+    auto insert_result = values.insert(std::make_pair(stripped, value));
     bool inserted = insert_result.second;
 
     // We don't throw the error if the two conflicting symbols are identical, or

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -5499,11 +5499,15 @@ void DescriptorBuilder::BuildMessage(const DescriptorProto& proto,
 
 void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     const DescriptorProto& proto, const Descriptor* result) {
+  // Two passes: one looking only at default JSON names, and one that considers
+  // custom JSON names. We can skip the first pass for proto2. (There may be some
+  // value in it, since FieldMask only uses default JSON names; but we skip it
+  // because it can be confusing, especially for fields that have custom names.)
   FileDescriptor::Syntax syntax = result->file()->syntax();
   std::string message_name = result->full_name();
-  // two passes: one looking only at default JSON names, and one that considers
-  // custom JSON names
-  CheckFieldJsonNameUniqueness(message_name, proto, syntax, false);
+  if (syntax != FileDescriptor::SYNTAX_PROTO2) {
+    CheckFieldJsonNameUniqueness(message_name, proto, syntax, false);
+  }
   CheckFieldJsonNameUniqueness(message_name, proto, syntax, true);
 }
 

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -3867,9 +3867,10 @@ class DescriptorBuilder {
 
   void CheckFieldJsonNameUniqueness(const DescriptorProto& proto,
                                     const Descriptor* result);
-  void CheckFieldJsonNameUniqueness(std::string message_name,
+  void CheckFieldJsonNameUniqueness(const std::string& message_name,
                                     const DescriptorProto& message,
-                                    bool is_proto2, bool use_custom_names);
+                                    FileDescriptor::Syntax syntax,
+                                    bool use_custom_names);
   void CheckEnumValueUniqueness(const EnumDescriptorProto& proto,
                                 const EnumDescriptor* result);
 
@@ -5498,12 +5499,12 @@ void DescriptorBuilder::BuildMessage(const DescriptorProto& proto,
 
 void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     const DescriptorProto& proto, const Descriptor* result) {
-  bool is_proto2 = result->file()->syntax() == FileDescriptor::SYNTAX_PROTO2;
+  FileDescriptor::Syntax syntax = result->file()->syntax();
   std::string message_name = result->full_name();
   // two passes: one looking only at default JSON names, and one that considers
   // custom JSON names
-  CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, false);
-  CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, true);
+  CheckFieldJsonNameUniqueness(message_name, proto, syntax, false);
+  CheckFieldJsonNameUniqueness(message_name, proto, syntax, true);
 }
 
 namespace {
@@ -5528,8 +5529,8 @@ struct JsonNameDetails {
 } // namespace
 
 void DescriptorBuilder::CheckFieldJsonNameUniqueness(
-    std::string message_name, const DescriptorProto& message, bool is_proto2,
-    bool use_custom_names) {
+    const std::string& message_name, const DescriptorProto& message,
+    FileDescriptor::Syntax syntax, bool use_custom_names) {
 
   absl::flat_hash_map<std::string, JsonNameDetails> name_to_field;
   for (const FieldDescriptorProto& field : message.field()) {
@@ -5537,43 +5538,43 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     std::string name = GetJsonName(field, use_custom_names, &is_custom);
     std::string lowercase_name = absl::AsciiStrToLower(name);
     auto existing = name_to_field.find(lowercase_name);
-    if (existing != name_to_field.end()) {
-      JsonNameDetails& match = existing->second;
-      if (use_custom_names && !is_custom && !match.is_custom) {
-        // if this pass is considering custom JSON names, but neither of the
-        // names involved in the conflict are custom, don't bother with a
-        // message. That will have been reported from other pass (non-custom
-        // JSON names).
-        continue;
-      }
-      absl::string_view this_type = is_custom ? "custom" : "default";
-      absl::string_view existing_type = match.is_custom ? "custom" : "default";
-      // If the matched name differs (which it can only differ in case), include
-      // it in the error message, for maximum clarity to user.
-      absl::string_view name_suffix = "";
-      if (name != match.orig_name) {
-        name_suffix = absl::StrCat(" (\"", match.orig_name, "\")");
-      }
-      std::string error_message =
-          absl::StrFormat("The %s JSON name of field \"%s\" (\"%s\") conflicts "
-                          "with the %s JSON name of field \"%s\"%s.",
-                          this_type, field.name(), name, existing_type,
-                          match.field->name(), name_suffix);
-
-      bool involves_default = !is_custom || !match.is_custom;
-      if (is_proto2 && involves_default) {
-        AddWarning(message_name, field, DescriptorPool::ErrorCollector::NAME,
-                   error_message);
-      } else {
-        if (involves_default) {
-          absl::StrAppend(&error_message, " This is not allowed in proto3.");
-        }
-        AddError(message_name, field, DescriptorPool::ErrorCollector::NAME,
-                 error_message);
-      }
-    } else {
+    if (existing == name_to_field.end()) {
       JsonNameDetails details = {&field, name, is_custom};
       name_to_field[lowercase_name] = details;
+      continue;
+    }
+    JsonNameDetails& match = existing->second;
+    if (use_custom_names && !is_custom && !match.is_custom) {
+      // if this pass is considering custom JSON names, but neither of the
+      // names involved in the conflict are custom, don't bother with a
+      // message. That will have been reported from other pass (non-custom
+      // JSON names).
+      continue;
+    }
+    absl::string_view this_type = is_custom ? "custom" : "default";
+    absl::string_view existing_type = match.is_custom ? "custom" : "default";
+    // If the matched name differs (which it can only differ in case), include
+    // it in the error message, for maximum clarity to user.
+    absl::string_view name_suffix = "";
+    if (name != match.orig_name) {
+      name_suffix = absl::StrCat(" (\"", match.orig_name, "\")");
+    }
+    std::string error_message =
+        absl::StrFormat("The %s JSON name of field \"%s\" (\"%s\") conflicts "
+                        "with the %s JSON name of field \"%s\"%s.",
+                        this_type, field.name(), name, existing_type,
+                        match.field->name(), name_suffix);
+
+    bool involves_default = !is_custom || !match.is_custom;
+    if (syntax == FileDescriptor::SYNTAX_PROTO2 && involves_default) {
+      AddWarning(message_name, field, DescriptorPool::ErrorCollector::NAME,
+                 error_message);
+    } else {
+      if (involves_default) {
+        absl::StrAppend(&error_message, " This is not allowed in proto3.");
+      }
+      AddError(message_name, field, DescriptorPool::ErrorCollector::NAME,
+               error_message);
     }
   }
 }

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -3865,9 +3865,9 @@ class DescriptorBuilder {
                    const ServiceDescriptor* parent, MethodDescriptor* result,
                    internal::FlatAllocator& alloc);
 
-  void CheckFieldJSONNameUniqueness(const DescriptorProto& proto,
+  void CheckFieldJsonNameUniqueness(const DescriptorProto& proto,
                                     const Descriptor* result);
-  void CheckFieldJSONNameUniqueness(std::string message_name,
+  void CheckFieldJsonNameUniqueness(std::string message_name,
                                     const DescriptorProto& message,
                                     bool is_proto2, bool use_custom_names);
   void CheckEnumValueUniqueness(const EnumDescriptorProto& proto,
@@ -5428,7 +5428,7 @@ void DescriptorBuilder::BuildMessage(const DescriptorProto& proto,
     }
   }
 
-  CheckFieldJSONNameUniqueness(proto, result);
+  CheckFieldJsonNameUniqueness(proto, result);
 
   // Check that fields aren't using reserved names or numbers and that they
   // aren't using extension numbers.
@@ -5496,7 +5496,7 @@ void DescriptorBuilder::BuildMessage(const DescriptorProto& proto,
   }
 }
 
-std::string GetJSONName(const FieldDescriptorProto& field, bool use_custom, bool* was_custom) {
+std::string GetJsonName(const FieldDescriptorProto& field, bool use_custom, bool* was_custom) {
   if (use_custom && field.has_json_name()) {
     *was_custom = true;
     return field.json_name();
@@ -5505,28 +5505,28 @@ std::string GetJSONName(const FieldDescriptorProto& field, bool use_custom, bool
   return ToJsonName(field.name());
 }
 
-void DescriptorBuilder::CheckFieldJSONNameUniqueness(
+void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     const DescriptorProto& proto, const Descriptor* result) {
   bool is_proto2 = result->file()->syntax() == FileDescriptor::SYNTAX_PROTO2;
   std::string message_name = result->full_name();
   // two passes: one looking only at default JSON names, and one that considers custom JSON names
-  CheckFieldJSONNameUniqueness(message_name, proto, is_proto2, false);
-  CheckFieldJSONNameUniqueness(message_name, proto, is_proto2, true);
+  CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, false);
+  CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, true);
 }
 
-struct JSONNameDetails {
+struct JsonNameDetails {
   const FieldDescriptorProto* field;
   std::string orig_name;
   bool is_custom;
 };
 
-void DescriptorBuilder::CheckFieldJSONNameUniqueness(
+void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     std::string message_name,const DescriptorProto& message, bool is_proto2, bool use_custom_names) {
 
-  std::map<std::string, struct JSONNameDetails> name_to_field;
+  std::map<std::string, JsonNameDetails> name_to_field;
   for (int i = 0; i < message.field_size(); ++i) {
     bool is_custom;
-    std::string name = GetJSONName(message.field(i), use_custom_names, &is_custom);
+    std::string name = GetJsonName(message.field(i), use_custom_names, &is_custom);
     std::string lowercase_name = absl::AsciiStrToLower(name);
     auto existing = name_to_field.find(lowercase_name);
     if (existing != name_to_field.end()) {
@@ -5559,7 +5559,7 @@ void DescriptorBuilder::CheckFieldJSONNameUniqueness(
                  DescriptorPool::ErrorCollector::NAME, error_message);
       }
     } else {
-      struct JSONNameDetails details = { &message.field(i), name, is_custom };
+      JsonNameDetails details = { &message.field(i), name, is_custom };
       name_to_field[lowercase_name] = details;
     }
   }

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -5993,9 +5993,8 @@ void DescriptorBuilder::CheckEnumValueUniqueness(
           "Enum name " + value->name() + " has the same name as " +
           values[stripped]->name() +
           " if you ignore case and strip out the enum name prefix (if any). "
-          "This is error-prone and can lead to undefined behavior. "
-          "Please avoid doing this. If you are using allow_alias, please "
-          "assign the same numeric value to both enums.";
+          "(If you are using allow_alias, please assign the same numeric "
+          "value to both enums.)";
       // There are proto2 enums out there with conflicting names, so to preserve
       // compatibility we issue only a warning for proto2.
       if (result->file()->syntax() == FileDescriptor::SYNTAX_PROTO2) {

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -5496,15 +5496,6 @@ void DescriptorBuilder::BuildMessage(const DescriptorProto& proto,
   }
 }
 
-std::string GetJsonName(const FieldDescriptorProto& field, bool use_custom, bool* was_custom) {
-  if (use_custom && field.has_json_name()) {
-    *was_custom = true;
-    return field.json_name();
-  }
-  *was_custom = false;
-  return ToJsonName(field.name());
-}
-
 void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     const DescriptorProto& proto, const Descriptor* result) {
   bool is_proto2 = result->file()->syntax() == FileDescriptor::SYNTAX_PROTO2;
@@ -5514,52 +5505,68 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
   CheckFieldJsonNameUniqueness(message_name, proto, is_proto2, true);
 }
 
+namespace {
+// Helpers for function below
+
+std::string GetJsonName(const FieldDescriptorProto& field, bool use_custom, bool* was_custom) {
+  if (use_custom && field.has_json_name()) {
+    *was_custom = true;
+    return field.json_name();
+  }
+  *was_custom = false;
+  return ToJsonName(field.name());
+}
+
 struct JsonNameDetails {
   const FieldDescriptorProto* field;
   std::string orig_name;
   bool is_custom;
 };
 
+} // namespace
+
 void DescriptorBuilder::CheckFieldJsonNameUniqueness(
     std::string message_name,const DescriptorProto& message, bool is_proto2, bool use_custom_names) {
 
-  std::map<std::string, JsonNameDetails> name_to_field;
-  for (int i = 0; i < message.field_size(); ++i) {
+  absl::flat_hash_map<std::string, JsonNameDetails> name_to_field;
+  for (const FieldDescriptorProto& field : message.field()) {
     bool is_custom;
-    std::string name = GetJsonName(message.field(i), use_custom_names, &is_custom);
+    std::string name = GetJsonName(field, use_custom_names, &is_custom);
     std::string lowercase_name = absl::AsciiStrToLower(name);
     auto existing = name_to_field.find(lowercase_name);
     if (existing != name_to_field.end()) {
-      auto match = existing->second;
+      JsonNameDetails& match = existing->second;
       if (use_custom_names && !is_custom && !match.is_custom) {
         // if this pass is considering custom JSON names, but neither of the
         // names involved in the conflict are custom, don't bother with a message.
         // That will have been reported from other pass (non-custom JSON names).
         continue;
       }
-      std::string this_type = is_custom ? "custom" : "default";
-      std::string existing_type = match.is_custom ? "custom" : "default";
+      absl::string_view this_type = is_custom ? "custom" : "default";
+      absl::string_view existing_type = match.is_custom ? "custom" : "default";
       // If the matched name differs (which it can only differ in case), include it
       // in the error message, for maximum clarity to user.
-      std::string name_suffix = name == match.orig_name ? "" : " (\"" + match.orig_name + "\")";
-      std::string error_message =
-          "The " + this_type + " JSON name of field \"" + message.field(i).name() +
-          "\" (\"" + name + "\") conflicts with the " + existing_type + " JSON name of field \"" +
-          match.field->name() + "\"" + name_suffix + ".";
+      absl::string_view name_suffix = "";
+      if (name != match.orig_name) {
+        name_suffix = absl::StrCat(" (\"", match.orig_name, "\")");
+      }
+      std::string error_message = absl::StrFormat(
+          "The %s JSON name of field \"%s\" (\"%s\") conflicts with the %s JSON name of field \"%s\"%s.",
+          this_type, field.name(), name, existing_type, match.field->name(), name_suffix);
 
       bool involves_default = !is_custom || !match.is_custom;
       if (is_proto2 && involves_default) {
-        AddWarning(message_name, message.field(i),
+        AddWarning(message_name, field,
                  DescriptorPool::ErrorCollector::NAME, error_message);
       } else {
         if (involves_default) {
-          error_message += " This is not allowed in proto3.";
+          absl::StrAppend(&error_message, " This is not allowed in proto3.");
         }
-        AddError(message_name, message.field(i),
+        AddError(message_name, field,
                  DescriptorPool::ErrorCollector::NAME, error_message);
       }
     } else {
-      JsonNameDetails details = { &message.field(i), name, is_custom };
+      JsonNameDetails details = { &field, name, is_custom };
       name_to_field[lowercase_name] = details;
     }
   }
@@ -5972,12 +5979,12 @@ void DescriptorBuilder::CheckEnumValueUniqueness(
   //     NAME_TYPE_LAST_NAME = 2,
   //   }
   PrefixRemover remover(result->name());
-  std::map<std::string, const EnumValueDescriptor*> values;
+  absl::flat_hash_map<std::string, const EnumValueDescriptor*> values;
   for (int i = 0; i < result->value_count(); i++) {
     const EnumValueDescriptor* value = result->value(i);
     std::string stripped =
         EnumValueToPascalCase(remover.MaybeRemove(value->name()));
-    std::pair<std::map<std::string, const EnumValueDescriptor*>::iterator, bool>
+    std::pair<absl::flat_hash_map<std::string, const EnumValueDescriptor*>::iterator, bool>
         insert_result = values.insert(std::make_pair(stripped, value));
     bool inserted = insert_result.second;
 
@@ -5989,19 +5996,18 @@ void DescriptorBuilder::CheckEnumValueUniqueness(
     // stripping should de-dup the labels in this case).
     if (!inserted && insert_result.first->second->name() != value->name() &&
         insert_result.first->second->number() != value->number()) {
-      std::string error_message =
-          "Enum name " + value->name() + " has the same name as " +
-          values[stripped]->name() +
-          " if you ignore case and strip out the enum name prefix (if any). "
-          "(If you are using allow_alias, please assign the same numeric "
-          "value to both enums.)";
+      std::string error_message = absl::StrFormat(
+          "Enum name %s has the same name as %s if you ignore case and strip "
+          "out the enum name prefix (if any). (If you are using allow_alias, "
+          "please assign the same numeric value to both enums.)",
+          value->name(), values[stripped]->name());
       // There are proto2 enums out there with conflicting names, so to preserve
       // compatibility we issue only a warning for proto2.
       if (result->file()->syntax() == FileDescriptor::SYNTAX_PROTO2) {
         AddWarning(value->full_name(), proto.value(i),
                    DescriptorPool::ErrorCollector::NAME, error_message);
       } else {
-        error_message += " This is not allowed in proto3.";
+        absl::StrAppend(&error_message, " This is not allowed in proto3.");
         AddError(value->full_name(), proto.value(i),
                  DescriptorPool::ErrorCollector::NAME, error_message);
       }

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -3854,8 +3854,6 @@ class DescriptorBuilder {
                           internal::FlatAllocator& alloc);
   void BuildOneof(const OneofDescriptorProto& proto, Descriptor* parent,
                   OneofDescriptor* result, internal::FlatAllocator& alloc);
-  void CheckEnumValueUniqueness(const EnumDescriptorProto& proto,
-                                const EnumDescriptor* result);
   void BuildEnum(const EnumDescriptorProto& proto, const Descriptor* parent,
                  EnumDescriptor* result, internal::FlatAllocator& alloc);
   void BuildEnumValue(const EnumValueDescriptorProto& proto,
@@ -3866,6 +3864,14 @@ class DescriptorBuilder {
   void BuildMethod(const MethodDescriptorProto& proto,
                    const ServiceDescriptor* parent, MethodDescriptor* result,
                    internal::FlatAllocator& alloc);
+
+  void CheckFieldJSONNameUniqueness(const DescriptorProto& proto,
+                                    const Descriptor* result);
+  void CheckFieldJSONNameUniqueness(std::string message_name,
+                                    const DescriptorProto& message,
+                                    bool is_proto2, bool use_custom_names);
+  void CheckEnumValueUniqueness(const EnumDescriptorProto& proto,
+                                const EnumDescriptor* result);
 
   void LogUnusedDependency(const FileDescriptorProto& proto,
                            const FileDescriptor* result);
@@ -5422,7 +5428,10 @@ void DescriptorBuilder::BuildMessage(const DescriptorProto& proto,
     }
   }
 
+  CheckFieldJSONNameUniqueness(proto, result);
 
+  // Check that fields aren't using reserved names or numbers and that they
+  // aren't using extension numbers.
   for (int i = 0; i < result->field_count(); i++) {
     const FieldDescriptor* field = result->field(i);
     for (int j = 0; j < result->extension_range_count(); j++) {
@@ -5483,6 +5492,75 @@ void DescriptorBuilder::BuildMessage(const DescriptorProto& proto,
                                   range2->start, range2->end - 1, range1->start,
                                   range1->end - 1));
       }
+    }
+  }
+}
+
+std::string GetJSONName(const FieldDescriptorProto& field, bool use_custom, bool* was_custom) {
+  if (use_custom && field.has_json_name()) {
+    *was_custom = true;
+    return field.json_name();
+  }
+  *was_custom = false;
+  return ToJsonName(field.name());
+}
+
+void DescriptorBuilder::CheckFieldJSONNameUniqueness(
+    const DescriptorProto& proto, const Descriptor* result) {
+  bool is_proto2 = result->file()->syntax() == FileDescriptor::SYNTAX_PROTO2;
+  std::string message_name = result->full_name();
+  // two passes: one looking only at default JSON names, and one that considers custom JSON names
+  CheckFieldJSONNameUniqueness(message_name, proto, is_proto2, false);
+  CheckFieldJSONNameUniqueness(message_name, proto, is_proto2, true);
+}
+
+struct JSONNameDetails {
+  const FieldDescriptorProto* field;
+  std::string orig_name;
+  bool is_custom;
+};
+
+void DescriptorBuilder::CheckFieldJSONNameUniqueness(
+    std::string message_name,const DescriptorProto& message, bool is_proto2, bool use_custom_names) {
+
+  std::map<std::string, struct JSONNameDetails> name_to_field;
+  for (int i = 0; i < message.field_size(); ++i) {
+    bool is_custom;
+    std::string name = GetJSONName(message.field(i), use_custom_names, &is_custom);
+    std::string lowercase_name = absl::AsciiStrToLower(name);
+    auto existing = name_to_field.find(lowercase_name);
+    if (existing != name_to_field.end()) {
+      auto match = existing->second;
+      if (use_custom_names && !is_custom && !match.is_custom) {
+        // if this pass is considering custom JSON names, but neither of the
+        // names involved in the conflict are custom, don't bother with a message.
+        // That will have been reported from other pass (non-custom JSON names).
+        continue;
+      }
+      std::string this_type = is_custom ? "custom" : "default";
+      std::string existing_type = match.is_custom ? "custom" : "default";
+      // If the matched name differs (which it can only differ in case), include it
+      // in the error message, for maximum clarity to user.
+      std::string name_suffix = name == match.orig_name ? "" : " (\"" + match.orig_name + "\")";
+      std::string error_message =
+          "The " + this_type + " JSON name of field \"" + message.field(i).name() +
+          "\" (\"" + name + "\") conflicts with the " + existing_type + " JSON name of field \"" +
+          match.field->name() + "\"" + name_suffix + ".";
+
+      bool involves_default = !is_custom || !match.is_custom;
+      if (is_proto2 && involves_default) {
+        AddWarning(message_name, message.field(i),
+                 DescriptorPool::ErrorCollector::NAME, error_message);
+      } else {
+        if (involves_default) {
+          error_message += " This is not allowed in proto3.";
+        }
+        AddError(message_name, message.field(i),
+                 DescriptorPool::ErrorCollector::NAME, error_message);
+      }
+    } else {
+      struct JSONNameDetails details = { &message.field(i), name, is_custom };
+      name_to_field[lowercase_name] = details;
     }
   }
 }
@@ -5924,6 +6002,7 @@ void DescriptorBuilder::CheckEnumValueUniqueness(
         AddWarning(value->full_name(), proto.value(i),
                    DescriptorPool::ErrorCollector::NAME, error_message);
       } else {
+        error_message += " This is not allowed in proto3.";
         AddError(value->full_name(), proto.value(i),
                  DescriptorPool::ErrorCollector::NAME, error_message);
       }
@@ -6790,20 +6869,6 @@ void DescriptorBuilder::ValidateProto3(FileDescriptor* file,
   }
 }
 
-static std::string ToLowercaseWithoutUnderscores(const std::string& name) {
-  std::string result;
-  for (char character : name) {
-    if (character != '_') {
-      if (character >= 'A' && character <= 'Z') {
-        result.push_back(character - 'A' + 'a');
-      } else {
-        result.push_back(character);
-      }
-    }
-  }
-  return result;
-}
-
 void DescriptorBuilder::ValidateProto3Message(Descriptor* message,
                                               const DescriptorProto& proto) {
   for (int i = 0; i < message->nested_type_count(); ++i) {
@@ -6827,25 +6892,6 @@ void DescriptorBuilder::ValidateProto3Message(Descriptor* message,
     // Using MessageSet doesn't make sense since we disallow extensions.
     AddError(message->full_name(), proto, DescriptorPool::ErrorCollector::NAME,
              "MessageSet is not supported in proto3.");
-  }
-
-  // In proto3, we reject field names if they conflict in camelCase.
-  // Note that we currently enforce a stricter rule: Field names must be
-  // unique after being converted to lowercase with underscores removed.
-  std::map<std::string, const FieldDescriptor*> name_to_field;
-  for (int i = 0; i < message->field_count(); ++i) {
-    std::string lowercase_name =
-        ToLowercaseWithoutUnderscores(message->field(i)->name());
-    if (name_to_field.find(lowercase_name) != name_to_field.end()) {
-      AddError(message->full_name(), proto.field(i),
-               DescriptorPool::ErrorCollector::NAME,
-               "The JSON camel-case name of field \"" +
-                   message->field(i)->name() + "\" conflicts with field \"" +
-                   name_to_field[lowercase_name]->name() + "\". This is not " +
-                   "allowed in proto3.");
-    } else {
-      name_to_field[lowercase_name] = message->field(i);
-    }
   }
 }
 

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -5563,7 +5563,7 @@ void DescriptorBuilder::CheckFieldJsonNameUniqueness(
       continue;
     }
     bool same_oneof = false;
-    if (use_custom_names && details.is_custom && match.is_custom
+    if (use_custom_names && (details.is_custom || match.is_custom)
         && field.has_oneof_index() && match.field->has_oneof_index()
         && field.oneof_index() == match.field->oneof_index()) {
       // For custom name conflicts between fields in the same oneof, we

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -5517,7 +5517,8 @@ struct JsonNameDetails {
 };
 
 JsonNameDetails GetJsonNameDetails(const FieldDescriptorProto* field, bool use_custom) {
-  if (use_custom && field->has_json_name()) {
+  if (use_custom && field->has_json_name() &&
+      field->json_name() != ToJsonName(field->name())) {
     return {field, field->json_name(), true};
   }
   return {field, ToJsonName(field->name()), false};

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -6896,7 +6896,7 @@ TEST_F(ValidationErrorTest, ValidateProto3JsonName) {
       "}",
       "foo.proto: Foo: NAME: The default JSON name of field \"Name\" (\"Name\") "
       "conflicts with the default JSON name of field \"name\" (\"name\"). This is "
-      "not allowed in proto3.\n");
+      "not allowed in proto3 (unless fields are in the same oneof).\n");
   // Underscores are ignored.
   BuildFileWithErrors(
       "name: 'foo.proto' "
@@ -6908,7 +6908,7 @@ TEST_F(ValidationErrorTest, ValidateProto3JsonName) {
       "}",
       "foo.proto: Foo: NAME: The default JSON name of field \"_a__b_\" (\"AB\") "
       "conflicts with the default JSON name of field \"ab\" (\"ab\"). This is not "
-      "allowed in proto3.\n");
+      "allowed in proto3 (unless fields are in the same oneof).\n");
 }
 
 

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -6482,9 +6482,8 @@ TEST_F(ValidationErrorTest, EnumValuesConflictWithDifferentCasing) {
       "}",
       "foo.proto: bar: NAME: Enum name bar has the same name as BAR "
       "if you ignore case and strip out the enum name prefix (if any). "
-      "This is error-prone and can lead to undefined behavior. "
-      "Please avoid doing this. If you are using allow_alias, please assign "
-      "the same numeric value to both enums.\n");
+      "(If you are using allow_alias, please assign the same numeric "
+      "value to both enums.) This is not allowed in proto3.\n");
 
   // Not an error because both enums are mapped to the same value.
   BuildFile(
@@ -6510,9 +6509,8 @@ TEST_F(ValidationErrorTest, EnumValuesConflictWhenPrefixesStripped) {
       "}",
       "foo.proto: BAZ: NAME: Enum name BAZ has the same name as FOO_ENUM_BAZ "
       "if you ignore case and strip out the enum name prefix (if any). "
-      "This is error-prone and can lead to undefined behavior. "
-      "Please avoid doing this. If you are using allow_alias, please assign "
-      "the same numeric value to both enums.\n");
+      "(If you are using allow_alias, please assign the same numeric value "
+      "to both enums.) This is not allowed in proto3.\n");
 
   BuildFileWithErrors(
       "syntax: 'proto3'"
@@ -6524,9 +6522,8 @@ TEST_F(ValidationErrorTest, EnumValuesConflictWhenPrefixesStripped) {
       "}",
       "foo.proto: BAZ: NAME: Enum name BAZ has the same name as FOOENUM_BAZ "
       "if you ignore case and strip out the enum name prefix (if any). "
-      "This is error-prone and can lead to undefined behavior. "
-      "Please avoid doing this. If you are using allow_alias, please assign "
-      "the same numeric value to both enums.\n");
+      "(If you are using allow_alias, please assign the same numeric value "
+      "to both enums.) This is not allowed in proto3.\n");
 
   BuildFileWithErrors(
       "syntax: 'proto3'"
@@ -6538,9 +6535,8 @@ TEST_F(ValidationErrorTest, EnumValuesConflictWhenPrefixesStripped) {
       "}",
       "foo.proto: BAR__BAZ: NAME: Enum name BAR__BAZ has the same name as "
       "FOO_ENUM_BAR_BAZ if you ignore case and strip out the enum name prefix "
-      "(if any). This is error-prone and can lead to undefined behavior. "
-      "Please avoid doing this. If you are using allow_alias, please assign "
-      "the same numeric value to both enums.\n");
+      "(if any). (If you are using allow_alias, please assign the same numeric "
+      "value to both enums.) This is not allowed in proto3.\n");
 
   BuildFileWithErrors(
       "syntax: 'proto3'"
@@ -6552,9 +6548,8 @@ TEST_F(ValidationErrorTest, EnumValuesConflictWhenPrefixesStripped) {
       "}",
       "foo.proto: BAR_BAZ: NAME: Enum name BAR_BAZ has the same name as "
       "FOO_ENUM__BAR_BAZ if you ignore case and strip out the enum name prefix "
-      "(if any). This is error-prone and can lead to undefined behavior. "
-      "Please avoid doing this. If you are using allow_alias, please assign "
-      "the same numeric value to both enums.\n");
+      "(if any). (If you are using allow_alias, please assign the same numeric "
+      "value to both enums.) This is not allowed in proto3.\n");
 
   // This isn't an error because the underscore will cause the PascalCase to
   // differ by case (BarBaz vs. Barbaz).
@@ -6899,8 +6894,9 @@ TEST_F(ValidationErrorTest, ValidateProto3JsonName) {
       "  field { name:'name' number:1 label:LABEL_OPTIONAL type:TYPE_INT32 }"
       "  field { name:'Name' number:2 label:LABEL_OPTIONAL type:TYPE_INT32 }"
       "}",
-      "foo.proto: Foo: NAME: The JSON camel-case name of field \"Name\" "
-      "conflicts with field \"name\". This is not allowed in proto3.\n");
+      "foo.proto: Foo: NAME: The default JSON name of field \"Name\" (\"Name\") "
+      "conflicts with the default JSON name of field \"name\" (\"name\"). This is "
+      "not allowed in proto3.\n");
   // Underscores are ignored.
   BuildFileWithErrors(
       "name: 'foo.proto' "
@@ -6910,8 +6906,9 @@ TEST_F(ValidationErrorTest, ValidateProto3JsonName) {
       "  field { name:'ab' number:1 label:LABEL_OPTIONAL type:TYPE_INT32 }"
       "  field { name:'_a__b_' number:2 label:LABEL_OPTIONAL type:TYPE_INT32 }"
       "}",
-      "foo.proto: Foo: NAME: The JSON camel-case name of field \"_a__b_\" "
-      "conflicts with field \"ab\". This is not allowed in proto3.\n");
+      "foo.proto: Foo: NAME: The default JSON name of field \"_a__b_\" (\"AB\") "
+      "conflicts with the default JSON name of field \"ab\" (\"ab\"). This is not "
+      "allowed in proto3.\n");
 }
 
 


### PR DESCRIPTION
This is a re-do of #10581. Merging this PR previously caused issues when importing the change into Google's internal repo (IIUC). So additional testing is needed before attempting to merge again. cc @mkruskal-google 

----

This makes a few other related changes, for consistency:

* Adds the existing checks, for default JSON names, to run even for proto2 files, but only as warnings (symmetry with similar check for enum value names).
* Tweaks the similar check for enum value names to include "This is not allowed in proto3", for clarity, since it's only a warning in proto2.

When checking custom JSON names, this considers it an error even in proto2 if two `json_name` options conflict. However, if a `json_name` option conflicts with a default JSON name, it is just a warning in proto2 (aligns with the existing check and the similar check for enum value names).

Fixes #5063.