### PR TITLE
Add @deprecated tag for doc block for service, method and message

### DIFF
--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -1799,6 +1799,10 @@ void GenerateMessageDocComment(io::Printer* printer, const Descriptor* message,
                                const Options& options) {
   printer->Print("/**\n");
   GenerateDocCommentBody(printer, message);
+  if (message->options().deprecated()) {
+    printer->Print(" * @deprecated\n");
+  }
+
   printer->Print(
     " * Generated from protobuf message <code>^messagename^</code>\n"
     " */\n",
@@ -1840,6 +1844,9 @@ void GenerateMessageConstructorDocComment(io::Printer* printer,
 void GenerateServiceDocComment(io::Printer* printer,
                                const ServiceDescriptor* service) {
   printer->Print("/**\n");
+  if (service->options().deprecated()) {
+    printer->Print(" * @deprecated\n");
+  }
   GenerateDocCommentBody(printer, service);
   printer->Print(
     " * Protobuf type <code>^fullname^</code>\n"
@@ -1917,6 +1924,9 @@ void GenerateWrapperFieldSetterDocComment(io::Printer* printer, const FieldDescr
 void GenerateEnumDocComment(io::Printer* printer, const EnumDescriptor* enum_,
                             const Options& options) {
   printer->Print("/**\n");
+  if (enum_->options().deprecated()) {
+    printer->Print(" * @deprecated\n");
+  }
   GenerateDocCommentBody(printer, enum_);
   printer->Print(
     " * Protobuf type <code>^fullname^</code>\n"
@@ -1938,6 +1948,9 @@ void GenerateServiceMethodDocComment(io::Printer* printer,
                                      const MethodDescriptor* method) {
   printer->Print("/**\n");
   GenerateDocCommentBody(printer, method);
+  if (method->options().deprecated()) {
+    printer->Print(" * @deprecated\n");
+  }
   printer->Print(
     " * Method <code>^method_name^</code>\n"
     " *\n",


### PR DESCRIPTION
At the moment, `protoc` ignores `option deprecated = true` for these entities.

It seems good to add the tag `@deprecated` to highlight the deprecation in the client code. It works for fields bot not for messages/service/method.

I wanted to add the test for this change, but I couldn't find any test for the generator. I will be happy if you can guide me in the right direction