### PR TITLE
Strip "src" from file name of plugin.proto

### DIFF
--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -20,6 +20,7 @@ proto_library(
         "//:__pkg__",
         "//pkg:__pkg__",
     ],
+    strip_import_prefix = "src",
     deps = ["//:descriptor_proto"],
 )
 

--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -20,7 +20,7 @@ proto_library(
         "//:__pkg__",
         "//pkg:__pkg__",
     ],
-    strip_import_prefix = "src",
+    strip_import_prefix = "/src",
     deps = ["//:descriptor_proto"],
 )
 


### PR DESCRIPTION
In 22.x, we accidentally omitted stripping the "src" import prefix for plugin.proto. We stripped the prefix in 21.x and for all other well known types in 22.x.

This reverts that unintentional change.