### PR TITLE
Apply registration for `protocel` extensions

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -451,3 +451,8 @@ with info about your project (name and website) so we can add an entry for you.
 
     *   Website: http://connect.build/
     *   Extension: 1167-1176
+
+1.  protocel
+
+    *   Website: https://github.com/Neakxs/protocel
+    *   Extension: 1177-1178


### PR DESCRIPTION
Apply registration for `protoc-gen-cel-authorize` and `protoc-gen-cel-validate` extensions, both located in the [protocel](https://github.com/Neakxs/protocel) repository.