### PR TITLE
fix: avoid warnings on Windows

### DIFF
--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -505,7 +505,7 @@ template <typename Element>
 inline RepeatedField<Element>::RepeatedField(const RepeatedField& rhs)
     : current_size_(0), total_size_(0), arena_or_elements_(nullptr) {
   StaticValidityCheck();
-  if (size_t size = rhs.current_size_) {
+  if (auto size = rhs.current_size_) {
     Grow(0, size);
     ExchangeCurrentSize(size);
     UninitializedCopyN(rhs.elements(), size, unsafe_elements());
@@ -786,7 +786,7 @@ inline void RepeatedField<Element>::Clear() {
 template <typename Element>
 inline void RepeatedField<Element>::MergeFrom(const RepeatedField& rhs) {
   ABSL_DCHECK_NE(&rhs, this);
-  if (size_t size = rhs.current_size_) {
+  if (auto size = rhs.current_size_) {
     Reserve(current_size_ + size);
     Element* dst = elements() + ExchangeCurrentSize(current_size_ + size);
     UninitializedCopyN(rhs.elements(), size, dst);


### PR DESCRIPTION
On Wndows, `size_t` is 64-bits, and `int` is 32-bits. That makes conversions from `size_t` to `int` potentially lossy, and they generate warnings.  In this case an `int` variable was assigned to `size_t` and then passed to functions consuming `int`. Seems simpler to use `auto` and avoid these problems altogether.