### PR TITLE
protobuf-mode: Remove no-op easy-menu-add call.

### DIFF
--- a/editors/protobuf-mode.el
+++ b/editors/protobuf-mode.el
@@ -206,7 +206,6 @@ Key bindings:
   (c-initialize-cc-mode t)
   (c-init-language-vars protobuf-mode)
   (c-common-init 'protobuf-mode)
-  (easy-menu-add protobuf-menu)
   (setq imenu-generic-expression
 	    '(("Message" "^[[:space:]]*message[[:space:]]+\\([[:alnum:]]+\\)" 1)
           ("Enum" "^[[:space:]]*enum[[:space:]]+\\([[:alnum:]]+\\)" 1)


### PR DESCRIPTION
easy-menu-add has always been a no-op in GNU emacs. It did something in XEmacs, but XEmacs is dead.
