### PR TITLE
Ignore intentional integer overflow

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -810,7 +810,11 @@ class KeyMapBase {
   }
 
   template <typename K>
-  size_type BucketNumber(const K& k) const {
+  size_type
+  #if defined(__clang__)
+  __attribute__((no_sanitize("unsigned-integer-overflow")))
+  #endif
+  BucketNumber(const K& k) const {
     // We xor the hash value against the random seed so that we effectively
     // have a random hash function.
     uint64_t h = hash_function()(k) ^ seed_;


### PR DESCRIPTION
Clang's unsigned integer overflow sanitizer is flagging BucketNumber as having an overflow. This seems to be intentional, and we should disable the sanitizer for this function.