### PR TITLE
Reserve option for proto-telemetry

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -471,3 +471,8 @@ with info about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/EngFlow/engflowapis
     *   Extensions: 1181
+
+1. Proto-telemetry
+
+    *   Website: https://github.com/clly/proto-telemetry
+    *   Extensions: 1182


### PR DESCRIPTION
Hello! I'm looking to reserve an option for a project I'm calling proto-telemetry. It will create open-telemetry compatible functions that add attributes to a span. Once this is accepted I'll update the project to use the reserved option number.

Thanks so much!