### PR TITLE
Add support for .NET Native AOT

### DIFF
--- a/csharp/install_dotnet_sdk.ps1
+++ b/csharp/install_dotnet_sdk.ps1
@@ -18,3 +18,4 @@ Invoke-WebRequest -Uri $InstallScriptUrl -OutFile $InstallScriptPath
 # installed by kokoro/linux/dockerfile/test/csharp/Dockerfile
 &$InstallScriptPath -Version 3.1.415
 &$InstallScriptPath -Version 6.0.100
+&$InstallScriptPath -Version 7.0.100

--- a/csharp/src/Google.Protobuf.Test.NativeAot/Assert.cs
+++ b/csharp/src/Google.Protobuf.Test.NativeAot/Assert.cs
@@ -1,0 +1,90 @@
+﻿#region Copyright notice and license
+// Protocol Buffers - Google's data interchange format
+// Copyright 2016 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+namespace Google.Protobuf.Test.NativeAot
+{
+    /// <summary>
+    /// A slim version of the Assert class to avoid the dependency on NUnits framework.
+    /// </summary>
+    internal static class Assert
+    {
+        public static void IsNull(object value)
+        {
+            if (value != null)
+            {
+                throw new Exception("Expected null");
+            }
+        }
+
+        public static void IsNotNull(object value)
+        {
+            if (value == null)
+            {
+                throw new Exception("Expected not null");
+            }
+        }
+
+        public static void AreEqual<T>(T expected, T actual)
+        {
+            if (!Equals(expected, actual))
+            {
+                throw new Exception($"Expected {expected} but was {actual}");
+            }
+        }
+
+        public static void AreNotEqual<T>(T expected, T actual)
+        {
+            if (Equals(expected, actual))
+            {
+                throw new Exception($"Expected not {expected}");
+            }
+        }
+
+        public static TActual Throws<TActual>(Action code) where TActual : Exception
+        {
+            try
+            {
+                code();
+            }
+            catch (TActual ex)
+            {
+                return ex;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Expected {typeof(TActual)} but was {ex.GetType()}", ex);
+            }
+
+            throw new Exception($"Expected {typeof(TActual)} but no exception was thrown");
+        }
+    }
+}

--- a/csharp/src/Google.Protobuf.Test.NativeAot/Google.Protobuf.Test.NativeAot.csproj
+++ b/csharp/src/Google.Protobuf.Test.NativeAot/Google.Protobuf.Test.NativeAot.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Protobuf\Google.Protobuf.csproj" />
+    <ProjectReference Include="..\Google.Protobuf.Test.TestProtos\Google.Protobuf.Test.TestProtos.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/csharp/src/Google.Protobuf.Test.NativeAot/Program.cs
+++ b/csharp/src/Google.Protobuf.Test.NativeAot/Program.cs
@@ -1,0 +1,68 @@
+﻿#region Copyright notice and license
+// Protocol Buffers - Google's data interchange format
+// Copyright 2016 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+using Google.Protobuf.Test.NativeAot.Reflection;
+
+try
+{
+    // This project tests specific Google.Protobuf features with .NET Native AOT.
+    // It is designed to be published as a native app, and then run.
+    // Return value of 0 is success, 1 is failure.
+    //
+    // Because of trimming, there is a chance a scenario might not work in isolation.
+    // For now, all these tests are compiled and run together. Re-evaluate if this becomes a problem.
+    // Could be isolated by adding #ifdef here and then caller passes compiler flag to run specific tests.
+    Descriptors.GetFileDescriptorMessages();
+    Descriptors.GetMessageFields();
+    Descriptors.GetMessageEnumTypes();
+    Descriptors.GetEnumFields();
+    Descriptors.GetEnumDescriptorFields();
+    Descriptors.AccessorSingleFieldReflection();
+    Descriptors.AccessorOneOfFieldReflection();
+    Descriptors.AccessorRepeatingFieldReflection();
+    Descriptors.GetFileDescriptorServices();
+    Extensions.GetExtensionSingle();
+    Extensions.GetExtensionRepeated();
+    Extensions.GetExtensionEnumSingle();
+    Extensions.GetExtensionValue();
+    Extensions.ExtensionsIsInitialized();
+    Extensions.OptionLocations();
+    Json.FormatJson();
+    Json.ParseJson();
+
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.WriteLine(ex);
+    return 1;
+}

--- a/csharp/src/Google.Protobuf.Test.NativeAot/Reflection/Descriptors.cs
+++ b/csharp/src/Google.Protobuf.Test.NativeAot/Reflection/Descriptors.cs
@@ -1,0 +1,161 @@
+﻿#region Copyright notice and license
+// Protocol Buffers - Google's data interchange format
+// Copyright 2016 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+using System.Collections;
+using System.Reflection;
+using ProtobufTestMessages.Proto3;
+using UnitTest.Issues.TestProtos;
+
+namespace Google.Protobuf.Test.NativeAot.Reflection
+{
+    internal static class Descriptors
+    {
+        public static void GetFileDescriptorMessages()
+        {
+            var messageTypes = TestMessagesProto3Reflection.Descriptor.MessageTypes;
+            Assert.AreNotEqual(0, messageTypes.Count);
+            
+            foreach (var item in messageTypes)
+            {
+                Console.WriteLine($"{item.Name} message");
+            }
+            Console.WriteLine($"{messageTypes.Count} messages");
+        }
+        
+        public static void GetMessageFields()
+        {
+            var fields = TestAllTypesProto3.Descriptor.Fields.InDeclarationOrder();
+            Assert.AreNotEqual(0, fields.Count);
+            
+            foreach (var item in fields)
+            {
+                Console.WriteLine($"{item.Name} field");
+            }
+            Console.WriteLine($"{fields.Count} fields");
+        }
+
+        public static void GetMessageEnumTypes()
+        {
+            var enumTypes = TestAllTypesProto3.Descriptor.EnumTypes;
+            Assert.AreNotEqual(0, enumTypes.Count);
+
+            foreach (var item in enumTypes)
+            {
+                Console.WriteLine($"{item.Name} enum type");
+            }
+            Console.WriteLine($"{enumTypes.Count} enum types");
+        }
+
+        public static void GetEnumFields()
+        {
+            var enumFields = typeof(TestAllTypesProto3.Types.NestedEnum).GetFields(BindingFlags.Static | BindingFlags.Public);
+            Assert.AreEqual(4, enumFields.Length);
+
+            foreach (var item in enumFields)
+            {
+                Console.WriteLine($"{item.Name} enum field");
+            }
+            Console.WriteLine($"{enumFields.Length} enum fields");
+        }
+
+        public static void GetEnumDescriptorFields()
+        {
+            var enumDescriptor = TestAllTypesProto3.Descriptor.EnumTypes.Single(t => t.Name == "NestedEnum");
+            Assert.AreEqual(4, enumDescriptor.Values.Count);
+
+            foreach (var item in enumDescriptor.Values)
+            {
+                Console.WriteLine($"{item.Name} {item.Number} enum value");
+            }
+            Console.WriteLine($"{enumDescriptor.Values.Count} enum values");
+        }
+
+        public static void AccessorSingleFieldReflection()
+        {
+            var field = TestAllTypesProto3.Descriptor.FindFieldByName("fieldname1");
+            var message = (IMessage)Activator.CreateInstance(TestAllTypesProto3.Descriptor.ClrType)!;
+
+            field.Accessor.SetValue(message, 101);
+
+            var value = (int)field.Accessor.GetValue(message);
+            Assert.AreEqual(101, value);
+
+            field.Accessor.Clear(message);
+
+            value = (int) field.Accessor.GetValue(message);
+            Assert.AreEqual(0, value);
+        }
+
+        public static void AccessorOneOfFieldReflection()
+        {
+            var bytesfield = TestAllTypesProto3.Descriptor.FindFieldByName("oneof_bytes");
+            var stringfield = TestAllTypesProto3.Descriptor.FindFieldByName("oneof_string");
+            var message = (IMessage) Activator.CreateInstance(TestAllTypesProto3.Descriptor.ClrType)!;
+
+            bytesfield.Accessor.SetValue(message, ByteString.CopyFrom(new byte[] { 1, 2, 3 }));
+
+            var bytesValue = (ByteString) bytesfield.Accessor.GetValue(message);
+            if (!bytesValue.Span.SequenceEqual(new byte[] { 1, 2, 3 }))
+            {
+                throw new Exception($"Expected 1,2,3.");
+            }
+
+            Assert.AreEqual(true, bytesfield.Accessor.HasValue(message));
+
+            stringfield.Accessor.SetValue(message, "abc");
+
+            Assert.AreEqual("abc", (string) stringfield.Accessor.GetValue(message));
+            Assert.AreEqual(false, bytesfield.Accessor.HasValue(message));
+        }
+
+        public static void AccessorRepeatingFieldReflection()
+        {
+            var field = TestAllTypesProto3.Descriptor.FindFieldByName("repeated_int32");
+            var message = (IMessage) Activator.CreateInstance(TestAllTypesProto3.Descriptor.ClrType)!;
+
+            var list = (IList) field.Accessor.GetValue(message);
+            Assert.IsNotNull(list);
+        }
+
+        public static void GetFileDescriptorServices()
+        {
+            var serviceDescriptor = UnittestCustomOptionsProto3Reflection.Descriptor.Services.Single(s => s.Name == "TestServiceWithCustomOptions");
+            Assert.IsNotNull(serviceDescriptor);
+            Assert.AreNotEqual(0, serviceDescriptor.Methods.Count);
+
+            foreach (var method in serviceDescriptor.Methods)
+            {
+                Console.WriteLine($"{method.Name} method");
+            }
+        }
+    }
+}

--- a/csharp/src/Google.Protobuf.Test.NativeAot/Reflection/Extensions.cs
+++ b/csharp/src/Google.Protobuf.Test.NativeAot/Reflection/Extensions.cs
@@ -1,0 +1,217 @@
+﻿#region Copyright notice and license
+// Protocol Buffers - Google's data interchange format
+// Copyright 2016 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+using System.Collections;
+using Google.Protobuf.TestProtos.Proto2;
+using UnitTest.Issues.TestProtos;
+using static Google.Protobuf.TestProtos.Proto2.UnittestExtensions;
+using static UnitTest.Issues.TestProtos.UnittestCustomOptionsProto3Extensions;
+
+namespace Google.Protobuf.Test.NativeAot.Reflection
+{
+    internal static class Extensions
+    {
+        public static void GetExtensionSingle()
+        {
+            var extensionValue = new TestAllTypes.Types.NestedMessage() { Bb = 42 };
+            var untypedExtension = new Extension<TestAllExtensions, object>(OptionalNestedMessageExtension.FieldNumber, codec: null);
+            var wrongTypedExtension = new Extension<TestAllExtensions, TestAllTypes>(OptionalNestedMessageExtension.FieldNumber, codec: null);
+
+            var message = new TestAllExtensions();
+
+            var value1 = message.GetExtension(untypedExtension);
+            Assert.IsNull(value1);
+
+            message.SetExtension(OptionalNestedMessageExtension, extensionValue);
+            var value2 = message.GetExtension(untypedExtension);
+            Assert.IsNotNull(value2);
+            Assert.AreEqual(extensionValue, value2);
+
+            var valueBytes = ((IMessage) value2).ToByteArray();
+            var parsedValue = TestProtos.Proto2.TestAllTypes.Types.NestedMessage.Parser.ParseFrom(valueBytes);
+            Assert.AreEqual(extensionValue, parsedValue);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => message.GetExtension(wrongTypedExtension));
+
+            var expectedMessage = "The stored extension value has a type of 'Google.Protobuf.TestProtos.Proto2.TestAllTypes+Types+NestedMessage, Google.Protobuf.Test.TestProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604'. " +
+                "This a different from the requested type of 'Google.Protobuf.TestProtos.Proto2.TestAllTypes, Google.Protobuf.Test.TestProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604'.";
+            Assert.AreEqual(expectedMessage, ex.Message);
+        }
+
+        public static void GetExtensionEnumSingle()
+        {
+            var message = new TestAllExtensions();
+            message.SetExtension(OptionalForeignEnumExtension, ForeignEnum.ForeignBar);
+
+            var value = message.GetExtension(OptionalForeignEnumExtension);
+            Assert.AreEqual(ForeignEnum.ForeignBar, value);
+
+            Console.WriteLine($"Got value {value} for extension {OptionalForeignEnumExtension.FieldNumber}");
+        }
+
+        public static void GetExtensionRepeated()
+        {
+            var extensionValue = new TestAllTypes.Types.NestedMessage() { Bb = 42 };
+            var untypedExtension = new Extension<TestAllExtensions, IList>(RepeatedNestedMessageExtension.FieldNumber, codec: null);
+            var wrongTypedExtension = new RepeatedExtension<TestAllExtensions, TestAllTypes>(RepeatedNestedMessageExtension.FieldNumber, codec: null);
+
+            var message = new TestAllExtensions();
+
+            var value1 = message.GetExtension(untypedExtension);
+            Assert.IsNull(value1);
+
+            var repeatedField = message.GetOrInitializeExtension<TestAllTypes.Types.NestedMessage>(RepeatedNestedMessageExtension);
+            repeatedField.Add(extensionValue);
+
+            var value2 = message.GetExtension(untypedExtension);
+            Assert.IsNotNull(value2);
+            Assert.AreEqual(1, value2.Count);
+
+            var valueBytes = ((IMessage) value2[0]!).ToByteArray();
+            var parsedValue = TestProtos.Proto2.TestAllTypes.Types.NestedMessage.Parser.ParseFrom(valueBytes);
+            Assert.AreEqual(extensionValue, parsedValue);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => message.GetExtension(wrongTypedExtension));
+
+            var expectedMessage = "The stored extension value has a type of 'Google.Protobuf.TestProtos.Proto2.TestAllTypes+Types+NestedMessage, Google.Protobuf.Test.TestProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604'. " +
+                "This a different from the requested type of 'Google.Protobuf.TestProtos.Proto2.TestAllTypes, Google.Protobuf.Test.TestProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604'.";
+            Assert.AreEqual(expectedMessage, ex.Message);
+        }
+
+        public static void GetExtensionValue()
+        {
+            var message = CreateFullTestAllExtensions();
+
+            Assert.AreEqual(true, message.GetExtension(OptionalBoolExtension));
+
+            var ex = Assert.Throws<NotSupportedException>(() => TestProtos.Proto2.TestAllExtensions.Descriptor.FindFieldByNumber(OptionalBoolExtension.FieldNumber).Accessor.GetValue(message));
+            Assert.AreEqual("Extensions reflection is not supported with AOT.", ex.Message);
+        }
+
+        public static void ExtensionsIsInitialized()
+        {
+            var message = new TestAllExtensions();
+            Assert.AreEqual(true, message.IsInitialized());
+        }
+
+        public static void OptionLocations()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            var fileDescriptor = UnittestCustomOptionsProto3Reflection.Descriptor;
+            AssertOption(9876543210UL, FileOpt1, fileDescriptor.GetOption, fileDescriptor.GetOptions().GetExtension);
+
+            var messageDescriptor = TestMessageWithCustomOptions.Descriptor;
+            AssertOption(-56, MessageOpt1, messageDescriptor.GetOption, messageDescriptor.GetOptions().GetExtension);
+
+            var fieldDescriptor = TestMessageWithCustomOptions.Descriptor.Fields["field1"];
+            AssertOption(8765432109UL, FieldOpt1, fieldDescriptor.GetOption, fieldDescriptor.GetOptions().GetExtension);
+
+            var oneofDescriptor = TestMessageWithCustomOptions.Descriptor.Oneofs[0];
+            AssertOption(-99, OneofOpt1, oneofDescriptor.GetOption, oneofDescriptor.GetOptions().GetExtension);
+
+            var enumDescriptor = TestMessageWithCustomOptions.Descriptor.EnumTypes[0];
+            AssertOption(-789, EnumOpt1, enumDescriptor.GetOption, enumDescriptor.GetOptions().GetExtension);
+
+            var enumValueDescriptor = TestMessageWithCustomOptions.Descriptor.EnumTypes[0].FindValueByNumber(2);
+            AssertOption(123, EnumValueOpt1, enumValueDescriptor.GetOption, enumValueDescriptor.GetOptions().GetExtension);
+
+            var serviceDescriptor = UnittestCustomOptionsProto3Reflection.Descriptor.Services
+                .Single(s => s.Name == "TestServiceWithCustomOptions");
+            AssertOption(-9876543210, ServiceOpt1, serviceDescriptor.GetOption, serviceDescriptor.GetOptions().GetExtension);
+
+            var methodDescriptor = serviceDescriptor.Methods[0];
+            AssertOption(UnitTest.Issues.TestProtos.MethodOpt1.Val2, UnittestCustomOptionsProto3Extensions.MethodOpt1, methodDescriptor.GetOption, methodDescriptor.GetOptions().GetExtension);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        private static void AssertOption<T, D>(T expected, Extension<D, T> extension, Func<Extension<D, T>, T> getOptionFetcher, Func<Extension<D, T>, T> extensionFetcher) where D : IExtendableMessage<D>
+        {
+            T getOptionValue = getOptionFetcher(extension);
+            Assert.AreEqual(expected, getOptionValue);
+
+            T extensionValue = extensionFetcher(extension);
+            Assert.AreEqual(expected, extensionValue);
+        }
+
+        public static TestAllExtensions CreateFullTestAllExtensions()
+        {
+            var message = new TestAllExtensions();
+            message.SetExtension(OptionalBoolExtension, true);
+            message.SetExtension(OptionalBytesExtension, ByteString.CopyFrom(1, 2, 3, 4));
+            message.SetExtension(OptionalDoubleExtension, 23.5);
+            message.SetExtension(OptionalFixed32Extension, 23u);
+            message.SetExtension(OptionalFixed64Extension, 1234567890123u);
+            message.SetExtension(OptionalFloatExtension, 12.25f);
+            message.SetExtension(OptionalForeignEnumExtension, ForeignEnum.ForeignBar);
+            message.SetExtension(OptionalForeignMessageExtension, new ForeignMessage { C = 10 });
+            message.SetExtension(OptionalImportEnumExtension, ImportEnum.ImportBaz);
+            message.SetExtension(OptionalImportMessageExtension, new ImportMessage { D = 20 });
+            message.SetExtension(OptionalInt32Extension, 100);
+            message.SetExtension(OptionalInt64Extension, 3210987654321);
+            message.SetExtension(OptionalNestedEnumExtension, TestProtos.Proto2.TestAllTypes.Types.NestedEnum.Foo);
+            message.SetExtension(OptionalNestedMessageExtension, new TestProtos.Proto2.TestAllTypes.Types.NestedMessage { Bb = 35 });
+            message.SetExtension(OptionalPublicImportMessageExtension, new PublicImportMessage { E = 54 });
+            message.SetExtension(OptionalSfixed32Extension, -123);
+            message.SetExtension(OptionalSfixed64Extension, -12345678901234);
+            message.SetExtension(OptionalSint32Extension, -456);
+            message.SetExtension(OptionalSint64Extension, -12345678901235);
+            message.SetExtension(OptionalStringExtension, "test");
+            message.SetExtension(OptionalUint32Extension, UInt32.MaxValue);
+            message.SetExtension(OptionalUint64Extension, UInt64.MaxValue);
+            message.SetExtension(OptionalGroupExtension, new OptionalGroup_extension { A = 10 });
+            message.GetOrInitializeExtension(RepeatedBoolExtension).AddRange(new[] { true, false });
+            message.GetOrInitializeExtension(RepeatedBytesExtension).AddRange(new[] { ByteString.CopyFrom(1, 2, 3, 4), ByteString.CopyFrom(5, 6), ByteString.CopyFrom(new byte[1000]) });
+            message.GetOrInitializeExtension(RepeatedDoubleExtension).AddRange(new[] { -12.25, 23.5 });
+            message.GetOrInitializeExtension(RepeatedFixed32Extension).AddRange(new[] { UInt32.MaxValue, 23u });
+            message.GetOrInitializeExtension(RepeatedFixed64Extension).AddRange(new[] { UInt64.MaxValue, 1234567890123ul });
+            message.GetOrInitializeExtension(RepeatedFloatExtension).AddRange(new[] { 100f, 12.25f });
+            message.GetOrInitializeExtension(RepeatedForeignEnumExtension).AddRange(new[] { ForeignEnum.ForeignFoo, ForeignEnum.ForeignBar });
+            message.GetOrInitializeExtension(RepeatedForeignMessageExtension).AddRange(new[] { new ForeignMessage(), new ForeignMessage { C = 10 } });
+            message.GetOrInitializeExtension(RepeatedImportEnumExtension).AddRange(new[] { ImportEnum.ImportBaz, ImportEnum.ImportFoo });
+            message.GetOrInitializeExtension(RepeatedImportMessageExtension).AddRange(new[] { new ImportMessage { D = 20 }, new ImportMessage { D = 25 } });
+            message.GetOrInitializeExtension(RepeatedInt32Extension).AddRange(new[] { 100, 200 });
+            message.GetOrInitializeExtension(RepeatedInt64Extension).AddRange(new[] { 3210987654321, Int64.MaxValue });
+            message.GetOrInitializeExtension(RepeatedNestedEnumExtension).AddRange(new[] { TestProtos.Proto2.TestAllTypes.Types.NestedEnum.Foo, TestProtos.Proto2.TestAllTypes.Types.NestedEnum.Neg });
+            message.GetOrInitializeExtension(RepeatedNestedMessageExtension).AddRange(new[] { new TestProtos.Proto2.TestAllTypes.Types.NestedMessage { Bb = 35 }, new TestProtos.Proto2.TestAllTypes.Types.NestedMessage { Bb = 10 } });
+            message.GetOrInitializeExtension(RepeatedSfixed32Extension).AddRange(new[] { -123, 123 });
+            message.GetOrInitializeExtension(RepeatedSfixed64Extension).AddRange(new[] { -12345678901234, 12345678901234 });
+            message.GetOrInitializeExtension(RepeatedSint32Extension).AddRange(new[] { -456, 100 });
+            message.GetOrInitializeExtension(RepeatedSint64Extension).AddRange(new[] { -12345678901235, 123 });
+            message.GetOrInitializeExtension(RepeatedStringExtension).AddRange(new[] { "foo", "bar" });
+            message.GetOrInitializeExtension(RepeatedUint32Extension).AddRange(new[] { UInt32.MaxValue, UInt32.MinValue });
+            message.GetOrInitializeExtension(RepeatedUint64Extension).AddRange(new[] { UInt64.MaxValue, UInt32.MinValue });
+            message.GetOrInitializeExtension(RepeatedGroupExtension).AddRange(new[] { new TestProtos.Proto2.RepeatedGroup_extension { A = 10 }, new TestProtos.Proto2.RepeatedGroup_extension { A = 20 } });
+            message.SetExtension(OneofStringExtension, "Oneof string");
+            return message;
+        }
+    }
+}

--- a/csharp/src/Google.Protobuf.Test.NativeAot/Reflection/Json.cs
+++ b/csharp/src/Google.Protobuf.Test.NativeAot/Reflection/Json.cs
@@ -1,0 +1,66 @@
+﻿#region Copyright notice and license
+// Protocol Buffers - Google's data interchange format
+// Copyright 2016 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+using Google.Protobuf.TestProtos.Proto2;
+
+namespace Google.Protobuf.Test.NativeAot.Reflection
+{
+    internal static class Json
+    {
+        public static void FormatJson()
+        {
+            var message = new TestAllTypes
+            {
+                OptionalNestedMessage = new TestAllTypes.Types.NestedMessage() { Bb = 42 },
+                OneofString = "Value!",
+                RepeatedBool = { true, false, true },
+            };
+
+            var json = JsonFormatter.Default.Format(message);
+            Assert.AreEqual("{ \"optionalNestedMessage\": { \"bb\": 42 }, \"repeatedBool\": [ true, false, true ], \"oneofString\": \"Value!\" }", json);
+
+            Console.WriteLine(json);
+        }
+        
+        public static void ParseJson()
+        {
+            var json = "{ \"optionalNestedMessage\": { \"bb\": 42 }, \"repeatedBool\": [ true, false, true ], \"oneofString\": \"Value!\" }";
+
+            var message = (TestAllTypes) JsonParser.Default.Parse(json, TestAllTypes.Descriptor);
+            Assert.AreEqual(42, message.OptionalNestedMessage.Bb);
+            Assert.AreEqual("Value!", message.OneofString);
+            Assert.AreEqual(true, message.RepeatedBool[0]);
+            Assert.AreEqual(false, message.RepeatedBool[1]);
+            Assert.AreEqual(true, message.RepeatedBool[2]);
+        }
+    }
+}

--- a/csharp/src/Google.Protobuf.sln
+++ b/csharp/src/Google.Protobuf.sln
@@ -1,6 +1,7 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26114.2
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33103.201
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AddressBook", "AddressBook\AddressBook.csproj", "{AFB63919-1E05-43B4-802A-8FB8C9B2F463}"
 EndProject
@@ -12,7 +13,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Protobuf.Conformance
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Protobuf.JsonDump", "Google.Protobuf.JsonDump\Google.Protobuf.JsonDump.csproj", "{9695E08F-9829-497D-B95C-B38F28D48690}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Protobuf.Test.TestProtos", "Google.Protobuf.Test.TestProtos\Google.Protobuf.Test.TestProtos.csproj", "{ADF24BEB-A318-4530-8448-356B72B820EA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Protobuf.Test.TestProtos", "Google.Protobuf.Test.TestProtos\Google.Protobuf.Test.TestProtos.csproj", "{ADF24BEB-A318-4530-8448-356B72B820EA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Protobuf.Test.NativeAot", "Google.Protobuf.Test.NativeAot\Google.Protobuf.Test.NativeAot.csproj", "{642232EA-FA89-4E84-9CA0-423EA98F37ED}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +47,10 @@ Global
 		{ADF24BEB-A318-4530-8448-356B72B820EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADF24BEB-A318-4530-8448-356B72B820EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADF24BEB-A318-4530-8448-356B72B820EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{642232EA-FA89-4E84-9CA0-423EA98F37ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{642232EA-FA89-4E84-9CA0-423EA98F37ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{642232EA-FA89-4E84-9CA0-423EA98F37ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{642232EA-FA89-4E84-9CA0-423EA98F37ED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <!-- If you update this, update the .csproj in the Docker file as well -->
 
   <PropertyGroup>
@@ -23,6 +23,7 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IsTrimmable>true</IsTrimmable>
+    <EnableAOTAnalyzer>true</EnableAOTAnalyzer>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.100",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
- [x] Support reflection accessors
- [x] Support extensions
- [ ] Integrate Native AOT app into unit tests **EDIT:** Should these run automatically? How? From CI script or as part of unit test publishing and launching app?

Previously added trim attributes enables most of Google.Protobuf to work with Native AOT. There are some problematic `MakeGenericType` usages around reflection and extensions that need work.