### PR TITLE
Fix shared object ABI exports (#5144)

### DIFF
--- a/src/libprotobuf-lite.map
+++ b/src/libprotobuf-lite.map
@@ -3,6 +3,8 @@
     extern "C++" {
       *google*;
     };
+    scc_info_*;
+    descriptor_table_*;
 
   local:
     *;

--- a/src/libprotobuf.map
+++ b/src/libprotobuf.map
@@ -3,6 +3,8 @@
     extern "C++" {
       *google*;
     };
+    scc_info_*;
+    descriptor_table_*;
 
   local:
     *;

--- a/src/libprotoc.map
+++ b/src/libprotoc.map
@@ -3,6 +3,8 @@
     extern "C++" {
       *google*;
     };
+    scc_info_*;
+    descriptor_table_*;
 
   local:
     *;


### PR DESCRIPTION
On some linkers, the ABI definitions in src/libprotoc.map and friends do not match all symbols that need to be exported. This causes a linker error when trying to use the resulting shared object library: `undefined reference to 'scc_info_FileDescriptorProto_google_2fprotobuf_2fdescriptor_2eproto'`

Quite a few people seem to be affected by this, see #5144 for discussion. It seems that yocto now applies this patch itself, but that doesn't help people building in other places (I encountered this on some HPC machines), so it would probably be good to apply it upstream as well.