### PR TITLE
Update auto-generation script to handle well-known types

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -551,7 +551,6 @@ pkg_files(
         "WORKSPACE",
         "cmake/CMakeLists.txt",
         "cmake/README.md",
-        "cmake/update_file_lists.sh",
         "generate_descriptor_proto.sh",
         "maven_install.json",
         "//third_party:BUILD.bazel",

--- a/cmake/update_file_lists.sh
+++ b/cmake/update_file_lists.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -u
-
-# This script generates file lists from Bazel for CMake.
-
-set -e
-
-bazel build //pkg:gen_src_file_lists
-cp -v bazel-bin/pkg/src_file_lists.cmake src/file_lists.cmake


### PR DESCRIPTION
I went ahead and deleted the update_file_list.sh script, because (a) there was no good reason for it to be in a separate script and (b) we now need to handle the well-known types in addition to file_lists.cmake. With this change, we just invoke the staleness tests from the main script to update everything.

While I was at it I made a couple small fixes:
- Don't skip the update step just because the previous commit was by "Protobuf Team Bot". Copybara commits use this name and we still want to do the auto-update step after them.
- Include the CL number in the description if the previous commit came from a CL.