### PR TITLE
Update Google.Protobuf.Tools.nuspec

### DIFF
--- a/csharp/Google.Protobuf.Tools.nuspec
+++ b/csharp/Google.Protobuf.Tools.nuspec
@@ -21,17 +21,17 @@
     <file src="protoc/linux_x86/protoc" target="tools/linux_x86/protoc"/>
     <file src="protoc/linux_x64/protoc" target="tools/linux_x64/protoc"/>
     <file src="protoc/macosx_x64/protoc" target="tools/macosx_x64/protoc"/>
-    <file src="../src/google/protobuf/any.proto" target="tools/google/protobuf"/>
-    <file src="../src/google/protobuf/api.proto" target="tools/google/protobuf"/>
-    <file src="../src/google/protobuf/descriptor.proto" target="tools/google/protobuf"/>
-    <file src="../src/google/protobuf/duration.proto" target="tools/google/protobuf"/>
-    <file src="../src/google/protobuf/empty.proto" target="tools/google/protobuf"/>
-    <file src="../src/google/protobuf/field_mask.proto" target="tools/google/protobuf"/>
-    <file src="../src/google/protobuf/source_context.proto" target="tools/google/protobuf"/>
-    <file src="../src/google/protobuf/struct.proto" target="tools/google/protobuf"/>
-    <file src="../src/google/protobuf/timestamp.proto" target="tools/google/protobuf"/>
-    <file src="../src/google/protobuf/type.proto" target="tools/google/protobuf"/>
-    <file src="../src/google/protobuf/wrappers.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/any.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/api.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/descriptor.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/duration.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/empty.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/field_mask.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/source_context.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/struct.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/timestamp.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/type.proto" target="tools/google/protobuf"/>
+    <file src="src/google/protobuf/wrappers.proto" target="tools/google/protobuf"/>
     <file src="Google.Protobuf.Tools.targets" target="buildCrossTargeting"/>
     <file src="Google.Protobuf.Tools.targets" target="build"/>
   </files>


### PR DESCRIPTION
Find all source files inside the csharp directory. We have to prepopulate this directory anyway, so we can put the .proto files directly into the csharp directory.

The current setup can find the files in linux, but for some reason it isn't copying them correctly unless the files are in the csharp folder