### PR TITLE
fix: missing -DPROTOBUF_USE_DLLS in pkg-config

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -12,6 +12,10 @@ foreach (_target IN LISTS _pc_target_list)
   string(CONCAT _protobuf_PC_REQUIRES "${_protobuf_PC_REQUIRES}" "${_sep}" "${_target}")
   set(_sep " ")
 endforeach ()
+set(_protobuf_PC_CFLAGS)
+if (protobuf_BUILD_SHARED_LIBS)
+  set(_protobuf_PC_CFLAGS -DPROTOBUF_USE_DLLS)
+endif ()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/protobuf.pc.cmake
                ${CMAKE_CURRENT_BINARY_DIR}/protobuf.pc @ONLY)

--- a/cmake/protobuf-lite.pc.cmake
+++ b/cmake/protobuf-lite.pc.cmake
@@ -8,5 +8,5 @@ Description: Google's Data Interchange Format
 Version: @protobuf_VERSION@
 Requires: @_protobuf_PC_REQUIRES@
 Libs: -L${libdir} -lprotobuf-lite @CMAKE_THREAD_LIBS_INIT@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @_protobuf_PC_CFLAGS@
 Conflicts: protobuf

--- a/cmake/protobuf.pc.cmake
+++ b/cmake/protobuf.pc.cmake
@@ -8,5 +8,5 @@ Description: Google's Data Interchange Format
 Version: @protobuf_VERSION@
 Requires: @_protobuf_PC_REQUIRES@
 Libs: -L${libdir} -lprotobuf @CMAKE_THREAD_LIBS_INIT@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @_protobuf_PC_CFLAGS@
 Conflicts: protobuf-lite


### PR DESCRIPTION
When the protobuf libraries have been compiled as shared libraries the users of the library need to add `-DPROTOBUF_USE_DLLS` to their build line. Otherwise some symbols are missing.

Fixes #12699 

FWIW, I am not sure this is an ideal fix.  It may be better to fix the headers such that no macros change the ABI.