### PR TITLE
Add missing cstdint include to port.h

### DIFF
--- a/src/google/protobuf/port.h
+++ b/src/google/protobuf/port.h
@@ -38,6 +38,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <new>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
Fixes compile errors with GCC 13.

port.h:186:67: error: ‘uint32_t’ was not declared in this scope
port.h:187:67: error: ‘uint64_t’ was not declared in this scope