### PR TITLE
Fixes #12432 Remove a warning related to unrelated types, of int and std::vector<g…

### DIFF
--- a/src/google/protobuf/compiler/retention.cc
+++ b/src/google/protobuf/compiler/retention.cc
@@ -185,7 +185,7 @@ void StripSourceCodeInfo(std::vector<std::vector<int>>& stripped_paths,
   old_locations.resize(locations->size());
   locations->ExtractSubrange(0, locations->size(), old_locations.data());
   locations->Reserve(old_locations.size() - indices_to_delete.size());
-  for (int i = 0; i < old_locations.size(); ++i) {
+  for (std::vector<google::protobuf::SourceCodeInfo_Location*>::size_type i = 0; i < old_locations.size(); ++i) {
     if (indices_to_delete.contains(i)) {
       delete old_locations[i];
     } else {


### PR DESCRIPTION
…oogle::protobuf::SourceCodeInfo_Location*>::size_type

This fixes #12432 

Here, the code change clears a warning regarding comparison of integers with different signedness.

The logs after this - show that the warning will not appear again:

```
[bob@bob-systemproductname protobuf]$ bazel build --local_cpu_resources=HOST_CPUS*.5 @upb//python/dist:binary_wheel
INFO: Analyzed target @upb//python/dist:binary_wheel (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target @upb//python/dist:binary_wheel up-to-date:
  bazel-bin/external/upb/python/dist/protobuf-4.22.2-cp310-abi3-linux_x86_64.whl
INFO: Elapsed time: 1.888s, Critical Path: 1.69s
INFO: 47 processes: 1 internal, 46 linux-sandbox.
INFO: Build completed successfully, 47 total actions
[bob@bob-systemproductname protobuf]$ bazel clean --expunge
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.
[bob@bob-systemproductname protobuf]$ bazel build --local_cpu_resources=HOST_CPUS*.5 @upb//python/dist:binary_wheel
Starting local Bazel server and connecting to it...
DEBUG: /home/bob/.cache/bazel/_bazel_bob/e5231cd959fa834e92ffd9f3be8a916e/external/rules_ruby/ruby/private/toolchains/ruby_runtime.bzl:297:14: WARNING: no system ruby available, builds against system ruby will fail
DEBUG: /home/bob/.cache/bazel/_bazel_bob/e5231cd959fa834e92ffd9f3be8a916e/external/system_ruby/bundle.bzl:3:10: WARNING: no system ruby found for bundle
INFO: Analyzed target @upb//python/dist:binary_wheel (169 packages loaded, 2424 targets configured).
INFO: Found 1 target...
INFO: From Compiling src/google/protobuf/generated_message_tctable_lite.cc [for tool]:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/generated_message_tctable_decl.h:45,
                 from src/google/protobuf/generated_message_tctable_lite.cc:37:
bazel-out/k8-opt-exec-2B5CBBC6/bin/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:961:1: warning: 'always_inline' function might not be inlinable [-Wattributes]
  961 | ParseContext::ParseLengthDelimitedInlined(const char* ptr, const Func& func) {
      | ^~~~~~~~~~~~
src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
  871 | PROTOBUF_ALWAYS_INLINE const char* TcParser::FastVarintS1(
      |                                    ^~~~~~~~
src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
INFO: From Compiling src/google/protobuf/generated_message_tctable_lite.cc [for tool]:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/generated_message_tctable_decl.h:45,
                 from external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:37:
bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:961:1: warning: 'always_inline' function might not be inlinable [-Wattributes]
  961 | ParseContext::ParseLengthDelimitedInlined(const char* ptr, const Func& func) {
      | ^~~~~~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
  871 | PROTOBUF_ALWAYS_INLINE const char* TcParser::FastVarintS1(
      |                                    ^~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
INFO: From Building wheel @upb//python/dist:binary_wheel:
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/any_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/api_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/compiler/plugin_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/descriptor_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/duration_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/empty_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/field_mask_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/source_context_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/struct_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/timestamp_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/type_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
/usr/lib/python3.10/zipfile.py:1517: UserWarning: Duplicate name: 'google/protobuf/wrappers_pb2.py'
  return self._open_to_write(zinfo, force_zip64=force_zip64)
Target @upb//python/dist:binary_wheel up-to-date:
  bazel-bin/external/upb/python/dist/protobuf-4.22.2-cp310-abi3-linux_x86_64.whl
INFO: Elapsed time: 79.036s, Critical Path: 22.42s
INFO: 1105 processes: 448 internal, 657 linux-sandbox.
INFO: Build completed successfully, 1105 total actions
```

Should there be any errors or problems with this approach? please do let me know.