### PR TITLE
Update third_party.md

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -21,6 +21,7 @@ These are projects we know about implementing Protocol Buffers for other program
 * C: https://github.com/eerimoq/pbtools
 * C++: https://github.com/protocolbuffers/protobuf (Google-official implementation)
 * C++: https://EmbeddedProto.com
+* C++: https://github.com/yksten/ProtobufWrapper
 * C/C++: http://spbc.sf.net/
 * C#: https://code.google.com/p/protobuf-csharp-port
 * C#: https://silentorbit.com/protobuf/


### PR DESCRIPTION
C++struct and protobuf conversion library, which also supports generating header files according to proto.