### PR TITLE
Add additional field number allocations for ygot.

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -187,7 +187,7 @@ with info about your project (name and website) so we can add an entry for you.
 1.  ygot
 
     *   Website: https://github.com/openconfig/ygot
-    *   Extensions: 1040
+    *   Extensions: 1040, 1179, 1180
 
 1.  go-grpcmw
 


### PR DESCRIPTION
```
* (M) docs/options.md
  - Add two addition field options that are used as markers for
    specific YANG types in generated protobufs.
```

This adds two additional unique `FieldOptions` field numbers for annotat YANG leaf-lists, and leaf-lists of unions that need specific handling in field option code. Definitions for these fields are in github.com/openconfig/ygygot, particularly https://github.com/openconfig/ygot/blob/master/proto/yext/yext.proto.
