### PR TITLE
Add explicit abort() at the end of AlignFail (Backports #10188)

### DIFF
--- a/src/google/protobuf/generated_message_tctable_impl.h
+++ b/src/google/protobuf/generated_message_tctable_impl.h
@@ -32,6 +32,7 @@
 #define GOOGLE_PROTOBUF_GENERATED_MESSAGE_TCTABLE_IMPL_H__
 
 #include <cstdint>
+#include <cstdlib>
 #include <type_traits>
 
 #include <google/protobuf/parse_context.h>
@@ -100,6 +101,9 @@ template <size_t align>
 #endif
 void AlignFail(uintptr_t address) {
   GOOGLE_LOG(FATAL) << "Unaligned (" << align << ") access at " << address;
+  // This abort() is unreachable; it is only here to silence compiler warnings
+  // that do not know that FATAL always terminates the program.
+  abort();
 }
 
 extern template void AlignFail<4>(uintptr_t);


### PR DESCRIPTION
GCC cannot infer that `LogMessage::Finish()` (called indirectly by `GOOGLE_LOG(FAIL)` in `AlignFail`) exits program when `level_ == LOGLEVEL_FATAL`. Compilation will create a warning in projects importing the library for debug builds. The attribute cannot be individually assigned to `LogMessage::Finish()` because it does return conditionally of the log level. Tried with GCC 9.3.0 and GCC 12.1.0.

This change adds an explicit abort() for compiler to clearly understand this does not return, and enables `[[noreturn]]` for MSVC as well.

Cherry-picked from: 1e9d43fe711b46bcb9bb82849d495f137c9d1ef8
Backports PR-#10188 from 74abfe447