### PR TITLE
Fix inconsistent timestamp json encode/decode

### DIFF
--- a/php/src/Google/Protobuf/Internal/GPBUtil.php
+++ b/php/src/Google/Protobuf/Internal/GPBUtil.php
@@ -485,6 +485,10 @@ class GPBUtil
                 $nanoseconds = substr($timestamp, $periodIndex + 1, $nanosecondsLength);
                 $nanoseconds = intval($nanoseconds);
 
+                if ($nanosecondsLength < 9) {
+                    $nanoseconds = $nanoseconds * pow(10, 9 - $nanosecondsLength);
+                }
+
                 // remove the nanoseconds and preceding period from the timestamp
                 $date = substr($timestamp, 0, $periodIndex);
                 $timezone = substr($timestamp, $periodIndex + $nanosecondsLength + 1);

--- a/php/tests/EncodeDecodeTest.php
+++ b/php/tests/EncodeDecodeTest.php
@@ -992,6 +992,16 @@ class EncodeDecodeTest extends TestBase
                             $m->serializeToJsonString());
     }
 
+    public function testEncodeDecodeTimestampConsistency()
+    {
+        $m = new Google\Protobuf\Timestamp();
+        $m->setSeconds(946684800);
+        $m->setNanos(123000000);
+        $m->mergeFromJsonString($m->serializeToJsonString());
+        $this->assertEquals(946684800, $m->getSeconds());
+        $this->assertEquals(123000000, $m->getNanos());
+    }
+
     public function testDecodeTopLevelValue()
     {
         $m = new Value();


### PR DESCRIPTION
Protobuf php lib encodes 123_000_000 nano like this: 2000-01-01T00:00:00.**123**Z but then it gets decoded into 123 nanoseconds instead of 123_000_000.

There were issue opened some time ago that also describes this behaviour #4335 