### PR TITLE
Fix segfaults on FreeBSD

### DIFF
--- a/ruby/ext/google/protobuf_c/extconf.rb
+++ b/ruby/ext/google/protobuf_c/extconf.rb
@@ -6,7 +6,7 @@ ext_name = "google/protobuf_c"
 
 dir_config(ext_name)
 
-if RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
+if RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/ || RUBY_PLATFORM =~ /freebsd/
   $CFLAGS += " -std=gnu99 -O3 -DNDEBUG -fvisibility=hidden -Wall -Wsign-compare -Wno-declaration-after-statement"
 else
   $CFLAGS += " -std=gnu99 -O3 -DNDEBUG"


### PR DESCRIPTION
If more than one version of rubygem google-protobuf is installed it causes problem. Make sure symbols are also hidden on FreeBSD like it is already done for Linux and Darwin.

This fixes problems reported here:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266925
https://gitlab.com/gitlab-org/gitlab/-/issues/345693