### PR TITLE
Fix the macro PROTOBUF_LITTLE_ENDIAN cannot be set correctly on the l…

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -67,10 +67,10 @@
 #include <sys/isa_defs.h>  // __BYTE_ORDER
 #elif defined(_AIX) || defined(__TOS_AIX__)
 #include <sys/machine.h>  // BYTE_ORDER
+#elif defined(__QNX__)
+#include <sys/param.h>  // BYTE_ORDER
 #else
-#if !defined(__QNX__)
 #include <endian.h>  // __BYTE_ORDER
-#endif
 #endif
 #if ((defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)) ||   \
      (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN) || \


### PR DESCRIPTION
…ittle endian QNX. (#11750)

Fix the macro PROTOBUF_LITTLE_ENDIAN cannot be set correctly on the little endian QNX.

Signed-off-by: wugaoyin <1132954336@qq.com>

Closes #11750

COPYBARA_INTEGRATE_REVIEW=https://github.com/protocolbuffers/protobuf/pull/11750 from WuGaoyin:main 09ec1a19e9c2eaad7085fad81b7bc8648db40de1
PiperOrigin-RevId: 506979012