### PR TITLE
Update version.json to 23-dev

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,17 +1,17 @@
 {
     "main": {
-        "protoc_version": "22-dev",
+        "protoc_version": "23-dev",
         "lts": false,
-        "date": "2022-07-21",
+        "date": "2023-01-26",
         "languages": {
-            "cpp": "4.22-dev",
-            "csharp": "3.22-dev",
-            "java": "3.22-dev",
-            "javascript": "3.22-dev",
-            "objectivec": "3.22-dev",
-            "php": "3.22-dev",
-            "python": "4.22-dev",
-            "ruby": "3.22-dev"
+            "cpp": "4.23-dev",
+            "csharp": "3.23-dev",
+            "java": "3.23-dev",
+            "javascript": "3.23-dev",
+            "objectivec": "3.23-dev",
+            "php": "3.23-dev",
+            "python": "4.23-dev",
+            "ruby": "3.23-dev"
         }
     }
 }


### PR DESCRIPTION
This commit should have been auto-generated as in https://github.com/protocolbuffers/protobuf/commit/96ecd25b9c88d59113cb629505e61ebf4130f3ad, but we missed the step merging this to main from CSR when 22.x was cut.