### PR TITLE
Remove erroneous dependencies @com_google_googletest//:gtest and @com_google_googletest//:gtest_main from //src/google/protobuf/json:parser

### DIFF
--- a/src/google/protobuf/json/BUILD.bazel
+++ b/src/google/protobuf/json/BUILD.bazel
@@ -227,8 +227,6 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 


### PR DESCRIPTION
Downstream bazel projects that depend on protoc would need to provide googletest dependencies when it should not be necessary to do so.

Fixes #11409
