### PR TITLE
Add prebuilt binaries for Ruby 3.2

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -133,7 +133,7 @@ else
     ['x86-mingw32', 'x64-mingw32', 'x64-mingw-ucrt', 'x86_64-linux', 'x86-linux'].each do |plat|
       RakeCompilerDock.sh <<-"EOT", platform: plat
         bundle && \
-        IN_DOCKER=true rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem RUBY_CC_VERSION=3.1.0:3.0.0:2.7.0:2.6.0
+        IN_DOCKER=true rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem RUBY_CC_VERSION=3.2.0:3.1.0:3.0.0:2.7.0:2.6.0
       EOT
     end
   end
@@ -141,7 +141,7 @@ else
   if RUBY_PLATFORM =~ /darwin/
     task 'gem:native' do
       system "rake genproto"
-      system "rake cross native gem RUBY_CC_VERSION=3.1.0:3.0.0:2.7.0:2.6.0"
+      system "rake cross native gem RUBY_CC_VERSION=3.2.0:3.1.0:3.0.0:2.7.0:2.6.0"
     end
   else
     task 'gem:native' => [:genproto, 'gem:windows', 'gem:java']

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   else
     s.files     += Dir.glob('ext/**/*')
     s.extensions= ["ext/google/protobuf_c/extconf.rb"]
-    s.add_development_dependency "rake-compiler-dock", "= 1.2.1"  end
+    s.add_development_dependency "rake-compiler-dock", "= 1.3.0"  end
   s.required_ruby_version = '>= 2.3'
-  s.add_development_dependency "rake-compiler", "~> 1.1.0"
+  s.add_development_dependency "rake-compiler", "~> 1.2.1"
   s.add_development_dependency "test-unit", '~> 3.0', '>= 3.0.9'
 end


### PR DESCRIPTION
This PR adds pre-compiled Ruby binaries for Ruby 3.2. Note that such binaries are already available on other Ruby versions.

Fixes issues:
- https://github.com/protocolbuffers/protobuf/issues/11578
- https://github.com/protocolbuffers/protobuf/issues/11538

(Those issues should not have been closed without a fix...)

The protobufs Ruby maintainers should get in the habit of updating this every year when there is a new Ruby release. Please set a calendar reminder to check in early Jan with the maintainers of `rake-compiler` gem; when they release cross-compilation support for the new Ruby version it's an easy change to add it to protobufs (can basically copy this PR.)