### PR TITLE
Varint: Save a branch in over-serialized case and remove inline-assembly

### DIFF
--- a/src/google/protobuf/varint_shuffle.h
+++ b/src/google/protobuf/varint_shuffle.h
@@ -151,15 +151,8 @@ inline PROTOBUF_ALWAYS_INLINE const char* ShiftMixParseVarint(const char* p,
   // over-serialized varint. This case should not happen, but if does (say, due
   // to a nonconforming serializer), deassert the continuation bit that came
   // from ptr[8].
-  if (kIs64BitVarint && (last() & 1) == 0) {
-    static constexpr int bits = 64 - 1;
-#if defined(__GCC_ASM_FLAG_OUTPUTS__) && defined(__x86_64__)
-    // Use a small instruction since this is an uncommon code path.
-    asm("btc %[bits], %[res3]" : [res3] "+r"(res3) : [bits] "i"(bits));
-#else
-    res3 ^= int64_t{1} << bits;
-#endif
-  }
+  if (kIs64BitVarint)
+    res3 ^= int64_t{~last() & 1} << 63;
 
 done2:
   res2 &= res3;


### PR DESCRIPTION
```
if(x & 1 == 0)
    y ^= 1 << 63

```

Is equivilent to:
```
y ^= (~x & 1) << 63
```

And the latter saves a branch at no instruction cost.

LLVM-17 currently doesn't get this (although patchset going there too
to fix that).

The inline-assembly version does save an instruction (if
macrofused). But 1-branch for 2-alu is almost certainly a worthwhile
trade.