### PR TITLE
Move //:protoc_static to //pkg:protoc

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -169,6 +169,12 @@ cc_binary(
     name = "protoc",
     copts = COPTS,
     linkopts = LINK_OPTS,
+    features = select({
+      # This isn't possible on mac because there is no static library for lcrt0.o
+      "//build_defs:config_osx": [],
+      # When cross-compiling we need to statically link all C++ libraries.
+      "//conditions:default": ["fully_static_link"],
+    }),
     visibility = ["//visibility:public"],
     deps = ["//src/google/protobuf/compiler:protoc_lib"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -173,20 +173,6 @@ cc_binary(
     deps = ["//src/google/protobuf/compiler:protoc_lib"],
 )
 
-cc_binary(
-    name = "protoc_static",
-    copts = COPTS,
-    linkopts = LINK_OPTS,
-    features = select({
-      # This isn't possible on mac because there is no static library for lcrt0.o
-      "//build_defs:config_osx": [],
-      # When cross-compiling we need to statically link all C++ libraries.
-      "//conditions:default": ["fully_static_link"],
-    }),
-    visibility = ["//visibility:public"],
-    deps = ["//src/google/protobuf/compiler:protoc_lib"],
-)
-
 ################################################################################
 # C++ runtime
 ################################################################################

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "pkg_files",
     "strip_prefix",
 )
+load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
 load("//:protobuf_release.bzl", "package_naming")
 load(":build_systems.bzl", "gen_file_lists")
 load(":cc_dist_library.bzl", "cc_dist_library")
@@ -37,6 +38,20 @@ pkg_files(
 # Generates protoc release artifacts.
 ################################################################################
 
+cc_binary(
+    name = "protoc",
+    copts = COPTS,
+    linkopts = LINK_OPTS,
+    features = select({
+      # This isn't possible on mac because there is no static library for lcrt0.o
+      "//build_defs:config_osx": [],
+      # When cross-compiling we need to statically link all C++ libraries.
+      "//conditions:default": ["fully_static_link"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = ["//src/google/protobuf/compiler:protoc_lib"],
+)
+
 genrule(
     name = "protoc_readme",
     outs = ["readme.txt"],
@@ -59,7 +74,7 @@ Please refer to our official github site for more installation instructions:
 
 pkg_files(
     name = "protoc_files",
-    srcs = ["//:protoc_static"],
+    srcs = [":protoc"],
     attributes = pkg_attributes(mode = "0555"),
     prefix = "bin/",
     visibility = ["//visibility:private"],

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "pkg_files",
     "strip_prefix",
 )
-load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
 load("//:protobuf_release.bzl", "package_naming")
 load(":build_systems.bzl", "gen_file_lists")
 load(":cc_dist_library.bzl", "cc_dist_library")
@@ -38,20 +37,6 @@ pkg_files(
 # Generates protoc release artifacts.
 ################################################################################
 
-cc_binary(
-    name = "protoc",
-    copts = COPTS,
-    linkopts = LINK_OPTS,
-    features = select({
-      # This isn't possible on mac because there is no static library for lcrt0.o
-      "//build_defs:config_osx": [],
-      # When cross-compiling we need to statically link all C++ libraries.
-      "//conditions:default": ["fully_static_link"],
-    }),
-    visibility = ["//visibility:public"],
-    deps = ["//src/google/protobuf/compiler:protoc_lib"],
-)
-
 genrule(
     name = "protoc_readme",
     outs = ["readme.txt"],
@@ -74,7 +59,7 @@ Please refer to our official github site for more installation instructions:
 
 pkg_files(
     name = "protoc_files",
-    srcs = [":protoc"],
+    srcs = ["//:protoc"],
     attributes = pkg_attributes(mode = "0555"),
     prefix = "bin/",
     visibility = ["//visibility:private"],


### PR DESCRIPTION
We need the name of the published executable to be `protoc`