### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -439,6 +439,9 @@ if __name__ == '__main__':
       download_url='https://github.com/protocolbuffers/protobuf/releases',
       long_description="Protocol Buffers are Google's data interchange format",
       url='https://developers.google.com/protocol-buffers/',
+      project_urls={
+          'Source': 'https://github.com/protocolbuffers/protobuf',
+      },
       maintainer='protobuf@googlegroups.com',
       maintainer_email='protobuf@googlegroups.com',
       license='BSD-3-Clause',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)