### PR TITLE
Fix bazel builds

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -6,8 +6,13 @@ load(
     "pkg_files",
     "strip_prefix",
 )
+load("//:protobuf_release.bzl", "package_naming")
 load(":build_systems.bzl", "gen_file_lists")
 load(":cc_dist_library.bzl", "cc_dist_library")
+
+package_naming(
+    name = "protobuf_pkg_naming",
+)
 
 pkg_files(
     name = "wkt_protos_files",


### PR DESCRIPTION
Adding package_naming back as a dependency to fix builds. It was erroneously removed [here](https://github.com/protocolbuffers/protobuf/commit/32bea52ee660abeb6a2891e3dce979a909cbd6ea#diff-2506fc8252647768f02580dc9c2800f0c25ad053ec8c64359f11d2823eea7ed8).