### PR TITLE
Clean up the dotnet test output

### DIFF
--- a/csharp/src/Google.Protobuf.Test/RefStructCompatibilityTest.cs
+++ b/csharp/src/Google.Protobuf.Test/RefStructCompatibilityTest.cs
@@ -67,7 +67,10 @@ namespace Google.Protobuf
             // We build the code with GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE to avoid the use of ref struct in the generated code.
             var compatibilityFlag = "-define:GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE";
             var sources = "*.cs";  // the generated sources from the TestProtos project
-            var args = $"-langversion:3 -target:library {compatibilityFlag} -reference:{testProtosOutputDir}\\Google.Protobuf.dll -out:{testProtosOutputDir}\\TestProtos.RefStructCompatibilityTest.OldCompiler.dll {sources}";
+            // We suppress CS1691, which flags a warning for the generated line of
+            // #pragma warning disable 1591, 0612, 3021, 8981
+            // because CS8981 is unknown to this version of the compiler.
+            var args = $"-langversion:3 -nologo -nowarn:1691 -target:library {compatibilityFlag} -reference:{testProtosOutputDir}\\Google.Protobuf.dll -out:{testProtosOutputDir}\\TestProtos.RefStructCompatibilityTest.OldCompiler.dll {sources}";
             RunOldCsharpCompilerAndCheckSuccess(args, testProtosProjectDir);
         }
 


### PR DESCRIPTION
Prior to this change, running "dotnet test" would result in a warning about csc only supporting C# up to version 5, and warnings of unrecognized warnings being suppressed.

With this change in place, the test output doesn't include anything from csc.