### PR TITLE
JsonFormat - allow one-liners

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -442,8 +442,8 @@ public class JsonFormat {
      * @throws InvalidProtocolBufferException if the input is not valid JSON
      *         proto3 format or there are unknown fields in the input.
      */
-    public Message.Builder merge(String json, Message.Builder builder) throws InvalidProtocolBufferException {
-      // TODO(xiaofeng): Investigate the allocation overhead and optimize for
+    public <T extends Message.Builder> T merge(String json, T builder) throws InvalidProtocolBufferException {
+      // TODO: Investigate the allocation overhead and optimize for
       // mobile.
       new ParserImpl(registry, oldRegistry, ignoringUnknownFields, recursionLimit)
           .merge(json, builder);
@@ -457,8 +457,8 @@ public class JsonFormat {
      *         format or there are unknown fields in the input
      * @throws IOException if reading from the input throws
      */
-    public Message.Builder merge(Reader json, Message.Builder builder) throws IOException {
-      // TODO(xiaofeng): Investigate the allocation overhead and optimize for
+    public <T extends Message.Builder> T merge(Reader json, T builder) throws IOException {
+      // TODO: Investigate the allocation overhead and optimize for
       // mobile.
       new ParserImpl(registry, oldRegistry, ignoringUnknownFields, recursionLimit)
           .merge(json, builder);

--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -442,11 +442,12 @@ public class JsonFormat {
      * @throws InvalidProtocolBufferException if the input is not valid JSON
      *         proto3 format or there are unknown fields in the input.
      */
-    public void merge(String json, Message.Builder builder) throws InvalidProtocolBufferException {
-      // TODO: Investigate the allocation overhead and optimize for
+    public Message.Builder merge(String json, Message.Builder builder) throws InvalidProtocolBufferException {
+      // TODO(xiaofeng): Investigate the allocation overhead and optimize for
       // mobile.
       new ParserImpl(registry, oldRegistry, ignoringUnknownFields, recursionLimit)
           .merge(json, builder);
+      return builder;
     }
 
     /**
@@ -456,11 +457,12 @@ public class JsonFormat {
      *         format or there are unknown fields in the input
      * @throws IOException if reading from the input throws
      */
-    public void merge(Reader json, Message.Builder builder) throws IOException {
-      // TODO: Investigate the allocation overhead and optimize for
+    public Message.Builder merge(Reader json, Message.Builder builder) throws IOException {
+      // TODO(xiaofeng): Investigate the allocation overhead and optimize for
       // mobile.
       new ParserImpl(registry, oldRegistry, ignoringUnknownFields, recursionLimit)
           .merge(json, builder);
+      return builder;
     }
 
     // For testing only.


### PR DESCRIPTION
With proposed change simpler code is possible, for example
```
FooMessage fooMessage = JsonFormat.parser().merge(json, FooMessage.newBuilder()).build();