### PR TITLE
Fix misdetection of libatomic with strict compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ if (NOT MSVC)
   check_cxx_source_compiles("
     #include <atomic>
     int main() {
-      return std::atomic<int64_t>{};
+      return static_cast<int>(std::atomic<int64_t>{});
     }
   " protobuf_HAVE_BUILTIN_ATOMICS)
   if (NOT protobuf_HAVE_BUILTIN_ATOMICS)


### PR DESCRIPTION
With strict flags and -Werror, the detection for libatomic breaks, causing it to be included in places where it is not needed.  And on macOS, this leads to a link error when libatomic cannot be found.

Adding a static_cast fixes the problem by making the test compatible with strict compiler flags.

Closes #10899