### PR TITLE
fix(libprotoc): export useful symbols from .so

### DIFF
--- a/src/google/protobuf/compiler/cpp/helpers.h
+++ b/src/google/protobuf/compiler/cpp/helpers.h
@@ -119,10 +119,10 @@ std::string Namespace(const FileDescriptor* d, const Options& options);
 std::string Namespace(const Descriptor* d, const Options& options);
 std::string Namespace(const FieldDescriptor* d, const Options& options);
 std::string Namespace(const EnumDescriptor* d, const Options& options);
-std::string Namespace(const FileDescriptor* d);
-std::string Namespace(const Descriptor* d);
-std::string Namespace(const FieldDescriptor* d);
-std::string Namespace(const EnumDescriptor* d);
+PROTOC_EXPORT std::string Namespace(const FileDescriptor* d);
+PROTOC_EXPORT std::string Namespace(const Descriptor* d);
+PROTOC_EXPORT std::string Namespace(const FieldDescriptor* d);
+PROTOC_EXPORT std::string Namespace(const EnumDescriptor* d);
 
 class MessageSCCAnalyzer;
 
@@ -136,14 +136,14 @@ bool CanClearByZeroing(const FieldDescriptor* field);
 bool HasTrivialSwap(const FieldDescriptor* field, const Options& options,
                     MessageSCCAnalyzer* scc_analyzer);
 
-std::string ClassName(const Descriptor* descriptor);
-std::string ClassName(const EnumDescriptor* enum_descriptor);
+PROTOC_EXPORT std::string ClassName(const Descriptor* descriptor);
+PROTOC_EXPORT std::string ClassName(const EnumDescriptor* enum_descriptor);
 
 std::string QualifiedClassName(const Descriptor* d, const Options& options);
 std::string QualifiedClassName(const EnumDescriptor* d, const Options& options);
 
-std::string QualifiedClassName(const Descriptor* d);
-std::string QualifiedClassName(const EnumDescriptor* d);
+PROTOC_EXPORT std::string QualifiedClassName(const Descriptor* d);
+PROTOC_EXPORT std::string QualifiedClassName(const EnumDescriptor* d);
 
 // DEPRECATED just use ClassName or QualifiedClassName, a boolean is very
 // unreadable at the callsite.
@@ -215,7 +215,7 @@ std::string ResolveKeyword(absl::string_view name);
 // The name is coerced to lower-case to emulate proto1 behavior.  People
 // should be using lowercase-with-underscores style for proto field names
 // anyway, so normally this just returns field->name().
-std::string FieldName(const FieldDescriptor* field);
+PROTOC_EXPORT std::string FieldName(const FieldDescriptor* field);
 
 // Returns the (unqualified) private member name for this field in C++ code.
 std::string FieldMemberName(const FieldDescriptor* field, bool split);

--- a/src/google/protobuf/compiler/cpp/names.h
+++ b/src/google/protobuf/compiler/cpp/names.h
@@ -57,10 +57,10 @@ namespace cpp {
 //   message Baz { message Moo {} }
 // Then the qualified namespace for Moo would be:
 //   ::foo::bar
-std::string Namespace(const FileDescriptor* d);
-std::string Namespace(const Descriptor* d);
-std::string Namespace(const FieldDescriptor* d);
-std::string Namespace(const EnumDescriptor* d);
+PROTOC_EXPORT std::string Namespace(const FileDescriptor* d);
+PROTOC_EXPORT std::string Namespace(const Descriptor* d);
+PROTOC_EXPORT std::string Namespace(const FieldDescriptor* d);
+PROTOC_EXPORT std::string Namespace(const EnumDescriptor* d);
 
 // Returns the unqualified C++ name.
 //
@@ -69,8 +69,8 @@ std::string Namespace(const EnumDescriptor* d);
 //   message Baz { message Moo {} }
 // Then the non-qualified version would be:
 //   Baz_Moo
-std::string ClassName(const Descriptor* descriptor);
-std::string ClassName(const EnumDescriptor* enum_descriptor);
+PROTOC_EXPORT std::string ClassName(const Descriptor* descriptor);
+PROTOC_EXPORT std::string ClassName(const EnumDescriptor* enum_descriptor);
 
 // Returns the fully qualified C++ name.
 //
@@ -79,25 +79,26 @@ std::string ClassName(const EnumDescriptor* enum_descriptor);
 //   message Baz { message Moo {} }
 // Then the qualified ClassName for Moo would be:
 //   ::foo::bar::Baz_Moo
-std::string QualifiedClassName(const Descriptor* d);
-std::string QualifiedClassName(const EnumDescriptor* d);
-std::string QualifiedExtensionName(const FieldDescriptor* d);
+PROTOC_EXPORT std::string QualifiedClassName(const Descriptor* d);
+PROTOC_EXPORT std::string QualifiedClassName(const EnumDescriptor* d);
+PROTOC_EXPORT std::string QualifiedExtensionName(const FieldDescriptor* d);
 
 // Get the (unqualified) name that should be used for this field in C++ code.
 // The name is coerced to lower-case to emulate proto1 behavior.  People
 // should be using lowercase-with-underscores style for proto field names
 // anyway, so normally this just returns field->name().
-std::string FieldName(const FieldDescriptor* field);
+PROTOC_EXPORT std::string FieldName(const FieldDescriptor* field);
 
 // Requires that this field is in a oneof. Returns the (unqualified) case
 // constant for this field.
-std::string OneofCaseConstantName(const FieldDescriptor* field);
+PROTOC_EXPORT std::string OneofCaseConstantName(const FieldDescriptor* field);
 // Returns the quafilied case constant for this field.
-std::string QualifiedOneofCaseConstantName(const FieldDescriptor* field);
+PROTOC_EXPORT std::string QualifiedOneofCaseConstantName(
+    const FieldDescriptor* field);
 
 // Get the (unqualified) name that should be used for this enum value in C++
 // code.
-std::string EnumValueName(const EnumValueDescriptor* enum_value);
+PROTOC_EXPORT std::string EnumValueName(const EnumValueDescriptor* enum_value);
 
 // Strips ".proto" or ".protodevel" from the end of a filename.
 PROTOC_EXPORT std::string StripProto(absl::string_view filename);


### PR DESCRIPTION
Cherrypick of https://github.com/protocolbuffers/protobuf/pull/12619