### PR TITLE
Fix attribute ordering compilation error

### DIFF
--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -1160,8 +1160,8 @@ class RepeatedPtrField final : private internal::RepeatedPtrFieldBase {
   //
   // This method cannot be called when the repeated field is on an arena; doing
   // so will trigger a GOOGLE_ABSL_DCHECK-failure.
-  ABSL_DEPRECATED("This will be removed in a future release")
-  PROTOBUF_NODISCARD Element* ReleaseCleared();
+  PROTOBUF_NODISCARD ABSL_DEPRECATED("This will be removed in a future release")
+  Element* ReleaseCleared();
 #endif  // !PROTOBUF_FUTURE_REMOVE_CLEARED_API
 
   // Removes the element referenced by position.


### PR DESCRIPTION
The `[[nodiscard]]` attribute seemingly needs to come before `__attribute__((deprecated(foo)))`.

Error:

```
In file included from external/com_google_protobuf/src/google/protobuf/compiler/subprocess.cc:52:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_nowkt/google/protobuf/message.h:126:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_nowkt/google/protobuf/generated_message_reflection.h:50:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_nowkt/google/protobuf/unknown_field_set.h:52:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:47:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/implicit_weak_message.h:39:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/repeated_field.h:61:
bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/repeated_ptr_field.h:1164:3: error: 'nodiscard' attribute cannot be applied to types
  PROTOBUF_NODISCARD Element* ReleaseCleared();
  ^
bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/port_def/google/protobuf/port_def.inc:558:30: note: expanded from macro 'PROTOBUF_NODISCARD'
#define PROTOBUF_NODISCARD [[nodiscard]]
                             ^
1 error generated.
```