### PR TITLE
Add Cybozu to options.md

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -456,3 +456,8 @@ with info about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/Neakxs/protocel
     *   Extension: 1177-1178
+
+1.  Cybozu
+
+    *   Website: https://github.com/cybozu/protobuf
+    *   Extension: 1179


### PR DESCRIPTION
Hello.

We want to make our protobuf repository public which contains a custom extension.
Our code is already available at https://github.com/cybozu/protobuf.

Please let us use extension number 1179.

Regards,