### PR TITLE
Edit toolchain to work with absl dep

### DIFF
--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -91,11 +91,16 @@ cc_toolchain_config(
 cc_toolchain_config(
     name = "osx-aarch_64-config",
     extra_compiler_flags = [
-        "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include/c++/v1",
-        "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include"
+        "-I/usr/tools/xcode_14_0/macosx/usr/include/c++/v1",
+        "-I/usr/tools/xcode_14_0/macosx/usr/include",
+        "-F/usr/tools/xcode_14_0/macosx/System/Library/Frameworks",
+        "-Wno-error=nullability-completeness",
+        "-Wno-error=availability",
+        "-Wno-error=elaborated-enum-base",
     ],
+    extra_linker_flags = ["-framework CoreFoundation"],
     linker_path = "/usr/tools",
-    sysroot = "/usr/tools/apple_sdks/xcode_13_0/macosx",
+    sysroot = "/usr/tools/xcode_14_0/macosx",
     target_cpu = "aarch64",
     target_full_name = "aarch64-apple-macosx11.3",
 )
@@ -103,11 +108,16 @@ cc_toolchain_config(
 cc_toolchain_config(
     name = "osx-x86_64-config",
     extra_compiler_flags = [
-        "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include/c++/v1",
-        "-I/usr/tools/apple_sdks/xcode_13_0/macosx/usr/include"
+        "-I/usr/tools/xcode_14_0/macosx/usr/include/c++/v1",
+        "-I/usr/tools/xcode_14_0/macosx/usr/include",
+        "-F/usr/tools/xcode_14_0/macosx/System/Library/Frameworks",
+        "-Wno-error=nullability-completeness",
+        "-Wno-error=availability",
+        "-Wno-error=elaborated-enum-base",
     ],
+    extra_linker_flags = ["-framework CoreFoundation"],
     linker_path = "/usr/tools",
-    sysroot = "/usr/tools/apple_sdks/xcode_13_0/macosx",
+    sysroot = "/usr/tools/xcode_14_0/macosx",
     target_cpu = "x86_64",
     target_full_name = "x86_64-apple-macosx11.3",
 )
@@ -122,6 +132,7 @@ cc_toolchain_config(
     extra_include = "/usr/lib/gcc/i686-w64-mingw32",
     extra_linker_flags = [
         "-L/usr/lib/gcc/i686-w64-mingw32/8.3-posix",
+        "-ldbghelp",
         "-pthread",
     ],
     linker_path = "/usr/bin/ld",
@@ -139,6 +150,7 @@ cc_toolchain_config(
     extra_include = "/usr/lib/gcc/x86_64-w64-mingw32/8.3-posix/include",
     extra_linker_flags = [
         "-L/usr/lib/gcc/x86_64-w64-mingw32/8.3-posix",
+        "-ldbghelp",
     ],
     linker_path = "/usr/bin/ld",
     sysroot = "/usr/x86_64-w64-mingw32",


### PR DESCRIPTION
When the absl dep was added, our windows and darwin builds broke. Adding some more compiler flags to fix the builds.

In addition, I updated to xcode 14 and changed up a bit of the directory structure there.