### PR TITLE
Update cc_dist_library() to include transitive sources

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -344,15 +344,8 @@ cc_dist_library(
     }),
     tags = ["manual"],
     deps = [
-        "//src/google/protobuf:arena",
         "//src/google/protobuf:arena_align",
-        "//src/google/protobuf:arena_allocation_policy",
-        "//src/google/protobuf:arena_cleanup",
-        "//src/google/protobuf:arena_config",
         "//src/google/protobuf:protobuf_lite",
-        "//src/google/protobuf/io",
-        "//src/google/protobuf/io:io_win32",
-        "//src/google/protobuf/stubs:lite",
     ],
 )
 
@@ -367,33 +360,11 @@ cc_dist_library(
     }),
     tags = ["manual"],
     deps = [
-        "//src/google/protobuf:arena",
         "//src/google/protobuf:arena_align",
-        "//src/google/protobuf:arena_allocation_policy",
-        "//src/google/protobuf:arena_cleanup",
-        "//src/google/protobuf:arena_config",
-        "//src/google/protobuf:port_def",
-        "//src/google/protobuf:protobuf_lite",
         "//src/google/protobuf:protobuf_nowkt",
         "//src/google/protobuf:wkt_cc_proto",
         "//src/google/protobuf/compiler:importer",
-        "//src/google/protobuf/io",
-        "//src/google/protobuf/io:gzip_stream",
-        "//src/google/protobuf/io:io_win32",
-        "//src/google/protobuf/io:printer",
-        "//src/google/protobuf/io:tokenizer",
-        "//src/google/protobuf/io:zero_copy_sink",
         "//src/google/protobuf/json",
-        "//src/google/protobuf/json:descriptor_traits",
-        "//src/google/protobuf/json:lexer",
-        "//src/google/protobuf/json:message_path",
-        "//src/google/protobuf/json:parser",
-        "//src/google/protobuf/json:unparser",
-        "//src/google/protobuf/json:untyped_message",
-        "//src/google/protobuf/json:writer",
-        "//src/google/protobuf/json:zero_copy_buffered_stream",
-        "//src/google/protobuf/stubs",
-        "//src/google/protobuf/stubs:lite",
         "//src/google/protobuf/util:delimited_message_util",
         "//src/google/protobuf/util:differencer",
         "//src/google/protobuf/util:field_mask_util",
@@ -407,24 +378,18 @@ cc_dist_library(
     name = "protoc",
     tags = ["manual"],
     deps = [
-        "//src/google/protobuf/compiler:code_generator",
         "//src/google/protobuf/compiler:command_line_interface",
         "//src/google/protobuf/compiler/cpp",
-        "//src/google/protobuf/compiler/cpp:names",
-        "//src/google/protobuf/compiler/cpp:names_internal",
         "//src/google/protobuf/compiler/csharp",
-        "//src/google/protobuf/compiler/csharp:names",
         "//src/google/protobuf/compiler/java",
-        "//src/google/protobuf/compiler/java:names",
-        "//src/google/protobuf/compiler/java:names_internal",
         "//src/google/protobuf/compiler/objectivec",
-        "//src/google/protobuf/compiler/objectivec:line_consumer",
-        "//src/google/protobuf/compiler/objectivec:names",
-        "//src/google/protobuf/compiler/objectivec:names_internal",
         "//src/google/protobuf/compiler/php",
-        "//src/google/protobuf/compiler/php:names",
         "//src/google/protobuf/compiler/python",
         "//src/google/protobuf/compiler/ruby",
+    ],
+    dist_deps = [
+        ":protobuf",
+        ":protobuf_lite",
     ],
 )
 
@@ -433,6 +398,7 @@ cc_dist_library(
     testonly = 1,
     tags = ["manual"],
     deps = ["//src/google/protobuf:lite_test_util"],
+    dist_deps = [":protobuf_lite"],
 )
 
 cc_dist_library(
@@ -446,6 +412,13 @@ cc_dist_library(
         "//src/google/protobuf/compiler:annotation_test_util",
         "//src/google/protobuf/compiler/cpp:unittest_lib",
     ],
+    dist_deps = [
+      ":common_test",
+      ":lite_test_util",
+      ":protoc",
+      ":protobuf",
+      ":protobuf_lite",
+    ],
 )
 
 cc_dist_library(
@@ -455,6 +428,11 @@ cc_dist_library(
     deps = [
         "//src/google/protobuf/compiler:mock_code_generator",
         "//src/google/protobuf/testing",
+    ],
+    dist_deps = [
+        ":protobuf",
+        ":protobuf_lite",
+        ":protoc",
     ],
 )
 

--- a/src/file_lists.cmake
+++ b/src/file_lists.cmake
@@ -254,6 +254,8 @@ set(libprotobuf_lite_hdrs
   ${protobuf_SOURCE_DIR}/src/google/protobuf/metadata_lite.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/parse_context.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/port.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/port_def.inc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/port_undef.inc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/repeated_field.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/repeated_ptr_field.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/stubs/callback.h
@@ -545,6 +547,8 @@ set(lite_test_util_hdrs
   ${protobuf_SOURCE_DIR}/src/google/protobuf/map_lite_test_util.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/map_test_util_impl.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/proto3_lite_unittest.inc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/test_util.inc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/test_util2.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/test_util_lite.h
 )
 
@@ -574,8 +578,6 @@ set(test_util_hdrs
   ${protobuf_SOURCE_DIR}/src/google/protobuf/reflection_tester.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/test_util.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/test_util.inc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/test_util2.h
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/test_util_lite.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_unittest.inc
 )
 


### PR DESCRIPTION
The cc_dist_library() rule originally included only the sources from direct dependencies. This resulted in a less than ideal developer experience, because if you ever added a new cc_library() then you would have to carefully update the necessary cc_dist_library() targets to ensure that the change was correctly reflected in the CMake build.

This commit addresses that issue by making cc_dist_library() include transitive sources. We have to be careful to avoid introducing ODR violations (e.g. from libprotoc duplicating sources from libprotobuf), so we introduce a new dist_deps attribute on cc_dist_library(). Anything in dist_deps is assumed to be covered by a separate cc_dist_library() and is not included. We also make sure to exclude anything that's not part of our repo (i.e. Abseil and zlib).