### PR TITLE
Fix compile-time error for Google.Protobuf in C# 11

### DIFF
--- a/csharp/src/Google.Protobuf/ParseContext.cs
+++ b/csharp/src/Google.Protobuf/ParseContext.cs
@@ -64,8 +64,9 @@ namespace Google.Protobuf
             state.recursionLimit = DefaultRecursionLimit;
             state.currentLimit = int.MaxValue;
             state.bufferSize = buffer.Length;
-
-            Initialize(buffer, ref state, out ctx);
+            // Equivalent to Initialize(buffer, ref state, out ctx);
+            ctx.buffer = buffer;
+            ctx.state = state;
         }
 
         /// <summary>
@@ -74,6 +75,7 @@ namespace Google.Protobuf
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void Initialize(ReadOnlySpan<byte> buffer, ref ParserInternalState state, out ParseContext ctx)
         {
+            // Note: if this code ever changes, also change the initialization above.
             ctx.buffer = buffer;
             ctx.state = state;
         }


### PR DESCRIPTION
Note that the error only affects users trying to build Google.Protobuf directly using C# 11. It doesn't affect users who are compiling code against the pre-built library (which is likely to be basically everyone).

Fixes #11004.

(This is code I'm less familiar with than most of the library, and I'd be nervous of making any more wide-ranging changes. This seems pretty safe though.)

cc @JamesNK who first noticed this.