### PR TITLE
Condition executable name on build system

### DIFF
--- a/build_defs/BUILD.bazel
+++ b/build_defs/BUILD.bazel
@@ -84,6 +84,14 @@ config_setting(
     },
 )
 
+selects.config_setting_group(
+    name = "config_win",
+    match_any = [
+        ":config_win32",
+        ":config_win64",
+    ]
+)
+
 config_setting(
     name = "config_osx_aarch64",
     values = {"cpu": "osx-aarch_64"},

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -62,11 +62,23 @@ genrule(
     srcs = ["//:protoc_static"],
     outs = ["bin/protoc"],
     cmd = "cp $< $@",
+    tags = ["manual"],
+)
+
+genrule(
+    name = "rename_protoc_exe",
+    srcs = ["//:protoc_static"],
+    outs = ["bin/protoc.exe"],
+    cmd = "cp $< $@",
+    tags = ["manual"],
 )
 
 pkg_files(
     name = "protoc_files",
-    srcs = ["bin/protoc"],
+    srcs = select({
+        "//build_defs:config_win": ["bin/protoc.exe"],
+        "//conditions:default": ["bin/protoc"],
+    }),
     attributes = pkg_attributes(mode = "0555"),
     prefix = "bin/",
     visibility = ["//visibility:private"],


### PR DESCRIPTION
Windows executables should have a `.exe` suffix.