### PR TITLE
Upgrade pinned Abseil version

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -41,8 +41,8 @@ def protobuf_deps():
         _github_archive(
             name = "com_google_absl",
             repo = "https://github.com/abseil/abseil-cpp",
-            commit = "273292d1cfc0a94a65082ee350509af1d113344d",
-            sha256 = "6764f226bd6e2d8ab9fe2f3cab5f45fb1a4a15c04b58b87ba7fa87456054f98b",
+            commit = "f2b8a81d637fd480c760e92b06a542bbc63843d2",
+            sha256 = "b31ee94323ef6ea98d186b89f740738a97c7dec33b44be52b227a28a0a8a9f9e",
         )
 
     if not native.existing_rule("zlib"):


### PR DESCRIPTION
Upgrade Abseil to a new pin along main branch.  This is necessary for a CMake fix that unbreaks windows DLL builds.  We will need the next Abseil release anyway for logging, so this shouldn't delay 22.x at all.