### PR TITLE
Fix crash in #12104 (cherry-pick)

### DIFF
--- a/src/google/protobuf/wire_format.h
+++ b/src/google/protobuf/wire_format.h
@@ -357,8 +357,9 @@ inline size_t WireFormat::TagSize(int field_number,
 inline void WireFormat::VerifyUTF8String(const char* data, int size,
                                          WireFormat::Operation op) {
 #ifdef GOOGLE_PROTOBUF_UTF8_VALIDATION_ENABLED
-  WireFormatLite::VerifyUtf8String(
-      data, size, static_cast<WireFormatLite::Operation>(op), nullptr);
+  WireFormatLite::VerifyUtf8String(data, size,
+                                   static_cast<WireFormatLite::Operation>(op),
+                                   /* field_name = */ "");
 #else
   // Avoid the compiler warning about unused variables.
   (void)data;


### PR DESCRIPTION
This crash was due to the fact that we were passing `nullptr` as a `const char*` parameter and relying on that implicitly converting into an empty `absl::string_view`. `absl::string_view` supports that functionality, but starting with C++17 its behavior changes since it's just a type alias for `std::string_view`. `std::string_view` does not have any special conversion for nullptr and so we were just getting crashes.

PiperOrigin-RevId: 530431663