### PR TITLE
Update zlib to 1.2.13

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -48,9 +48,12 @@ def protobuf_deps():
         http_archive(
             name = "zlib",
             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-            sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
-            strip_prefix = "zlib-1.2.11",
-            urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
+            sha256 = "d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98",
+            strip_prefix = "zlib-1.2.13",
+            urls = [
+                "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.xz",
+                "https://zlib.net/zlib-1.2.13.tar.xz",
+            ],
         )
 
     if not native.existing_rule("rules_cc"):


### PR DESCRIPTION
This pulls in the fix for CVE-2022-37434.

(PR'ed to main already in https://github.com/protocolbuffers/protobuf/pull/10786)