### PR TITLE
Ensure VarintParseSlowArm{32,64} are exported with PROTOBUF_EXPORT

### DIFF
--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -617,7 +617,9 @@ inline const char* VarintParseSlow(const char* p, uint32_t res, uint64_t* out) {
 }
 
 #ifdef __aarch64__
+PROTOBUF_EXPORT
 const char* VarintParseSlowArm64(const char* p, uint64_t* out, uint64_t first8);
+PROTOBUF_EXPORT
 const char* VarintParseSlowArm32(const char* p, uint32_t* out, uint64_t first8);
 
 inline const char* VarintParseSlowArm(const char* p, uint32_t* out,


### PR DESCRIPTION
Cherry-pick the fix for #11996 into 22.x to make sure it's included in the 22.1 release.

PiperOrigin-RevId: 511917449