### PR TITLE
Update to .NET 7 SDK

### DIFF
--- a/csharp/install_dotnet_sdk.ps1
+++ b/csharp/install_dotnet_sdk.ps1
@@ -18,3 +18,4 @@ Invoke-WebRequest -Uri $InstallScriptUrl -OutFile $InstallScriptPath
 # installed by kokoro/linux/dockerfile/test/csharp/Dockerfile
 &$InstallScriptPath -Version 3.1.415
 &$InstallScriptPath -Version 6.0.100
+&$InstallScriptPath -Version 7.0.100

--- a/csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
+++ b/csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>

--- a/csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
+++ b/csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net60</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net60;net70</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../keys/Google.Protobuf.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <IsPackable>False</IsPackable>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/kokoro/linux/aarch64/test_csharp_aarch64.sh
+++ b/kokoro/linux/aarch64/test_csharp_aarch64.sh
@@ -16,7 +16,7 @@ fi
 # Tests are built "dotnet publish" because we want all the dependencies to the copied to the destination directory
 # (we want to avoid references to ~/.nuget that won't be available in the subsequent docker run)
 CSHARP_BUILD_COMMAND="dotnet publish -c Release -f net60 csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj"
-docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -e "DOTNET_CLI_TELEMETRY_OPTOUT=true" -e "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work mcr.microsoft.com/dotnet/sdk:6.0.100-bullseye-slim bash -c "$CSHARP_BUILD_COMMAND"
+docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -e "DOTNET_CLI_TELEMETRY_OPTOUT=true" -e "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work mcr.microsoft.com/dotnet/sdk:7.0.100-bullseye-slim bash -c "$CSHARP_BUILD_COMMAND"
 
 # Use an actual aarch64 docker image to run protobuf C# tests with an emulator. "dotnet vstest" allows
 # running tests from a pre-built project.
@@ -26,4 +26,4 @@ docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-
 #   otherwise the UID would be homeless under the docker container and pip install wouldn't work. For simplicity,
 #   we just run map the user's home to a throwaway temporary directory
 CSHARP_TEST_COMMAND="dotnet vstest csharp/src/Google.Protobuf.Test/bin/Release/net60/publish/Google.Protobuf.Test.dll"
-docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -e "DOTNET_CLI_TELEMETRY_OPTOUT=true" -e "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work mcr.microsoft.com/dotnet/sdk:6.0.100-bullseye-slim-arm64v8 bash -c "$CSHARP_TEST_COMMAND"
+docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -e "DOTNET_CLI_TELEMETRY_OPTOUT=true" -e "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work mcr.microsoft.com/dotnet/sdk:7.0.100-bullseye-slim-arm64v8 bash -c "$CSHARP_TEST_COMMAND"

--- a/kokoro/linux/aarch64/test_csharp_aarch64.sh
+++ b/kokoro/linux/aarch64/test_csharp_aarch64.sh
@@ -15,7 +15,7 @@ fi
 # First, build protobuf C# tests under x86_64 docker image
 # Tests are built "dotnet publish" because we want all the dependencies to the copied to the destination directory
 # (we want to avoid references to ~/.nuget that won't be available in the subsequent docker run)
-CSHARP_BUILD_COMMAND="dotnet publish -c Release -f net60 csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj"
+CSHARP_BUILD_COMMAND="dotnet publish -c Release -f net70 csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj"
 docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -e "DOTNET_CLI_TELEMETRY_OPTOUT=true" -e "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work mcr.microsoft.com/dotnet/sdk:7.0.100-bullseye-slim bash -c "$CSHARP_BUILD_COMMAND"
 
 # Use an actual aarch64 docker image to run protobuf C# tests with an emulator. "dotnet vstest" allows

--- a/kokoro/linux/aarch64/test_csharp_aarch64.sh
+++ b/kokoro/linux/aarch64/test_csharp_aarch64.sh
@@ -25,5 +25,5 @@ docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-
 #   running under current user's UID and GID. To be able to do that, we need to provide a home directory for the user
 #   otherwise the UID would be homeless under the docker container and pip install wouldn't work. For simplicity,
 #   we just run map the user's home to a throwaway temporary directory
-CSHARP_TEST_COMMAND="dotnet vstest csharp/src/Google.Protobuf.Test/bin/Release/net60/publish/Google.Protobuf.Test.dll"
+CSHARP_TEST_COMMAND="dotnet vstest csharp/src/Google.Protobuf.Test/bin/Release/net70/publish/Google.Protobuf.Test.dll"
 docker run $DOCKER_TTY_ARGS --rm --user "$(id -u):$(id -g)" -e "HOME=/home/fake-user" -e "DOTNET_CLI_TELEMETRY_OPTOUT=true" -e "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true" -v "$(mktemp -d):/home/fake-user" -v "$(pwd)":/work -w /work mcr.microsoft.com/dotnet/sdk:7.0.100-bullseye-slim-arm64v8 bash -c "$CSHARP_TEST_COMMAND"

--- a/kokoro/linux/csharp/common.cfg
+++ b/kokoro/linux/csharp/common.cfg
@@ -6,7 +6,7 @@ timeout_mins: 1440
 
 env_vars {
   key: "CONTAINER_IMAGE"
-  value: "gcr.io/protobuf-build/csharp/linux:3.1.415-6.0.100-6bbe70439ba5b0404bb12662cebc0296909389fa"
+  value: "gcr.io/protobuf-build/csharp/linux:3.1.415-7.0.100-fd08677658055819df3448f36d9dda0dde715294"
 }
 
 env_vars {


### PR DESCRIPTION
This is in preparation for https://github.com/protocolbuffers/protobuf/pull/10978. We will now need to build with .NET 7, but will keep other versions installed to test with.