### PR TITLE
Cherrypick bug fixes to update PHP repo GHA.

### DIFF
--- a/.github/workflows/update_php_repo.yml
+++ b/.github/workflows/update_php_repo.yml
@@ -29,7 +29,7 @@ jobs:
           git config user.email "protobuf-team-bot@google.com"
       - name: Get PHP Version
         run: |
-          unformatted_version=$( cat protobuf/version.json | jq -r '.main.languages.php' )
+          unformatted_version=$( cat protobuf/version.json | jq -r '.[].languages.php' )
           version=${unformatted_version/-rc/RC}
           version_tag=v$version
           echo "VERSION=$version" >> $GITHUB_ENV
@@ -42,7 +42,8 @@ jobs:
           rm -rf protobuf
       - name: Push Changes
         run: |
-          git commit -a -m "${{ env.VERSION }} sync"
+          git add --all
+          git commit -m "${{ env.VERSION }} sync"
           git push --force origin master
           git tag -a ${{ env.VERSION_TAG }} -m "Tag release ${{ env.VERSION_TAG }}"
           git push origin ${{ env.VERSION_TAG }}


### PR DESCRIPTION
Pull the first index with jq instead of looking for "main"
Git add all artifacts since "git commit -a" doesn't add new ones

Cherrypick of https://github.com/protocolbuffers/protobuf/commit/e89747c6ece4f3874c2b27ce6bd67eb4a51b21e4

PiperOrigin-RevId: 506933714