### PR TITLE
Downgrade jsoncpp for CMake usage

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -55,11 +55,12 @@ def protobuf_deps():
         )
 
     if not native.existing_rule("jsoncpp"):
-        _github_archive(
+        http_archive(
             name = "jsoncpp",
-            repo = "https://github.com/open-source-parsers/jsoncpp",
-            commit = "5defb4ed1a4293b8e2bf641e16b156fb9de498cc",
-            sha256 = "a03d3136ff6dd092143bba8d3ded641e87b44e6c0b1f632b368f6cc8587524b5",
+            build_file = "@com_google_protobuf//:third_party/jsoncpp.BUILD",
+            sha256 = "e34a628a8142643b976c7233ef381457efad79468c67cb1ae0b83a33d7493999",
+            strip_prefix = "jsoncpp-1.9.4",
+            urls = ["https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.4.tar.gz"],
         )
 
     if not native.existing_rule("rules_cc"):

--- a/third_party/jsoncpp.BUILD
+++ b/third_party/jsoncpp.BUILD
@@ -1,0 +1,37 @@
+licenses(["unencumbered"])  # Public Domain or MIT
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "jsoncpp",
+    srcs = [
+        "src/lib_json/json_reader.cpp",
+        "src/lib_json/json_tool.h",
+        "src/lib_json/json_value.cpp",
+        "src/lib_json/json_writer.cpp",
+    ],
+    hdrs = [
+        "include/json/allocator.h",
+        "include/json/assertions.h",
+        "include/json/config.h",
+        "include/json/json_features.h",
+        "include/json/forwards.h",
+        "include/json/json.h",
+        "include/json/reader.h",
+        "include/json/value.h",
+        "include/json/version.h",
+        "include/json/writer.h",
+    ],
+    copts = [
+        "-DJSON_USE_EXCEPTION=0",
+        "-DJSON_HAS_INT64",
+    ],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [":private"],
+)
+
+cc_library(
+    name = "private",
+    textual_hdrs = ["src/lib_json/json_valueiterator.inl"],
+)


### PR DESCRIPTION
jsoncpp 1.9.5 provides Bazel support, but substantially reduces CMake support.  For CMake builds we should use 1.9.4 until we can resolve these issues.

Closes #10749