### PR TITLE
Use bit-field int values in buildPartial to skip work on unset groups of fields.

### DIFF
--- a/src/google/protobuf/compiler/java/enum_field.cc
+++ b/src/google/protobuf/compiler/java/enum_field.cc
@@ -32,24 +32,24 @@
 //  Based on original Protocol Buffers design by
 //  Sanjay Ghemawat, Jeff Dean, and others.
 
-#include <google/protobuf/compiler/java/enum_field.h>
+#include "google/protobuf/compiler/java/enum_field.h"
 
 #include <cstdint>
 #include <map>
 #include <string>
 
-#include <google/protobuf/stubs/logging.h>
-#include <google/protobuf/stubs/common.h>
-#include <google/protobuf/io/printer.h>
-#include <google/protobuf/wire_format.h>
-#include <google/protobuf/stubs/strutil.h>
-#include <google/protobuf/compiler/java/context.h>
-#include <google/protobuf/compiler/java/doc_comment.h>
-#include <google/protobuf/compiler/java/helpers.h>
-#include <google/protobuf/compiler/java/name_resolver.h>
+#include "google/protobuf/stubs/logging.h"
+#include "google/protobuf/stubs/common.h"
+#include "google/protobuf/io/printer.h"
+#include "google/protobuf/wire_format.h"
+#include "google/protobuf/stubs/strutil.h"
+#include "google/protobuf/compiler/java/context.h"
+#include "google/protobuf/compiler/java/doc_comment.h"
+#include "google/protobuf/compiler/java/helpers.h"
+#include "google/protobuf/compiler/java/name_resolver.h"
 
 // Must be last.
-#include <google/protobuf/port_def.inc>
+#include "google/protobuf/port_def.inc"
 
 namespace google {
 namespace protobuf {
@@ -58,10 +58,11 @@ namespace java {
 
 namespace {
 
-void SetEnumVariables(const FieldDescriptor* descriptor, int messageBitIndex,
-                      int builderBitIndex, const FieldGeneratorInfo* info,
-                      ClassNameResolver* name_resolver,
-                      std::map<std::string, std::string>* variables) {
+void SetEnumVariables(
+    const FieldDescriptor* descriptor, int messageBitIndex, int builderBitIndex,
+    const FieldGeneratorInfo* info, ClassNameResolver* name_resolver,
+    std::map<std::string, std::string>* variables,
+    Context* context) {
   SetCommonFieldVariables(descriptor, info, variables);
 
   (*variables)["type"] =
@@ -80,40 +81,27 @@ void SetEnumVariables(const FieldDescriptor* descriptor, int messageBitIndex,
   // by the proto compiler
   (*variables)["deprecation"] =
       descriptor->options().deprecated() ? "@java.lang.Deprecated " : "";
-  (*variables)["kt_deprecation"] =
-      descriptor->options().deprecated()
-          ? "@kotlin.Deprecated(message = \"Field " + (*variables)["name"] +
-                " is deprecated\") "
-          : "";
-  (*variables)["on_changed"] = "onChanged();";
-  // Use deprecated valueOf() method to be compatible with old generated code
-  // for v2.5.0/v2.6.1.
-  // TODO(xiaofeng): Use "forNumber" when we no longer support compatibility
-  // with v2.5.0/v2.6.1, and remove the @SuppressWarnings annotations.
-  (*variables)["for_number"] = "valueOf";
-
+  variables->insert(
+      {"kt_deprecation",
+       descriptor->options().deprecated()
+           ? StrCat("@kotlin.Deprecated(message = \"Field ",
+                          (*variables)["name"], " is deprecated\") ")
+           : ""});
   if (HasHasbit(descriptor)) {
     // For singular messages and builders, one bit is used for the hasField bit.
     (*variables)["get_has_field_bit_message"] = GenerateGetBit(messageBitIndex);
-    (*variables)["get_has_field_bit_builder"] = GenerateGetBit(builderBitIndex);
-
     // Note that these have a trailing ";".
     (*variables)["set_has_field_bit_message"] =
         GenerateSetBit(messageBitIndex) + ";";
-    (*variables)["set_has_field_bit_builder"] =
-        GenerateSetBit(builderBitIndex) + ";";
-    (*variables)["clear_has_field_bit_builder"] =
-        GenerateClearBit(builderBitIndex) + ";";
-
+    (*variables)["set_has_field_bit_to_local"] =
+        GenerateSetBitToLocal(messageBitIndex);
     (*variables)["is_field_present_message"] = GenerateGetBit(messageBitIndex);
   } else {
     (*variables)["set_has_field_bit_message"] = "";
-    (*variables)["set_has_field_bit_builder"] = "";
-    (*variables)["clear_has_field_bit_builder"] = "";
-
-    (*variables)["is_field_present_message"] =
-        (*variables)["name"] + "_ != " + (*variables)["default"] +
-        ".getNumber()";
+    (*variables)["set_has_field_bit_to_local"] = "";
+    variables->insert({"is_field_present_message",
+                       StrCat((*variables)["name"], "_ != ",
+                                    (*variables)["default"], ".getNumber()")});
   }
 
   // For repeated builders, one bit is used for whether the array is immutable.
@@ -121,15 +109,21 @@ void SetEnumVariables(const FieldDescriptor* descriptor, int messageBitIndex,
   (*variables)["set_mutable_bit_builder"] = GenerateSetBit(builderBitIndex);
   (*variables)["clear_mutable_bit_builder"] = GenerateClearBit(builderBitIndex);
 
+  (*variables)["get_has_field_bit_builder"] = GenerateGetBit(builderBitIndex);
+
+  // Note that these have a trailing ";".
+  (*variables)["set_has_field_bit_builder"] =
+      GenerateSetBit(builderBitIndex) + ";";
+  (*variables)["clear_has_field_bit_builder"] =
+      GenerateClearBit(builderBitIndex) + ";";
   (*variables)["get_has_field_bit_from_local"] =
       GenerateGetBitFromLocal(builderBitIndex);
-  (*variables)["set_has_field_bit_to_local"] =
-      GenerateSetBitToLocal(messageBitIndex);
 
   if (SupportUnknownEnumValue(descriptor->file())) {
-    (*variables)["unknown"] = (*variables)["type"] + ".UNRECOGNIZED";
+    variables->insert(
+        {"unknown", StrCat((*variables)["type"], ".UNRECOGNIZED")});
   } else {
-    (*variables)["unknown"] = (*variables)["default"];
+    variables->insert({"unknown", (*variables)["default"]});
   }
 }
 
@@ -140,21 +134,30 @@ void SetEnumVariables(const FieldDescriptor* descriptor, int messageBitIndex,
 ImmutableEnumFieldGenerator::ImmutableEnumFieldGenerator(
     const FieldDescriptor* descriptor, int messageBitIndex, int builderBitIndex,
     Context* context)
-    : descriptor_(descriptor), name_resolver_(context->GetNameResolver()) {
+    : descriptor_(descriptor),
+      message_bit_index_(messageBitIndex),
+      builder_bit_index_(builderBitIndex),
+      name_resolver_(context->GetNameResolver()) {
   SetEnumVariables(descriptor, messageBitIndex, builderBitIndex,
                    context->GetFieldGeneratorInfo(descriptor), name_resolver_,
-                   &variables_);
+                   &variables_, context);
 }
 
 ImmutableEnumFieldGenerator::~ImmutableEnumFieldGenerator() {}
+
+int ImmutableEnumFieldGenerator::GetMessageBitIndex() const {
+  return message_bit_index_;
+}
+
+int ImmutableEnumFieldGenerator::GetBuilderBitIndex() const {
+  return builder_bit_index_;
+}
 
 int ImmutableEnumFieldGenerator::GetNumBitsForMessage() const {
   return HasHasbit(descriptor_) ? 1 : 0;
 }
 
-int ImmutableEnumFieldGenerator::GetNumBitsForBuilder() const {
-  return GetNumBitsForMessage();
-}
+int ImmutableEnumFieldGenerator::GetNumBitsForBuilder() const { return 1; }
 
 void ImmutableEnumFieldGenerator::GenerateInterfaceMembers(
     io::Printer* printer) const {
@@ -173,7 +176,7 @@ void ImmutableEnumFieldGenerator::GenerateInterfaceMembers(
 }
 
 void ImmutableEnumFieldGenerator::GenerateMembers(io::Printer* printer) const {
-  printer->Print(variables_, "private int $name$_;\n");
+  printer->Print(variables_, "private int $name$_ = $default_number$;\n");
   PrintExtraFieldInfo(variables_, printer);
   if (HasHazzer(descriptor_)) {
     WriteFieldAccessorDocComment(printer, descriptor_, HAZZER);
@@ -197,8 +200,7 @@ void ImmutableEnumFieldGenerator::GenerateMembers(io::Printer* printer) const {
   printer->Print(variables_,
                  "@java.lang.Override $deprecation$public $type$ "
                  "${$get$capitalized_name$$}$() {\n"
-                 "  @SuppressWarnings(\"deprecation\")\n"
-                 "  $type$ result = $type$.$for_number$($name$_);\n"
+                 "  $type$ result = $type$.forNumber($name$_);\n"
                  "  return result == null ? $unknown$ : result;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -229,9 +231,9 @@ void ImmutableEnumFieldGenerator::GenerateBuilderMembers(
     printer->Print(variables_,
                    "$deprecation$public Builder "
                    "${$set$capitalized_name$Value$}$(int value) {\n"
-                   "  $set_has_field_bit_builder$\n"
                    "  $name$_ = value;\n"
-                   "  $on_changed$\n"
+                   "  $set_has_field_bit_builder$\n"
+                   "  onChanged();\n"
                    "  return this;\n"
                    "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -240,8 +242,7 @@ void ImmutableEnumFieldGenerator::GenerateBuilderMembers(
   printer->Print(variables_,
                  "@java.lang.Override\n"
                  "$deprecation$public $type$ ${$get$capitalized_name$$}$() {\n"
-                 "  @SuppressWarnings(\"deprecation\")\n"
-                 "  $type$ result = $type$.$for_number$($name$_);\n"
+                 "  $type$ result = $type$.forNumber($name$_);\n"
                  "  return result == null ? $unknown$ : result;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -255,7 +256,7 @@ void ImmutableEnumFieldGenerator::GenerateBuilderMembers(
                  "  }\n"
                  "  $set_has_field_bit_builder$\n"
                  "  $name$_ = value.getNumber();\n"
-                 "  $on_changed$\n"
+                 "  onChanged();\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -266,7 +267,7 @@ void ImmutableEnumFieldGenerator::GenerateBuilderMembers(
       "$deprecation$public Builder ${$clear$capitalized_name$$}$() {\n"
       "  $clear_has_field_bit_builder$\n"
       "  $name$_ = $default_number$;\n"
-      "  $on_changed$\n"
+      "  onChanged();\n"
       "  return this;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -313,9 +314,7 @@ void ImmutableEnumFieldGenerator::GenerateInitializationCode(
 
 void ImmutableEnumFieldGenerator::GenerateBuilderClearCode(
     io::Printer* printer) const {
-  printer->Print(variables_,
-                 "$name$_ = $default_number$;\n"
-                 "$clear_has_field_bit_builder$\n");
+  printer->Print(variables_, "$name$_ = $default_number$;\n");
 }
 
 void ImmutableEnumFieldGenerator::GenerateMergingCode(
@@ -338,13 +337,13 @@ void ImmutableEnumFieldGenerator::GenerateMergingCode(
 
 void ImmutableEnumFieldGenerator::GenerateBuildingCode(
     io::Printer* printer) const {
-  if (HasHazzer(descriptor_)) {
-    printer->Print(variables_,
-                   "if ($get_has_field_bit_from_local$) {\n"
-                   "  $set_has_field_bit_to_local$;\n"
-                   "}\n");
+  printer->Print(variables_,
+                 "if ($get_has_field_bit_from_local$) {\n"
+                 "  result.$name$_ = $name$_;\n");
+  if (GetNumBitsForMessage() > 0) {
+    printer->Print(variables_, "  $set_has_field_bit_to_local$;\n");
   }
-  printer->Print(variables_, "result.$name$_ = $name$_;\n");
+  printer->Print("}\n");
 }
 
 void ImmutableEnumFieldGenerator::GenerateBuilderParsingCode(
@@ -440,8 +439,7 @@ void ImmutableEnumOneofFieldGenerator::GenerateMembers(
   printer->Print(variables_,
                  "$deprecation$public $type$ ${$get$capitalized_name$$}$() {\n"
                  "  if ($has_oneof_case_message$) {\n"
-                 "    @SuppressWarnings(\"deprecation\")\n"
-                 "    $type$ result = $type$.$for_number$(\n"
+                 "    $type$ result = $type$.forNumber(\n"
                  "        (java.lang.Integer) $oneof_name$_);\n"
                  "    return result == null ? $unknown$ : result;\n"
                  "  }\n"
@@ -480,7 +478,7 @@ void ImmutableEnumOneofFieldGenerator::GenerateBuilderMembers(
                    "${$set$capitalized_name$Value$}$(int value) {\n"
                    "  $set_oneof_case_message$;\n"
                    "  $oneof_name$_ = value;\n"
-                   "  $on_changed$\n"
+                   "  onChanged();\n"
                    "  return this;\n"
                    "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -490,14 +488,14 @@ void ImmutableEnumOneofFieldGenerator::GenerateBuilderMembers(
                  "@java.lang.Override\n"
                  "$deprecation$public $type$ ${$get$capitalized_name$$}$() {\n"
                  "  if ($has_oneof_case_message$) {\n"
-                 "    @SuppressWarnings(\"deprecation\")\n"
-                 "    $type$ result = $type$.$for_number$(\n"
+                 "    $type$ result = $type$.forNumber(\n"
                  "        (java.lang.Integer) $oneof_name$_);\n"
                  "    return result == null ? $unknown$ : result;\n"
                  "  }\n"
                  "  return $default$;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
+
   WriteFieldAccessorDocComment(printer, descriptor_, SETTER,
                                /* builder */ true);
   printer->Print(variables_,
@@ -508,10 +506,11 @@ void ImmutableEnumOneofFieldGenerator::GenerateBuilderMembers(
                  "  }\n"
                  "  $set_oneof_case_message$;\n"
                  "  $oneof_name$_ = value.getNumber();\n"
-                 "  $on_changed$\n"
+                 "  onChanged();\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
+
   WriteFieldAccessorDocComment(printer, descriptor_, CLEARER,
                                /* builder */ true);
   printer->Print(
@@ -520,7 +519,7 @@ void ImmutableEnumOneofFieldGenerator::GenerateBuilderMembers(
       "  if ($has_oneof_case_message$) {\n"
       "    $clear_oneof_case_message$;\n"
       "    $oneof_name$_ = null;\n"
-      "    $on_changed$\n"
+      "    onChanged();\n"
       "  }\n"
       "  return this;\n"
       "}\n");
@@ -534,10 +533,7 @@ void ImmutableEnumOneofFieldGenerator::GenerateBuilderClearCode(
 
 void ImmutableEnumOneofFieldGenerator::GenerateBuildingCode(
     io::Printer* printer) const {
-  printer->Print(variables_,
-                 "if ($has_oneof_case_message$) {\n"
-                 "  result.$oneof_name$_ = $oneof_name$_;\n"
-                 "}\n");
+  // No-Op: Handled by single statement for the oneof
 }
 
 void ImmutableEnumOneofFieldGenerator::GenerateMergingCode(
@@ -626,11 +622,8 @@ void ImmutableEnumOneofFieldGenerator::GenerateHashCode(
 RepeatedImmutableEnumFieldGenerator::RepeatedImmutableEnumFieldGenerator(
     const FieldDescriptor* descriptor, int messageBitIndex, int builderBitIndex,
     Context* context)
-    : descriptor_(descriptor), name_resolver_(context->GetNameResolver()) {
-  SetEnumVariables(descriptor, messageBitIndex, builderBitIndex,
-                   context->GetFieldGeneratorInfo(descriptor), name_resolver_,
-                   &variables_);
-}
+    : ImmutableEnumFieldGenerator(descriptor, messageBitIndex, builderBitIndex,
+                                  context) {}
 
 RepeatedImmutableEnumFieldGenerator::~RepeatedImmutableEnumFieldGenerator() {}
 
@@ -670,6 +663,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateMembers(
     io::Printer* printer) const {
   printer->Print(
       variables_,
+      "@SuppressWarnings(\"serial\")\n"
       "private java.util.List<java.lang.Integer> $name$_;\n"
       "private static final "
       "com.google.protobuf.Internal.ListAdapter.Converter<\n"
@@ -677,8 +671,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateMembers(
       "        new com.google.protobuf.Internal.ListAdapter.Converter<\n"
       "            java.lang.Integer, $type$>() {\n"
       "          public $type$ convert(java.lang.Integer from) {\n"
-      "            @SuppressWarnings(\"deprecation\")\n"
-      "            $type$ result = $type$.$for_number$(from);\n"
+      "            $type$ result = $type$.forNumber(from);\n"
       "            return result == null ? $unknown$ : result;\n"
       "          }\n"
       "        };\n");
@@ -794,7 +787,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
                  "  }\n"
                  "  ensure$capitalized_name$IsMutable();\n"
                  "  $name$_.set(index, value.getNumber());\n"
-                 "  $on_changed$\n"
+                 "  onChanged();\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -808,7 +801,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
                  "  }\n"
                  "  ensure$capitalized_name$IsMutable();\n"
                  "  $name$_.add(value.getNumber());\n"
-                 "  $on_changed$\n"
+                 "  onChanged();\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -821,7 +814,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
                  "  for ($type$ value : values) {\n"
                  "    $name$_.add(value.getNumber());\n"
                  "  }\n"
-                 "  $on_changed$\n"
+                 "  onChanged();\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -832,7 +825,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
       "$deprecation$public Builder ${$clear$capitalized_name$$}$() {\n"
       "  $name$_ = java.util.Collections.emptyList();\n"
       "  $clear_mutable_bit_builder$;\n"
-      "  $on_changed$\n"
+      "  onChanged();\n"
       "  return this;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -862,7 +855,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
         "    int index, int value) {\n"
         "  ensure$capitalized_name$IsMutable();\n"
         "  $name$_.set(index, value);\n"
-        "  $on_changed$\n"
+        "  onChanged();\n"
         "  return this;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -873,7 +866,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
                    "${$add$capitalized_name$Value$}$(int value) {\n"
                    "  ensure$capitalized_name$IsMutable();\n"
                    "  $name$_.add(value);\n"
-                   "  $on_changed$\n"
+                   "  onChanged();\n"
                    "  return this;\n"
                    "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -887,7 +880,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
         "  for (int value : values) {\n"
         "    $name$_.add(value);\n"
         "  }\n"
-        "  $on_changed$\n"
+        "  onChanged();\n"
         "  return this;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -927,7 +920,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateMergingCode(
                  "    ensure$capitalized_name$IsMutable();\n"
                  "    $name$_.addAll(other.$name$_);\n"
                  "  }\n"
-                 "  $on_changed$\n"
+                 "  onChanged();\n"
                  "}\n");
 }
 
@@ -1154,4 +1147,4 @@ std::string RepeatedImmutableEnumFieldGenerator::GetBoxedType() const {
 }  // namespace protobuf
 }  // namespace google
 
-#include <google/protobuf/port_undef.inc>
+#include "google/protobuf/port_undef.inc"

--- a/src/google/protobuf/compiler/java/enum_field.h
+++ b/src/google/protobuf/compiler/java/enum_field.h
@@ -38,7 +38,7 @@
 #include <map>
 #include <string>
 
-#include <google/protobuf/compiler/java/field.h>
+#include "google/protobuf/compiler/java/field.h"
 
 namespace google {
 namespace protobuf {
@@ -61,10 +61,15 @@ class ImmutableEnumFieldGenerator : public ImmutableFieldGenerator {
   explicit ImmutableEnumFieldGenerator(const FieldDescriptor* descriptor,
                                        int messageBitIndex, int builderBitIndex,
                                        Context* context);
+  ImmutableEnumFieldGenerator(const ImmutableEnumFieldGenerator&) = delete;
+  ImmutableEnumFieldGenerator& operator=(const ImmutableEnumFieldGenerator&) =
+      delete;
   ~ImmutableEnumFieldGenerator() override;
 
   // implements ImmutableFieldGenerator
   // ---------------------------------------
+  int GetMessageBitIndex() const override;
+  int GetBuilderBitIndex() const override;
   int GetNumBitsForMessage() const override;
   int GetNumBitsForBuilder() const override;
   void GenerateInterfaceMembers(io::Printer* printer) const override;
@@ -87,11 +92,10 @@ class ImmutableEnumFieldGenerator : public ImmutableFieldGenerator {
 
  protected:
   const FieldDescriptor* descriptor_;
+  int message_bit_index_;
+  int builder_bit_index_;
   std::map<std::string, std::string> variables_;
   ClassNameResolver* name_resolver_;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ImmutableEnumFieldGenerator);
 };
 
 class ImmutableEnumOneofFieldGenerator : public ImmutableEnumFieldGenerator {
@@ -99,6 +103,10 @@ class ImmutableEnumOneofFieldGenerator : public ImmutableEnumFieldGenerator {
   ImmutableEnumOneofFieldGenerator(const FieldDescriptor* descriptor,
                                    int messageBitIndex, int builderBitIndex,
                                    Context* context);
+  ImmutableEnumOneofFieldGenerator(const ImmutableEnumOneofFieldGenerator&) =
+      delete;
+  ImmutableEnumOneofFieldGenerator& operator=(
+      const ImmutableEnumOneofFieldGenerator&) = delete;
   ~ImmutableEnumOneofFieldGenerator() override;
 
   void GenerateMembers(io::Printer* printer) const override;
@@ -111,16 +119,17 @@ class ImmutableEnumOneofFieldGenerator : public ImmutableEnumFieldGenerator {
   void GenerateSerializedSizeCode(io::Printer* printer) const override;
   void GenerateEqualsCode(io::Printer* printer) const override;
   void GenerateHashCode(io::Printer* printer) const override;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ImmutableEnumOneofFieldGenerator);
 };
 
-class RepeatedImmutableEnumFieldGenerator : public ImmutableFieldGenerator {
+class RepeatedImmutableEnumFieldGenerator : public ImmutableEnumFieldGenerator {
  public:
   explicit RepeatedImmutableEnumFieldGenerator(
       const FieldDescriptor* descriptor, int messageBitIndex,
       int builderBitIndex, Context* context);
+  RepeatedImmutableEnumFieldGenerator(
+      const RepeatedImmutableEnumFieldGenerator&) = delete;
+  RepeatedImmutableEnumFieldGenerator& operator=(
+      const RepeatedImmutableEnumFieldGenerator&) = delete;
   ~RepeatedImmutableEnumFieldGenerator() override;
 
   // implements ImmutableFieldGenerator ---------------------------------------
@@ -145,13 +154,6 @@ class RepeatedImmutableEnumFieldGenerator : public ImmutableFieldGenerator {
   void GenerateKotlinDslMembers(io::Printer* printer) const override;
 
   std::string GetBoxedType() const override;
-
- private:
-  const FieldDescriptor* descriptor_;
-  std::map<std::string, std::string> variables_;
-  ClassNameResolver* name_resolver_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(RepeatedImmutableEnumFieldGenerator);
 };
 
 }  // namespace java

--- a/src/google/protobuf/compiler/java/field.h
+++ b/src/google/protobuf/compiler/java/field.h
@@ -68,6 +68,8 @@ class ImmutableFieldGenerator {
   ImmutableFieldGenerator() {}
   virtual ~ImmutableFieldGenerator();
 
+  virtual int GetMessageBitIndex() const = 0;
+  virtual int GetBuilderBitIndex() const = 0;
   virtual int GetNumBitsForMessage() const = 0;
   virtual int GetNumBitsForBuilder() const = 0;
   virtual void GenerateInterfaceMembers(io::Printer* printer) const = 0;

--- a/src/google/protobuf/compiler/java/map_field.h
+++ b/src/google/protobuf/compiler/java/map_field.h
@@ -31,7 +31,7 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_JAVA_MAP_FIELD_H__
 #define GOOGLE_PROTOBUF_COMPILER_JAVA_MAP_FIELD_H__
 
-#include <google/protobuf/compiler/java/field.h>
+#include "google/protobuf/compiler/java/field.h"
 
 namespace google {
 namespace protobuf {
@@ -46,6 +46,8 @@ class ImmutableMapFieldGenerator : public ImmutableFieldGenerator {
   ~ImmutableMapFieldGenerator() override;
 
   // implements ImmutableFieldGenerator ---------------------------------------
+  int GetMessageBitIndex() const override;
+  int GetBuilderBitIndex() const override;
   int GetNumBitsForMessage() const override;
   int GetNumBitsForBuilder() const override;
   void GenerateInterfaceMembers(io::Printer* printer) const override;
@@ -68,8 +70,11 @@ class ImmutableMapFieldGenerator : public ImmutableFieldGenerator {
 
  private:
   const FieldDescriptor* descriptor_;
+  int message_bit_index_;
+  int builder_bit_index_;
   std::map<std::string, std::string> variables_;
   ClassNameResolver* name_resolver_;
+  Context* context_;
   void GenerateMapGetters(io::Printer* printer) const;
 };
 

--- a/src/google/protobuf/compiler/java/message_builder.h
+++ b/src/google/protobuf/compiler/java/message_builder.h
@@ -69,6 +69,11 @@ class MessageBuilderGenerator {
 
  private:
   void GenerateCommonBuilderMethods(io::Printer* printer);
+  void GenerateBuildPartial(io::Printer* printer);
+  int GenerateBuildPartialPiece(io::Printer* printer, int piece,
+                                int first_field);
+  int GenerateBuildPartialPieceWithoutPresence(io::Printer* printer, int piece,
+                                               int first_field);
   void GenerateDescriptorMethods(io::Printer* printer);
   void GenerateBuilderParsingMethods(io::Printer* printer);
   void GenerateBuilderFieldParsingCases(io::Printer* printer);

--- a/src/google/protobuf/compiler/java/message_field.cc
+++ b/src/google/protobuf/compiler/java/message_field.cc
@@ -32,21 +32,21 @@
 //  Based on original Protocol Buffers design by
 //  Sanjay Ghemawat, Jeff Dean, and others.
 
-#include <google/protobuf/compiler/java/message_field.h>
+#include "google/protobuf/compiler/java/message_field.h"
 
 #include <map>
 #include <string>
 
-#include <google/protobuf/io/printer.h>
-#include <google/protobuf/wire_format.h>
-#include <google/protobuf/stubs/strutil.h>
-#include <google/protobuf/compiler/java/context.h>
-#include <google/protobuf/compiler/java/doc_comment.h>
-#include <google/protobuf/compiler/java/helpers.h>
-#include <google/protobuf/compiler/java/name_resolver.h>
+#include "google/protobuf/io/printer.h"
+#include "google/protobuf/wire_format.h"
+#include "google/protobuf/stubs/strutil.h"
+#include "google/protobuf/compiler/java/context.h"
+#include "google/protobuf/compiler/java/doc_comment.h"
+#include "google/protobuf/compiler/java/helpers.h"
+#include "google/protobuf/compiler/java/name_resolver.h"
 
 // Must be last.
-#include <google/protobuf/port_def.inc>
+#include "google/protobuf/port_def.inc"
 
 namespace google {
 namespace protobuf {
@@ -56,10 +56,11 @@ namespace java {
 
 namespace {
 
-void SetMessageVariables(const FieldDescriptor* descriptor, int messageBitIndex,
-                         int builderBitIndex, const FieldGeneratorInfo* info,
-                         ClassNameResolver* name_resolver,
-                         std::map<std::string, std::string>* variables) {
+void SetMessageVariables(
+    const FieldDescriptor* descriptor, int messageBitIndex, int builderBitIndex,
+    const FieldGeneratorInfo* info, ClassNameResolver* name_resolver,
+    std::map<std::string, std::string>* variables,
+    Context* context) {
   SetCommonFieldVariables(descriptor, info, variables);
 
   (*variables)["type"] =
@@ -74,11 +75,12 @@ void SetMessageVariables(const FieldDescriptor* descriptor, int messageBitIndex,
   // by the proto compiler
   (*variables)["deprecation"] =
       descriptor->options().deprecated() ? "@java.lang.Deprecated " : "";
-  (*variables)["kt_deprecation"] =
-      descriptor->options().deprecated()
-          ? "@kotlin.Deprecated(message = \"Field " + (*variables)["name"] +
-                " is deprecated\") "
-          : "";
+  variables->insert(
+      {"kt_deprecation",
+       descriptor->options().deprecated()
+           ? StrCat("@kotlin.Deprecated(message = \"Field ",
+                          (*variables)["name"], " is deprecated\") ")
+           : ""});
   (*variables)["on_changed"] = "onChanged();";
   (*variables)["ver"] = GeneratedCodeVersionSuffix();
   (*variables)["get_parser"] =
@@ -88,24 +90,16 @@ void SetMessageVariables(const FieldDescriptor* descriptor, int messageBitIndex,
   if (HasHasbit(descriptor)) {
     // For singular messages and builders, one bit is used for the hasField bit.
     (*variables)["get_has_field_bit_message"] = GenerateGetBit(messageBitIndex);
-    (*variables)["get_has_field_bit_builder"] = GenerateGetBit(builderBitIndex);
 
     // Note that these have a trailing ";".
-    (*variables)["set_has_field_bit_message"] =
-        GenerateSetBit(messageBitIndex) + ";";
-    (*variables)["set_has_field_bit_builder"] =
-        GenerateSetBit(builderBitIndex) + ";";
-    (*variables)["clear_has_field_bit_builder"] =
-        GenerateClearBit(builderBitIndex) + ";";
+    (*variables)["set_has_field_bit_to_local"] =
+        GenerateSetBitToLocal(messageBitIndex);
 
     (*variables)["is_field_present_message"] = GenerateGetBit(messageBitIndex);
   } else {
-    (*variables)["set_has_field_bit_message"] = "";
-    (*variables)["set_has_field_bit_builder"] = "";
-    (*variables)["clear_has_field_bit_builder"] = "";
-
-    (*variables)["is_field_present_message"] =
-        (*variables)["name"] + "_ != null";
+    (*variables)["set_has_field_bit_to_local"] = "";
+    variables->insert({"is_field_present_message",
+                       StrCat((*variables)["name"], "_ != null")});
   }
 
   // For repeated builders, one bit is used for whether the array is immutable.
@@ -113,10 +107,13 @@ void SetMessageVariables(const FieldDescriptor* descriptor, int messageBitIndex,
   (*variables)["set_mutable_bit_builder"] = GenerateSetBit(builderBitIndex);
   (*variables)["clear_mutable_bit_builder"] = GenerateClearBit(builderBitIndex);
 
+  (*variables)["get_has_field_bit_builder"] = GenerateGetBit(builderBitIndex);
+  (*variables)["set_has_field_bit_builder"] =
+      GenerateSetBit(builderBitIndex) + ";";
+  (*variables)["clear_has_field_bit_builder"] =
+      GenerateClearBit(builderBitIndex) + ";";
   (*variables)["get_has_field_bit_from_local"] =
       GenerateGetBitFromLocal(builderBitIndex);
-  (*variables)["set_has_field_bit_to_local"] =
-      GenerateSetBitToLocal(messageBitIndex);
 }
 
 }  // namespace
@@ -126,21 +123,31 @@ void SetMessageVariables(const FieldDescriptor* descriptor, int messageBitIndex,
 ImmutableMessageFieldGenerator::ImmutableMessageFieldGenerator(
     const FieldDescriptor* descriptor, int messageBitIndex, int builderBitIndex,
     Context* context)
-    : descriptor_(descriptor), name_resolver_(context->GetNameResolver()) {
+    : descriptor_(descriptor),
+      message_bit_index_(messageBitIndex),
+      builder_bit_index_(builderBitIndex),
+      name_resolver_(context->GetNameResolver()),
+      context_(context) {
   SetMessageVariables(descriptor, messageBitIndex, builderBitIndex,
                       context->GetFieldGeneratorInfo(descriptor),
-                      name_resolver_, &variables_);
+                      name_resolver_, &variables_, context);
 }
 
 ImmutableMessageFieldGenerator::~ImmutableMessageFieldGenerator() {}
+
+int ImmutableMessageFieldGenerator::GetMessageBitIndex() const {
+  return message_bit_index_;
+}
+
+int ImmutableMessageFieldGenerator::GetBuilderBitIndex() const {
+  return builder_bit_index_;
+}
 
 int ImmutableMessageFieldGenerator::GetNumBitsForMessage() const {
   return HasHasbit(descriptor_) ? 1 : 0;
 }
 
-int ImmutableMessageFieldGenerator::GetNumBitsForBuilder() const {
-  return GetNumBitsForMessage();
-}
+int ImmutableMessageFieldGenerator::GetNumBitsForBuilder() const { return 1; }
 
 void ImmutableMessageFieldGenerator::GenerateInterfaceMembers(
     io::Printer* printer) const {
@@ -173,24 +180,6 @@ void ImmutableMessageFieldGenerator::GenerateMembers(
         "  return $get_has_field_bit_message$;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
-    WriteFieldAccessorDocComment(printer, descriptor_, GETTER);
-    printer->Print(
-        variables_,
-        "@java.lang.Override\n"
-        "$deprecation$public $type$ ${$get$capitalized_name$$}$() {\n"
-        "  return $name$_ == null ? $type$.getDefaultInstance() : $name$_;\n"
-        "}\n");
-    printer->Annotate("{", "}", descriptor_);
-
-    WriteFieldDocComment(printer, descriptor_);
-    printer->Print(
-        variables_,
-        "@java.lang.Override\n"
-        "$deprecation$public $type$OrBuilder "
-        "${$get$capitalized_name$OrBuilder$}$() {\n"
-        "  return $name$_ == null ? $type$.getDefaultInstance() : $name$_;\n"
-        "}\n");
-    printer->Annotate("{", "}", descriptor_);
   } else {
     WriteFieldAccessorDocComment(printer, descriptor_, HAZZER);
     printer->Print(
@@ -200,24 +189,25 @@ void ImmutableMessageFieldGenerator::GenerateMembers(
         "  return $name$_ != null;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
-    WriteFieldAccessorDocComment(printer, descriptor_, GETTER);
-    printer->Print(
-        variables_,
-        "@java.lang.Override\n"
-        "$deprecation$public $type$ ${$get$capitalized_name$$}$() {\n"
-        "  return $name$_ == null ? $type$.getDefaultInstance() : $name$_;\n"
-        "}\n");
-    printer->Annotate("{", "}", descriptor_);
-
-    WriteFieldDocComment(printer, descriptor_);
-    printer->Print(variables_,
-                   "@java.lang.Override\n"
-                   "$deprecation$public $type$OrBuilder "
-                   "${$get$capitalized_name$OrBuilder$}$() {\n"
-                   "  return get$capitalized_name$();\n"
-                   "}\n");
-    printer->Annotate("{", "}", descriptor_);
   }
+  WriteFieldAccessorDocComment(printer, descriptor_, GETTER);
+  printer->Print(
+      variables_,
+      "@java.lang.Override\n"
+      "$deprecation$public $type$ ${$get$capitalized_name$$}$() {\n"
+      "  return $name$_ == null ? $type$.getDefaultInstance() : $name$_;\n"
+      "}\n");
+  printer->Annotate("{", "}", descriptor_);
+
+  WriteFieldDocComment(printer, descriptor_);
+  printer->Print(
+      variables_,
+      "@java.lang.Override\n"
+      "$deprecation$public $type$OrBuilder "
+      "${$get$capitalized_name$OrBuilder$}$() {\n"
+      "  return $name$_ == null ? $type$.getDefaultInstance() : $name$_;\n"
+      "}\n");
+  printer->Annotate("{", "}", descriptor_);
 }
 
 void ImmutableMessageFieldGenerator::PrintNestedBuilderCondition(
@@ -255,9 +245,6 @@ void ImmutableMessageFieldGenerator::GenerateBuilderMembers(
   // When using nested-builders, the code initially works just like the
   // non-nested builder case. It only creates a nested builder lazily on
   // demand and then forever delegates to it after creation.
-
-  bool has_hasbit = HasHasbit(descriptor_);
-
   printer->Print(variables_, "private $type$ $name$_;\n");
 
   printer->Print(variables_,
@@ -272,21 +259,11 @@ void ImmutableMessageFieldGenerator::GenerateBuilderMembers(
 
   // boolean hasField()
   WriteFieldAccessorDocComment(printer, descriptor_, HAZZER);
-  if (has_hasbit) {
-    printer->Print(
-        variables_,
-        "$deprecation$public boolean ${$has$capitalized_name$$}$() {\n"
-        "  return $get_has_field_bit_builder$;\n"
-        "}\n");
-    printer->Annotate("{", "}", descriptor_);
-  } else {
-    printer->Print(
-        variables_,
-        "$deprecation$public boolean ${$has$capitalized_name$$}$() {\n"
-        "  return $name$Builder_ != null || $name$_ != null;\n"
-        "}\n");
-    printer->Annotate("{", "}", descriptor_);
-  }
+  printer->Print(variables_,
+                 "$deprecation$public boolean ${$has$capitalized_name$$}$() {\n"
+                 "  return $get_has_field_bit_builder$;\n"
+                 "}\n");
+  printer->Annotate("{", "}", descriptor_);
 
   // Field getField()
   WriteFieldAccessorDocComment(printer, descriptor_, GETTER);
@@ -304,12 +281,12 @@ void ImmutableMessageFieldGenerator::GenerateBuilderMembers(
       "if (value == null) {\n"
       "  throw new NullPointerException();\n"
       "}\n"
-      "$name$_ = value;\n"
-      "$on_changed$\n",
+      "$name$_ = value;\n",
 
       "$name$Builder_.setMessage(value);\n",
 
       "$set_has_field_bit_builder$\n"
+      "$on_changed$\n"
       "return this;\n");
 
   // Field.Builder setField(Field.Builder builderForValue)
@@ -319,58 +296,48 @@ void ImmutableMessageFieldGenerator::GenerateBuilderMembers(
       "$deprecation$public Builder ${$set$capitalized_name$$}$(\n"
       "    $type$.Builder builderForValue)",
 
-      "$name$_ = builderForValue.build();\n"
-      "$on_changed$\n",
+      "$name$_ = builderForValue.build();\n",
 
       "$name$Builder_.setMessage(builderForValue.build());\n",
 
       "$set_has_field_bit_builder$\n"
+      "$on_changed$\n"
       "return this;\n");
 
-  // Field.Builder mergeField(Field value)
+  // Message.Builder mergeField(Field value)
   WriteFieldDocComment(printer, descriptor_);
   PrintNestedBuilderFunction(
       printer,
       "$deprecation$public Builder ${$merge$capitalized_name$$}$($type$ value)",
-
-      has_hasbit
-          ? "if ($get_has_field_bit_builder$ &&\n"
-            "    $name$_ != null &&\n"
-            "    $name$_ != $type$.getDefaultInstance()) {\n"
-            "  $name$_ =\n"
-            "    $type$.newBuilder($name$_).mergeFrom(value).buildPartial();\n"
-            "} else {\n"
-            "  $name$_ = value;\n"
-            "}\n"
-            "$on_changed$\n"
-          : "if ($name$_ != null) {\n"
-            "  $name$_ =\n"
-            "    $type$.newBuilder($name$_).mergeFrom(value).buildPartial();\n"
-            "} else {\n"
-            "  $name$_ = value;\n"
-            "}\n"
-            "$on_changed$\n",
+      "if ($get_has_field_bit_builder$ &&\n"
+      "  $name$_ != null &&\n"
+      "  $name$_ != $type$.getDefaultInstance()) {\n"
+      "  get$capitalized_name$Builder().mergeFrom(value);\n"
+      "} else {\n"
+      "  $name$_ = value;\n"
+      "}\n",
 
       "$name$Builder_.mergeFrom(value);\n",
 
       "$set_has_field_bit_builder$\n"
+      "$on_changed$\n"
       "return this;\n");
 
-  // Field.Builder clearField()
+  // Message.Builder clearField()
   WriteFieldDocComment(printer, descriptor_);
-  PrintNestedBuilderFunction(
-      printer, "$deprecation$public Builder ${$clear$capitalized_name$$}$()",
+  printer->Print(variables_,
+                 "$deprecation$public Builder clear$capitalized_name$() {\n"
+                 "  $clear_has_field_bit_builder$\n"
+                 "  $name$_ = null;\n"
+                 "  if ($name$Builder_ != null) {\n"
+                 "    $name$Builder_.dispose();\n"
+                 "    $name$Builder_ = null;\n"
+                 "  }\n"
+                 "  $on_changed$\n"
+                 "  return this;\n"
+                 "}\n");
 
-      "$name$_ = null;\n"
-      "$on_changed$\n",
-
-      has_hasbit ? "$name$Builder_.clear();\n"
-                 : "$name$_ = null;\n"
-                   "$name$Builder_ = null;\n",
-
-      "$clear_has_field_bit_builder$\n"
-      "return this;\n");
-
+  // Field.Builder getFieldBuilder()
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
                  "$deprecation$public $type$.Builder "
@@ -380,6 +347,8 @@ void ImmutableMessageFieldGenerator::GenerateBuilderMembers(
                  "  return get$capitalized_name$FieldBuilder().getBuilder();\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
+
+  // FieldOrBuilder getFieldOrBuilder()
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
                  "$deprecation$public $type$OrBuilder "
@@ -392,6 +361,8 @@ void ImmutableMessageFieldGenerator::GenerateBuilderMembers(
                  "  }\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
+
+  // SingleFieldBuilder getFieldFieldBuilder
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(
       variables_,
@@ -449,9 +420,7 @@ void ImmutableMessageFieldGenerator::GenerateKotlinOrNull(io::Printer* printer) 
 
 void ImmutableMessageFieldGenerator::GenerateFieldBuilderInitializationCode(
     io::Printer* printer) const {
-  if (HasHasbit(descriptor_)) {
-    printer->Print(variables_, "get$capitalized_name$FieldBuilder();\n");
-  }
+  printer->Print(variables_, "get$capitalized_name$FieldBuilder();\n");
 }
 
 void ImmutableMessageFieldGenerator::GenerateInitializationCode(
@@ -459,17 +428,13 @@ void ImmutableMessageFieldGenerator::GenerateInitializationCode(
 
 void ImmutableMessageFieldGenerator::GenerateBuilderClearCode(
     io::Printer* printer) const {
-  if (HasHasbit(descriptor_)) {
-    PrintNestedBuilderCondition(printer, "$name$_ = null;\n",
-
-                                "$name$Builder_.clear();\n");
-    printer->Print(variables_, "$clear_has_field_bit_builder$\n");
-  } else {
-    PrintNestedBuilderCondition(printer, "$name$_ = null;\n",
-
-                                "$name$_ = null;\n"
-                                "$name$Builder_ = null;\n");
-  }
+  // No need to clear the has-bit since we clear the bitField ints all at once.
+  printer->Print(variables_,
+                 "$name$_ = null;\n"
+                 "if ($name$Builder_ != null) {\n"
+                 "  $name$Builder_.dispose();\n"
+                 "  $name$Builder_ = null;\n"
+                 "}\n");
 }
 
 void ImmutableMessageFieldGenerator::GenerateMergingCode(
@@ -482,19 +447,15 @@ void ImmutableMessageFieldGenerator::GenerateMergingCode(
 
 void ImmutableMessageFieldGenerator::GenerateBuildingCode(
     io::Printer* printer) const {
-  if (HasHasbit(descriptor_)) {
-    printer->Print(variables_, "if ($get_has_field_bit_from_local$) {\n");
-    printer->Indent();
-    PrintNestedBuilderCondition(printer, "result.$name$_ = $name$_;\n",
-                                "result.$name$_ = $name$Builder_.build();\n");
-    printer->Outdent();
-    printer->Print(variables_,
-                   "  $set_has_field_bit_to_local$;\n"
-                   "}\n");
-  } else {
-    PrintNestedBuilderCondition(printer, "result.$name$_ = $name$_;\n",
-                                "result.$name$_ = $name$Builder_.build();\n");
+  printer->Print(variables_,
+                 "if ($get_has_field_bit_from_local$) {\n"
+                 "  result.$name$_ = $name$Builder_ == null\n"
+                 "      ? $name$_\n"
+                 "      : $name$Builder_.build();\n");
+  if (GetNumBitsForMessage() > 0) {
+    printer->Print(variables_, "  $set_has_field_bit_to_local$;\n");
   }
+  printer->Print("}\n");
 }
 
 void ImmutableMessageFieldGenerator::GenerateBuilderParsingCode(
@@ -575,6 +536,7 @@ void ImmutableMessageOneofFieldGenerator::GenerateMembers(
                  "  return $has_oneof_case_message$;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
+
   WriteFieldAccessorDocComment(printer, descriptor_, GETTER);
   printer->Print(variables_,
                  "@java.lang.Override\n"
@@ -758,7 +720,7 @@ void ImmutableMessageOneofFieldGenerator::GenerateBuilderMembers(
       "    $oneof_name$_ = null;\n"
       "  }\n"
       "  $set_oneof_case_message$;\n"
-      "  $on_changed$;\n"
+      "  $on_changed$\n"
       "  return $name$Builder_;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -775,16 +737,11 @@ void ImmutableMessageOneofFieldGenerator::GenerateBuilderClearCode(
 
 void ImmutableMessageOneofFieldGenerator::GenerateBuildingCode(
     io::Printer* printer) const {
-  printer->Print(variables_, "if ($has_oneof_case_message$) {\n");
-  printer->Indent();
-
-  PrintNestedBuilderCondition(
-      printer, "result.$oneof_name$_ = $oneof_name$_;\n",
-
-      "result.$oneof_name$_ = $name$Builder_.build();\n");
-
-  printer->Outdent();
-  printer->Print("}\n");
+  printer->Print(variables_,
+                 "if ($has_oneof_case_message$ &&\n"
+                 "    $name$Builder_ != null) {\n"
+                 "  result.$oneof_name$_ = $name$Builder_.build();\n"
+                 "}\n");
 }
 
 void ImmutableMessageOneofFieldGenerator::GenerateMergingCode(
@@ -834,11 +791,8 @@ void ImmutableMessageOneofFieldGenerator::GenerateSerializedSizeCode(
 RepeatedImmutableMessageFieldGenerator::RepeatedImmutableMessageFieldGenerator(
     const FieldDescriptor* descriptor, int messageBitIndex, int builderBitIndex,
     Context* context)
-    : descriptor_(descriptor), name_resolver_(context->GetNameResolver()) {
-  SetMessageVariables(descriptor, messageBitIndex, builderBitIndex,
-                      context->GetFieldGeneratorInfo(descriptor),
-                      name_resolver_, &variables_);
-}
+    : ImmutableMessageFieldGenerator(descriptor, messageBitIndex,
+                                     builderBitIndex, context) {}
 
 RepeatedImmutableMessageFieldGenerator::
     ~RepeatedImmutableMessageFieldGenerator() {}
@@ -881,7 +835,8 @@ void RepeatedImmutableMessageFieldGenerator::GenerateInterfaceMembers(
 
 void RepeatedImmutableMessageFieldGenerator::GenerateMembers(
     io::Printer* printer) const {
-  printer->Print(variables_, "private java.util.List<$type$> $name$_;\n");
+  printer->Print(variables_, "@SuppressWarnings(\"serial\")\n"
+                             "private java.util.List<$type$> $name$_;\n");
   PrintExtraFieldInfo(variables_, printer);
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
@@ -891,6 +846,8 @@ void RepeatedImmutableMessageFieldGenerator::GenerateMembers(
                  "  return $name$_;\n"  // note:  unmodifiable list
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
+
+  // List<FieldOrBuilder> getFieldOrBuilderList()
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(
       variables_,
@@ -900,6 +857,8 @@ void RepeatedImmutableMessageFieldGenerator::GenerateMembers(
       "  return $name$_;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
+
+  // int getFieldCount()
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(
       variables_,
@@ -908,6 +867,8 @@ void RepeatedImmutableMessageFieldGenerator::GenerateMembers(
       "  return $name$_.size();\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
+
+  // Field getField(int index)
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(
       variables_,
@@ -916,6 +877,8 @@ void RepeatedImmutableMessageFieldGenerator::GenerateMembers(
       "  return $name$_.get(index);\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
+
+  // FieldOrBuilder getFieldOrBuilder(int index)
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
                  "@java.lang.Override\n"
@@ -1141,7 +1104,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
 
       "return this;\n");
 
-  // Builder clearAllRepeatedField()
+  // Builder clearRepeatedField()
   WriteFieldDocComment(printer, descriptor_);
   PrintNestedBuilderFunction(
       printer, "$deprecation$public Builder ${$clear$capitalized_name$$}$()",
@@ -1168,6 +1131,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
 
       "return this;\n");
 
+  // Field.Builder getRepeatedFieldBuilder(int index)
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(
       variables_,
@@ -1177,6 +1141,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
       "}\n");
   printer->Annotate("{", "}", descriptor_);
 
+  // FieldOrBuilder getRepeatedFieldOrBuilder(int index)
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
                  "$deprecation$public $type$OrBuilder "
@@ -1190,6 +1155,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
 
+  // List<FieldOrBuilder> getRepeatedFieldOrBuilderList()
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(
       variables_,
@@ -1203,6 +1169,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
       "}\n");
   printer->Annotate("{", "}", descriptor_);
 
+  // Field.Builder addRepeatedField()
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
                  "$deprecation$public $type$.Builder "
@@ -1211,6 +1178,8 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
                  "      $type$.getDefaultInstance());\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
+
+  // Field.Builder addRepeatedFieldBuilder(int index)
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(
       variables_,
@@ -1220,6 +1189,8 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
       "      index, $type$.getDefaultInstance());\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
+
+  // List<Field.Builder> getRepeatedFieldBuilderList()
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(
       variables_,
@@ -1478,4 +1449,4 @@ void RepeatedImmutableMessageFieldGenerator::GenerateKotlinDslMembers(
 }  // namespace protobuf
 }  // namespace google
 
-#include <google/protobuf/port_undef.inc>
+#include "google/protobuf/port_undef.inc"

--- a/src/google/protobuf/compiler/java/message_field.h
+++ b/src/google/protobuf/compiler/java/message_field.h
@@ -38,7 +38,7 @@
 #include <map>
 #include <string>
 
-#include <google/protobuf/compiler/java/field.h>
+#include "google/protobuf/compiler/java/field.h"
 
 namespace google {
 namespace protobuf {
@@ -62,10 +62,16 @@ class ImmutableMessageFieldGenerator : public ImmutableFieldGenerator {
                                           int messageBitIndex,
                                           int builderBitIndex,
                                           Context* context);
+  ImmutableMessageFieldGenerator(const ImmutableMessageFieldGenerator&) =
+      delete;
+  ImmutableMessageFieldGenerator& operator=(
+      const ImmutableMessageFieldGenerator&) = delete;
   ~ImmutableMessageFieldGenerator() override;
 
   // implements ImmutableFieldGenerator
   // ---------------------------------------
+  int GetMessageBitIndex() const override;
+  int GetBuilderBitIndex() const override;
   int GetNumBitsForMessage() const override;
   int GetNumBitsForBuilder() const override;
   void GenerateInterfaceMembers(io::Printer* printer) const override;
@@ -88,20 +94,22 @@ class ImmutableMessageFieldGenerator : public ImmutableFieldGenerator {
 
  protected:
   const FieldDescriptor* descriptor_;
+  int message_bit_index_;
+  int builder_bit_index_;
   std::map<std::string, std::string> variables_;
   ClassNameResolver* name_resolver_;
+  Context* context_;
 
-  void PrintNestedBuilderCondition(io::Printer* printer,
-                                   const char* regular_case,
-                                   const char* nested_builder_case) const;
-  void PrintNestedBuilderFunction(io::Printer* printer,
-                                  const char* method_prototype,
-                                  const char* regular_case,
-                                  const char* nested_builder_case,
-                                  const char* trailing_code) const;
+  virtual void PrintNestedBuilderCondition(
+      io::Printer* printer, const char* regular_case,
+      const char* nested_builder_case) const;
+  virtual void PrintNestedBuilderFunction(io::Printer* printer,
+                                          const char* method_prototype,
+                                          const char* regular_case,
+                                          const char* nested_builder_case,
+                                          const char* trailing_code) const;
 
  private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ImmutableMessageFieldGenerator);
   void GenerateKotlinOrNull(io::Printer* printer) const;
 };
 
@@ -111,6 +119,10 @@ class ImmutableMessageOneofFieldGenerator
   ImmutableMessageOneofFieldGenerator(const FieldDescriptor* descriptor,
                                       int messageBitIndex, int builderBitIndex,
                                       Context* context);
+  ImmutableMessageOneofFieldGenerator(
+      const ImmutableMessageOneofFieldGenerator&) = delete;
+  ImmutableMessageOneofFieldGenerator& operator=(
+      const ImmutableMessageOneofFieldGenerator&) = delete;
   ~ImmutableMessageOneofFieldGenerator() override;
 
   void GenerateMembers(io::Printer* printer) const override;
@@ -121,16 +133,18 @@ class ImmutableMessageOneofFieldGenerator
   void GenerateBuilderParsingCode(io::Printer* printer) const override;
   void GenerateSerializationCode(io::Printer* printer) const override;
   void GenerateSerializedSizeCode(io::Printer* printer) const override;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ImmutableMessageOneofFieldGenerator);
 };
 
-class RepeatedImmutableMessageFieldGenerator : public ImmutableFieldGenerator {
+class RepeatedImmutableMessageFieldGenerator
+    : public ImmutableMessageFieldGenerator {
  public:
   explicit RepeatedImmutableMessageFieldGenerator(
       const FieldDescriptor* descriptor, int messageBitIndex,
       int builderBitIndex, Context* context);
+  RepeatedImmutableMessageFieldGenerator(
+      const RepeatedImmutableMessageFieldGenerator&) = delete;
+  RepeatedImmutableMessageFieldGenerator& operator=(
+      const RepeatedImmutableMessageFieldGenerator&) = delete;
   ~RepeatedImmutableMessageFieldGenerator() override;
 
   // implements ImmutableFieldGenerator ---------------------------------------
@@ -155,21 +169,14 @@ class RepeatedImmutableMessageFieldGenerator : public ImmutableFieldGenerator {
   std::string GetBoxedType() const override;
 
  protected:
-  const FieldDescriptor* descriptor_;
-  std::map<std::string, std::string> variables_;
-  ClassNameResolver* name_resolver_;
-
-  void PrintNestedBuilderCondition(io::Printer* printer,
-                                   const char* regular_case,
-                                   const char* nested_builder_case) const;
+  void PrintNestedBuilderCondition(
+      io::Printer* printer, const char* regular_case,
+      const char* nested_builder_case) const override;
   void PrintNestedBuilderFunction(io::Printer* printer,
                                   const char* method_prototype,
                                   const char* regular_case,
                                   const char* nested_builder_case,
-                                  const char* trailing_code) const;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(RepeatedImmutableMessageFieldGenerator);
+                                  const char* trailing_code) const override;
 };
 
 }  // namespace java

--- a/src/google/protobuf/compiler/java/primitive_field.h
+++ b/src/google/protobuf/compiler/java/primitive_field.h
@@ -38,7 +38,7 @@
 #include <map>
 #include <string>
 
-#include <google/protobuf/compiler/java/field.h>
+#include "google/protobuf/compiler/java/field.h"
 
 namespace google {
 namespace protobuf {
@@ -62,10 +62,16 @@ class ImmutablePrimitiveFieldGenerator : public ImmutableFieldGenerator {
                                             int messageBitIndex,
                                             int builderBitIndex,
                                             Context* context);
+  ImmutablePrimitiveFieldGenerator(const ImmutablePrimitiveFieldGenerator&) =
+      delete;
+  ImmutablePrimitiveFieldGenerator& operator=(
+      const ImmutablePrimitiveFieldGenerator&) = delete;
   ~ImmutablePrimitiveFieldGenerator() override;
 
   // implements ImmutableFieldGenerator
   // ---------------------------------------
+  int GetMessageBitIndex() const override;
+  int GetBuilderBitIndex() const override;
   int GetNumBitsForMessage() const override;
   int GetNumBitsForBuilder() const override;
   void GenerateInterfaceMembers(io::Printer* printer) const override;
@@ -88,11 +94,10 @@ class ImmutablePrimitiveFieldGenerator : public ImmutableFieldGenerator {
 
  protected:
   const FieldDescriptor* descriptor_;
+  int message_bit_index_;
+  int builder_bit_index_;
   std::map<std::string, std::string> variables_;
   ClassNameResolver* name_resolver_;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ImmutablePrimitiveFieldGenerator);
 };
 
 class ImmutablePrimitiveOneofFieldGenerator
@@ -101,6 +106,10 @@ class ImmutablePrimitiveOneofFieldGenerator
   ImmutablePrimitiveOneofFieldGenerator(const FieldDescriptor* descriptor,
                                         int messageBitIndex,
                                         int builderBitIndex, Context* context);
+  ImmutablePrimitiveOneofFieldGenerator(
+      const ImmutablePrimitiveOneofFieldGenerator&) = delete;
+  ImmutablePrimitiveOneofFieldGenerator& operator=(
+      const ImmutablePrimitiveOneofFieldGenerator&) = delete;
   ~ImmutablePrimitiveOneofFieldGenerator() override;
 
   void GenerateMembers(io::Printer* printer) const override;
@@ -111,17 +120,18 @@ class ImmutablePrimitiveOneofFieldGenerator
   void GenerateBuilderParsingCode(io::Printer* printer) const override;
   void GenerateSerializationCode(io::Printer* printer) const override;
   void GenerateSerializedSizeCode(io::Printer* printer) const override;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ImmutablePrimitiveOneofFieldGenerator);
 };
 
 class RepeatedImmutablePrimitiveFieldGenerator
-    : public ImmutableFieldGenerator {
+    : public ImmutablePrimitiveFieldGenerator {
  public:
   explicit RepeatedImmutablePrimitiveFieldGenerator(
       const FieldDescriptor* descriptor, int messageBitIndex,
       int builderBitIndex, Context* context);
+  RepeatedImmutablePrimitiveFieldGenerator(
+      const RepeatedImmutablePrimitiveFieldGenerator&) = delete;
+  RepeatedImmutablePrimitiveFieldGenerator& operator=(
+      const RepeatedImmutablePrimitiveFieldGenerator&) = delete;
   ~RepeatedImmutablePrimitiveFieldGenerator() override;
 
   // implements ImmutableFieldGenerator ---------------------------------------
@@ -146,13 +156,6 @@ class RepeatedImmutablePrimitiveFieldGenerator
   void GenerateKotlinDslMembers(io::Printer* printer) const override;
 
   std::string GetBoxedType() const override;
-
- private:
-  const FieldDescriptor* descriptor_;
-  std::map<std::string, std::string> variables_;
-  ClassNameResolver* name_resolver_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(RepeatedImmutablePrimitiveFieldGenerator);
 };
 
 }  // namespace java

--- a/src/google/protobuf/compiler/java/string_field.h
+++ b/src/google/protobuf/compiler/java/string_field.h
@@ -39,7 +39,7 @@
 #include <map>
 #include <string>
 
-#include <google/protobuf/compiler/java/field.h>
+#include "google/protobuf/compiler/java/field.h"
 
 namespace google {
 namespace protobuf {
@@ -62,10 +62,15 @@ class ImmutableStringFieldGenerator : public ImmutableFieldGenerator {
   explicit ImmutableStringFieldGenerator(const FieldDescriptor* descriptor,
                                          int messageBitIndex,
                                          int builderBitIndex, Context* context);
+  ImmutableStringFieldGenerator(const ImmutableStringFieldGenerator&) = delete;
+  ImmutableStringFieldGenerator& operator=(
+      const ImmutableStringFieldGenerator&) = delete;
   ~ImmutableStringFieldGenerator() override;
 
   // implements ImmutableFieldGenerator
   // ---------------------------------------
+  int GetMessageBitIndex() const override;
+  int GetBuilderBitIndex() const override;
   int GetNumBitsForMessage() const override;
   int GetNumBitsForBuilder() const override;
   void GenerateInterfaceMembers(io::Printer* printer) const override;
@@ -88,11 +93,10 @@ class ImmutableStringFieldGenerator : public ImmutableFieldGenerator {
 
  protected:
   const FieldDescriptor* descriptor_;
+  int message_bit_index_;
+  int builder_bit_index_;
   std::map<std::string, std::string> variables_;
   ClassNameResolver* name_resolver_;
-
- private:
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ImmutableStringFieldGenerator);
 };
 
 class ImmutableStringOneofFieldGenerator
@@ -101,6 +105,10 @@ class ImmutableStringOneofFieldGenerator
   ImmutableStringOneofFieldGenerator(const FieldDescriptor* descriptor,
                                      int messageBitIndex, int builderBitIndex,
                                      Context* context);
+  ImmutableStringOneofFieldGenerator(
+      const ImmutableStringOneofFieldGenerator&) = delete;
+  ImmutableStringOneofFieldGenerator& operator=(
+      const ImmutableStringOneofFieldGenerator&) = delete;
   ~ImmutableStringOneofFieldGenerator() override;
 
  private:
@@ -112,15 +120,18 @@ class ImmutableStringOneofFieldGenerator
   void GenerateBuilderParsingCode(io::Printer* printer) const override;
   void GenerateSerializationCode(io::Printer* printer) const override;
   void GenerateSerializedSizeCode(io::Printer* printer) const override;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ImmutableStringOneofFieldGenerator);
 };
 
-class RepeatedImmutableStringFieldGenerator : public ImmutableFieldGenerator {
+class RepeatedImmutableStringFieldGenerator
+    : public ImmutableStringFieldGenerator {
  public:
   explicit RepeatedImmutableStringFieldGenerator(
       const FieldDescriptor* descriptor, int messageBitIndex,
       int builderBitIndex, Context* context);
+  RepeatedImmutableStringFieldGenerator(
+      const RepeatedImmutableStringFieldGenerator&) = delete;
+  RepeatedImmutableStringFieldGenerator& operator=(
+      const RepeatedImmutableStringFieldGenerator&) = delete;
   ~RepeatedImmutableStringFieldGenerator() override;
 
   // implements ImmutableFieldGenerator ---------------------------------------
@@ -143,13 +154,6 @@ class RepeatedImmutableStringFieldGenerator : public ImmutableFieldGenerator {
   void GenerateKotlinDslMembers(io::Printer* printer) const override;
 
   std::string GetBoxedType() const override;
-
- private:
-  const FieldDescriptor* descriptor_;
-  std::map<std::string, std::string> variables_;
-  ClassNameResolver* name_resolver_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(RepeatedImmutableStringFieldGenerator);
 };
 
 }  // namespace java


### PR DESCRIPTION
Changes to make this improvement:

1) All non-repeated builder fields (including maps) now have a presence bit regardless of syntax.

2) The buildPartial method is split into one method per 32-field block (aligned with bit-mask ints) 3) If a presence bit-mask int is set to 0, no fields are present, so we can skip the logic for all of those fields in the buildPartial step.

For messages with a lot of fields (> 100) that are sparsely populated this can result in a significant improvement. Not only does it potentially skip a lot of field copying logic, but also breaks the buildPartial method into chunks that should be more easily digested by the JIT compiler as discussed in this issue: https://github.com/protocolbuffers/protobuf/issues/10247.

PiperOrigin-RevId: 485952448