### PR TITLE
Pin to bundler with ruby 2.5 support

### DIFF
--- a/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
+++ b/kokoro/release/ruby/macos/ruby/ruby_build_environment.sh
@@ -21,7 +21,8 @@ set -e  # rvm commands are very verbose
 time rvm install 2.5.0
 rvm use 2.5.0
 gem install rake-compiler --no-document
-gem install bundler --no-document
+# Pin to bundler with ruby 2.5 support
+gem install bundler -v 2.3.26 --no-document
 time rvm install 3.1.0
 rvm use 3.1.0
 gem install rake-compiler --no-document

--- a/ruby/travis-test.sh
+++ b/ruby/travis-test.sh
@@ -13,7 +13,8 @@ test_version() {
       "rvm install $version && rvm use $version && rvm get head && \
        which ruby && \
        git clean -f && \
-       gem install --no-document bundler && bundle && \
+       gem install --no-document bundler -v 2.3.26 && \ # Pin to bundler with ruby 2.5 support
+       bundle && \
        rake test && \
        rake gc_test && \
        cd ../conformance && make test_jruby && \


### PR DESCRIPTION
The newest bundler that is auto installed doesn't have ruby 2.5, this should fix failing presubmit/CI tests.