### PR TITLE
In Ruby repeated fields, each_index actually iterates over the index

### DIFF
--- a/ruby/compatibility_tests/v3.0.0/tests/repeated_field_test.rb
+++ b/ruby/compatibility_tests/v3.0.0/tests/repeated_field_test.rb
@@ -119,6 +119,20 @@ class RepeatedFieldTest < Test::Unit::TestCase
     assert_equal ['string'] * 5, result
   end
 
+  
+  def test_each_index
+    m = TestMessage.new
+    5.times{|i| m.repeated_string << 'string' }
+
+    expected = 0
+    m.repeated_string.each_index do |idx|
+      assert_equal expected, idx
+      expected += 1
+      assert_equal 'string', m.repeated_string[idx]
+    end
+    assert_equal 5, expected
+  end
+
 
   def test_empty?
     m = TestMessage.new

--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -117,7 +117,6 @@ module Google
       end
 
       # array aliases into enumerable
-      alias_method :each_index, :each_with_index
       alias_method :slice, :[]
       alias_method :values_at, :select
       alias_method :map, :collect
@@ -168,7 +167,7 @@ module Google
       end
 
 
-      %w(collect! compact! delete_if fill flatten! insert reverse!
+      %w(collect! compact! delete_if each_index fill flatten! insert reverse!
         rotate! select! shuffle! sort! sort_by! uniq!).each do |method_name|
         define_array_wrapper_with_result_method(method_name)
       end

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -141,6 +141,20 @@ class RepeatedFieldTest < Test::Unit::TestCase
   end
 
 
+  def test_each_index
+    m = TestMessage.new
+    5.times{|i| m.repeated_string << 'string' }
+
+    expected = 0
+    m.repeated_string.each_index do |idx|
+      assert_equal expected, idx
+      expected += 1
+      assert_equal 'string', m.repeated_string[idx]
+    end
+    assert_equal 5, expected
+  end
+
+
   def test_empty?
     m = TestMessage.new
     assert_equal true, m.repeated_string.empty?


### PR DESCRIPTION
Currently we're aliasing `each_index` to `each_with_index`, incorrectly passing both the index and the value of a repeated field to the block.

What we want is to just pass the index. Luckily this is a method on Ruby arrays, so we just wrap the native Ruby array method.

Fixes https://github.com/protocolbuffers/protobuf/issues/7806