### PR TITLE
Backport GCC tests+fixes

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -114,11 +114,15 @@ jobs:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
         include:
-          - flags: -Dprotobuf_BUILD_EXAMPLES=ON
+          - flags: -Dprotobuf_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=14
           - name: Ninja
-            flags: -G Ninja
+            flags: -G Ninja -DCMAKE_CXX_STANDARD=14
           - name: Shared
-            flags: -Dprotobuf_BUILD_SHARED_LIBS=ON -Dprotobuf_BUILD_EXAMPLES=ON
+            flags: -Dprotobuf_BUILD_SHARED_LIBS=ON -Dprotobuf_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=14
+          - name: C++17
+            flags: -DCMAKE_CXX_STANDARD=17
+          - name: C++20
+            flags: -DCMAKE_CXX_STANDARD=20
 
     name: Linux CMake ${{ matrix.name}}
     runs-on: ubuntu-latest
@@ -202,7 +206,18 @@ jobs:
             cmake --build .
 
   linux-cmake-gcc:
-    name: Linux CMake GCC
+    strategy:
+      fail-fast: false   # Don't cancel all jobs if one fails.
+      matrix:
+        include:
+          - name: C++14
+            flags: -DCMAKE_CXX_STANDARD=14
+          - name: C++17
+            flags: -DCMAKE_CXX_STANDARD=17
+          - name: C++20
+            flags: -DCMAKE_CXX_STANDARD=20
+
+    name: Linux CMake GCC ${{ matrix.name }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pending changes
@@ -214,7 +229,7 @@ jobs:
       - name: Setup ccache
         uses: protocolbuffers/protobuf-ci/ccache@v1
         with:
-          cache-prefix: linux-cmake-gcc
+          cache-prefix: linux-cmake-gcc-${{ matrix.name }}
 
       - name: Run tests
         uses: protocolbuffers/protobuf-ci/docker@v1
@@ -226,7 +241,7 @@ jobs:
               -c 'set -ex;
               cd /workspace;
               ccache -z;
-              cmake . -DCMAKE_CXX_STANDARD=14 ${{ env.CCACHE_CMAKE_FLAGS }};
+              cmake . ${{ matrix.flags }} ${{ env.CCACHE_CMAKE_FLAGS }};
               cmake --build . --parallel 20;
               ctest --verbose --parallel 20;
               ccache -s'

--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -679,6 +679,12 @@ static_assert(PROTOBUF_CPLUSPLUS_MIN(201402L), "Protobuf only supports C++14 and
 #  define PROTOBUF_CONSTINIT
 #  define PROTOBUF_CONSTEXPR constexpr
 # endif
+#elif defined(__GNUC__) && !defined(__clang__)
+// GCC doesn't support constinit aggregate initialization of absl::Cord.
+# if PROTOBUF_GNUC_MIN(12, 2)
+#  define PROTOBUF_CONSTINIT
+#  define PROTOBUF_CONSTEXPR constexpr
+# endif
 #else
 # if defined(__cpp_constinit) && !defined(__CYGWIN__)
 #  define PROTOBUF_CONSTINIT constinit
@@ -692,9 +698,6 @@ static_assert(PROTOBUF_CPLUSPLUS_MIN(201402L), "Protobuf only supports C++14 and
         ((defined(__APPLE__) && PROTOBUF_CLANG_MIN(13, 0)) ||             \
      (!defined(__APPLE__) && PROTOBUF_CLANG_MIN(12, 0)))
 #  define PROTOBUF_CONSTINIT [[clang::require_constant_initialization]]
-#  define PROTOBUF_CONSTEXPR constexpr
-# elif PROTOBUF_GNUC_MIN(12, 2)
-#  define PROTOBUF_CONSTINIT __constinit
 #  define PROTOBUF_CONSTEXPR constexpr
 # endif
 #endif


### PR DESCRIPTION
This also adds tests for C++17 and C++20 to prevent further regressions.

PiperOrigin-RevId: 530693318