### PR TITLE
C# release fixes

### DIFF
--- a/csharp/build_release.sh
+++ b/csharp/build_release.sh
@@ -6,9 +6,5 @@ cd $(dirname $(readlink $BASH_SOURCE))
 set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 set DOTNET_CLI_TELEMETRY_OPTOUT=true
 
-# Work around https://github.com/dotnet/core/issues/5881
-dotnet nuget locals all --clear
-
 # Builds Google.Protobuf NuGet packages
-dotnet restore src/Google.Protobuf.sln
-dotnet pack -c Release src/Google.Protobuf.sln -p:ContinuousIntegrationBuild=true
+dotnet pack --no-restore -c Release src/Google.Protobuf.sln -p:ContinuousIntegrationBuild=true

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <!-- If you update this, update the .csproj in the Docker file as well -->
 
   <PropertyGroup>
     <Description>C# runtime library for Protocol Buffers - Google's data interchange format.</Description>


### PR DESCRIPTION
Fixing C# release to no longer need internet at runtime. This requires a copy of .csproj file, so put a warning there and change `dotnet pack` command to be in offline mode.