### PR TITLE
fix: remove extension exception

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -115,11 +115,6 @@ static const upb_FieldDef *get_field(Message *msg, PROTO_STR *member) {
   const upb_FieldDef *f =
       upb_MessageDef_FindFieldByNameWithSize(m, PROTO_STRVAL_P(member), PROTO_STRLEN_P(member));
 
-  if (!f) {
-    zend_throw_exception_ex(NULL, 0, "No such property %s.",
-                            ZSTR_VAL(msg->desc->class_entry->name));
-  }
-
   return f;
 }
 


### PR DESCRIPTION
 - for parity with the native implementation (changing the implementation to match the message would break BC)
 - the return value is already checked everywhere this method is called ([1](https://github.com/protocolbuffers/protobuf/blob/main/php/ext/google/protobuf/message.c#L290), [2](https://github.com/protocolbuffers/protobuf/blob/main/php/ext/google/protobuf/message.c#L324), [3](https://github.com/protocolbuffers/protobuf/blob/main/php/ext/google/protobuf/message.c#L361), [4](https://github.com/protocolbuffers/protobuf/blob/main/php/ext/google/protobuf/message.c#L392))

There's also an issue we've seen here when an API removes fields, and we want to keep the methods in order to preserve BC. The protobuf message throws an exception (only in the extension) because the fields exist, even if they're never used. It would be easier to just removed this unnecessary exception.