### PR TITLE
Fix pom_template dependencies

### DIFF
--- a/java/core/pom_template.xml
+++ b/java/core/pom_template.xml
@@ -15,4 +15,7 @@
     Core Protocol Buffers library. Protocol Buffers are a way of encoding structured data in an
     efficient yet extensible format.
   </description>
+  <dependencies>
+    {dependencies}
+  </dependencies>
 </project>

--- a/java/kotlin-lite/pom_template.xml
+++ b/java/kotlin-lite/pom_template.xml
@@ -15,6 +15,13 @@
     Kotlin lite Protocol Buffers library. Protocol Buffers are a way of encoding structured data in an
     efficient yet extensible format.
   </description>
+  <dependencies>
+    <dependency>
+      <groupId>${groupId}</groupId>
+      <artifactId>protobuf-javalite</artifactId>
+    </dependency>
+    {dependencies}
+  </dependencies>
 
   <properties>
     <kotlin.version>1.6.0</kotlin.version>

--- a/java/kotlin/pom_template.xml
+++ b/java/kotlin/pom_template.xml
@@ -15,6 +15,13 @@
     Kotlin core Protocol Buffers library. Protocol Buffers are a way of encoding structured data in an
     efficient yet extensible format.
   </description>
+  <dependencies>
+    <dependency>
+      <groupId>${groupId}</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    {dependencies}
+  </dependencies>
 
   <properties>
     <kotlin.version>1.6.0</kotlin.version>

--- a/java/lite/pom_template.xml
+++ b/java/lite/pom_template.xml
@@ -15,5 +15,8 @@
     Lite version of Protocol Buffers library. This version is optimized for code size, but does
     not guarantee API/ABI stability.
   </description>
+  <dependencies>
+    {dependencies}
+  </dependencies>
 
 </project>

--- a/java/util/pom_template.xml
+++ b/java/util/pom_template.xml
@@ -13,6 +13,10 @@
   <name>Protocol Buffers [Util]</name>
   <description>Utilities for Protocol Buffers</description>
   <dependencies>
+    <dependency>
+      <groupId>${groupId}</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
     {dependencies}
   </dependencies>
 


### PR DESCRIPTION
All pom files need a dependency section and kotlin + util need to depend on protobuf-java and kotlin-lite should depend on protobuf-javalite.

This is a cherry-pick of https://github.com/protocolbuffers/protobuf/commit/9b5a2c6f6fc76da3c93f6793550fa488ae62abaf and  fixes https://github.com/protocolbuffers/protobuf/issues/11976

PiperOrigin-RevId: 511252224