### PR TITLE
[C#] Replace regex that validates descriptor names

### DIFF
--- a/csharp/src/Google.Protobuf/Reflection/DescriptorPool.cs
+++ b/csharp/src/Google.Protobuf/Reflection/DescriptorPool.cs
@@ -187,35 +187,24 @@ namespace Google.Protobuf.Reflection
                 throw new DescriptorValidationException(descriptor, "Missing name.");
             }
 
-            if (!IsValidSymbolNameFormat(descriptor.Name))
-            {
-                throw new DescriptorValidationException(descriptor,
-                                                        "\"" + descriptor.Name + "\" is not a valid identifier.");
-            }
-        }
-
-        /// <summary>
-        /// Symbol name must start with a letter or underscore, and it can contain letters, numbers and underscores.
-        /// </summary>
-        private static bool IsValidSymbolNameFormat(string name)
-        {
+            // Symbol name must start with a letter or underscore, and it can contain letters, numbers and underscores.
+            string name = descriptor.Name;
             if (!IsAsciiLetter(name[0]) && name[0] != '_')
             {
-                return false;
+                ThrowInvalidSymbolNameException(descriptor);
             }
-
             for (int i = 1; i < name.Length; i++)
             {
                 if (!IsAsciiLetter(name[i]) && !IsAsciiDigit(name[i]) && name[i] != '_')
                 {
-                    return false;
+                    ThrowInvalidSymbolNameException(descriptor);
                 }
             }
 
-            return true;
-
             static bool IsAsciiLetter(char c) => (uint) ((c | 0x20) - 'a') <= 'z' - 'a';
-            static bool IsAsciiDigit(char c) => (uint) (c - '0') <= ('9' - '0');
+            static bool IsAsciiDigit(char c) => (uint) (c - '0') <= '9' - '0';
+            static void ThrowInvalidSymbolNameException(IDescriptor descriptor) =>
+                throw new DescriptorValidationException(descriptor, "\"" + descriptor.Name + "\" is not a valid identifier.");
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/DescriptorPool.cs
+++ b/csharp/src/Google.Protobuf/Reflection/DescriptorPool.cs
@@ -32,6 +32,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -176,8 +177,6 @@ namespace Google.Protobuf.Reflection
             descriptorsByName[fullName] = descriptor;
         }
 
-        private static readonly Regex ValidationRegex = new Regex("^[_A-Za-z][_A-Za-z0-9]*$", FrameworkPortability.CompiledRegexWhereAvailable);
-
         /// <summary>
         /// Verifies that the descriptor's name is valid (i.e. it contains
         /// only letters, digits and underscores, and does not start with a digit).
@@ -189,11 +188,36 @@ namespace Google.Protobuf.Reflection
             {
                 throw new DescriptorValidationException(descriptor, "Missing name.");
             }
-            if (!ValidationRegex.IsMatch(descriptor.Name))
+
+            if (!IsValidSymbolNameFormat(descriptor.Name))
             {
                 throw new DescriptorValidationException(descriptor,
                                                         "\"" + descriptor.Name + "\" is not a valid identifier.");
             }
+        }
+
+        /// <summary>
+        /// Symbol name must start with a letter or underscore, and it can contain letters, numbers and underscores.
+        /// </summary>
+        private static bool IsValidSymbolNameFormat(string name)
+        {
+            if (!IsAsciiLetter(name[0]) && name[0] != '_')
+            {
+                return false;
+            }
+
+            for (int i = 1; i < name.Length; i++)
+            {
+                if (!IsAsciiLetter(name[i]) && !IsAsciiDigit(name[i]) && name[i] != '_')
+                {
+                    return false;
+                }
+            }
+
+            return true;
+
+            static bool IsAsciiLetter(char c) => (uint) ((c | 0x20) - 'a') <= 'z' - 'a';
+            static bool IsAsciiDigit(char c) => (uint) (c - '0') <= ('9' - '0');
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/DescriptorPool.cs
+++ b/csharp/src/Google.Protobuf/Reflection/DescriptorPool.cs
@@ -32,9 +32,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Google.Protobuf.Reflection
 {


### PR DESCRIPTION
This PR replaces the descriptor name validation regex with a validation method. This change allows the `System.Text.RegularExpressions` engine to be trimmed away in published apps that do standard protobuf serialization.

There are some other usages of `Regex` in Google.Protobuf, but they in `JsonParser`. They are only included in a published app if `JsonParser` is used.

Another benefit is a slightly faster app startup time. The removed regex was compiled, which has a high-ish fixed cost.

cc @jskeet @jtattermusch 