### PR TITLE
Fix CMake tests

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -123,7 +123,7 @@ jobs:
       # Initialize/update the submodule from remote to validate a new fetch based on .gitmodules
       # We have to do this separately since actions/checkout doesn't support the "--remote" flag
       - name: Update submodules
-        run: git submodule update --init --remote --recursive
+        run: git submodule update --init --recursive
 
       - name: Setup ccache
         uses: protocolbuffers/protobuf-ci/ccache@v1
@@ -147,7 +147,7 @@ jobs:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Update submodules
-        run: git submodule update --init --remote --recursive
+        run: git submodule update --init --recursive
 
       - name: Setup ccache
         uses: protocolbuffers/protobuf-ci/ccache@v1
@@ -178,7 +178,7 @@ jobs:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Update submodules
-        run: git submodule update --init --remote --recursive
+        run: git submodule update --init --recursive
 
       - name: Setup ccache
         uses: protocolbuffers/protobuf-ci/ccache@v1
@@ -309,7 +309,7 @@ jobs:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Update submodules
-        run: git submodule update --init --remote --recursive
+        run: git submodule update --init --recursive
 
       - name: Setup ccache
         uses: protocolbuffers/protobuf-ci/ccache@v1


### PR DESCRIPTION
Don't pull from remote for cmake tests, keep to the local pin of subrepositories.