### PR TITLE
Do not force C++14

### DIFF
--- a/build_defs/cpp_opts.bzl
+++ b/build_defs/cpp_opts.bzl
@@ -14,14 +14,12 @@ COPTS = select({
         "/wd4506",    # no definition for inline function 'function'
         "/wd4800",    # 'type' : forcing value to bool 'true' or 'false' (performance warning)
         "/wd4996",    # The compiler encountered a deprecated declaration.
-        "/std:c++14", # Use C++14
     ],
     "//conditions:default": [
         "-DHAVE_ZLIB",
         "-Woverloaded-virtual",
         "-Wno-sign-compare",
         "-Werror",
-        "-std=c++14",  # Protobuf requires C++14.
     ],
 })
 # Android and MSVC builds do not need to link in a separate pthread library.

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -53,9 +53,16 @@
 #error "C++ versions less than C++14 are not supported."
 #endif  // _MSVC_LANG < 201402L
 #elif defined(__cplusplus)
+// Special-case GCC < 5.0, as it has a strange __cplusplus value for C++14
+#if defined(__GNUC__) && __GNUC__ < 5
+#if __cplusplus < 201300L
+#error "C++ versions less than C++14 are not supported."
+#endif  // __cplusplus < 201300L
+#else // defined(__GNUC__) && __GNUC__ < 5
 #if __cplusplus < 201402L
 #error "C++ versions less than C++14 are not supported."
 #endif  // __cplusplus < 201402L
+#endif // defined(__GNUC__) && __GNUC__ < 5
 #endif
 
 #ifndef PROTOBUF_USE_EXCEPTIONS

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -47,10 +47,6 @@
 #include "google/protobuf/stubs/platform_macros.h"
 #include "google/protobuf/stubs/port.h"
 
-#if !defined(PROTOBUF_FORCE_OLD_CPP_VERSION_WE_KNOW_WHAT_WE_ARE_DOING) && __cplusplus < 201402L
-#error "Protobuf requires at least C++14"
-#endif
-
 #ifndef PROTOBUF_USE_EXCEPTIONS
 #if defined(_MSC_VER) && defined(_CPPUNWIND)
   #define PROTOBUF_USE_EXCEPTIONS 1

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -47,6 +47,10 @@
 #include "google/protobuf/stubs/platform_macros.h"
 #include "google/protobuf/stubs/port.h"
 
+#if !defined(PROTOBUF_FORCE_OLD_CPP_VERSION_WE_KNOW_WHAT_WE_ARE_DOING) && __cplusplus < 201402L
+#error "Protobuf requires at least C++14"
+#endif
+
 #ifndef PROTOBUF_USE_EXCEPTIONS
 #if defined(_MSC_VER) && defined(_CPPUNWIND)
   #define PROTOBUF_USE_EXCEPTIONS 1

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -47,6 +47,10 @@
 #include "google/protobuf/stubs/platform_macros.h"
 #include "google/protobuf/stubs/port.h"
 
+#if __cplusplus < 201402L || (defined(_MSVC_LANG) && _MSVC_LANG < 201402L)
+#error "Protobuf requires at least C++14"
+#endif
+
 #ifndef PROTOBUF_USE_EXCEPTIONS
 #if defined(_MSC_VER) && defined(_CPPUNWIND)
   #define PROTOBUF_USE_EXCEPTIONS 1

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -47,8 +47,15 @@
 #include "google/protobuf/stubs/platform_macros.h"
 #include "google/protobuf/stubs/port.h"
 
-#if __cplusplus < 201402L || (defined(_MSVC_LANG) && _MSVC_LANG < 201402L)
-#error "Protobuf requires at least C++14"
+// Enforce C++14 as the minimum.
+#if defined(_MSVC_LANG)
+#if _MSVC_LANG < 201402L
+#error "C++ versions less than C++14 are not supported."
+#endif  // _MSVC_LANG < 201402L
+#elif defined(__cplusplus)
+#if __cplusplus < 201402L
+#error "C++ versions less than C++14 are not supported."
+#endif  // __cplusplus < 201402L
 #endif
 
 #ifndef PROTOBUF_USE_EXCEPTIONS


### PR DESCRIPTION
Rather than forcing protobuf to always compile in exactly C++14, overriding all settings in .bazelrc and environment variables and commandline options, ~~instead guard the codebase against versions that are too low~~ simply don't do that. This allows for compiling in higher C++ standards, such as those that have `std::string_view` instead of `absl::string_view` without generating objects that are incompatible.