### PR TITLE
Fix csharp fieldmasktree merge on optional primitive fields

### DIFF
--- a/csharp/src/Google.Protobuf.Test/FieldMaskTreeTest.cs
+++ b/csharp/src/Google.Protobuf.Test/FieldMaskTreeTest.cs
@@ -34,6 +34,7 @@ using Google.Protobuf.Collections;
 using Google.Protobuf.TestProtos;
 using NUnit.Framework;
 using Google.Protobuf.WellKnownTypes;
+using ProtobufUnittest;
 
 namespace Google.Protobuf
 {
@@ -469,6 +470,28 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void MergeOptionalFieldsWithNullFieldsInSource()
+        {
+            var destination = new TestProto3Optional();
+            var source = new TestProto3Optional();
+
+            Assert.False(source.HasOptionalString);
+            Assert.False(source.HasOptionalSint32);
+
+            Assert.False(destination.HasOptionalString);
+            Assert.False(destination.HasOptionalSint32);
+
+            Merge(new FieldMaskTree().AddFieldPath("optional_string").AddFieldPath("optional_sint32"),
+                source,
+                destination,
+                new FieldMask.MergeOptions(),
+                false);
+
+            Assert.False(destination.HasOptionalString);
+            Assert.False(destination.HasOptionalSint32);
+        }
+
+            [Test]
         [TestCase(false, "Hello", 24)]
         [TestCase(true, null, null)]
         public void MergeWrapperFieldsWithNullFieldsInSource(

--- a/csharp/src/Google.Protobuf/FieldMaskTree.cs
+++ b/csharp/src/Google.Protobuf/FieldMaskTree.cs
@@ -356,12 +356,12 @@ namespace Google.Protobuf
                     }
                     else
                     {
-                        if (sourceField != null
-                            || !options.ReplacePrimitiveFields)
+                        if ((!field.HasPresence && sourceField != null)
+                            || field.Accessor.HasValue(source))
                         {
                             field.Accessor.SetValue(destination, sourceField);
                         }
-                        else
+                        else if (options.ReplacePrimitiveFields)
                         {
                             field.Accessor.Clear(destination);
                         }


### PR DESCRIPTION
Mentioned in the bottom of #12685, but is a slightly unrelated issue with the same `FieldMask.Merge` function. This PR updates that function to properly handle `optional` primitives in csharp.