### PR TITLE
Add plugin.proto to the list of well known files for python

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -54,6 +54,7 @@ internal_py_proto_library(
 internal_copy_files(
     name = "copied_wkt_proto_files",
     srcs = [
+        "//:compiler_plugin_proto",
         "//:well_known_type_protos",
         "//src/google/protobuf:descriptor_proto_srcs",
     ],

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -54,9 +54,9 @@ internal_py_proto_library(
 internal_copy_files(
     name = "copied_wkt_proto_files",
     srcs = [
-        "//:compiler_plugin_proto",
         "//:well_known_type_protos",
         "//src/google/protobuf:descriptor_proto_srcs",
+        "//src/google/protobuf/compiler:plugin.proto",
     ],
     strip_prefix = "src",
 )

--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -207,7 +207,10 @@ filegroup(
 
 exports_files(
     srcs = ["plugin.proto"],
-    visibility = ["//:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//python:__pkg__",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
In 21.x, depending on "//python:well_known_types_py_pb2" provided a transitive dependency to `compiler/plugin.proto`. That dependency was incorrectly removed for 22.x.