### PR TITLE
fix warning in zlib when building with emscripten

### DIFF
--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -61,7 +61,8 @@ cc_library(
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [
             "-Wno-unused-variable",
-            "-Wno-implicit-function-declaration",
+            "-Wno-implicit-function-declaration", 
+            "-Wno-deprecated-non-prototype",
         ],
     }),
     includes = ["zlib/include/"],


### PR DESCRIPTION
Fixes the following error in zlib when building with emscripten:

```
external/zlib/adler32.c:63:15: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
uLong ZEXPORT adler32_z(adler, buf, len)
              ^
```

You can find the working branch that builds protoc with emscripten here:
https://github.com/archpaleus/protobuf/tree/emscripten