### PR TITLE
Update docs for Any type URLs

### DIFF
--- a/src/google/protobuf/any.proto
+++ b/src/google/protobuf/any.proto
@@ -95,7 +95,8 @@ option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 // 'type.googleapis.com/full.type.name' as the type URL and the unpack
 // methods only use the fully qualified type name after the last '/'
 // in the type URL, for example "foo.bar.com/x/y.z" will yield type
-// name "y.z".
+// name "y.z". See the documentation for the `type_url` field for details
+// on using type URLs in practice.
 //
 // JSON
 // ====
@@ -149,7 +150,8 @@ message Any {
   //
   // Note: this functionality is not currently available in the official
   // protobuf release, and it is not used for type URLs beginning with
-  // type.googleapis.com.
+  // type.googleapis.com. No widely-used type server currently exists,
+  // within Google or in open source.
   //
   // Schemes other than `http`, `https` (or the empty scheme) might be
   // used with implementation specific semantics.


### PR DESCRIPTION
The documentation for the well-known `Any` type spends quite a bit of time describing the behavior of a "type server," which is effectively a schema registry. Readers can easily walk away with the impression that type servers, and the associated `Type`, `Field`, `Enum`, etc. messages, are widely used within Google. From talking to @fowles, this impression is incorrect.

This PR preserves the original documentation, but adds a note that no widely-used type servers (as described on `Any`) exist within Google or in open-source.