### PR TITLE
chore: fix php lint

### DIFF
--- a/php/src/Google/Protobuf/Internal/AnyBase.php
+++ b/php/src/Google/Protobuf/Internal/AnyBase.php
@@ -50,7 +50,7 @@ class AnyBase extends \Google\Protobuf\Internal\Message
     /**
      * The type_url will be created according to the given message’s type and
      * the value is encoded data from the given message..
-     * @param message: A proto message.
+     * @param Message $msg A proto message.
      */
     public function pack($msg)
     {
@@ -73,7 +73,7 @@ class AnyBase extends \Google\Protobuf\Internal\Message
     /**
      * This method returns whether the type_url in any_message is corresponded
      * to the given class.
-     * @param klass: The fully qualified PHP class name of a proto message type.
+     * @param string $klass The fully qualified PHP class name of a proto message type.
      */
     public function is($klass)
     {

--- a/php/src/Google/Protobuf/Internal/CodedInputStream.php
+++ b/php/src/Google/Protobuf/Internal/CodedInputStream.php
@@ -113,7 +113,7 @@ class CodedInputStream
     /**
      * Read uint32 into $var. Advance buffer with consumed bytes. If the
      * contained varint is larger than 32 bits, discard the high order bits.
-     * @param $var.
+     * @param $var
      */
     public function readVarint32(&$var)
     {
@@ -142,7 +142,7 @@ class CodedInputStream
 
     /**
      * Read Uint64 into $var. Advance buffer with consumed bytes.
-     * @param $var.
+     * @param $var
      */
     public function readVarint64(&$var)
     {
@@ -208,7 +208,7 @@ class CodedInputStream
     /**
      * Read int into $var. If the result is larger than the largest integer, $var
      * will be -1. Advance buffer with consumed bytes.
-     * @param $var.
+     * @param $var
      */
     public function readVarintSizeAsInt(&$var)
     {
@@ -222,7 +222,7 @@ class CodedInputStream
     /**
      * Read 32-bit unsigned integer to $var. If the buffer has less than 4 bytes,
      * return false. Advance buffer with consumed bytes.
-     * @param $var.
+     * @param $var
      */
     public function readLittleEndian32(&$var)
     {
@@ -238,7 +238,7 @@ class CodedInputStream
     /**
      * Read 64-bit unsigned integer to $var. If the buffer has less than 8 bytes,
      * return false. Advance buffer with consumed bytes.
-     * @param $var.
+     * @param $var
      */
     public function readLittleEndian64(&$var)
     {
@@ -261,7 +261,6 @@ class CodedInputStream
 
     /**
      * Read tag into $var. Advance buffer with consumed bytes.
-     * @param $var.
      */
     public function readTag()
     {

--- a/php/src/Google/Protobuf/Internal/MapFieldIter.php
+++ b/php/src/Google/Protobuf/Internal/MapFieldIter.php
@@ -52,9 +52,8 @@ class MapFieldIter implements \Iterator
     /**
      * Create iterator instance for MapField.
      *
-     * @param MapField The MapField instance for which this iterator is
-     * created.
-     * @param GPBType Map key type.
+     * @param array $container
+     * @param GPBType $key_type Map key type.
      * @ignore
      */
     public function __construct($container, $key_type)

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -544,7 +544,7 @@ class Message
 
     /**
      * Clear all containing fields.
-     * @return null.
+     * @return null
      */
     public function clear()
     {
@@ -654,7 +654,7 @@ class Message
 
     /**
      * Clear all unknown fields previously parsed.
-     * @return null.
+     * @return null
      */
     public function discardUnknownFields()
     {
@@ -700,7 +700,7 @@ class Message
      * sub-messages are deep-copied.
      *
      * @param object $msg Protobuf message to be merged from.
-     * @return null.
+     * @return null
      */
     public function mergeFrom($msg)
     {
@@ -767,7 +767,7 @@ class Message
      * specified message.
      *
      * @param string $data Binary protobuf data.
-     * @return null.
+     * @return null
      * @throws \Exception Invalid data.
      */
     public function mergeFromString($data)
@@ -785,7 +785,8 @@ class Message
      * specified message.
      *
      * @param string $data Json protobuf data.
-     * @return null.
+     * @param bool $ignore_unknown
+     * @return null
      * @throws \Exception Invalid data.
      */
     public function mergeFromJsonString($data, $ignore_unknown = false)
@@ -1053,7 +1054,7 @@ class Message
      * must receive data that is either a string or a StringValue object.
      *
      * @param array $array An array containing message properties and values.
-     * @return null.
+     * @return null
      */
     protected function mergeFromArray(array $array)
     {

--- a/php/src/Google/Protobuf/Internal/RepeatedFieldIter.php
+++ b/php/src/Google/Protobuf/Internal/RepeatedFieldIter.php
@@ -56,8 +56,7 @@ class RepeatedFieldIter implements \Iterator
     /**
      * Create iterator instance for RepeatedField.
      *
-     * @param RepeatedField The RepeatedField instance for which this iterator
-     * is created.
+     * @param array $container
      * @ignore
      */
     public function __construct($container)


### PR DESCRIPTION
fixes https://github.com/protocolbuffers/protobuf/issues/11387

Addresses misc PHPDoc formatting issues. 

Note: This does the bare minimum to suppress the errors. In some cases, most notably in `CodedInputStream`, the `@param` tag is still missing a typehint, and should have one added (in those cases, the variable is being passed in as `int`, but then used in the function as `string`, so it will take consideration)