### PR TITLE
Add custom option numbers for use by Buf

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -202,7 +202,7 @@ with info about your project (name and website) so we can add an entry for you.
    * Extensions: 1070
 
 1. Protoc-gen-validate
-   * Website: https://github.com/envoyproxy/protoc-gen-validate
+   * Website: https://github.com/bufbuild/protoc-gen-validate
    * Extensions: 1071
 
 1. Protokt
@@ -352,3 +352,11 @@ with info about your project (name and website) so we can add an entry for you.
 1. Perfetto
    * Website: https://perfetto.dev
    * Extension: 1156
+
+1. Buf
+   * Website: http://buf.build/
+   * Extension: 1157-1166
+
+1. Connect
+   * Website: http://connect.build/
+   * Extension: 1167-1176


### PR DESCRIPTION
We are requesting a range of numbers instead of just one since we have some plans for a variety of orthogonal kinds of custom options. For example:
1. Injecting extra metadata into FileDescriptorProtos via custom options. (These options are inserted by the Buf tool when building proto sources, to encode additional metadata about the unit of files compiled.)
2. Configuration options for protoc plugins, that generate extra metadata into sources. (These options may be used by users when writing proto sources.)
 
The suggested approach of reserving just one number and making it a message that contains *all* options is unattractive since users of one category of options is unlikely to want to import types related to another category.

FWIW, there are several other rows above that have also chosen to reserve ranges of 5 or 10 numbers.