### PR TITLE
Remove unnecessary cast to Builder in generated Java lite code.

### DIFF
--- a/src/google/protobuf/compiler/java/message_lite.cc
+++ b/src/google/protobuf/compiler/java/message_lite.cc
@@ -699,7 +699,7 @@ void ImmutableMessageLiteGenerator::GenerateBuilder(io::Printer* printer) {
       "  return (Builder) DEFAULT_INSTANCE.createBuilder();\n"
       "}\n"
       "public static Builder newBuilder($classname$ prototype) {\n"
-      "  return (Builder) DEFAULT_INSTANCE.createBuilder(prototype);\n"
+      "  return DEFAULT_INSTANCE.createBuilder(prototype);\n"
       "}\n"
       "\n",
       "classname", name_resolver_->GetImmutableClassName(descriptor_));


### PR DESCRIPTION
Fixes #5139 

Previously the fix https://github.com/protocolbuffers/protobuf/pull/5247 has removed unnecessary cast to Builder in generated Java code, and the current PR is doing a similar one for Java lite code.

After this PR, both Java and Java lite code won't have an unnecessary cast to Builder, thus #5139 will be fixed.

This change simply removed those casts to Builder for 2 methods, and the reason it will work is:

DEFAULT_INSTANCE.createBuilder method is defined in the superclass, and the return value is a generic value which is exactly the Builder class passed in.
