### PR TITLE
Added functionality for Dynamic Messaging in C#

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Reflection/DynamicMessageTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Reflection/DynamicMessageTest.cs
@@ -1,0 +1,306 @@
+﻿using Google.Protobuf.TestProtos;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Google.Protobuf.Reflection
+{
+    public class DynamicMessageTest
+    {
+
+
+
+        [Test]
+        public void TestDynamicMessageUsage()
+        {
+            string fileName = "testFile.txt";
+            MessageDescriptor desc = TestAllTypes.Descriptor;
+
+            //create 
+            DynamicMessage dm = new DynamicMessage(desc);
+            dm.Add("single_string", "sss");
+            //serialize
+            //Stream output = WriteTo(dm);
+            using (var output = File.Create(fileName))
+            {
+                dm.WriteTo(output);
+            }
+            //deserialize
+            DynamicMessage deserializedDm;
+            DynamicMessage tempdm = new DynamicMessage(desc);
+            using (var input = File.OpenRead(fileName))
+            {
+                deserializedDm = (DynamicMessage) tempdm.Parser.ParseFrom(input);
+            }
+
+        }
+
+
+        [Test]
+        public void TestDynamicMessageParsingSingleString()
+        {
+            string val = "str1";
+            TestAllTypes msg = new()
+            {
+                SingleString = val
+            };
+
+            ByteString byteStr = msg.ToByteString();
+            MessageDescriptor desc = TestAllTypes.Descriptor;
+            FieldDescriptor fd = desc.FindFieldByName("single_string");
+            DynamicMessage res = ParseFrom(desc, byteStr);
+            Assert.NotNull(res);
+            Assert.AreEqual(val, res.FieldSet.GetField(fd));
+        }
+
+        public DynamicMessage ParseFrom(MessageDescriptor type, ByteString data)
+        {
+            DynamicMessage dynMsg = new DynamicMessage(type);
+            dynMsg = (DynamicMessage) dynMsg.Parser.ParseFrom(data);
+            return dynMsg;
+        }
+
+        [Test]
+        public void TestDynamicMessageParseFromAllTypes()
+        {
+            TestAllTypes message = GetAllTypesMessage();
+            MessageDescriptor desc = TestAllTypes.Descriptor;
+            ByteString byteStr = message.ToByteString();
+            DynamicMessage res = ParseFrom(desc, byteStr);
+            Assertions(desc, res);
+        }
+
+        [Test]
+        public void TestDynamicMessageWriteTo()
+        {
+            MessageDescriptor desc = TestAllTypes.Descriptor;
+            DynamicMessage dm = new DynamicMessage(desc);
+            string fieldName = "single_string";
+            string fieldValue = "sss";
+            dm.Add(fieldName, fieldValue);
+
+            Stream stream = WriteTo(dm);
+
+            var input = new CodedInputStream(stream);
+            int fieldNumber = WireFormat.GetTagFieldNumber(input.ReadTag());
+            Assert.AreEqual(desc.FindFieldByNumber(fieldNumber).Name, fieldName);
+            Assert.AreEqual(fieldValue, input.ReadString());
+        }
+
+
+
+        [Test]
+        public void TestDynamicMessageSetterRejectsNull()
+        {
+            MessageDescriptor desc = TestAllTypes.Descriptor;
+            DynamicMessage dm = new DynamicMessage(desc);
+            var exc = Assert.Throws<ArgumentNullException>(() => dm.FieldSet.SetField(desc.FindFieldByName("single_string"), null));
+            Assert.That(exc.ParamName, Is.EqualTo("single_string"));
+        }
+
+        [Test]
+        public void TestDynamicMessageSerializedSize()
+        {
+            var message = GetAllTypesMessage();
+            MessageDescriptor desc = TestAllTypes.Descriptor;
+            ByteString byteStr = message.ToByteString();
+            DynamicMessage dm = ParseFrom(desc, byteStr);
+            Assert.AreEqual(1386, dm.CalculateSize());
+        }
+
+
+        [Test]
+        public void TestUnknownField()
+        {
+
+            TestAllTypes testAllTypes = new TestAllTypes
+            {
+                SingleString = "test"
+            };
+
+            var fdProto = new FieldDescriptorProto()
+            {
+                Name = "single_string2",
+                Type = FieldDescriptorProto.Types.Type.String,
+                Number = 1,
+                Label = FieldDescriptorProto.Types.Label.Optional
+
+            };
+            List<FieldDescriptorProto> fields = new List<FieldDescriptorProto>();
+            fields.Add(fdProto);
+            MessageDescriptor desc = GetMessageDescriptor("Test", fields);
+
+            DynamicMessage dm = (DynamicMessage) new DynamicMessage(desc).Parser.ParseFrom(testAllTypes.ToByteArray());
+
+            Stream stream = WriteTo(dm);
+
+            var input = new CodedInputStream(stream);
+            uint tag = input.ReadTag();
+            int fieldNumber = WireFormat.GetTagFieldNumber(tag);
+            Assert.AreEqual(fieldNumber, 14);
+            Assert.AreEqual("test", input.ReadString());
+        }
+
+
+        private static MessageDescriptor GetMessageDescriptor(string baseFieldName, List<FieldDescriptorProto> fields)
+        {
+            var fileDescProto = new FileDescriptorProto();
+            fileDescProto.Name = baseFieldName;
+            var descP = new DescriptorProto();
+            descP.Name = baseFieldName;
+            foreach (FieldDescriptorProto fdProto in fields)
+            {
+                descP.Field.Add(fdProto);
+            }
+            fileDescProto.MessageType.Add(descP);
+            return ConvertToDescriptor(fileDescProto, baseFieldName);
+        }
+        private static MessageDescriptor ConvertToDescriptor(FileDescriptorProto fileDescProto, string baseFieldName)
+        {
+            var fileDescSet = new FileDescriptorSet();
+            fileDescSet.File.Add(fileDescProto);
+            var byteStrings = fileDescSet.File.Select(f => f.ToByteString()).ToList();
+            IReadOnlyList<FileDescriptor> descriptors = FileDescriptor.BuildFromByteStrings(byteStrings);
+            //In the descriptors only 1 element is added.
+            return descriptors.First().FindTypeByName<MessageDescriptor>(baseFieldName);
+        }
+
+        private static Stream WriteTo(DynamicMessage dm)
+        {
+            var stream = new MemoryStream();
+            var output = new CodedOutputStream(stream);
+            dm.WriteTo(output);
+            output.Flush();
+            stream.Position = 0;// TODO check if reqd
+            return stream;
+        }
+
+        private static TestAllTypes GetAllTypesMessage()
+        {
+            return new TestAllTypes
+            {
+                SingleBool = true,
+                SingleBytes = ByteString.CopyFrom(1, 2, 3, 4),
+                SingleDouble = 23.5,
+                SingleFixed32 = 23,
+                SingleFixed64 = 1234567890123,
+                SingleFloat = 12.25f,
+                SingleForeignEnum = ForeignEnum.ForeignBar,
+                SingleForeignMessage = new ForeignMessage { C = 10 },
+                SingleImportEnum = ImportEnum.ImportBaz,
+                SingleImportMessage = new ImportMessage { D = 20 },
+                SingleInt32 = 100,
+                SingleInt64 = 3210987654321,
+                SingleNestedEnum = TestAllTypes.Types.NestedEnum.Foo,
+                SingleNestedMessage = new TestAllTypes.Types.NestedMessage { Bb = 35 },
+                SinglePublicImportMessage = new PublicImportMessage { E = 54 },
+                SingleSfixed32 = -123,
+                SingleSfixed64 = -12345678901234,
+                SingleSint32 = -456,
+                SingleSint64 = -12345678901235,
+                SingleString = "test",
+                SingleUint32 = UInt32.MaxValue,
+                SingleUint64 = UInt64.MaxValue,
+                RepeatedBytes = { ByteString.CopyFrom(1, 2, 3, 4), ByteString.CopyFrom(5, 6), ByteString.CopyFrom(new byte[1000]) },
+                RepeatedForeignMessage = { new ForeignMessage(), new ForeignMessage { C = 10 } },
+                RepeatedImportMessage = { new ImportMessage { D = 20 }, new ImportMessage { D = 25 } },
+                RepeatedNestedMessage = { new TestAllTypes.Types.NestedMessage { Bb = 35 }, new TestAllTypes.Types.NestedMessage { Bb = 10 } },
+                RepeatedPublicImportMessage = { new PublicImportMessage { E = 54 }, new PublicImportMessage { E = -1 } },
+                RepeatedString = { "foo", "bar" },
+                OneofString = "Oneof string",
+                RepeatedBool = { true, false },
+                RepeatedSfixed32 = { -123, 123 },
+                RepeatedSfixed64 = { -12345678901234, 12345678901234 },
+                RepeatedSint32 = { -456, 100 },
+                RepeatedSint64 = { -12345678901235, 123 },
+                RepeatedInt32 = { 100, 200 },
+                RepeatedInt64 = { 3210987654321, Int64.MaxValue },
+                RepeatedDouble = { -12.25, 23.5 },
+                RepeatedFixed32 = { UInt32.MaxValue, 23 },
+                RepeatedFixed64 = { UInt64.MaxValue, 1234567890123 },
+                RepeatedFloat = { 100f, 12.25f },
+                RepeatedUint32 = { UInt32.MaxValue, UInt32.MinValue },
+                RepeatedUint64 = { UInt64.MaxValue, UInt64.MinValue }
+            };
+        }
+
+        private static void Assertions(MessageDescriptor desc, DynamicMessage res)
+        {
+            Assert.NotNull(res);
+            Assert.AreEqual("test", GetField(desc, res, "single_string"));
+            Assert.AreEqual(100, GetField(desc, res, "repeated_int32[0]"));
+            Assert.AreEqual(4294967295, GetField(desc, res, "repeated_fixed32[0]"));
+            Assert.AreEqual(10, GetField(desc, res, "single_foreign_message.c"));
+            Assert.AreEqual(20, GetField(desc, res, "single_import_message.d"));
+            Assert.AreEqual((int) TestAllTypes.Types.NestedEnum.Foo, GetField(desc, res, "single_nested_enum"));
+            Assert.AreEqual(54, GetField(desc, res, "single_public_import_message.e"));
+            Assert.AreEqual((int) ForeignEnum.ForeignBar, GetField(desc, res, "single_foreign_enum"));
+            Assert.AreEqual(ByteString.CopyFrom(1, 2, 3, 4), GetField(desc, res, "repeated_bytes[0]"));
+            Assert.AreEqual(ByteString.CopyFrom(5, 6), GetField(desc, res, "repeated_bytes[1]"));
+            Assert.AreEqual(10, GetField(desc, res, "repeated_foreign_message[1].c"));
+            Assert.AreEqual(null, GetField(desc, res, "repeated_foreign_message[0].c"));
+            Assert.AreEqual(10, GetField(desc, res, "repeated_foreign_message[1].c"));
+            Assert.AreEqual(20, GetField(desc, res, "repeated_import_message[0].d"));
+            Assert.AreEqual(25, GetField(desc, res, "repeated_import_message[1].d"));
+            Assert.AreEqual(35, GetField(desc, res, "repeated_nested_message[0].bb"));
+            Assert.AreEqual(10, GetField(desc, res, "repeated_nested_message[1].bb"));
+            Assert.AreEqual(54, GetField(desc, res, "repeated_public_import_message[0].e"));
+            Assert.AreEqual(-1, GetField(desc, res, "repeated_public_import_message[1].e"));
+            Assert.AreEqual("foo", GetField(desc, res, "repeated_string[0]"));
+            Assert.AreEqual("bar", GetField(desc, res, "repeated_string[1]"));
+            Assert.AreEqual("Oneof string", GetField(desc, res, "oneof_string"));
+            Assert.AreEqual(UInt64.MaxValue, GetField(desc, res, "repeated_fixed64[0]"));
+            Assert.AreEqual(1234567890123, GetField(desc, res, "repeated_fixed64[1]"));
+            Assert.AreEqual(100f, GetField(desc, res, "repeated_float[0]"));
+            Assert.AreEqual(12.25f, GetField(desc, res, "repeated_float[1]"));
+            Assert.AreEqual(UInt32.MaxValue, GetField(desc, res, "repeated_uint32[0]"));
+            Assert.AreEqual(UInt32.MinValue, GetField(desc, res, "repeated_uint32[1]"));
+            Assert.AreEqual(UInt64.MaxValue, GetField(desc, res, "repeated_uint64[0]"));
+            Assert.AreEqual(UInt64.MinValue, GetField(desc, res, "repeated_uint64[1]"));
+        }
+
+        private static object GetField(MessageDescriptor desc, DynamicMessage dm, String fieldFullName)
+        {
+            if (!fieldFullName.Contains(".") && !fieldFullName.Contains("["))
+            {
+                return dm.FieldSet.GetField(desc.FindFieldByName(fieldFullName));
+            }
+            else if (fieldFullName.Contains("[") && !fieldFullName.Contains("."))
+            {
+                string fieldName = fieldFullName.Substring(0, fieldFullName.IndexOf("["));
+                int index = int.Parse(fieldFullName.Substring(fieldFullName.IndexOf("[") + 1, 1));
+                List<object> list = (List<object>) GetField(desc, dm, fieldName);
+                Assert.NotNull(list);
+                return list[index];
+            }
+            else
+            {
+                string[] fields = fieldFullName.Split('.');
+                DynamicMessage tempDm = dm;
+                MessageDescriptor tempDesc = desc;
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    string field = fields[i];
+
+                    if (i == fields.Length - 1)
+                        return GetField(tempDesc, tempDm, field);
+                    else
+                    {
+                        tempDm = (DynamicMessage) GetField(tempDesc, tempDm, field);
+                        string tempField = field;
+                        if (field.Contains("["))
+                        {
+                            tempField = field.Substring(0, field.IndexOf("["));
+                        }
+                        tempDesc = tempDesc.FindFieldByName(tempField).MessageType;
+                    }
+
+                }
+            }
+            return null;
+        }
+
+    }
+}

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <!-- If you update this, update the .csproj in the Docker file as well -->
 
   <PropertyGroup>
     <Description>C# runtime library for Protocol Buffers - Google's data interchange format.</Description>
     <Copyright>Copyright 2015, Google Inc.</Copyright>
     <AssemblyTitle>Google Protocol Buffers</AssemblyTitle>
-    <VersionPrefix>3.21.12</VersionPrefix>
+    <VersionPrefix>3.21.13</VersionPrefix>
     <LangVersion>10.0</LangVersion>
     <Authors>Google Inc.</Authors>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net45;net50</TargetFrameworks>

--- a/csharp/src/Google.Protobuf/Reflection/DynamicMessage.cs
+++ b/csharp/src/Google.Protobuf/Reflection/DynamicMessage.cs
@@ -1,0 +1,322 @@
+﻿using Google.Protobuf.Collections;
+using System;
+using System.Collections;
+
+namespace Google.Protobuf.Reflection
+{
+
+    /// <summary>
+    /// An implementation of IMessage that can represent arbitrary types, given a MessageaDescriptor.
+    /// </summary>
+    public sealed partial class DynamicMessage : IMessage<DynamicMessage>
+    {
+
+        private readonly MessageParser<DynamicMessage> _parser = null;
+        private FieldSet _fieldSet = FieldSet.CreateInstance();
+        private UnknownFieldSet _unknownFields = new UnknownFieldSet();
+        private readonly MessageDescriptor _descriptor = null;
+
+        /// <summary>
+        /// Properties for parsing.
+        /// </summary> 
+        public MessageParser<DynamicMessage> Parser { get { return _parser; } }
+
+        /// <summary>
+        /// The default const being replaced with this one.
+        /// The constructor takes in message descriptor.
+        /// </summary>
+        /// <param name="descriptor"></param>
+        public DynamicMessage(MessageDescriptor descriptor)
+        {
+            _descriptor = descriptor;
+            _parser = new MessageParser<DynamicMessage>(() => new DynamicMessage(descriptor));
+            OnConstruction();
+        }
+
+        partial void OnConstruction();
+
+        /// <summary>
+        /// The FieldSet reference
+        /// </summary>
+        public FieldSet FieldSet => _fieldSet;
+
+        /// <summary>
+        /// Descriptor for this message.
+        /// </summary>
+        MessageDescriptor IMessage.Descriptor { get { return _descriptor; } }
+
+        /// <summary>
+        /// Used to calculate the size of the serialized message.
+        /// </summary>
+        /// <returns></returns>
+        public int CalculateSize()
+        {
+            int size = _fieldSet.GetSerializedSize();
+            if (_unknownFields != null)
+            {
+                size += _unknownFields.CalculateSize();
+            }
+            return size;
+        }
+
+        /// <summary>
+        /// Merges content from input into current DynamicMessage
+        /// </summary>
+        /// <param name="input"></param>
+        public void MergeFrom(CodedInputStream input)
+        {
+            uint tag;
+            while ((tag = input.ReadTag()) != 0)
+            {
+                int fieldNumber = WireFormat.GetTagFieldNumber(tag);
+                FieldDescriptor fd = _descriptor.FindFieldByNumber(fieldNumber);
+
+                if (fd == null)
+                {
+                    _unknownFields = UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+                }
+                else if (fd.FieldType == FieldType.Message)
+                {
+                    MergeFromMessageTypeField(input, fd);
+                }
+                else
+                {
+                    MergeFromPrimitiveTypeField(input, tag, fd);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Writes the message to CodedOutputStream.
+        /// </summary>
+        /// <param name="output"></param>
+        public void WriteTo(CodedOutputStream output)
+        {
+            _fieldSet.WriteTo(output);
+            _unknownFields?.WriteTo(output);
+        }
+
+        /// <summary>
+        /// Merges other DynamicMessage into current one.
+        /// </summary>
+        /// <param name="message"></param>
+        public void MergeFrom(DynamicMessage message)
+        {
+            if (message == null)
+                return;
+            _fieldSet.Merge(message._fieldSet);
+            _unknownFields = UnknownFieldSet.MergeFrom(_unknownFields, message._unknownFields);
+        }
+
+        /// <summary>
+        /// Compares for equality
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool Equals(DynamicMessage other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            if (ReferenceEquals(other, this))
+            {
+                return true;
+            }
+            if (!Equals(_fieldSet, other._fieldSet)) return false;
+            return Equals(_unknownFields, other._unknownFields);
+        }
+
+        /// <summary>
+        /// Clone a DynamicMessage
+        /// </summary>
+        /// <returns></returns>
+        public DynamicMessage Clone()
+        {
+            return new DynamicMessage(_descriptor)
+            {
+                _fieldSet = this._fieldSet.Clone(),
+                _unknownFields = UnknownFieldSet.Clone(this._unknownFields)
+            };
+        }
+
+        /// <summary>
+        /// To add a field to DynamicMessage
+        /// </summary>
+        /// <param name="fieldName"></param>
+        /// <param name="v"></param>
+        /// <exception cref="Exception"></exception>
+        public void Add(String fieldName, object v)
+        {
+            FieldDescriptor fieldDescriptor = _descriptor.FindFieldByName(fieldName);
+            if (fieldDescriptor == null)
+            {
+                throw new Exception("unknown field not supported by this version of the method");
+            }
+            else if (fieldDescriptor.IsRepeated)
+            {
+                _fieldSet.AddRepeatedField(fieldDescriptor, v);
+            }
+            else
+            {
+                _fieldSet.SetField(fieldDescriptor, v);
+            }
+        }
+
+        private void MergeFromPrimitiveTypeField(CodedInputStream input, uint tag, FieldDescriptor fd)
+        {
+            if (fd.ToProto().Label != FieldDescriptorProto.Types.Label.Repeated)
+            {
+                object value = ReadField(fd.FieldType, input);
+                _fieldSet.SetField(fd, value);
+            }
+            else
+            {
+                IEnumerator enumerator = GetFieldCodec(tag, fd.FieldType, input);
+                while (enumerator.MoveNext())
+                {
+                    _fieldSet.AddRepeatedField(fd, enumerator.Current);
+                }
+            }
+
+        }
+
+        private void MergeFromMessageTypeField(CodedInputStream input, FieldDescriptor fd)
+        {
+            DynamicMessage value = new DynamicMessage(fd.MessageType);
+            input.ReadMessage(value);
+            if (fd.ToProto().Label != FieldDescriptorProto.Types.Label.Repeated)
+            {
+                _fieldSet.SetField(fd, value);
+            }
+            else
+            {
+                _fieldSet.AddRepeatedField(fd, value);
+            }
+        }
+
+        /// <summary>
+        /// Reads the field from the CodedInputStream, based on the fieldType and returns it.
+        /// </summary>
+        /// <param name="fieldType"></param>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        private object ReadField(FieldType fieldType, CodedInputStream input)
+        {
+            switch (fieldType)
+            {
+                case FieldType.Int32:
+                    return input.ReadInt32();
+                case FieldType.Int64:
+                    return input.ReadInt64();
+                case FieldType.Bytes:
+                    return input.ReadBytes();
+                case FieldType.String:
+                    return input.ReadString();
+                case FieldType.Double:
+                    return input.ReadDouble();
+                case FieldType.Float:
+                    return input.ReadFloat();
+                case FieldType.Bool:
+                    return input.ReadBool();
+                case FieldType.UInt32:
+                    return input.ReadUInt32();
+                case FieldType.UInt64:
+                    return input.ReadUInt64();
+                case FieldType.Fixed32:
+                    return input.ReadFixed32();
+                case FieldType.Fixed64:
+                    return input.ReadFixed64();
+                case FieldType.SFixed64:
+                    return input.ReadSFixed64();
+                case FieldType.SFixed32:
+                    return input.ReadSFixed32();
+                case FieldType.SInt32:
+                    return input.ReadSInt32();
+                case FieldType.SInt64:
+                    return input.ReadSInt64();
+                case FieldType.Enum:
+                    return input.ReadEnum();
+            }
+            throw new Exception("FieldType:" + fieldType + ", not handled while reading field.");
+        }
+
+        /// <summary>
+        /// Used for repeated fields to get enumerator.
+        /// Based on the fieldType, creates Repeated field, adds entries from CodedInputStrem to repeatedField and returns enumerator on the repeated field.
+        /// </summary>
+        /// <param name="tag"></param>
+        /// <param name="fieldType"></param>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        private IEnumerator GetFieldCodec(uint tag, FieldType fieldType, CodedInputStream input)
+        {
+            switch (fieldType)
+            {
+                case FieldType.Int32:
+                    RepeatedField<int> rf = new RepeatedField<int>();
+                    rf.AddEntriesFrom(input, FieldCodec.ForInt32(tag));
+                    return rf.GetEnumerator();
+                case FieldType.Int64:
+                    RepeatedField<long> rf1 = new RepeatedField<long>();
+                    rf1.AddEntriesFrom(input, FieldCodec.ForInt64(tag));
+                    return rf1.GetEnumerator();
+                case FieldType.Bool:
+                    RepeatedField<bool> rfBool = new RepeatedField<bool>();
+                    rfBool.AddEntriesFrom(input, FieldCodec.ForBool(tag));
+                    return rfBool.GetEnumerator();
+                case FieldType.UInt32:
+                    RepeatedField<uint> rfUint = new RepeatedField<uint>();
+                    rfUint.AddEntriesFrom(input, FieldCodec.ForUInt32(tag));
+                    return rfUint.GetEnumerator();
+                case FieldType.UInt64:
+                    RepeatedField<ulong> rfUint64 = new RepeatedField<ulong>();
+                    rfUint64.AddEntriesFrom(input, FieldCodec.ForUInt64(tag));
+                    return rfUint64.GetEnumerator();
+                case FieldType.SInt32:
+                    RepeatedField<int> rfSint32 = new RepeatedField<int>();
+                    rfSint32.AddEntriesFrom(input, FieldCodec.ForSInt32(tag));
+                    return rfSint32.GetEnumerator();
+                case FieldType.SInt64:
+                    RepeatedField<long> rfSint64 = new RepeatedField<long>();
+                    rfSint64.AddEntriesFrom(input, FieldCodec.ForSInt64(tag));
+                    return rfSint64.GetEnumerator();
+                case FieldType.Fixed32:
+                    RepeatedField<uint> rfFixed32 = new RepeatedField<uint>();
+                    rfFixed32.AddEntriesFrom(input, FieldCodec.ForFixed32(tag));
+                    return rfFixed32.GetEnumerator();
+                case FieldType.Fixed64:
+                    RepeatedField<ulong> rfFixed64 = new RepeatedField<ulong>();
+                    rfFixed64.AddEntriesFrom(input, FieldCodec.ForFixed64(tag));
+                    return rfFixed64.GetEnumerator();
+                case FieldType.SFixed32:
+                    RepeatedField<int> rfSFixed32 = new RepeatedField<int>();
+                    rfSFixed32.AddEntriesFrom(input, FieldCodec.ForSFixed32(tag));
+                    return rfSFixed32.GetEnumerator();
+                case FieldType.SFixed64:
+                    RepeatedField<long> rfSFixed64 = new RepeatedField<long>();
+                    rfSFixed64.AddEntriesFrom(input, FieldCodec.ForSFixed64(tag));
+                    return rfSFixed64.GetEnumerator();
+                case FieldType.Float:
+                    RepeatedField<float> rfFloat = new RepeatedField<float>();
+                    rfFloat.AddEntriesFrom(input, FieldCodec.ForFloat(tag));
+                    return rfFloat.GetEnumerator();
+                case FieldType.Double:
+                    RepeatedField<double> rfDouble = new RepeatedField<double>();
+                    rfDouble.AddEntriesFrom(input, FieldCodec.ForDouble(tag));
+                    return rfDouble.GetEnumerator();
+                case FieldType.String:
+                    RepeatedField<string> rfString = new RepeatedField<string>();
+                    rfString.AddEntriesFrom(input, FieldCodec.ForString(tag));
+                    return rfString.GetEnumerator();
+                case FieldType.Bytes:
+                    RepeatedField<ByteString> rfBytes = new RepeatedField<ByteString>();
+                    rfBytes.AddEntriesFrom(input, FieldCodec.ForBytes(tag));
+                    return rfBytes.GetEnumerator();
+            }
+            throw new Exception("FieldType:" + fieldType + ", not handled in GetFieldCodec method.");
+        }
+
+
+    }
+}

--- a/csharp/src/Google.Protobuf/Reflection/FieldSet.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldSet.cs
@@ -1,0 +1,390 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Google.Protobuf.Reflection
+{
+    /// <summary>
+    /// Class used to hold collection of FieldDescriptor and value mapping.
+    /// </summary>
+    public sealed class FieldSet : IEquatable<FieldSet>, IDeepCloneable<FieldSet>
+    {
+
+        private readonly IDictionary<FieldDescriptor, object> fields;
+
+        private IDictionary<FieldDescriptor, object> Fields => fields;
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <returns></returns>
+        internal static FieldSet CreateInstance()
+        {
+            return new FieldSet(new Dictionary<FieldDescriptor, object>());
+        }
+
+        private FieldSet(IDictionary<FieldDescriptor, object> fields)
+        {
+            this.fields = fields;
+        }
+
+        /// <summary>
+        /// Returns the serialized size.
+        /// </summary>
+        /// <returns></returns>
+        internal int GetSerializedSize()
+        {
+            int size = 0;
+            foreach (KeyValuePair<FieldDescriptor, object> kvPair in fields)
+            {
+                size += ComputeSize(kvPair.Key, kvPair.Value);
+            }
+            return size;
+        }
+
+        /// <summary>
+        /// Computes the size of the field. The computation varies if the field is repeated.
+        /// </summary>
+        /// <param name="desc"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private int ComputeSize(FieldDescriptor desc, object value)
+        {
+            if (desc.IsRepeated)
+            {
+                int dataSize = 0;
+                int tagSize = CodedOutputStream.ComputeTagSize(desc.FieldNumber);
+                foreach (object val in (IEnumerable) value)
+                {
+                    dataSize += ComputeElementSizeNoTag(desc.FieldType, val) + tagSize;
+                }
+                return dataSize;
+            }
+            else
+            {
+                return ComputeElementSize(desc.FieldType, desc.FieldNumber, value);
+            }
+
+        }
+
+        /// <summary>
+        /// Computes the total size of the filed, along with its tag.
+        /// </summary>
+        /// <param name="fieldType"></param>
+        /// <param name="fieldNumber"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private int ComputeElementSize(FieldType fieldType, int fieldNumber, object value)
+        {
+            int tagSize = CodedOutputStream.ComputeTagSize(fieldNumber);
+            return tagSize + ComputeElementSizeNoTag(fieldType, value);
+        }
+
+        /// <summary>
+        /// Computes the size of the field without tag.
+        /// </summary>
+        /// <param name="fieldType"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        private int ComputeElementSizeNoTag(FieldType fieldType, object value)
+        {
+            switch (fieldType)
+            {
+                case FieldType.String:
+                    return CodedOutputStream.ComputeStringSize(value.ToString());
+                case FieldType.Bool:
+                    return CodedOutputStream.ComputeBoolSize((bool) value);
+                case FieldType.Int32:
+                    return CodedOutputStream.ComputeInt32Size((int) value);
+                case FieldType.Int64:
+                    return CodedOutputStream.ComputeInt64Size((long) value);
+                case FieldType.Double:
+                    return CodedOutputStream.ComputeDoubleSize((double) value);
+                case FieldType.Float:
+                    return CodedOutputStream.ComputeFloatSize((float) value);
+                case FieldType.Bytes:
+                    return CodedOutputStream.ComputeBytesSize((ByteString) value);
+                case FieldType.UInt32:
+                    return CodedOutputStream.ComputeUInt32Size((uint) value);
+                case FieldType.UInt64:
+                    return CodedOutputStream.ComputeUInt64Size((ulong) value);
+                case FieldType.SInt32:
+                    return CodedOutputStream.ComputeSInt32Size((int) value);
+                case FieldType.SInt64:
+                    return CodedOutputStream.ComputeSInt64Size((long) value);
+                case FieldType.Fixed32:
+                    return CodedOutputStream.ComputeFixed32Size((uint) value);
+                case FieldType.Fixed64:
+                    return CodedOutputStream.ComputeFixed64Size((ulong) value);
+                case FieldType.SFixed32:
+                    return CodedOutputStream.ComputeSFixed32Size((int) value);
+                case FieldType.SFixed64:
+                    return CodedOutputStream.ComputeSFixed64Size((long) value);
+                case FieldType.Message:
+                    return CodedOutputStream.ComputeMessageSize((IMessage) value);
+                case FieldType.Enum:
+                    return CodedOutputStream.ComputeEnumSize((int) value);
+
+            }
+            throw new ArgumentException($"unidentified type :{fieldType}");
+        }
+
+        /// <summary>
+        /// Iterates all the fields and writes them to  CodedOutputStream.
+        /// </summary>
+        /// <param name="output"></param>
+        internal void WriteTo(CodedOutputStream output)
+        {
+            foreach (KeyValuePair<FieldDescriptor, object> kvPair in fields)
+            {
+                WriteField(kvPair.Key, kvPair.Value, output);
+            }
+        }
+
+        /// <summary>
+        /// Writes the field into output stream, based on isRepeated.
+        /// </summary>
+        /// <param name="descriptor"></param>
+        /// <param name="value"></param>
+        /// <param name="output"></param>
+        private void WriteField(FieldDescriptor descriptor, object value, CodedOutputStream output)
+        {
+            FieldType fieldType = descriptor.FieldType;
+            if (descriptor.IsRepeated)
+            {
+                foreach (object val in (IEnumerable) value)
+                {
+                    WriteElement(output, fieldType, descriptor.FieldNumber, val);
+                }
+            }
+            else
+            {
+                WriteElement(output, fieldType, descriptor.FieldNumber, value);
+            }
+        }
+
+        /// <summary>
+        /// Writes a single field, first tag and then data.
+        /// </summary>
+        /// <param name="output"></param>
+        /// <param name="type"></param>
+        /// <param name="number"></param>
+        /// <param name="value"></param>
+        private void WriteElement(CodedOutputStream output, FieldType type, int number, object value)
+        {
+            output.WriteTag(number, GetWireFormatForFieldType(type));
+            WriteElementNoTag(output, type, value);
+        }
+
+        /// <summary>
+        /// Returns the wire format for the field type.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        private WireFormat.WireType GetWireFormatForFieldType(FieldType type)
+        {
+            switch (type)
+            {
+                case FieldType.Float:
+                    return WireFormat.WireType.Fixed32;
+                case FieldType.Fixed32:
+                    return WireFormat.WireType.Fixed32;
+                case FieldType.SFixed32:
+                    return WireFormat.WireType.Fixed32;
+                case FieldType.Fixed64:
+                    return WireFormat.WireType.Fixed64;
+                case FieldType.SFixed64:
+                    return WireFormat.WireType.Fixed64;
+                case FieldType.Double:
+                    return WireFormat.WireType.Fixed64;
+                case FieldType.Bool:
+                    return WireFormat.WireType.Varint;
+                case FieldType.Int32:
+                    return WireFormat.WireType.Varint;
+                case FieldType.Int64:
+                    return WireFormat.WireType.Varint;
+                case FieldType.UInt32:
+                    return WireFormat.WireType.Varint;
+                case FieldType.UInt64:
+                    return WireFormat.WireType.Varint;
+                case FieldType.Enum:
+                    return WireFormat.WireType.Varint;
+                case FieldType.SInt32:
+                    return WireFormat.WireType.Varint;
+                case FieldType.SInt64:
+                    return WireFormat.WireType.Varint;
+                case FieldType.String:
+                    return WireFormat.WireType.LengthDelimited;
+                case FieldType.Bytes:
+                    return WireFormat.WireType.LengthDelimited;
+                case FieldType.Message:
+                    return WireFormat.WireType.LengthDelimited;
+                case FieldType.Group:
+                    return WireFormat.WireType.StartGroup;
+            }
+            throw new ArgumentException($"unidentified fieldtype :{type}");
+        }
+
+        /// <summary>
+        /// Write the element value into the output stream.
+        /// </summary>
+        /// <param name="output"></param>
+        /// <param name="type"></param>
+        /// <param name="value"></param>
+        /// <exception cref="ArgumentException"></exception>
+        private void WriteElementNoTag(CodedOutputStream output, FieldType type, object value)
+        {
+            switch (type)
+            {
+                case FieldType.String:
+                    output.WriteString((string) value);
+                    return;
+                case FieldType.Bool:
+                    output.WriteBool((bool) value);
+                    return;
+                case FieldType.Int32:
+                    output.WriteInt32((int) value);
+                    return;
+                case FieldType.Int64:
+                    output.WriteInt64((long) value);
+                    return;
+                case FieldType.Double:
+                    output.WriteDouble((double) value);
+                    return;
+                case FieldType.UInt32:
+                    output.WriteUInt32((uint) value);
+                    return;
+                case FieldType.UInt64:
+                    output.WriteUInt64((ulong) value);
+                    return;
+                case FieldType.SInt32:
+                    output.WriteSInt32((int) value);
+                    return;
+                case FieldType.SInt64:
+                    output.WriteSInt64((long) value);
+                    return;
+                case FieldType.Fixed32:
+                    output.WriteFixed32((uint) value);
+                    return;
+                case FieldType.Fixed64:
+                    output.WriteFixed64((ulong) value);
+                    return;
+                case FieldType.SFixed32:
+                    output.WriteSFixed32((int) value);
+                    return;
+                case FieldType.SFixed64:
+                    output.WriteSFixed64((long) value);
+                    return;
+                case FieldType.Float:
+                    output.WriteFloat((float) value);
+                    return;
+                case FieldType.Bytes:
+                    output.WriteBytes((ByteString) value);
+                    return;
+                case FieldType.Enum:
+                    output.WriteEnum((int) value);
+                    return;
+                case FieldType.Message:
+                    output.WriteMessage((IMessage) value);
+                    return;
+            }
+            throw new ArgumentException($"unidentified type :{type}");
+        }
+
+        /// <summary>
+        /// Sets the field, if the value is null throw exception.
+        /// </summary>
+        /// <param name="field"></param>
+        /// <param name="value"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        internal void SetField(FieldDescriptor field, object value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(field.Name);
+            }
+            fields.Add(field, value);
+        }
+
+        /// <summary>
+        /// Creates a list if field not present in the dictionary, and adds the value to the list.
+        /// If field is not repeated throw exception.
+        /// </summary>
+        /// <param name="field"></param>
+        /// <param name="value"></param>
+        /// <exception cref="ArgumentException"></exception>
+        internal void AddRepeatedField(FieldDescriptor field, object value)
+        {
+            if (!field.IsRepeated)
+            {
+                throw new ArgumentException("AddRepeatedField can only be called on repeated fields.");
+            }
+            if (!fields.TryGetValue(field, out object list))
+            {
+                list = new List<object>();
+                fields[field] = list;
+            }
+
+            ((IList<object>) list).Add(value);
+        }
+
+        /// <summary>
+        /// Returns the value of the field represented by FieldDescriptor.
+        /// </summary>
+        /// <param name="fd"></param>
+        /// <returns></returns>
+        public object GetField(FieldDescriptor fd)
+        {
+            fields.TryGetValue(fd, out object value);
+            return value;
+        }
+
+        internal void Merge(FieldSet fieldSet)
+        {
+            foreach (KeyValuePair<FieldDescriptor, object> kv in fieldSet.Fields)
+            {
+                FieldDescriptor fd = kv.Key;
+                object val = kv.Value;
+                if (fd.IsRepeated)
+                {
+                    AddRepeatedField(fd, val);
+                }
+                else
+                {
+                    SetField(fd, val);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Compare for equality
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool Equals(FieldSet other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            if (ReferenceEquals(other, this))
+            {
+                return true;
+            }
+            if (!fields.Equals(other.fields)) return false;
+            return true;
+        }
+
+        /// <summary>
+        /// To clone the FieldSet
+        /// </summary>
+        /// <returns></returns>
+        public FieldSet Clone()
+        {
+            return new FieldSet(new Dictionary<FieldDescriptor, object>(fields));
+        }
+    }
+
+}


### PR DESCRIPTION
- Added DynamicMessage functionality, following the similar usage and implementation pattern as other IMessage implementations
  - To create 
`DynamicMessage dm = new DynamicMessage(desc);
            dm.Add("single_string", "sss");`
  - To serialize
`dm.WriteTo(outputStream);`
  - To deserialize
` deserializedDm = (DynamicMessage) dm.Parser.ParseFrom(inputStream)`
  - The descriptor could not be made static, as every instance of DynamicMessage can have a separate descriptor. So the parser is also non-static.
- Added support for unknown fields
- Added Unit tests
- Removed the workflow file
- Removed the Builder pattern from DynamicMessage