### PR TITLE
Restore using protoc as protobuf compiler binary name

### DIFF
--- a/cmake/protoc.cmake
+++ b/cmake/protoc.cmake
@@ -9,6 +9,3 @@ target_link_libraries(protoc
   ${protobuf_ABSL_USED_TARGETS}
 )
 add_executable(protobuf::protoc ALIAS protoc)
-
-set_target_properties(protoc PROPERTIES
-    VERSION ${protobuf_VERSION})


### PR DESCRIPTION
This partially reverts changes made in #4579.

At the time protoc binary changes its filename with every new protobuf version being released.