### PR TITLE
Hide ruby native extension symbols on FreeBSD

### DIFF
--- a/ruby/ext/google/protobuf_c/extconf.rb
+++ b/ruby/ext/google/protobuf_c/extconf.rb
@@ -6,7 +6,7 @@ ext_name = "google/protobuf_c"
 
 dir_config(ext_name)
 
-if RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
+if RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/ || RUBY_PLATFORM =~ /freebsd/
   $CFLAGS += " -std=gnu99 -O3 -DNDEBUG -fvisibility=hidden -Wall -Wsign-compare -Wno-declaration-after-statement"
 else
   $CFLAGS += " -std=gnu99 -O3 -DNDEBUG"


### PR DESCRIPTION
They probably should be hidden on every ELF platform, but for now only do it on Darwin, Linux, and FreeBSD.

This prevents some load-time errors that have been seen in GitLab's gitaly server, and in a few other places.