### PR TITLE
Fix Int64Value's jstype

### DIFF
--- a/src/google/protobuf/wrappers.proto
+++ b/src/google/protobuf/wrappers.proto
@@ -71,7 +71,7 @@ message FloatValue {
 // The JSON representation for `Int64Value` is JSON string.
 message Int64Value {
   // The int64 value.
-  int64 value = 1;
+  int64 value = 1 [jstype = JS_STRING];
 }
 
 // Wrapper message for `uint64`.
@@ -79,7 +79,7 @@ message Int64Value {
 // The JSON representation for `UInt64Value` is JSON string.
 message UInt64Value {
   // The uint64 value.
-  uint64 value = 1;
+  uint64 value = 1 [jstype = JS_STRING];
 }
 
 // Wrapper message for `int32`.


### PR DESCRIPTION
The javascript `number` type capacity is equal to int32 type. So after parsing Int64Value, the result is not necessarily correct. The JS should parse it as an string.