### PR TITLE
Update submodule abseil-app branch to lts_2023_01_25

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "third_party/abseil-cpp"]
 	path = third_party/abseil-cpp
 	url = https://github.com/abseil/abseil-cpp.git
-	branch = lts_2023_01_24
+	branch = lts_2023_01_25
 [submodule "third_party/jsoncpp"]
 	path = third_party/jsoncpp
 	url = https://github.com/open-source-parsers/jsoncpp.git


### PR DESCRIPTION
I encountered a compilation error while developing in c++, and the following is part of the error:
```
onnx.pb.cc:(.text._ZN4absl12lts_2023012512log_internal10LogMessagelsILi59EEERS2_RAT__Kc[_ZN4absl12lts_2023012512log_internal10LogMessagelsILi59EEERS2_RAT__Kc]+0x58): undefined reference to `absl::Lts_20230125::log_internal::LogMessage::CopyToEncodedBuffer(std::basic_string_view<char, std::char_traits<char>>, absl::lts_20230125::log_internal::LogMessage::StringType)'
```

The abseil-cpp dependency declared in third_party [`third_party`](https://github.com/protocolbuffers/protobuf/tree/main/third_party) is commit [78be636](https://github.com/abseil/abseil-cpp/commit/78be63686ba732b25052be15f8d6dee891c05749). In absl/base/options.hz in this commit set the absl_lst version to 20230125 as follows:
```cpp
#define ABSL_LTS_RELEASE_VERSION 20230125
```

The branch lts_2023_01_24 has now been removed from abseil-cpp, and the .gitmodules still depend on that branch.
