### PR TITLE
Make warning message type more specific

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-message(WARNING "Calling of cmake with source directory set to \"cmake\" subdirectory of Protocol Buffers project is deprecated. Top-level directory of Protocol Buffers project should be used instead.")
+message(DEPRECATION "Calling of cmake with source directory set to \"cmake\" subdirectory of Protocol Buffers project is deprecated. Top-level directory of Protocol Buffers project should be used instead.")
 
 project(protobuf C CXX)
 


### PR DESCRIPTION
The minimum required CMake version is 3.5. Thus, this message type is supported.

Ref.:
https://cmake.org/cmake/help/v3.5/command/message.html