### PR TITLE
feat(6178): emit ruby enum as integer

### DIFF
--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -1164,6 +1164,11 @@ static VALUE Message_encode_json(int argc, VALUE* argv, VALUE klass) {
                               Qfalse))) {
       options |= upb_JsonEncode_EmitDefaults;
     }
+
+    if (RTEST(rb_hash_lookup2(hash_args, ID2SYM(rb_intern("enums_as_integers")),
+                              Qfalse))) {
+      options |= upb_JsonEncode_FormatEnumsAsIntegers;
+    }
   }
 
   upb_Status_Clear(&status);

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -1165,7 +1165,7 @@ static VALUE Message_encode_json(int argc, VALUE* argv, VALUE klass) {
       options |= upb_JsonEncode_EmitDefaults;
     }
 
-    if (RTEST(rb_hash_lookup2(hash_args, ID2SYM(rb_intern("enums_as_integers")),
+    if (RTEST(rb_hash_lookup2(hash_args, ID2SYM(rb_intern("format_enums_as_integers")),
                               Qfalse))) {
       options |= upb_JsonEncode_FormatEnumsAsIntegers;
     }

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
@@ -669,6 +669,7 @@ public class RubyMessage extends RubyObject {
    * @param options [Hash] options for the decoder
    *  preserve_proto_fieldnames: set true to use original fieldnames (default is to camelCase)
    *  emit_defaults: set true to emit 0/false values (default is to omit them)
+   *  enums_as_integers: set true to emit enum values as integer (default is string)
    */
   @JRubyMethod(name = "encode_json", required = 1, optional = 1, meta = true)
   public static IRubyObject encodeJson(
@@ -690,6 +691,7 @@ public class RubyMessage extends RubyObject {
 
       IRubyObject emitDefaults = options.fastARef(runtime.newSymbol("emit_defaults"));
       IRubyObject preserveNames = options.fastARef(runtime.newSymbol("preserve_proto_fieldnames"));
+      IRubyObject enumAsIntegers = options.fastARef(runtime.newSymbol("enums_as_integers"));
 
       if (emitDefaults != null && emitDefaults.isTrue()) {
         printer = printer.includingDefaultValueFields();
@@ -697,6 +699,10 @@ public class RubyMessage extends RubyObject {
 
       if (preserveNames != null && preserveNames.isTrue()) {
         printer = printer.preservingProtoFieldNames();
+      }
+      
+      if (enumAsIntegers != null && printingEnumsAsInts.isTrue()) {
+        printer = printer.printingEnumsAsInts();
       }
     }
     printer =

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
@@ -669,7 +669,7 @@ public class RubyMessage extends RubyObject {
    * @param options [Hash] options for the decoder
    *  preserve_proto_fieldnames: set true to use original fieldnames (default is to camelCase)
    *  emit_defaults: set true to emit 0/false values (default is to omit them)
-   *  enums_as_integers: set true to emit enum values as integer (default is string)
+   *  format_enums_as_integers: set true to emit enum values as integer (default is string)
    */
   @JRubyMethod(name = "encode_json", required = 1, optional = 1, meta = true)
   public static IRubyObject encodeJson(
@@ -691,7 +691,7 @@ public class RubyMessage extends RubyObject {
 
       IRubyObject emitDefaults = options.fastARef(runtime.newSymbol("emit_defaults"));
       IRubyObject preserveNames = options.fastARef(runtime.newSymbol("preserve_proto_fieldnames"));
-      IRubyObject enumAsIntegers = options.fastARef(runtime.newSymbol("enums_as_integers"));
+      IRubyObject printingEnumsAsInts = options.fastARef(runtime.newSymbol("format_enums_as_integers"));
 
       if (emitDefaults != null && emitDefaults.isTrue()) {
         printer = printer.includingDefaultValueFields();
@@ -701,7 +701,7 @@ public class RubyMessage extends RubyObject {
         printer = printer.preservingProtoFieldNames();
       }
       
-      if (enumAsIntegers != null && printingEnumsAsInts.isTrue()) {
+      if (printingEnumsAsInts != null && printingEnumsAsInts.isTrue()) {
         printer = printer.printingEnumsAsInts();
       }
     }

--- a/ruby/tests/encode_decode_test.rb
+++ b/ruby/tests/encode_decode_test.rb
@@ -84,6 +84,34 @@ class EncodeDecodeTest < Test::Unit::TestCase
     )
 
     assert_match 'optional_int32', json
+
+
+    # Test for enums printing as ints.
+    msg = A::B::C::TestMessage.new({ optional_enum: 1 })
+    json = A::B::C::TestMessage.encode_json(
+      msg, 
+      { :enums_as_integers => true }
+    )
+
+    assert_match '"optionalEnum":1', json
+
+    # Test for default enum being printed as int.
+    msg = A::B::C::TestMessage.new({ optional_enum: 0 })
+    json = A::B::C::TestMessage.encode_json(
+      msg, 
+      { :enums_as_integers => true, :emit_defaults => true }
+    )
+
+    assert_match '"optionalEnum":0', json
+
+    # Test for repeated enums printing as ints.
+    msg = A::B::C::TestMessage.new({ repeated_enum: [0,1,2,3] })
+    json = A::B::C::TestMessage.encode_json(
+      msg, 
+      { :enums_as_integers => true }
+    )
+
+    assert_match '"repeatedEnum":[0,1,2,3]', json
   end
 
   def test_encode_wrong_msg

--- a/ruby/tests/encode_decode_test.rb
+++ b/ruby/tests/encode_decode_test.rb
@@ -90,7 +90,7 @@ class EncodeDecodeTest < Test::Unit::TestCase
     msg = A::B::C::TestMessage.new({ optional_enum: 1 })
     json = A::B::C::TestMessage.encode_json(
       msg, 
-      { :enums_as_integers => true }
+      { :format_enums_as_integers => true }
     )
 
     assert_match '"optionalEnum":1', json
@@ -99,7 +99,7 @@ class EncodeDecodeTest < Test::Unit::TestCase
     msg = A::B::C::TestMessage.new({ optional_enum: 0 })
     json = A::B::C::TestMessage.encode_json(
       msg, 
-      { :enums_as_integers => true, :emit_defaults => true }
+      { :format_enums_as_integers => true, :emit_defaults => true }
     )
 
     assert_match '"optionalEnum":0', json
@@ -108,7 +108,7 @@ class EncodeDecodeTest < Test::Unit::TestCase
     msg = A::B::C::TestMessage.new({ repeated_enum: [0,1,2,3] })
     json = A::B::C::TestMessage.encode_json(
       msg, 
-      { :enums_as_integers => true }
+      { :format_enums_as_integers => true }
     )
 
     assert_match '"repeatedEnum":[0,1,2,3]', json


### PR DESCRIPTION
Fixes #6178

- Add a new option `enums_as_integers` to emit enum as integer value.