### PR TITLE
Allow empty commits for update_php_repo

### DIFF
--- a/.github/workflows/update_php_repo.yml
+++ b/.github/workflows/update_php_repo.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Push Changes
         run: |
           git add --all
-          git commit -m "${{ env.VERSION }} sync"
+          git commit --allow-empty -m "${{ env.VERSION }} sync"
           git push --force origin master
           git tag -a ${{ env.VERSION_TAG }} -m "Tag release ${{ env.VERSION_TAG }}"
           git push origin ${{ env.VERSION_TAG }}


### PR DESCRIPTION
Fix exit code on git commit which was preventing force-push and tagging from running even though these should work without a new commit. An empty commit is probably clearer anyways to show that sync has happened.

PiperOrigin-RevId: 511248097