### PR TITLE
Fix PHP homebrew installation failures

### DIFF
--- a/kokoro/macos/php74/build.sh
+++ b/kokoro/macos/php74/build.sh
@@ -9,8 +9,9 @@ cd $(dirname $0)/../../..
 source kokoro/macos/prepare_build_macos_rc
 
 # Install Dependencies
+# PHP 7.4 is already installed on the machine
 brew cleanup
-brew install coreutils php@7.4
+brew install coreutils
 
 # Configure path
 PHP_FOLDER=$(find $HOMEBREW_PREFIX -type d -regex ".*php.*/7.4.[0-9_.]*" | sort -n | tail -n 1)

--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -5,6 +5,7 @@
 set -eux
 
 export HOMEBREW_PREFIX=$(brew --prefix)
+export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 # Do not automatically update packages.
 
 ##
 # Select Xcode version


### PR DESCRIPTION
Disables homebrew's automatic updates, which will make tests more hermetic. Also stops failure related to homebrew no longer supporting php 7.4.

Remove the homebrew install of PHP 7.4 for our PHP 7.4 tests as we can't install it and it's already on the machine.