### PR TITLE
Add java8 tests and build flags

### DIFF
--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -14,13 +14,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: OpenJDK 8
+            version: '8'
+            image: us-docker.pkg.dev/protobuf-build/containers/test/linux/bazel:8-03a376b5d6ef66f827fc307716e3b841cc26b709
+            targets: //java/... //java/internal:java_version
           - name: OpenJDK 11
             version: '11'
-            image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:5.1.1-aec4d74f2eb6938fc53ef7d9a79a4bf2da24abc1
+            image: us-docker.pkg.dev/protobuf-build/containers/test/linux/bazel:11-03a376b5d6ef66f827fc307716e3b841cc26b709
             targets: //java/... //java/internal:java_version
           - name: OpenJDK 17
             version: '17'
-            image: us-docker.pkg.dev/protobuf-build/containers/test/linux/java:17-65526ea124d1034eac33e7c37cc6d65c5bef054f
+            image: us-docker.pkg.dev/protobuf-build/containers/test/linux/java:17-03a376b5d6ef66f827fc307716e3b841cc26b709
             targets: //java/... //java/internal:java_version
           - name: aarch64
             version: 'aarch64'

--- a/build_defs/java_opts.bzl
+++ b/build_defs/java_opts.bzl
@@ -1,0 +1,21 @@
+"""Java options and protobuf-specific java build rules with those options."""
+load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_jvm_external//:defs.bzl", "java_export")
+
+JAVA_OPTS = [
+    "-source 8",
+    "-target 8",
+    "-Xep:Java8ApiChecker:ERROR",
+]
+
+def protobuf_java_export(**kwargs):
+    java_export(
+        javacopts = JAVA_OPTS,
+        **kwargs,
+    )
+
+def protobuf_java_library(**kwargs):
+    java_library(
+        javacopts = JAVA_OPTS,
+        **kwargs,
+    )

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@rules_java//java:defs.bzl", "java_library", "java_lite_proto_library", "java_proto_library")
-load("@rules_jvm_external//:defs.bzl", "java_export")
+load("@rules_java//java:defs.bzl", "java_lite_proto_library", "java_proto_library")
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
+load("//build_defs:java_opts.bzl", "protobuf_java_export", "protobuf_java_library")
 load("//conformance:defs.bzl", "conformance_test")
 load("//:protobuf.bzl", "internal_gen_well_known_protos_java")
 load("//:protobuf_version.bzl", "PROTOBUF_JAVA_VERSION")
@@ -121,7 +121,7 @@ internal_gen_well_known_protos_java(
 )
 
 # Should be used as `//java/lite`.
-java_library(
+protobuf_java_library(
     name = "lite",
     srcs = LITE_SRCS + [
         ":gen_well_known_protos_javalite",
@@ -132,7 +132,7 @@ java_library(
 )
 
 # Bazel users, don't depend on this target, use //java/lite.
-java_export(
+protobuf_java_export(
     name = "lite_mvn",
     maven_coordinates = "com.google.protobuf:protobuf-javalite:%s" % PROTOBUF_JAVA_VERSION,
     pom_template = "//java/lite:pom_template.xml",
@@ -143,7 +143,7 @@ java_export(
     runtime_deps = [":lite"],
 )
 
-java_library(
+protobuf_java_library(
     name = "lite_runtime_only",
     srcs = LITE_SRCS,
 )
@@ -166,7 +166,7 @@ internal_gen_well_known_protos_java(
     ],
 )
 
-java_library(
+protobuf_java_library(
     name = "core",
     srcs = glob(
         [
@@ -186,7 +186,7 @@ java_library(
 )
 
 # Bazel users, don't depend on this target, use :core.
-java_export(
+protobuf_java_export(
     name = "core_mvn",
     maven_coordinates = "com.google.protobuf:protobuf-java:%s" % PROTOBUF_JAVA_VERSION,
     pom_template = "pom_template.xml",
@@ -269,7 +269,7 @@ java_proto_library(
     deps = [":java_test_protos"],
 )
 
-java_library(
+protobuf_java_library(
     name = "test_util",
     srcs = [
         "src/test/java/com/google/protobuf/TestUtil.java",
@@ -390,7 +390,7 @@ genrule(
     cmd = "awk -f $(location //java/lite:lite.awk) $(location src/test/java/com/google/protobuf/TestUtil.java) > $@",
 )
 
-java_library(
+protobuf_java_library(
     name = "test_util_lite",
     srcs = [
         "src/test/java/com/google/protobuf/TestUtilLite.java",

--- a/java/util/BUILD.bazel
+++ b/java/util/BUILD.bazel
@@ -1,11 +1,11 @@
 load("@rules_java//java:defs.bzl", "java_proto_library")
-load("@rules_jvm_external//:defs.bzl", "java_export")
 load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//build_defs:java_opts.bzl", "protobuf_java_export", "protobuf_java_library")
 load("//:protobuf_version.bzl", "PROTOBUF_JAVA_VERSION")
 load("//java/internal:testing.bzl", "junit_tests")
 
-java_library(
+protobuf_java_library(
     name = "util",
     srcs = glob([
         "src/main/java/com/google/protobuf/util/*.java",
@@ -22,7 +22,7 @@ java_library(
 )
 
 # Bazel users, don't depend on this target, use :util.
-java_export(
+protobuf_java_export(
     name = "util_mvn",
     deploy_env = ["//java/core"],
     maven_coordinates = "com.google.protobuf:protobuf-java-util:%s" % PROTOBUF_JAVA_VERSION,


### PR DESCRIPTION
-Creates new macros `protobuf_java_library` and `protobuf_java_export` with default `javacopts` flags.
-Those flags will allow the published artifact to work with java 8
-Add java8 test and update the other java test images