### PR TITLE
Fix .gitmodules to use the correct absl branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "third_party/abseil-cpp"]
 	path = third_party/abseil-cpp
 	url = https://github.com/abseil/abseil-cpp.git
-	branch = lts_2023_01_24
+	branch = lts_2023_01_25
 [submodule "third_party/jsoncpp"]
 	path = third_party/jsoncpp
 	url = https://github.com/open-source-parsers/jsoncpp.git


### PR DESCRIPTION
The branch name is now lts_2023_01_25: https://github.com/abseil/abseil-cpp/tree/lts_2023_01_25