### PR TITLE
fix: avoid warnings with MSVC (#12762)

### DIFF
--- a/src/google/protobuf/has_bits.h
+++ b/src/google/protobuf/has_bits.h
@@ -71,7 +71,7 @@ class HasBits {
   }
 
   void Or(const HasBits<doublewords>& rhs) {
-    for (size_t i = 0; i < doublewords; i++) has_bits_[i] |= rhs[i];
+    for (size_t i = 0; i < doublewords; i++) has_bits_[i] |= rhs.has_bits_[i];
   }
 
   bool empty() const;

--- a/src/google/protobuf/string_block.h
+++ b/src/google/protobuf/string_block.h
@@ -142,10 +142,11 @@ inline size_t StringBlock::NextSize(StringBlock* block) {
 }
 
 inline StringBlock* StringBlock::Emplace(void* p, size_t n, StringBlock* next) {
-  ABSL_DCHECK_EQ(n, NextSize(next));
-  uint32_t doubled = static_cast<uint32_t>(n) * 2;
+  const auto count = static_cast<uint32_t>(n);
+  ABSL_DCHECK_EQ(count, NextSize(next));
+  uint32_t doubled = count * 2;
   uint32_t next_size = next ? std::min(doubled, max_size()) : min_size();
-  return new (p) StringBlock(next, false, RoundedSize(n), next_size);
+  return new (p) StringBlock(next, false, RoundedSize(count), next_size);
 }
 
 inline StringBlock* StringBlock::New(StringBlock* next) {


### PR DESCRIPTION
In both cases a `size_t` was being converted to a `uint32_t`. These headers are used from application code, or at least from generated code, and the application may be compiling with more warnings enabled than normal.

Closes #12762

COPYBARA_INTEGRATE_REVIEW=https://github.com/protocolbuffers/protobuf/pull/12762 from coryan:fix-avoid-warnings-with-MSVC 5ba6b5db1e889289273a1614730559e96749b73e PiperOrigin-RevId: 531506224