### PR TITLE
Disable CocoaPods watchOS validation

### DIFF
--- a/.github/workflows/objc_cocoapods.yml
+++ b/.github/workflows/objc_cocoapods.yml
@@ -24,7 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PLATFORM: ["ios", "macos", "tvos", "watchos"]
+        # Add back 'watchos'. See CocoaPods/CocoaPods#11558
+        PLATFORM: ["ios", "macos", "tvos"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
https://github.com/CocoaPods/CocoaPods/issues/11558 is causing this GHA to fail. It has been resolved in main, but this will continue to fail until a release is out and we migrate to it.