### PR TITLE
Add post_imports protoc_insertion_point for Python

### DIFF
--- a/src/google/protobuf/compiler/python/generator.cc
+++ b/src/google/protobuf/compiler/python/generator.cc
@@ -433,6 +433,7 @@ void Generator::PrintImports() const {
     printer_->Print("from $module$ import *\n", "module", module_name);
   }
   printer_->Print("\n");
+  printer_->Print("# @@protoc_insertion_point(post_imports)\n\n");
 }
 
 // Prints the single file descriptor for this file.


### PR DESCRIPTION
This is part of an incoming series of PR's intended to support what I call "unified_protos" (unifying the C++ runtime with the Python runtime for protobufs). My approach will not be in the way that the code currently seems to require (a statically linked python executable with all C++ protos and C-extensions linked into it), but through building a shared library for every C++ proto (via `cc_shared_library`) and loading them (in the post_imports hook) in the generated Python code and using an aspect to make them dynamic_deps for C extensions. This allows Python code and C/C++ code to pass protobufs back-and-forth without serializing/deserializing them.