### PR TITLE
Update CMake file generation to avoid including Bazel-specific WKT paths

### DIFF
--- a/pkg/build_systems.bzl
+++ b/pkg/build_systems.bzl
@@ -281,7 +281,10 @@ def _cmake_var_fragment(owner, varname, prefix, entries):
     ).format(
         owner = owner,
         varname = varname,
-        entries = "\n".join(["  %s%s" % (prefix, f) for f in entries]),
+        # Strip out "wkt/google/protobuf/" from the well-known type file paths.
+        # This is currently necessary to allow checked-in and generated
+        # versions of the well-known type generated code to coexist.
+        entries = "\n".join(["  %s%s" % (prefix, f.replace("wkt/google/protobuf/", "")) for f in entries]),
     )
 
 def _cmake_file_list_impl(ctx):

--- a/src/file_lists.cmake
+++ b/src/file_lists.cmake
@@ -11,16 +11,16 @@ endif()
 
 # //pkg:protobuf
 set(libprotobuf_srcs
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/any.pb.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/api.pb.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/duration.pb.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/empty.pb.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/field_mask.pb.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/source_context.pb.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/struct.pb.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/timestamp.pb.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/type.pb.cc
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/wrappers.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/any.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/api.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/duration.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/empty.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/field_mask.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/source_context.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/struct.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/timestamp.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/type.pb.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/wrappers.pb.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/any.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/any_lite.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena.cc
@@ -87,16 +87,16 @@ set(libprotobuf_srcs
 
 # //pkg:protobuf
 set(libprotobuf_hdrs
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/any.pb.h
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/api.pb.h
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/duration.pb.h
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/empty.pb.h
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/field_mask.pb.h
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/source_context.pb.h
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/struct.pb.h
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/timestamp.pb.h
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/type.pb.h
-  ${protobuf_SOURCE_DIR}/src/google/protobuf/wkt/google/protobuf/wrappers.pb.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/any.pb.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/api.pb.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/duration.pb.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/empty.pb.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/field_mask.pb.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/source_context.pb.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/struct.pb.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/timestamp.pb.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/type.pb.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/wrappers.pb.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/any.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/arena_align.h


### PR DESCRIPTION
To allow checked-in and generated versions of the well-known type generated code to coexist in the repo, we have to give the checked-in versions a long file path (e.g.
//src/google/protobuf:wkt/google/protobuf/any.pb.cc). However, this path inadvertently leaked into the generated file_lists.cmake file, so this commit corrects that problem.