### PR TITLE
Fix C# Builds

### DIFF
--- a/csharp/build_release.sh
+++ b/csharp/build_release.sh
@@ -7,4 +7,5 @@ set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 set DOTNET_CLI_TELEMETRY_OPTOUT=true
 
 # Builds Google.Protobuf NuGet packages
+dotnet restore -s /lib/csharp/ src/Google.Protobuf/Google.Protobuf.csproj
 dotnet pack --no-restore -c Release src/Google.Protobuf.sln -p:ContinuousIntegrationBuild=true


### PR DESCRIPTION
We need to call `dotnet restore` in order to properly setup the libraries to pack. The docker image we are using will save the packages in `/lib/csharp`