### PR TITLE
fix: php 8.2 dynamic property warning in MapFieldIter

### DIFF
--- a/php/src/Google/Protobuf/Internal/MapFieldIter.php
+++ b/php/src/Google/Protobuf/Internal/MapFieldIter.php
@@ -50,6 +50,11 @@ class MapFieldIter implements \Iterator
     private $container;
 
     /**
+     * @ignore
+     */
+    private $key_type;
+
+    /**
      * Create iterator instance for MapField.
      *
      * @param array $container


### PR DESCRIPTION
addresses #11452
addresses #11243

Defines `$key_type`, so as not to trigger PHP 8.2 warning. Note that this will change the visibility of `$key_type` from public in previous versions to private in this version. This is a breaking change, but anyone using `$key_type` in this way is misusing the library, so I think it's acceptable. 