### PR TITLE
Use forward slash instead of backslash in nuspec file

### DIFF
--- a/csharp/Google.Protobuf.Tools.nuspec
+++ b/csharp/Google.Protobuf.Tools.nuspec
@@ -16,22 +16,22 @@
     <tags>Protocol Buffers Binary Serialization Format Google proto proto3</tags>
   </metadata>
   <files>
-    <file src="protoc\windows_x86\protoc.exe" target="tools\windows_x86\protoc.exe"/>
-    <file src="protoc\windows_x64\protoc.exe" target="tools\windows_x64\protoc.exe"/>
-    <file src="protoc\linux_x86\protoc" target="tools\linux_x86\protoc"/>
-    <file src="protoc\linux_x64\protoc" target="tools\linux_x64\protoc"/>
-    <file src="protoc\macosx_x64\protoc" target="tools\macosx_x64\protoc"/>
-    <file src="..\src\google\protobuf\any.proto" target="tools\google\protobuf"/>
-    <file src="..\src\google\protobuf\api.proto" target="tools\google\protobuf"/>
-    <file src="..\src\google\protobuf\descriptor.proto" target="tools\google\protobuf"/>
-    <file src="..\src\google\protobuf\duration.proto" target="tools\google\protobuf"/>
-    <file src="..\src\google\protobuf\empty.proto" target="tools\google\protobuf"/>
-    <file src="..\src\google\protobuf\field_mask.proto" target="tools\google\protobuf"/>
-    <file src="..\src\google\protobuf\source_context.proto" target="tools\google\protobuf"/>
-    <file src="..\src\google\protobuf\struct.proto" target="tools\google\protobuf"/>
-    <file src="..\src\google\protobuf\timestamp.proto" target="tools\google\protobuf"/>
-    <file src="..\src\google\protobuf\type.proto" target="tools\google\protobuf"/>
-    <file src="..\src\google\protobuf\wrappers.proto" target="tools\google\protobuf"/>
+    <file src="protoc/windows_x86/protoc.exe" target="tools/windows_x86/protoc.exe"/>
+    <file src="protoc/windows_x64/protoc.exe" target="tools/windows_x64/protoc.exe"/>
+    <file src="protoc/linux_x86/protoc" target="tools/linux_x86/protoc"/>
+    <file src="protoc/linux_x64/protoc" target="tools/linux_x64/protoc"/>
+    <file src="protoc/macosx_x64/protoc" target="tools/macosx_x64/protoc"/>
+    <file src="../src/google/protobuf/any.proto" target="tools/google/protobuf"/>
+    <file src="../src/google/protobuf/api.proto" target="tools/google/protobuf"/>
+    <file src="../src/google/protobuf/descriptor.proto" target="tools/google/protobuf"/>
+    <file src="../src/google/protobuf/duration.proto" target="tools/google/protobuf"/>
+    <file src="../src/google/protobuf/empty.proto" target="tools/google/protobuf"/>
+    <file src="../src/google/protobuf/field_mask.proto" target="tools/google/protobuf"/>
+    <file src="../src/google/protobuf/source_context.proto" target="tools/google/protobuf"/>
+    <file src="../src/google/protobuf/struct.proto" target="tools/google/protobuf"/>
+    <file src="../src/google/protobuf/timestamp.proto" target="tools/google/protobuf"/>
+    <file src="../src/google/protobuf/type.proto" target="tools/google/protobuf"/>
+    <file src="../src/google/protobuf/wrappers.proto" target="tools/google/protobuf"/>
     <file src="Google.Protobuf.Tools.targets" target="buildCrossTargeting"/>
     <file src="Google.Protobuf.Tools.targets" target="build"/>
   </files>


### PR DESCRIPTION
We are going to pack this on a linux machine now, so we need to use forward slashes.