### PR TITLE
Enable the selection of system provided jsoncpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,9 @@ endif (protobuf_UNICODE)
 set(protobuf_ABSL_PROVIDER "module" CACHE STRING "Provider of absl library")
 set_property(CACHE protobuf_ABSL_PROVIDER PROPERTY STRINGS "module" "package")
 
+set(protobuf_JSONCPP_PROVIDER "module" CACHE STRING "Provider of jsoncpp library")
+set_property(CACHE protobuf_JSONCPP_PROVIDER PROPERTY STRINGS "module" "package")
+
 if (protobuf_BUILD_TESTS)
   include(${protobuf_SOURCE_DIR}/cmake/gtest.cmake)
 endif (protobuf_BUILD_TESTS)

--- a/cmake/conformance.cmake
+++ b/cmake/conformance.cmake
@@ -1,12 +1,15 @@
-
-if (NOT EXISTS "${protobuf_SOURCE_DIR}/third_party/jsoncpp/CMakeLists.txt")
-  message(FATAL_ERROR
-          "Cannot find third_party/jsoncpp directory that's needed to "
-          "build conformance tests. If you use git, make sure you have cloned "
-          "submodules:\n"
-          "  git submodule update --init --recursive\n"
-          "If instead you want to skip them, run cmake with:\n"
-          "  cmake -Dprotobuf_BUILD_CONFORMANCE=OFF\n")
+if (protobuf_JSONCPP_PROVIDER STREQUAL "module")
+  if (NOT EXISTS "${protobuf_SOURCE_DIR}/third_party/jsoncpp/CMakeLists.txt")
+    message(FATAL_ERROR
+            "Cannot find third_party/jsoncpp directory that's needed to "
+            "build conformance tests. If you use git, make sure you have cloned "
+            "submodules:\n"
+            "  git submodule update --init --recursive\n"
+            "If instead you want to skip them, run cmake with:\n"
+            "  cmake -Dprotobuf_BUILD_CONFORMANCE=OFF\n")
+  endif()
+elseif(protobuf_JSONCPP_PROVIDER STREQUAL "package")
+  find_package(jsoncpp REQUIRED)
 endif()
 
 add_custom_command(
@@ -84,6 +87,10 @@ add_test(NAME conformance_cpp_test
   DEPENDS conformance_test_runner conformance_cpp)
 
 set(JSONCPP_WITH_TESTS OFF CACHE BOOL "Disable tests")
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/jsoncpp third_party/jsoncpp)
-target_include_directories(conformance_test_runner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/jsoncpp/include)
-target_link_libraries(conformance_test_runner jsoncpp_lib)
+if(protobuf_JSONCPP_PROVIDER STREQUAL "module")
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/jsoncpp third_party/jsoncpp)
+  target_include_directories(conformance_test_runner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/jsoncpp/include)
+  target_link_libraries(conformance_test_runner jsoncpp_lib)
+else()
+  target_link_libraries(conformance_test_runner jsoncpp)
+endif()


### PR DESCRIPTION
Allows the use of an external `jsoncpp` library to be used. Replicates the model used by `abseil-cpp` as a "package" or "module" to the `protobuf_JSONCPP_PROVIDER` option.

Resolves: #11827