### PR TITLE
cleanup(cmake): automatically use newer policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,10 @@
-# Minimum CMake required
-cmake_minimum_required(VERSION 3.10)
+# Minimum CMake required. If available, accept the policy-controlled behavior up
+# to 3.26.
+cmake_minimum_required(VERSION 3.10...3.26)
 
 if(protobuf_VERBOSE)
   message(STATUS "Protocol Buffers Configuring...")
 endif()
-
-# MSVC runtime library flags are selected by an abstraction.
-# New in CMake 3.15: https://cmake.org/cmake/help/latest/policy/CMP0091.html
-if(POLICY CMP0091)
-  cmake_policy(SET CMP0091 NEW)
-endif()
-
-# option() honors normal variables
-# New in CMake 3.13: https://cmake.org/cmake/help/latest/policy/CMP0077.html
-if (POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif (POLICY CMP0077)
 
 # Project
 project(protobuf C CXX)


### PR DESCRIPTION
CMake has fairly strict backwards compatibility behavior. Saying `cmake_minimum_required(VERSION 3.10)` has two effects:

- It requires CMake to be version 3.10 or higher
- It configures CMake to behave exactly as it did in version 3.10

The code used to override some policies to get newer behavior if it was available. The alternative syntax in this PR says "require at least 3.10, and use the behavior (when available) up to 3.26". We can omit policy overrides by doing so. It does not seem like any other policies are important, so we can use the simpler syntax.