### PR TITLE
Mark nested builder as clean after clear is called

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
@@ -199,6 +199,9 @@ public class SingleFieldBuilderV3<
       builder = null;
     }
     onChanged();
+    // After clearing, parent is dirty, but this field builder is now clean and any changes should
+    // trickle up.
+    isClean = true;
     return this;
   }
 

--- a/java/core/src/test/proto/com/google/protobuf/nested_builders_test.proto
+++ b/java/core/src/test/proto/com/google/protobuf/nested_builders_test.proto
@@ -40,16 +40,16 @@ option java_outer_classname = "NestedBuilders";
 message Vehicle {
   optional Engine engine = 1;
   repeated Wheel wheel = 2;
-  optional TimingBelt timing_belt = 3;
-}
-
-message TimingBelt {
-  optional int32 number_of_teeth = 1;
 }
 
 message Engine {
   optional int32 cylinder = 1;
   optional int32 liters = 2;
+  optional TimingBelt timing_belt = 3;
+}
+
+message TimingBelt {
+  optional int32 number_of_teeth = 1;
 }
 
 message Wheel {

--- a/java/core/src/test/proto/com/google/protobuf/nested_builders_test.proto
+++ b/java/core/src/test/proto/com/google/protobuf/nested_builders_test.proto
@@ -40,6 +40,11 @@ option java_outer_classname = "NestedBuilders";
 message Vehicle {
   optional Engine engine = 1;
   repeated Wheel wheel = 2;
+  optional TimingBelt timing_belt = 3;
+}
+
+message TimingBelt {
+  optional int32 number_of_teeth = 1;
 }
 
 message Engine {


### PR DESCRIPTION
Omitting this step was leading to stale cached versions of nested messages. See https://github.com/protocolbuffers/protobuf/issues/10624