### PR TITLE
[Bazel, Python]: fix build during cross build

### DIFF
--- a/python/internal.bzl
+++ b/python/internal.bzl
@@ -1,5 +1,11 @@
 # Internal helpers for building the Python protobuf runtime.
 
+def _remove_cross_repo_path(path):
+    parts = path.split('/')
+    if parts[0] == '..':
+        return '/'.join(parts[2:])
+    return path
+
 def _internal_copy_files_impl(ctx):
     strip_prefix = ctx.attr.strip_prefix
     if strip_prefix[-1] != "/":
@@ -7,10 +13,11 @@ def _internal_copy_files_impl(ctx):
 
     src_dests = []
     for src in ctx.files.srcs:
-        if src.short_path[:len(strip_prefix)] != strip_prefix:
+        short_path = _remove_cross_repo_path(src.short_path)
+        if short_path[:len(strip_prefix)] != strip_prefix:
             fail("Source does not start with %s: %s" %
-                 (strip_prefix, src.short_path))
-        dest = ctx.actions.declare_file(src.short_path[len(strip_prefix):])
+                 (strip_prefix, short_path))
+        dest = ctx.actions.declare_file(short_path[len(strip_prefix):])
         src_dests.append([src, dest])
 
     if ctx.attr.is_windows:


### PR DESCRIPTION
Per https://github.com/protocolbuffers/protobuf/issues/12523, building protobuf's python runtime from another repository fails:

```
 %  bazel build @com_google_protobuf//python:all
ERROR: /home/zhongmingqu/.cache/bazel/_bazel_zhongmingqu/33d097c4393d1ec801bb3e6d74ed212d/external/com_google_protobuf/python/BUILD.bazel:191:20: in internal_copy_files_impl rule @com_google_protobuf//python:copied_test_messages_proto2_files:
Traceback (most recent call last):
        File "/home/zhongmingqu/.cache/bazel/_bazel_zhongmingqu/33d097c4393d1ec801bb3e6d74ed212d/external/com_google_protobuf/python/internal.bzl", line 11, column 17, in _internal_copy_files_impl
                fail("Source does not start with %s: %s" %
Error in fail: Source does not start with src/: ../com_google_protobuf/src/google/protobuf/test_messages_proto2.proto
```

This is caused by python/internal.bzl not taking into account the possibility of such crossbuilds.

UPB vendored a fix for this:
	https://github.com/protocolbuffers/upb/blob/ec75a3cbb60ba714b14efafa76304544dbf38624/bazel/protobuf.patch#L60

But that patch includes irrelevant chunks.

This commit fixes the problem by essentially copying UPB's fix.