### PR TITLE
feat: support riscv64

### DIFF
--- a/protobuf_release.bzl
+++ b/protobuf_release.bzl
@@ -22,6 +22,8 @@ def _package_naming_impl(ctx):
     cpu = "aarch_64"
   elif cpu == "ppc64":
     cpu = "ppcle_64"
+  elif cpu == "riscv64":
+    cpu = "riscv_64"
 
   # use the system name to determine the os and then create platform names
   if "apple" in system_name:

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -10,6 +10,7 @@ TOOLCHAINS = {
     "linux-aarch_64": "cc-compiler-linux-aarch_64",
     "linux-ppcle_64": "cc-compiler-linux-ppcle_64",
     "linux-s390_64": "cc-compiler-linux-s390_64",
+    "linux-riscv_64": "cc-compiler-linux-riscv_64",
     "linux-x86_32": "cc-compiler-linux-x86_32",
     "linux-x86_64": "cc-compiler-linux-x86_64",
     "win32": "cc-compiler-windows-x86_32",
@@ -70,6 +71,14 @@ cc_toolchain_config(
     sysroot = "/opt/manylinux/2014/s390x",
     target_cpu = "systemz",
     target_full_name = "s390x-linux-gnu",
+)
+
+cc_toolchain_config(
+    name = "linux-riscv_64-config",
+    linker_path = "/usr/bin/ld",
+    sysroot = "/opt/manylinux/2014/riscv64",
+    target_cpu = "systemz",
+    target_full_name = "riscv64-linux-gnu",
 )
 
 cc_toolchain_config(

--- a/toolchain/toolchains.bazelrc
+++ b/toolchain/toolchains.bazelrc
@@ -6,6 +6,7 @@ build:linux-aarch64 --config=cross_config --cpu=linux-aarch_64
 build:linux-ppcle_64 --config=cross_config --cpu=linux-ppcle_64
 build:linux-ppc64le --config=cross_config --cpu=linux-ppcle_64
 build:linux-s390_64 --config=cross_config --cpu=linux-s390_64
+build:linux-riscv_64 --config=cross_config --cpu=linux-riscv_64
 build:linux-x86_32 --config=cross_config --cpu=linux-x86_32
 build:linux-i386 --config=cross_config --cpu=linux-x86_32
 build:linux-x86_64 --config=cross_config --cpu=linux-x86_64


### PR DESCRIPTION
I want to add riscv64 support for protobuf.
The protobuf is part of Kubernetes build pipeline, so this change is required to add riscv64 support to Kubernetes.

I'm not quite familiar with profobuf codebase, please guide me how I can cross-compile protobuf for riscv64, I'll test it on my devboard.

Fix: #12266