### PR TITLE
python: make ctypes dependency optional

### DIFF
--- a/python/google/protobuf/internal/type_checkers.py
+++ b/python/google/protobuf/internal/type_checkers.py
@@ -45,11 +45,7 @@ TYPE_TO_DESERIALIZE_METHOD: A dictionary with field types and deserialization
 
 __author__ = 'robinson@google.com (Will Robinson)'
 
-try:
-  import ctypes
-except Exception:  # pylint: disable=broad-except
-  ctypes = None
-  import struct
+import struct
 import numbers
 
 from google.protobuf.internal import decoder
@@ -61,10 +57,7 @@ _FieldDescriptor = descriptor.FieldDescriptor
 
 
 def TruncateToFourByteFloat(original):
-  if ctypes:
-    return ctypes.c_float(original).value
-  else:
-    return struct.unpack('<f', struct.pack('<f', original))[0]
+  return struct.unpack('<f', struct.pack('<f', original))[0]
 
 
 def ToShortestFloat(original):

--- a/python/google/protobuf/internal/type_checkers.py
+++ b/python/google/protobuf/internal/type_checkers.py
@@ -45,7 +45,11 @@ TYPE_TO_DESERIALIZE_METHOD: A dictionary with field types and deserialization
 
 __author__ = 'robinson@google.com (Will Robinson)'
 
-import ctypes
+try:
+  import ctypes
+except Exception:  # pylint: disable=broad-except
+  ctypes = None
+  import struct
 import numbers
 
 from google.protobuf.internal import decoder
@@ -57,7 +61,10 @@ _FieldDescriptor = descriptor.FieldDescriptor
 
 
 def TruncateToFourByteFloat(original):
-  return ctypes.c_float(original).value
+  if ctypes:
+    return ctypes.c_float(original).value
+  else:
+    return struct.unpack('<f', struct.pack('<f', original))[0]
 
 
 def ToShortestFloat(original):


### PR DESCRIPTION
This allows the protobuf python library to work on cpython 3.11's new wasm target [1], which does not have ctypes.

This reverts back to the way TruncateToFourByteFloat worked before 75eff10d81233d3d08ce5ded215e526c1fcace88.

  [1] https://docs.python.org/3/whatsnew/3.11.html#build-changes:~:text=CPython%20now%20has%20PEP%2011%20Tier%203%20support%20for%20cross%20compiling%20to%20the%20WebAssembly%20platforms