### PR TITLE
Update IMessage.MergeFrom and MessageParser.ParseFrom to use zero-allocation spans for byte arrays

### DIFF
--- a/csharp/src/Google.Protobuf/MessageExtensions.cs
+++ b/csharp/src/Google.Protobuf/MessageExtensions.cs
@@ -253,37 +253,21 @@ namespace Google.Protobuf
         {
             ProtoPreconditions.CheckNotNull(message, nameof(message));
             ProtoPreconditions.CheckNotNull(data, nameof(data));
-            CodedInputStream input = new CodedInputStream(data)
-            {
-                DiscardUnknownFields = discardUnknownFields,
-                ExtensionRegistry = registry
-            };
-            message.MergeFrom(input);
-            input.CheckReadEndOfStreamTag();
+            MergeFrom(message, new ReadOnlySpan<byte>(data), discardUnknownFields, registry);
         }
 
         internal static void MergeFrom(this IMessage message, byte[] data, int offset, int length, bool discardUnknownFields, ExtensionRegistry registry)
         {
             ProtoPreconditions.CheckNotNull(message, nameof(message));
             ProtoPreconditions.CheckNotNull(data, nameof(data));
-            CodedInputStream input = new CodedInputStream(data, offset, length)
-            {
-                DiscardUnknownFields = discardUnknownFields,
-                ExtensionRegistry = registry
-            };
-            message.MergeFrom(input);
-            input.CheckReadEndOfStreamTag();
+            MergeFrom(message, new ReadOnlySpan<byte>(data, offset, length), discardUnknownFields, registry);
         }
 
         internal static void MergeFrom(this IMessage message, ByteString data, bool discardUnknownFields, ExtensionRegistry registry)
         {
             ProtoPreconditions.CheckNotNull(message, nameof(message));
             ProtoPreconditions.CheckNotNull(data, nameof(data));
-            CodedInputStream input = data.CreateCodedInput();
-            input.DiscardUnknownFields = discardUnknownFields;
-            input.ExtensionRegistry = registry;
-            message.MergeFrom(input);
-            input.CheckReadEndOfStreamTag();
+            MergeFrom(message, data.Span, discardUnknownFields, registry);
         }
 
         internal static void MergeFrom(this IMessage message, Stream input, bool discardUnknownFields, ExtensionRegistry registry)

--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -72,7 +72,7 @@ namespace Google.Protobuf
         public IMessage ParseFrom(byte[] data)
         {
             IMessage message = factory();
-            message.MergeFrom(data, DiscardUnknownFields, Extensions);
+            message.MergeFrom(new ReadOnlySpan<byte>(data), DiscardUnknownFields, Extensions);
             return message;
         }
 
@@ -86,7 +86,7 @@ namespace Google.Protobuf
         public IMessage ParseFrom(byte[] data, int offset, int length)
         {
             IMessage message = factory();
-            message.MergeFrom(data, offset, length, DiscardUnknownFields, Extensions);
+            message.MergeFrom(new ReadOnlySpan<byte>(data, offset, length), DiscardUnknownFields, Extensions);
             return message;
         }
 
@@ -98,7 +98,7 @@ namespace Google.Protobuf
         public IMessage ParseFrom(ByteString data)
         {
             IMessage message = factory();
-            message.MergeFrom(data, DiscardUnknownFields, Extensions);
+            message.MergeFrom(data.Span, DiscardUnknownFields, Extensions);
             return message;
         }
 

--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -282,7 +282,7 @@ namespace Google.Protobuf
         public new T ParseFrom(byte[] data)
         {
             T message = factory();
-            message.MergeFrom(data, DiscardUnknownFields, Extensions);
+            message.MergeFrom(new ReadOnlySpan<byte>(data), DiscardUnknownFields, Extensions);
             return message;
         }
 
@@ -296,7 +296,7 @@ namespace Google.Protobuf
         public new T ParseFrom(byte[] data, int offset, int length)
         {
             T message = factory();
-            message.MergeFrom(data, offset, length, DiscardUnknownFields, Extensions);
+            message.MergeFrom(new ReadOnlySpan<byte>(data, offset, length), DiscardUnknownFields, Extensions);
             return message;
         }
 
@@ -308,7 +308,7 @@ namespace Google.Protobuf
         public new T ParseFrom(ByteString data)
         {
             T message = factory();
-            message.MergeFrom(data, DiscardUnknownFields, Extensions);
+            message.MergeFrom(data.Span, DiscardUnknownFields, Extensions);
             return message;
         }
 


### PR DESCRIPTION
I was developing an application that caches protobuf messages serialized as byte arrays when I began looking into the various ways of deserializing those messages and noticed a discrepancy between the `ReadOnlySpan<byte>` implementation vs the `byte[]` implementation. This PR fixes that discrepancy by backing the `byte[]` and `ByteString` deserializers with the new zero-allocation `ReadOnlySpan<byte>` code path (introduced in  #8473) rather than the `CodedInputStream` code path.

I wrote a small benchmark (not included in this PR but it can be if there is interest) to demonstrate the small perf win. Note that ByteArray still takes slightly longer than Span due to more aggressive inlining when using the span methods.

```cs
[MemoryDiagnoser]
public class MergeFromBytes
{
    public static readonly byte[] Serialized = new TestAllTypes
    {
        SingleBool = true,
        SingleBytes = ByteString.CopyFrom(1, 2, 3, 4),
        SingleDouble = 23.5,
        SingleFixed32 = 23,
        SingleFixed64 = 1234567890123,
        SingleFloat = 12.25f,
        SingleForeignEnum = ForeignEnum.ForeignBar,
        SingleForeignMessage = new ForeignMessage { C = 10 },
        SingleImportEnum = ImportEnum.ImportBaz,
        SingleImportMessage = new ImportMessage { D = 20 },
        SingleInt32 = 100,
        SingleInt64 = 3210987654321,
        SingleNestedEnum = TestAllTypes.Types.NestedEnum.Foo,
        SingleNestedMessage = new TestAllTypes.Types.NestedMessage { Bb = 35 },
        SinglePublicImportMessage = new PublicImportMessage { E = 54 },
        SingleSfixed32 = -123,
        SingleSfixed64 = -12345678901234,
        SingleSint32 = -456,
        SingleSint64 = -12345678901235,
        SingleString = "test",
        SingleUint32 = uint.MaxValue,
        SingleUint64 = ulong.MaxValue
    }.ToByteArray();

    [Benchmark]
    public TestAllTypes ByteArray() => TestAllTypes.Parser.ParseFrom(Serialized);

    [Benchmark]
    public TestAllTypes CodedInputStream() => TestAllTypes.Parser.ParseFrom(new CodedInputStream(Serialized));

    [Benchmark]
    public TestAllTypes Span() => TestAllTypes.Parser.ParseFrom(new ReadOnlySpan<byte>(Serialized));
}
```

```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.963)
AMD Ryzen 7 2700X, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.404
  [Host]     : .NET 6.0.12 (6.0.1222.56807), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.12 (6.0.1222.56807), X64 RyuJIT AVX2
```
|           Method |     Mean |   Error |  StdDev |   Gen0 | Allocated |
|----------------- |---------:|--------:|--------:|-------:|----------:|
|        ByteArray | 683.6 ns | 1.59 ns | 1.41 ns | 0.3052 |   1.25 KB |
| CodedInputStream | 748.8 ns | 2.27 ns | 2.01 ns | 0.3462 |   1.41 KB |
|             Span | 663.7 ns | 2.00 ns | 1.87 ns | 0.3052 |   1.25 KB |
