### PR TITLE
Add $ back for osgi header

### DIFF
--- a/java/core/pom_template.xml
+++ b/java/core/pom_template.xml
@@ -31,7 +31,7 @@
             <Automatic-Module-Name>com.google.protobuf</Automatic-Module-Name> <!-- Java9+ Jigsaw module name -->
             <Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
             <Bundle-SymbolicName>com.google.protobuf</Bundle-SymbolicName>
-            <Export-Package>com.google.protobuf;version={project.version}</Export-Package>
+            <Export-Package>com.google.protobuf;version=${project.version}</Export-Package>
             <Import-Package>sun.misc;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>

--- a/java/lite/pom_template.xml
+++ b/java/lite/pom_template.xml
@@ -31,7 +31,7 @@
             <Automatic-Module-Name>com.google.protobuf</Automatic-Module-Name> <!-- Java9+ Jigsaw module name -->
             <Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
             <Bundle-SymbolicName>com.google.protobuf</Bundle-SymbolicName>
-            <Export-Package>com.google.protobuf;version={project.version}</Export-Package>
+            <Export-Package>com.google.protobuf;version=${project.version}</Export-Package>
             <Import-Package>sun.misc;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>

--- a/java/util/pom_template.xml
+++ b/java/util/pom_template.xml
@@ -32,7 +32,7 @@
             <Automatic-Module-Name>com.google.protobuf.util</Automatic-Module-Name> <!-- Java9+ Jigsaw module name -->
             <Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
             <Bundle-SymbolicName>com.google.protobuf.util</Bundle-SymbolicName>
-            <Export-Package>com.google.protobuf.util;version={project.version}</Export-Package>
+            <Export-Package>com.google.protobuf.util;version=${project.version}</Export-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/pull/12177 removed all the `$` qualifiers too eagerly, they should still be here in this plugin to match https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.12/protobuf-java-util-3.21.12.pom