### PR TITLE
fix(cmake): use `find_dependency()` in config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if (protobuf_WITH_ZLIB)
     # Using imported target if exists
     if (TARGET ZLIB::ZLIB)
       set(ZLIB_LIBRARIES ZLIB::ZLIB)
-      set(_protobuf_FIND_ZLIB "if(NOT ZLIB_FOUND)\n  find_package(ZLIB)\nendif()")
+      set(_protobuf_FIND_ZLIB "if(NOT ZLIB_FOUND)\n  find_dependency(ZLIB)\nendif()")
     endif (TARGET ZLIB::ZLIB)
   else (ZLIB_FOUND)
     set(HAVE_ZLIB 0)

--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -35,7 +35,7 @@ elseif(protobuf_ABSL_PROVIDER STREQUAL "package")
   # Use "CONFIG" as there is no built-in cmake module for absl.
   find_package(absl REQUIRED CONFIG)
 endif()
-set(_protobuf_FIND_ABSL "if(NOT TARGET absl::strings)\n  find_package(absl CONFIG)\nendif()")
+set(_protobuf_FIND_ABSL "if(NOT TARGET absl::strings)\n  find_dependency(absl CONFIG)\nendif()")
 
 if (BUILD_SHARED_LIBS AND MSVC)
   # On MSVC Abseil is bundled into a single DLL.

--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -2,6 +2,7 @@
 include("${CMAKE_CURRENT_LIST_DIR}/protobuf-options.cmake")
 
 # Depend packages
+include(CMakeFindDependencyMacro)
 @_protobuf_FIND_ZLIB@
 @_protobuf_FIND_ABSL@
 @_protobuf_FIND_UTF8_RANGE@

--- a/cmake/utf8_range.cmake
+++ b/cmake/utf8_range.cmake
@@ -12,4 +12,4 @@ if (NOT TARGET utf8_range)
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/utf8_range)
 endif ()
 
-set(_protobuf_FIND_UTF8_RANGE "if(NOT TARGET utf8_range)\n  find_package(utf8_range CONFIG)\nendif()")
+set(_protobuf_FIND_UTF8_RANGE "if(NOT TARGET utf8_range)\n  find_dependency(utf8_range CONFIG)\nendif()")


### PR DESCRIPTION
`find_dependency()` is designed to be used in `*-config.cmake` files. It is a thin wrapper around `find_package()` that propagates any `QUIET` or `REQUIRED` parameters:

  https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html

In general, the error messages from `find_dependency()` are easier to grok.  Without them it may be hard to find out why a `find_package(Protobuf CONFIG REQUIRED)` failed, or to understand why `find_package(Protobuf CONFIG QUIET)` is generating noise Protobuf's dependencies.