### PR TITLE
fix: avoid warnings on MSVC

### DIFF
--- a/src/google/protobuf/arena_align.h
+++ b/src/google/protobuf/arena_align.h
@@ -99,7 +99,7 @@ struct ArenaAlignDefault {
   }
 
   static inline PROTOBUF_ALWAYS_INLINE constexpr size_t Ceil(size_t n) {
-    return (n + align - 1) & -align;
+    return (n + align - 1) & ~(align - 1);
   }
   static inline PROTOBUF_ALWAYS_INLINE constexpr size_t Floor(size_t n) {
     return (n & ~(align - 1));
@@ -113,7 +113,7 @@ struct ArenaAlignDefault {
   template <typename T>
   static inline PROTOBUF_ALWAYS_INLINE T* Ceil(T* ptr) {
     uintptr_t intptr = reinterpret_cast<uintptr_t>(ptr);
-    return reinterpret_cast<T*>((intptr + align - 1) & -align);
+    return reinterpret_cast<T*>((intptr + align - 1) & ~(align - 1));
   }
 
   template <typename T>
@@ -142,7 +142,7 @@ struct ArenaAlign {
     return (reinterpret_cast<uintptr_t>(ptr) & (align - 1)) == 0U;
   }
 
-  constexpr size_t Ceil(size_t n) const { return (n + align - 1) & -align; }
+  constexpr size_t Ceil(size_t n) const { return (n + align - 1) & ~(align - 1); }
   constexpr size_t Floor(size_t n) const { return (n & ~(align - 1)); }
 
   constexpr size_t Padded(size_t n) const {
@@ -156,7 +156,7 @@ struct ArenaAlign {
   template <typename T>
   T* Ceil(T* ptr) const {
     uintptr_t intptr = reinterpret_cast<uintptr_t>(ptr);
-    return reinterpret_cast<T*>((intptr + align - 1) & -align);
+    return reinterpret_cast<T*>((intptr + align - 1) & ~(align - 1));
   }
 
   template <typename T>


### PR DESCRIPTION
Warnings in header files can be a problem for consumers that enable `/WX` (or `-Werror`).  In this case, using `... & -align` produces a warning (C4146) with MSVC. The fix is to use equivalent expression `...  & ~(align - 1)`, which was already used in the same file.

Fixes #12675 