### PR TITLE
Fix PHP 8.2 dynamic property deprecation warning

### DIFF
--- a/php/src/Google/Protobuf/Internal/MapFieldIter.php
+++ b/php/src/Google/Protobuf/Internal/MapFieldIter.php
@@ -49,6 +49,8 @@ class MapFieldIter implements \Iterator
      */
     private $container;
 
+    private $key_type;
+
     /**
      * Create iterator instance for MapField.
      *


### PR DESCRIPTION
PHP 8.2 [deprecates dynamic properties](https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties). `MapFieldIter` triggers a warning on PHP 8.2 because it doesn't declare the `key_type` property. This PR declares the property to fix the warning.