### PR TITLE
text_format_decode_data: Add missing cstdint include

### DIFF
--- a/src/google/protobuf/compiler/objectivec/text_format_decode_data.cc
+++ b/src/google/protobuf/compiler/objectivec/text_format_decode_data.cc
@@ -35,6 +35,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/escaping.h"

--- a/src/google/protobuf/compiler/objectivec/text_format_decode_data.h
+++ b/src/google/protobuf/compiler/objectivec/text_format_decode_data.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <cstdint>
 
 // Must be included last
 #include "google/protobuf/port_def.inc"


### PR DESCRIPTION
Fixes compile errors with GCC 13

../protobuf-22.3/src/google/protobuf/compiler/objectivec/text_format_decode_data.h:59:18: error: 'int32_t' has not been declared