### PR TITLE
Delete cmake/CMakeLists.txt in favor of CMakeLists.txt

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -566,7 +566,6 @@ pkg_files(
         "LICENSE",
         "README.md",
         "WORKSPACE",
-        "cmake/CMakeLists.txt",
         "cmake/README.md",
         "generate_descriptor_proto.sh",
         "maven_install.json",

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,9 +1,0 @@
-cmake_minimum_required(VERSION 3.5)
-
-message(DEPRECATION "Calling of cmake with source directory set to \"cmake\" subdirectory of Protocol Buffers project is deprecated. Top-level directory of Protocol Buffers project should be used instead.")
-
-project(protobuf C CXX)
-
-set(protobuf_DEPRECATED_CMAKE_SUBDIRECTORY_USAGE TRUE)
-
-include(../CMakeLists.txt)


### PR DESCRIPTION
This fixes https://github.com/protocolbuffers/protobuf/issues/12263, but we will not cherrypick to 22.x since it could be breaking.