### PR TITLE
Downgrade ruby major version

### DIFF
--- a/version.json
+++ b/version.json
@@ -11,7 +11,7 @@
             "objectivec": "3.22.0-dev",
             "php": "3.22.0-dev",
             "python": "4.22.0-dev",
-            "ruby": "4.22.0-dev"
+            "ruby": "3.22.0-dev"
         }
     }
 }


### PR DESCRIPTION
We have decided to hold off on upgrading ruby's major version to see if binary gems will be ready to release.