### PR TITLE
fix missing int32_t

### DIFF
--- a/src/google/protobuf/compiler/objectivec/text_format_decode_data.h
+++ b/src/google/protobuf/compiler/objectivec/text_format_decode_data.h
@@ -31,6 +31,7 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_TEXT_FORMAT_DECODE_DATA_H__
 #define GOOGLE_PROTOBUF_COMPILER_OBJECTIVEC_TEXT_FORMAT_DECODE_DATA_H__
 
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Fix for unknown type `int32_t` in `src/google/protobuf/compiler/objectivec/text_format_decode_data.h`

Issue encountered when building with GCC 13 (MinGW-w64 on Windows 64-bit).

Error:
```
In file included from R:/winlibs-gcc13-64/protobuf-22.3/src/google/protobuf/compiler/objectivec/text_format_decode_data.cc:31:
R:/winlibs-gcc13-64/protobuf-22.3/src/google/protobuf/compiler/objectivec/text_format_decode_data.h:59:18: error: 'int32_t' has not been declared
   59 |   void AddString(int32_t key, const std::string& input_for_decode,
      |                  ^~~~~~~
R:/winlibs-gcc13-64/protobuf-22.3/src/google/protobuf/compiler/objectivec/text_format_decode_data.h:68:21: error: 'int32_t' was not declared in this scope
   68 |   typedef std::pair<int32_t, std::string> DataEntry;
      |                     ^~~~~~~
R:/winlibs-gcc13-64/protobuf-22.3/src/google/protobuf/compiler/objectivec/text_format_decode_data.h:40:1: note: 'int32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   39 | #include "google/protobuf/port_def.inc"
  +++ |+#include <cstdint>
   40 |
```