### PR TITLE
Fix #12391 - Where BucketNumber has no return type associated, plus adding OP_NO_SANITIZE option cuases a set of warnings to go off in the build process

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -1010,8 +1010,8 @@ class KeyMapBase : public UntypedMapBase {
   }
 
   template <typename K>
-  size_type PROTOBUF_NO_SANITIZE("unsigned-integer-overflow")
-      BucketNumber(const K& k) const {
+  // size_type PROTOBUF_NO_SANITIZE("unsigned-integer-overflow")
+    uint64_t  BucketNumber(const K& k) const {
     // We xor the hash value against the random seed so that we effectively
     // have a random hash function.
     uint64_t h = hash_function()(k) ^ seed_;


### PR DESCRIPTION
…h it.
Fixes a build issue, where the typename is now specified.

