### PR TITLE
Pre-emptively suppress target framework EOL warnings

### DIFF
--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -9,6 +9,12 @@
     <LangVersion>10.0</LangVersion>
     <Authors>Google Inc.</Authors>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net45;net50</TargetFrameworks>
+    <!-- 
+      - We're aware we target older frameworks, for compatibility.
+      - Framework choice is reviewed periodically (and definitely on
+      - major version changes).
+      -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../keys/Google.Protobuf.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
We may want to remove .NET 5 support some time in 2023, but there's no rush to do so.