### PR TITLE
Change 'File.contents' field from string to bytes

### DIFF
--- a/src/google/protobuf/compiler/plugin.proto
+++ b/src/google/protobuf/compiler/plugin.proto
@@ -169,7 +169,7 @@ message CodeGeneratorResponse {
     optional string insertion_point = 2;
 
     // The file contents.
-    optional string content = 15;
+    optional bytes content = 15;
 
     // Information describing the file content being inserted. If an insertion
     // point is used, this information will be appropriately offset and inserted


### PR DESCRIPTION
`CodeGeneratorResponse.File.content` holds the data for a plugin generated file.  For languages that enforce UTF-8 encoding on protobuf string fields, like Java and Python, there is no easy way to write binary data to this field.   Most plugins don't face any issue here because the files they write are source code, which is UTF-8 compatible.   

However, a plugin that wants to write binary data it's force to choose a workaround:
 - Clone the .proto file and modify the type of the field 
 - Modify the descriptor at runtime and generate a compatible Message
 - Use a different programming language (eg, C++)

None of these are desirable, especially when this can easily be resolved by a one line change to the original `plugin.proto` file.

I'm proposing we simply change this type from `string` to `bytes`. This change is wire compatible but it will break any existing code that relies on the field type as a String, where the language makes a distinction (Java, Python, etc).