### PR TITLE
Standardise Link-Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Protocol Buffers - Google's data interchange format
 
 Copyright 2008 Google Inc.
 
-https://developers.google.com/protocol-buffers/
+[Protocol Buffers documentation](https://developers.google.com/protocol-buffers/)
 
 Overview
 --------
@@ -24,18 +24,14 @@ the [C++ Installation Instructions](src/README.md) to install protoc along
 with the C++ runtime.
 
 For non-C++ users, the simplest way to install the protocol compiler is to
-download a pre-built binary from our release page:
-
-  [https://github.com/protocolbuffers/protobuf/releases](https://github.com/protocolbuffers/protobuf/releases)
+download a pre-built binary from our [GitHub release page](https://github.com/protocolbuffers/protobuf/releases).
 
 In the downloads section of each release, you can find pre-built binaries in
-zip packages: protoc-$VERSION-$PLATFORM.zip. It contains the protoc binary
-as well as a set of standard .proto files distributed along with protobuf.
+zip packages: `protoc-$VERSION-$PLATFORM.zip`. It contains the protoc binary
+as well as a set of standard `.proto` files distributed along with protobuf.
 
 If you are looking for an old version that is not available in the release
-page, check out the maven repo here:
-
-  [https://repo1.maven.org/maven2/com/google/protobuf/protoc/](https://repo1.maven.org/maven2/com/google/protobuf/protoc/)
+page, check out the [Maven repository](https://repo1.maven.org/maven2/com/google/protobuf/protoc/).
 
 These pre-built binaries are only provided for released versions. If you want
 to use the github main version at HEAD, or you need to modify protobuf code,
@@ -67,10 +63,8 @@ how to install protobuf runtime for that specific language:
 Quick Start
 -----------
 
-The best way to learn how to use protobuf is to follow the tutorials in our
-developer guide:
-
-https://developers.google.com/protocol-buffers/docs/tutorials
+The best way to learn how to use protobuf is to follow the [tutorials in our
+developer guide](https://developers.google.com/protocol-buffers/docs/tutorials).
 
 If you want to learn from code examples, take a look at the examples in the
 [examples](examples) directory.
@@ -78,10 +72,7 @@ If you want to learn from code examples, take a look at the examples in the
 Documentation
 -------------
 
-The complete documentation for Protocol Buffers is available via the
-web at:
-
-https://developers.google.com/protocol-buffers/
+The complete documentation is available via the [Protocol Buffers documentation](https://developers.google.com/protocol-buffers/).
 
 Developer Community
 -------------------


### PR DESCRIPTION
The README file had not a consistent handling of links. Sometimes there was a Link with Text sometimes there was a Linked URL. Sometimes there was «here» mentioned in the text. 

The changes were made under the following rules:
* Links have a URL and a text
* Link-Text is a (human) meaningful description of the target (machine) URL

What was not touched/fixed:
* Line-breaks at different width