### PR TITLE
fix(sec): upgrade sphinx to 

### DIFF
--- a/python/docs/requirements.txt
+++ b/python/docs/requirements.txt
@@ -1,5 +1,5 @@
 googleapis-common-protos==1.56.1
 jinja2==3.0.0
-sphinx==2.3.1
+sphinx==3.0.4
 sphinx_rtd_theme==0.4.3
 sphinxcontrib-napoleon==0.7


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in sphinx 2.3.1
- [CVE-2020-11022](https://www.oscs1024.com/hd/CVE-2020-11022)


### What did I do？
Upgrade sphinx from 2.3.1 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS