### PR TITLE
Suppress -Wunused-parameter warning for GCC and clang.

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -994,6 +994,9 @@ static_assert(PROTOBUF_CPLUSPLUS_MIN(201402L), "Protobuf only supports C++14 and
 // Turn on -Wdeprecated-enum-enum-conversion. This deprecation comes in C++20
 // via http://wg21.link/p1120r0.
 #pragma clang diagnostic error "-Wdeprecated-enum-enum-conversion"
+// This error has been generally flaky, but we need to disable it specifically
+// to fix https://github.com/protocolbuffers/protobuf/issues/12313
+#pragma clang diagnostic ignored "-Wunused-parameter"
 #endif
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -1014,6 +1017,16 @@ static_assert(PROTOBUF_CPLUSPLUS_MIN(201402L), "Protobuf only supports C++14 and
 //   int index = ...
 //   int value = vec[index];
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+// This error has been generally flaky, but we need to disable it specifically
+// to fix https://github.com/protocolbuffers/protobuf/issues/12313
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#if __GNUC__ == 12 && __GNUC_MINOR__ < 4
+// Wrong warning emitted when assigning a single char c-string to a std::string
+// in c++20 mode and optimization on.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
+// Planned to be fixed by 12.3 but widen window to 12.4.
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
 #endif  // __GNUC__
 
 // Silence some MSVC warnings in all our code.

--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -1020,13 +1020,6 @@ static_assert(PROTOBUF_CPLUSPLUS_MIN(201402L), "Protobuf only supports C++14 and
 // This error has been generally flaky, but we need to disable it specifically
 // to fix https://github.com/protocolbuffers/protobuf/issues/12313
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#if __GNUC__ == 12 && __GNUC_MINOR__ < 4
-// Wrong warning emitted when assigning a single char c-string to a std::string
-// in c++20 mode and optimization on.
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
-// Planned to be fixed by 12.3 but widen window to 12.4.
-#pragma GCC diagnostic ignored "-Wrestrict"
-#endif
 #endif  // __GNUC__
 
 // Silence some MSVC warnings in all our code.


### PR DESCRIPTION
Closes https://github.com/protocolbuffers/protobuf/issues/12313

PiperOrigin-RevId: 520066451