### PR TITLE
Update zlib to 1.2.13.

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -49,9 +49,12 @@ def protobuf_deps():
         http_archive(
             name = "zlib",
             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-            sha256 = "d8688496ea40fb61787500e863cc63c9afcbc524468cedeb478068924eb54932",
-            strip_prefix = "zlib-1.2.12",
-            urls = ["https://github.com/madler/zlib/archive/v1.2.12.tar.gz"],
+            sha256 = "d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98",
+            strip_prefix = "zlib-1.2.13",
+            urls = [
+                "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.xz",
+                "https://zlib.net/zlib-1.2.13.tar.xz",
+            ],
         )
 
     if not native.existing_rule("jsoncpp"):


### PR DESCRIPTION
This pulls in the fix for CVE-2022-37434.