### PR TITLE
Modernize python code-base using the pyupgrade tool

### DIFF
--- a/conformance/conformance_python.py
+++ b/conformance/conformance_python.py
@@ -175,12 +175,12 @@ def do_test_io():
   if len(length_bytes) == 0:
     return False   # EOF
   elif len(length_bytes) != 4:
-    raise IOError("I/O error")
+    raise OSError("I/O error")
 
   length = struct.unpack("<I", length_bytes)[0]
   serialized_request = sys.stdin.buffer.read(length)
   if len(serialized_request) != length:
-    raise IOError("I/O error")
+    raise OSError("I/O error")
 
   request = conformance_pb2.ConformanceRequest()
   request.ParseFromString(serialized_request)
@@ -193,7 +193,7 @@ def do_test_io():
   sys.stdout.buffer.flush()
 
   if verbose:
-    sys.stderr.write("conformance_python: request=%s, response=%s\n" % (
+    sys.stderr.write("conformance_python: request={}, response={}\n".format(
                        request.ShortDebugString().c_str(),
                        response.ShortDebugString().c_str()))
 

--- a/examples/add_person.py
+++ b/examples/add_person.py
@@ -52,7 +52,7 @@ address_book = addressbook_pb2.AddressBook()
 try:
   with open(sys.argv[1], "rb") as f:
     address_book.ParseFromString(f.read())
-except IOError:
+except OSError:
   print(sys.argv[1] + ": File not found.  Creating a new file.")
 
 # Add an address.

--- a/examples/list_people.py
+++ b/examples/list_people.py
@@ -2,7 +2,6 @@
 
 # See README.md for information and build instructions.
 
-from __future__ import print_function
 import addressbook_pb2
 import sys
 

--- a/generate_changelog.py
+++ b/generate_changelog.py
@@ -34,7 +34,7 @@
 import sys
 import os
 
-class Language(object):
+class Language:
   def __init__(self, name, pathspec):
     self.name = name
     self.pathspec = pathspec

--- a/objectivec/DevTools/pddm.py
+++ b/objectivec/DevTools/pddm.py
@@ -140,7 +140,7 @@ class PDDMError(Exception):
     super().__init__(self.message)
 
 
-class MacroCollection(object):
+class MacroCollection:
   """Hold a set of macros and can resolve/expand them."""
 
   def __init__(self, a_file=None):
@@ -156,7 +156,7 @@ class MacroCollection(object):
     if a_file:
       self.ParseInput(a_file)
 
-  class MacroDefinition(object):
+  class MacroDefinition:
     """Holds a macro definition."""
 
     def __init__(self, name, arg_names):
@@ -361,7 +361,7 @@ class MacroCollection(object):
     return macro_ref_re.sub(_resolveMacro, text)
 
 
-class SourceFile(object):
+class SourceFile:
   """Represents a source file with PDDM directives in it."""
 
   def __init__(self, a_file, import_resolver=None):
@@ -380,7 +380,7 @@ class SourceFile(object):
     self._import_resolver = import_resolver
     self._processed_content = None
 
-  class SectionBase(object):
+  class SectionBase:
 
     def __init__(self, first_line_num):
       self._lines = []
@@ -661,9 +661,9 @@ def main(args):
       import_path = os.path.join(a_dir, name)
       if not os.path.exists(import_path):
         return None
-      return open(import_path, 'r')
+      return open(import_path)
 
-    with open(a_path, 'r') as f:
+    with open(a_path) as f:
       src_file = SourceFile(f, _ImportResolver)
 
     try:

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Protocol Buffers - Google's data interchange format
 # Copyright 2019 Google LLC.  All rights reserved.
 # https://developers.google.com/protocol-buffers/
@@ -48,12 +47,12 @@ import google.protobuf
 
 # -- Project information -----------------------------------------------------
 
-project = u"Protocol Buffers"
-copyright = u"2008, Google LLC"
-author = u"Google LLC"
+project = "Protocol Buffers"
+copyright = "2008, Google LLC"
+author = "Google LLC"
 
 # The short X.Y version
-version = u""
+version = ""
 # The full version, including alpha/beta/rc tags
 release = google.protobuf.__version__
 
@@ -96,7 +95,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [u"_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
@@ -202,7 +201,7 @@ texinfo_documents = [
   (
     master_doc,
     "ProtocolBuffers",
-    u"Protocol Buffers Documentation",
+    "Protocol Buffers Documentation",
     author,
     "ProtocolBuffers",
     "One line description of project.",

--- a/python/docs/generate_docs.py
+++ b/python/docs/generate_docs.py
@@ -170,7 +170,7 @@ def write_automodule(module):
 
 def replace_toc(modules):
   toctree = [module.replace(".", "/") for module in modules]
-  with open(DOCS_DIR / "index.rst", "r") as index_file:
+  with open(DOCS_DIR / "index.rst") as index_file:
     index_contents = index_file.read()
   toc = TOC_TEMPLATE.format(
     toctree="\n   ".join(toctree)
@@ -183,7 +183,7 @@ def replace_toc(modules):
 def main():
   modules = list(sorted(find_modules()))
   for module in modules:
-    print("Generating reference for {}".format(module))
+    print(f"Generating reference for {module}")
     write_automodule(module)
   print("Generating index.rst")
   replace_toc(modules)

--- a/python/google/protobuf/descriptor.py
+++ b/python/google/protobuf/descriptor.py
@@ -68,7 +68,7 @@ if _USE_C_DESCRIPTORS:
   class DescriptorMetaclass(type):
 
     def __instancecheck__(cls, obj):
-      if super(DescriptorMetaclass, cls).__instancecheck__(obj):
+      if super().__instancecheck__(obj):
         return True
       if isinstance(obj, cls._C_DESCRIPTOR_CLASS):
         return True
@@ -78,7 +78,7 @@ else:
   DescriptorMetaclass = type
 
 
-class _Lock(object):
+class _Lock:
   """Wrapper class of threading.Lock(), which is allowed by 'with'."""
 
   def __new__(cls):
@@ -211,7 +211,7 @@ class _NestedDescriptorBase(DescriptorBase):
         file.serialized_pb that describes this descriptor.
       serialized_options: Protocol message serialized options or None.
     """
-    super(_NestedDescriptorBase, self).__init__(
+    super().__init__(
         options, serialized_options, options_class_name)
 
     self.name = name
@@ -332,7 +332,7 @@ class Descriptor(_NestedDescriptorBase):
     if create_key is not _internal_create_key:
       _Deprecated('Descriptor')
 
-    super(Descriptor, self).__init__(
+    super().__init__(
         options, 'MessageOptions', name, full_name, file,
         containing_type, serialized_start=serialized_start,
         serialized_end=serialized_end, serialized_options=serialized_options)
@@ -345,30 +345,30 @@ class Descriptor(_NestedDescriptorBase):
     self.fields = fields
     for field in self.fields:
       field.containing_type = self
-    self.fields_by_number = dict((f.number, f) for f in fields)
-    self.fields_by_name = dict((f.name, f) for f in fields)
+    self.fields_by_number = {f.number: f for f in fields}
+    self.fields_by_name = {f.name: f for f in fields}
     self._fields_by_camelcase_name = None
 
     self.nested_types = nested_types
     for nested_type in nested_types:
       nested_type.containing_type = self
-    self.nested_types_by_name = dict((t.name, t) for t in nested_types)
+    self.nested_types_by_name = {t.name: t for t in nested_types}
 
     self.enum_types = enum_types
     for enum_type in self.enum_types:
       enum_type.containing_type = self
-    self.enum_types_by_name = dict((t.name, t) for t in enum_types)
-    self.enum_values_by_name = dict(
-        (v.name, v) for t in enum_types for v in t.values)
+    self.enum_types_by_name = {t.name: t for t in enum_types}
+    self.enum_values_by_name = {
+        v.name: v for t in enum_types for v in t.values}
 
     self.extensions = extensions
     for extension in self.extensions:
       extension.extension_scope = self
-    self.extensions_by_name = dict((f.name, f) for f in extensions)
+    self.extensions_by_name = {f.name: f for f in extensions}
     self.is_extendable = is_extendable
     self.extension_ranges = extension_ranges
     self.oneofs = oneofs if oneofs is not None else []
-    self.oneofs_by_name = dict((o.name, o) for o in self.oneofs)
+    self.oneofs_by_name = {o.name: o for o in self.oneofs}
     for oneof in self.oneofs:
       oneof.containing_type = self
     self.syntax = syntax or "proto2"
@@ -379,8 +379,8 @@ class Descriptor(_NestedDescriptorBase):
     :attr:`FieldDescriptor.camelcase_name`.
     """
     if self._fields_by_camelcase_name is None:
-      self._fields_by_camelcase_name = dict(
-          (f.camelcase_name, f) for f in self.fields)
+      self._fields_by_camelcase_name = {
+          f.camelcase_name: f for f in self.fields}
     return self._fields_by_camelcase_name
 
   def EnumValueName(self, enum, value):
@@ -408,7 +408,7 @@ class Descriptor(_NestedDescriptorBase):
       proto: An empty descriptor_pb2.DescriptorProto.
     """
     # This function is overridden to give a better doc comment.
-    super(Descriptor, self).CopyToProto(proto)
+    super().CopyToProto(proto)
 
 
 # TODO(robinson): We should have aggressive checking here,
@@ -580,7 +580,7 @@ class FieldDescriptor(DescriptorBase):
     if create_key is not _internal_create_key:
       _Deprecated('FieldDescriptor')
 
-    super(FieldDescriptor, self).__init__(
+    super().__init__(
         options, serialized_options, 'FieldOptions')
     self.name = name
     self.full_name = full_name
@@ -725,7 +725,7 @@ class EnumDescriptor(_NestedDescriptorBase):
     if create_key is not _internal_create_key:
       _Deprecated('EnumDescriptor')
 
-    super(EnumDescriptor, self).__init__(
+    super().__init__(
         options, 'EnumOptions', name, full_name, file,
         containing_type, serialized_start=serialized_start,
         serialized_end=serialized_end, serialized_options=serialized_options)
@@ -733,9 +733,9 @@ class EnumDescriptor(_NestedDescriptorBase):
     self.values = values
     for value in self.values:
       value.type = self
-    self.values_by_name = dict((v.name, v) for v in values)
+    self.values_by_name = {v.name: v for v in values}
     # Values are reversed to ensure that the first alias is retained.
-    self.values_by_number = dict((v.number, v) for v in reversed(values))
+    self.values_by_number = {v.number: v for v in reversed(values)}
 
   @property
   def is_closed(self):
@@ -768,7 +768,7 @@ class EnumDescriptor(_NestedDescriptorBase):
       proto (descriptor_pb2.EnumDescriptorProto): An empty descriptor proto.
     """
     # This function is overridden to give a better doc comment.
-    super(EnumDescriptor, self).CopyToProto(proto)
+    super().CopyToProto(proto)
 
 
 class EnumValueDescriptor(DescriptorBase):
@@ -807,7 +807,7 @@ class EnumValueDescriptor(DescriptorBase):
     if create_key is not _internal_create_key:
       _Deprecated('EnumValueDescriptor')
 
-    super(EnumValueDescriptor, self).__init__(
+    super().__init__(
         options, serialized_options, 'EnumValueOptions')
     self.name = name
     self.index = index
@@ -846,7 +846,7 @@ class OneofDescriptor(DescriptorBase):
     if create_key is not _internal_create_key:
       _Deprecated('OneofDescriptor')
 
-    super(OneofDescriptor, self).__init__(
+    super().__init__(
         options, serialized_options, 'OneofOptions')
     self.name = name
     self.full_name = full_name
@@ -898,13 +898,13 @@ class ServiceDescriptor(_NestedDescriptorBase):
     if create_key is not _internal_create_key:
       _Deprecated('ServiceDescriptor')
 
-    super(ServiceDescriptor, self).__init__(
+    super().__init__(
         options, 'ServiceOptions', name, full_name, file,
         None, serialized_start=serialized_start,
         serialized_end=serialized_end, serialized_options=serialized_options)
     self.index = index
     self.methods = methods
-    self.methods_by_name = dict((m.name, m) for m in methods)
+    self.methods_by_name = {m.name: m for m in methods}
     # Set the containing service for each method in this service.
     for method in self.methods:
       method.containing_service = self
@@ -930,7 +930,7 @@ class ServiceDescriptor(_NestedDescriptorBase):
       proto (descriptor_pb2.ServiceDescriptorProto): An empty descriptor proto.
     """
     # This function is overridden to give a better doc comment.
-    super(ServiceDescriptor, self).CopyToProto(proto)
+    super().CopyToProto(proto)
 
 
 class MethodDescriptor(DescriptorBase):
@@ -991,7 +991,7 @@ class MethodDescriptor(DescriptorBase):
     if create_key is not _internal_create_key:
       _Deprecated('MethodDescriptor')
 
-    super(MethodDescriptor, self).__init__(
+    super().__init__(
         options, serialized_options, 'MethodOptions')
     self.name = name
     self.full_name = full_name
@@ -1065,7 +1065,7 @@ class FileDescriptor(DescriptorBase):
       if serialized_pb:
         return _message.default_pool.AddSerializedFile(serialized_pb)
       else:
-        return super(FileDescriptor, cls).__new__(cls)
+        return super().__new__(cls)
 
   def __init__(self, name, package, options=None,
                serialized_options=None, serialized_pb=None,
@@ -1075,7 +1075,7 @@ class FileDescriptor(DescriptorBase):
     if create_key is not _internal_create_key:
       _Deprecated('FileDescriptor')
 
-    super(FileDescriptor, self).__init__(
+    super().__init__(
         options, serialized_options, 'FileOptions')
 
     if pool is None:

--- a/python/google/protobuf/descriptor_database.py
+++ b/python/google/protobuf/descriptor_database.py
@@ -43,7 +43,7 @@ class DescriptorDatabaseConflictingDefinitionError(Error):
   """Raised when a proto is added with the same name & different descriptor."""
 
 
-class DescriptorDatabase(object):
+class DescriptorDatabase:
   """A container accepting FileDescriptorProtos and maps DescriptorProtos."""
 
   def __init__(self):
@@ -171,7 +171,6 @@ def _ExtractSymbols(desc_proto, package):
   message_name = package + '.' + desc_proto.name if package else desc_proto.name
   yield message_name
   for nested_type in desc_proto.nested_type:
-    for symbol in _ExtractSymbols(nested_type, message_name):
-      yield symbol
+    yield from _ExtractSymbols(nested_type, message_name)
   for enum_type in desc_proto.enum_type:
     yield '.'.join((message_name, enum_type.name))

--- a/python/google/protobuf/descriptor_pool.py
+++ b/python/google/protobuf/descriptor_pool.py
@@ -115,7 +115,7 @@ def _IsMessageSetExtension(field):
           field.label == descriptor.FieldDescriptor.LABEL_OPTIONAL)
 
 
-class DescriptorPool(object):
+class DescriptorPool:
   """A collection of protobufs dynamically constructed by descriptor protos."""
 
   if _USE_C_DESCRIPTORS:
@@ -1108,7 +1108,7 @@ class DescriptorPool(object):
           field_proto.type == descriptor.FieldDescriptor.TYPE_FLOAT):
         field_desc.default_value = 0.0
       elif field_proto.type == descriptor.FieldDescriptor.TYPE_STRING:
-        field_desc.default_value = u''
+        field_desc.default_value = ''
       elif field_proto.type == descriptor.FieldDescriptor.TYPE_BOOL:
         field_desc.default_value = False
       elif field_proto.type == descriptor.FieldDescriptor.TYPE_ENUM:
@@ -1224,8 +1224,7 @@ class DescriptorPool(object):
 
     for desc in descriptors:
       yield (_PrefixWithDot(desc.full_name), desc)
-      for symbol in self._ExtractSymbols(desc.nested_types):
-        yield symbol
+      yield from self._ExtractSymbols(desc.nested_types)
       for enum in desc.enum_types:
         yield (_PrefixWithDot(enum.full_name), enum)
 

--- a/python/google/protobuf/internal/_parameterized.py
+++ b/python/google/protobuf/internal/_parameterized.py
@@ -171,7 +171,7 @@ def _CleanRepr(obj):
 # Helper function formerly from the unittest module, removed from it in
 # Python 2.7.
 def _StrClass(cls):
-  return '%s.%s' % (cls.__module__, cls.__name__)
+  return f'{cls.__module__}.{cls.__name__}'
 
 
 def _NonStringIterable(obj):
@@ -181,7 +181,7 @@ def _NonStringIterable(obj):
 
 def _FormatParameterList(testcase_params):
   if isinstance(testcase_params, collections_abc.Mapping):
-    return ', '.join('%s=%s' % (argname, _CleanRepr(value))
+    return ', '.join(f'{argname}={_CleanRepr(value)}'
                      for argname, value in testcase_params.items())
   elif _NonStringIterable(testcase_params):
     return ', '.join(map(_CleanRepr, testcase_params))
@@ -189,7 +189,7 @@ def _FormatParameterList(testcase_params):
     return _FormatParameterList((testcase_params,))
 
 
-class _ParameterizedTestIter(object):
+class _ParameterizedTestIter:
   """Callable and iterable class for producing new test cases."""
 
   def __init__(self, test_method, testcases, naming_type):
@@ -241,15 +241,15 @@ class _ParameterizedTestIter(object):
         # method of TestGeneratorMetaclass.
         # The metaclass will make sure to create a unique, but nondescriptive
         # name for this test.
-        BoundParamTest.__x_extra_id__ = '(%s)' % (
-            _FormatParameterList(testcase_params),)
+        BoundParamTest.__x_extra_id__ = '({})'.format(
+            _FormatParameterList(testcase_params))
       else:
-        raise RuntimeError('%s is not a valid naming type.' % (naming_type,))
+        raise RuntimeError(f'{naming_type} is not a valid naming type.')
 
-      BoundParamTest.__doc__ = '%s(%s)' % (
+      BoundParamTest.__doc__ = '{}({})'.format(
           BoundParamTest.__name__, _FormatParameterList(testcase_params))
       if test_method.__doc__:
-        BoundParamTest.__doc__ += '\n%s' % (test_method.__doc__,)
+        BoundParamTest.__doc__ += f'\n{test_method.__doc__}'
       return BoundParamTest
     return (MakeBoundParamTest(c) for c in self.testcases)
 
@@ -374,14 +374,14 @@ def _UpdateClassDictForParamTestCase(dct, id_suffix, name, iterator):
     iterator: The iterator generating the individual test cases.
   """
   for idx, func in enumerate(iterator):
-    assert callable(func), 'Test generators must yield callables, got %r' % (
-        func,)
+    assert callable(func), 'Test generators must yield callables, got {!r}'.format(
+        func)
     if getattr(func, '__x_use_name__', False):
       new_name = func.__name__
     else:
       new_name = '%s%s%d' % (name, _SEPARATOR, idx)
     assert new_name not in dct, (
-        'Name of parameterized test case "%s" not unique' % (new_name,))
+        f'Name of parameterized test case "{new_name}" not unique')
     dct[new_name] = func
     id_suffix[new_name] = getattr(func, '__x_extra_id__', '')
 
@@ -393,7 +393,7 @@ class TestCase(unittest.TestCase, metaclass=TestGeneratorMetaclass):
     return self._testMethodName.split(_SEPARATOR)[0]
 
   def __str__(self):
-    return '%s (%s)' % (self._OriginalName(), _StrClass(self.__class__))
+    return f'{self._OriginalName()} ({_StrClass(self.__class__)})'
 
   def id(self):  # pylint: disable=invalid-name
     """Returns the descriptive ID of the test.
@@ -404,7 +404,7 @@ class TestCase(unittest.TestCase, metaclass=TestGeneratorMetaclass):
     Returns:
       The test id.
     """
-    return '%s.%s%s' % (_StrClass(self.__class__),
+    return '{}.{}{}'.format(_StrClass(self.__class__),
                         self._OriginalName(),
                         self._id_suffix.get(self._testMethodName, ''))
 

--- a/python/google/protobuf/internal/api_implementation.py
+++ b/python/google/protobuf/internal/api_implementation.py
@@ -87,7 +87,7 @@ _implementation_type = os.getenv('PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION',
                                  _implementation_type)
 
 if _implementation_type not in ('python', 'cpp', 'upb'):
-  raise ValueError('PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION {0} is not '
+  raise ValueError('PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION {} is not '
                    'supported. Please set to \'python\', \'cpp\' or '
                    '\'upb\'.'.format(_implementation_type))
 

--- a/python/google/protobuf/internal/decoder.py
+++ b/python/google/protobuf/internal/decoder.py
@@ -553,7 +553,7 @@ def StringDecoder(field_number, is_repeated, is_packed, key, new_default,
       value = str(byte_str, 'utf-8')
     except UnicodeDecodeError as e:
       # add more information to the error message and re-raise it.
-      e.reason = '%s in field: %s' % (e, key.full_name)
+      e.reason = f'{e} in field: {key.full_name}'
       raise
 
     return value

--- a/python/google/protobuf/internal/descriptor_pool_test.py
+++ b/python/google/protobuf/internal/descriptor_pool_test.py
@@ -59,7 +59,7 @@ from google.protobuf import unittest_pb2
 warnings.simplefilter('error', DeprecationWarning)
 
 
-class DescriptorPoolTestBase(object):
+class DescriptorPoolTestBase:
 
   def testFindFileByName(self):
     name1 = 'google/protobuf/internal/factory_test1.proto'
@@ -338,7 +338,7 @@ class DescriptorPoolTestBase(object):
     another_field = factory_test2.extensions_by_name['another_field']
 
     extensions = self.pool.FindAllExtensions(factory1_message)
-    expected_extension_numbers = set([one_more_field, another_field])
+    expected_extension_numbers = {one_more_field, another_field}
     self.assertEqual(expected_extension_numbers, set(extensions))
     # Verify that mutating the returned list does not affect the pool.
     extensions.append('unexpected_element')
@@ -479,7 +479,7 @@ class DescriptorPoolTestBase(object):
       _CheckValueAndType(msg.optional_float, 0, (float, int))
       _CheckValueAndType(msg.optional_double, 0, (float, int))
       _CheckValueAndType(msg.optional_bool, False, bool)
-      _CheckValueAndType(msg.optional_string, u'', unicode_type)
+      _CheckValueAndType(msg.optional_string, '', unicode_type)
       _CheckValueAndType(msg.optional_bytes, b'', bytes)
       _CheckValueAndType(msg.optional_nested_enum, msg.FOO, int)
     # First for the generated message
@@ -713,7 +713,7 @@ class SecondaryDescriptorFromDescriptorDB(DescriptorPoolTestBase,
                        ' collector.ErrorMessage.MyOneof\\n' + error_msg)
 
 
-class ProtoFile(object):
+class ProtoFile:
 
   def __init__(self, name, package, messages, dependencies=None,
                public_dependencies=None):
@@ -735,7 +735,7 @@ class ProtoFile(object):
       msg_type.CheckType(test, None, name, file_desc)
 
 
-class EnumType(object):
+class EnumType:
 
   def __init__(self, values):
     self.values = values
@@ -756,7 +756,7 @@ class EnumType(object):
       test.assertIn(value, msg_desc.enum_values_by_name)
 
 
-class MessageType(object):
+class MessageType:
 
   def __init__(self, type_dict, field_list, is_extendable=False,
                extensions=None):
@@ -788,7 +788,7 @@ class MessageType(object):
       field.CheckField(test, desc, name, index, file_desc)
 
 
-class EnumField(object):
+class EnumField:
 
   def __init__(self, number, type_name, default_value):
     self.number = number
@@ -815,7 +815,7 @@ class EnumField(object):
     test.assertEqual(file_desc, enum_desc.file)
 
 
-class MessageField(object):
+class MessageField:
 
   def __init__(self, number, type_name):
     self.number = number
@@ -839,7 +839,7 @@ class MessageField(object):
     test.assertEqual(field_desc.default_value, None)
 
 
-class StringField(object):
+class StringField:
 
   def __init__(self, number, default_value):
     self.number = number
@@ -860,7 +860,7 @@ class StringField(object):
     test.assertEqual(file_desc, field_desc.file)
 
 
-class ExtensionField(object):
+class ExtensionField:
 
   def __init__(self, number, extended_type):
     self.number = number

--- a/python/google/protobuf/internal/enum_type_wrapper.py
+++ b/python/google/protobuf/internal/enum_type_wrapper.py
@@ -38,7 +38,7 @@ on proto classes.  For usage, see:
 __author__ = 'rabsatt@google.com (Kevin Rabsatt)'
 
 
-class EnumTypeWrapper(object):
+class EnumTypeWrapper:
   """A utility for finding the names of enum values."""
 
   DESCRIPTOR = None
@@ -115,9 +115,7 @@ class EnumTypeWrapper(object):
   def __getattr__(self, name):
     """Returns the value corresponding to the given enum name."""
     try:
-      return super(
-          EnumTypeWrapper,
-          self).__getattribute__('_enum_type').values_by_name[name].number
+      return super().__getattribute__('_enum_type').values_by_name[name].number
     except KeyError:
       pass  # fall out to break exception chaining
     raise AttributeError('Enum {} has no value defined for name {!r}'.format(

--- a/python/google/protobuf/internal/extension_dict.py
+++ b/python/google/protobuf/internal/extension_dict.py
@@ -60,7 +60,7 @@ def _VerifyExtensionHandle(message, extension_handle):
 # TODO(robinson): Unify error handling of "unknown extension" crap.
 # TODO(robinson): Support iteritems()-style iteration over all
 # extensions with the "has" bits turned on?
-class _ExtensionDict(object):
+class _ExtensionDict:
 
   """Dict-like container for Extension fields on proto instances.
 

--- a/python/google/protobuf/internal/field_mask.py
+++ b/python/google/protobuf/internal/field_mask.py
@@ -33,7 +33,7 @@
 from google.protobuf.descriptor import FieldDescriptor
 
 
-class FieldMask(object):
+class FieldMask:
   """Class for FieldMask message type."""
 
   __slots__ = ()
@@ -48,7 +48,7 @@ class FieldMask(object):
   def FromJsonString(self, value):
     """Converts string to FieldMask according to proto3 JSON spec."""
     if not isinstance(value, str):
-      raise ValueError('FieldMask JSON value not a string: {!r}'.format(value))
+      raise ValueError(f'FieldMask JSON value not a string: {value!r}')
     self.Clear()
     if value:
       for path in value.split(','):
@@ -135,7 +135,7 @@ def _CheckFieldMaskMessage(message):
   message_descriptor = message.DESCRIPTOR
   if (message_descriptor.name != 'FieldMask' or
       message_descriptor.file.name != 'google/protobuf/field_mask.proto'):
-    raise ValueError('Message {0} is not a FieldMask.'.format(
+    raise ValueError('Message {} is not a FieldMask.'.format(
         message_descriptor.full_name))
 
 
@@ -147,7 +147,7 @@ def _SnakeCaseToCamelCase(path_name):
     if c.isupper():
       raise ValueError(
           'Fail to print FieldMask to Json string: Path name '
-          '{0} must not contain uppercase letters.'.format(path_name))
+          '{} must not contain uppercase letters.'.format(path_name))
     if after_underscore:
       if c.islower():
         result.append(c.upper())
@@ -156,7 +156,7 @@ def _SnakeCaseToCamelCase(path_name):
         raise ValueError(
             'Fail to print FieldMask to Json string: The '
             'character after a "_" must be a lowercase letter '
-            'in path name {0}.'.format(path_name))
+            'in path name {}.'.format(path_name))
     elif c == '_':
       after_underscore = True
     else:
@@ -164,7 +164,7 @@ def _SnakeCaseToCamelCase(path_name):
 
   if after_underscore:
     raise ValueError('Fail to print FieldMask to Json string: Trailing "_" '
-                     'in path name {0}.'.format(path_name))
+                     'in path name {}.'.format(path_name))
   return ''.join(result)
 
 
@@ -174,7 +174,7 @@ def _CamelCaseToSnakeCase(path_name):
   for c in path_name:
     if c == '_':
       raise ValueError('Fail to parse FieldMask: Path name '
-                       '{0} must not contain "_"s.'.format(path_name))
+                       '{} must not contain "_"s.'.format(path_name))
     if c.isupper():
       result += '_'
       result += c.lower()
@@ -183,7 +183,7 @@ def _CamelCaseToSnakeCase(path_name):
   return ''.join(result)
 
 
-class _FieldMaskTree(object):
+class _FieldMaskTree:
   """Represents a FieldMask in a tree structure.
 
   For example, given a FieldMask "foo.bar,foo.baz,bar.baz",
@@ -290,13 +290,13 @@ def _MergeMessage(
     child = node[name]
     field = source_descriptor.fields_by_name[name]
     if field is None:
-      raise ValueError('Error: Can\'t find field {0} in message {1}.'.format(
+      raise ValueError('Error: Can\'t find field {} in message {}.'.format(
           name, source_descriptor.full_name))
     if child:
       # Sub-paths are only allowed for singular message fields.
       if (field.label == FieldDescriptor.LABEL_REPEATED or
           field.cpp_type != FieldDescriptor.CPPTYPE_MESSAGE):
-        raise ValueError('Error: Field {0} in message {1} is not a singular '
+        raise ValueError('Error: Field {} in message {} is not a singular '
                          'message field and cannot have sub-fields.'.format(
                              name, source_descriptor.full_name))
       if source.HasField(name):

--- a/python/google/protobuf/internal/generator_test.py
+++ b/python/google/protobuf/internal/generator_test.py
@@ -116,10 +116,10 @@ class GeneratorTest(unittest.TestCase):
         'default_int32': True,
     }
 
-    has_default_by_name = dict(
-        [(f.name, f.has_default_value)
+    has_default_by_name = {
+        f.name: f.has_default_value
          for f in desc.fields
-         if f.name in expected_has_default_by_name])
+         if f.name in expected_has_default_by_name}
     self.assertEqual(expected_has_default_by_name, has_default_by_name)
 
   def testContainingTypeBehaviorForExtensions(self):
@@ -232,11 +232,11 @@ class GeneratorTest(unittest.TestCase):
   def testNestedTypes(self):
     self.assertEqual(
         set(unittest_pb2.TestAllTypes.DESCRIPTOR.nested_types),
-        set([
+        {
             unittest_pb2.TestAllTypes.NestedMessage.DESCRIPTOR,
             unittest_pb2.TestAllTypes.OptionalGroup.DESCRIPTOR,
             unittest_pb2.TestAllTypes.RepeatedGroup.DESCRIPTOR,
-        ]))
+        })
     self.assertEqual(unittest_pb2.TestEmptyMessage.DESCRIPTOR.nested_types, [])
     self.assertEqual(
         unittest_pb2.TestAllTypes.NestedMessage.DESCRIPTOR.nested_types, [])
@@ -367,11 +367,11 @@ class GeneratorTest(unittest.TestCase):
     self.assertEqual(0, desc.oneofs[0].index)
     self.assertIs(desc, desc.oneofs[0].containing_type)
     self.assertIs(desc.oneofs[0], desc.oneofs_by_name['oneof_field'])
-    nested_names = set(['oneof_uint32', 'oneof_nested_message',
-                        'oneof_string', 'oneof_bytes'])
+    nested_names = {'oneof_uint32', 'oneof_nested_message',
+                        'oneof_string', 'oneof_bytes'}
     self.assertEqual(
         nested_names,
-        set([field.name for field in desc.oneofs[0].fields]))
+        {field.name for field in desc.oneofs[0].fields})
     for field_name, field_desc in desc.fields_by_name.items():
       if field_name in nested_names:
         self.assertIs(desc.oneofs[0], field_desc.containing_oneof)

--- a/python/google/protobuf/internal/import_test.py
+++ b/python/google/protobuf/internal/import_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Protocol Buffers - Google's data interchange format
 # Copyright 2008 Google Inc.  All rights reserved.
 # https://developers.google.com/protocol-buffers/

--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -236,7 +236,7 @@ class JsonFormatTest(JsonFormatBase):
             },
             '[protobuf_unittest.'
             'TestMessageSetExtension2.message_set_extension]': {
-                'str': u'foo',
+                'str': 'foo',
             },
         },
     }
@@ -256,7 +256,7 @@ class JsonFormatTest(JsonFormatBase):
     )
     expected_dict = {
         '[protobuf_unittest.TestExtension.ext]': {
-            'value': u'stuff',
+            'value': 'stuff',
         },
     }
     self.assertEqual(expected_dict, message_dict)
@@ -296,7 +296,7 @@ class JsonFormatTest(JsonFormatBase):
         '"&\\n<\\\"\\r>\\b\\t\\f\\\\\\u0001/\\u2028\\u2029"\n}')
     parsed_message = json_format_proto3_pb2.TestMessage()
     self.CheckParseBack(message, parsed_message)
-    text = u'{"int32Value": "\u0031"}'
+    text = '{"int32Value": "\u0031"}'
     json_format.Parse(text, message)
     self.assertEqual(message.int32_value, 1)
 
@@ -1110,7 +1110,7 @@ class JsonFormatTest(JsonFormatBase):
         r'Failed to parse value field: ListValue must be in \[\] which is '
         '1234 at TestListValue.value.', json_format.Parse, text, message)
 
-    class UnknownClass(object):
+    class UnknownClass:
 
       def __str__(self):
         return 'v'
@@ -1244,7 +1244,7 @@ class JsonFormatTest(JsonFormatBase):
     )
 
   def testParseDictUnknownValueType(self):
-    class UnknownClass(object):
+    class UnknownClass:
 
       def __repr__(self):
         return 'v'

--- a/python/google/protobuf/internal/keywords_test.py
+++ b/python/google/protobuf/internal/keywords_test.py
@@ -40,7 +40,7 @@ from google.protobuf import descriptor_pool
 class KeywordsConflictTest(unittest.TestCase):
 
   def setUp(self):
-    super(KeywordsConflictTest, self).setUp()
+    super().setUp()
     self.pool = descriptor_pool.Default()
 
   def testMessage(self):

--- a/python/google/protobuf/internal/message_factory_test.py
+++ b/python/google/protobuf/internal/message_factory_test.py
@@ -63,8 +63,8 @@ class MessageFactoryTest(unittest.TestCase):
     msg.factory_1_message.nested_factory_1_message.value = (
         'nested message value')
     msg.factory_1_message.scalar_value = 22
-    msg.factory_1_message.list_value.extend([u'one', u'two', u'three'])
-    msg.factory_1_message.list_value.append(u'four')
+    msg.factory_1_message.list_value.extend(['one', 'two', 'three'])
+    msg.factory_1_message.list_value.append('four')
     msg.factory_1_enum = 1
     msg.nested_factory_1_enum = 0
     msg.nested_factory_1_message.value = 'nested message value'
@@ -72,8 +72,8 @@ class MessageFactoryTest(unittest.TestCase):
     msg.circular_message.circular_message.mandatory = 2
     msg.circular_message.scalar_value = 'one deep'
     msg.scalar_value = 'zero deep'
-    msg.list_value.extend([u'four', u'three', u'two'])
-    msg.list_value.append(u'one')
+    msg.list_value.extend(['four', 'three', 'two'])
+    msg.list_value.append('one')
     msg.grouped.add()
     msg.grouped[0].part_1 = 'hello'
     msg.grouped[0].part_2 = 'world'
@@ -124,18 +124,18 @@ class MessageFactoryTest(unittest.TestCase):
       messages = message_factory.GetMessages([self.factory_test2_fd,
                                               self.factory_test1_fd])
       self.assertTrue(
-          set(['google.protobuf.python.internal.Factory2Message',
-               'google.protobuf.python.internal.Factory1Message'],
-             ).issubset(set(messages.keys())))
+          {'google.protobuf.python.internal.Factory2Message',
+               'google.protobuf.python.internal.Factory1Message'
+             }.issubset(set(messages.keys())))
       self._ExerciseDynamicClass(
           messages['google.protobuf.python.internal.Factory2Message'])
       factory_msg1 = messages['google.protobuf.python.internal.Factory1Message']
-      self.assertTrue(set(
-          ['google.protobuf.python.internal.Factory2Message.one_more_field',
-           'google.protobuf.python.internal.another_field'],).issubset(set(
+      self.assertTrue({
+          'google.protobuf.python.internal.Factory2Message.one_more_field',
+           'google.protobuf.python.internal.another_field'}.issubset({
                ext.full_name
                for ext in factory_msg1.DESCRIPTOR.file.pool.FindAllExtensions(
-                   factory_msg1.DESCRIPTOR))))
+                   factory_msg1.DESCRIPTOR)}))
       msg1 = messages['google.protobuf.python.internal.Factory1Message']()
       ext1 = msg1.Extensions._FindExtensionByName(
           'google.protobuf.python.internal.Factory2Message.one_more_field')

--- a/python/google/protobuf/internal/message_listener.py
+++ b/python/google/protobuf/internal/message_listener.py
@@ -37,7 +37,7 @@ Also defines a null implementation of this interface.
 __author__ = 'robinson@google.com (Will Robinson)'
 
 
-class MessageListener(object):
+class MessageListener:
 
   """Listens for modifications made to a message.  Meant to be registered via
   Message._SetListener().
@@ -70,7 +70,7 @@ class MessageListener(object):
     raise NotImplementedError
 
 
-class NullMessageListener(object):
+class NullMessageListener:
 
   """No-op MessageListener implementation."""
 

--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Protocol Buffers - Google's data interchange format
 # Copyright 2008 Google Inc.  All rights reserved.
 # https://developers.google.com/protocol-buffers/
@@ -158,7 +157,7 @@ class MessageTest(unittest.TestCase):
     class BadArgError(Exception):
       pass
 
-    class BadArg(object):
+    class BadArg:
 
       def __nonzero__(self):
         raise BadArgError()
@@ -579,7 +578,7 @@ class MessageTest(unittest.TestCase):
     self.assertEqual(message.repeated_string[0], 'a')
     self.assertEqual(message.repeated_string[1], 'b')
     self.assertEqual(message.repeated_string[2], 'c')
-    self.assertEqual(str(message.repeated_string), str([u'a', u'b', u'c']))
+    self.assertEqual(str(message.repeated_string), str(['a', 'b', 'c']))
 
     message.repeated_bytes.append(b'a')
     message.repeated_bytes.append(b'c')
@@ -838,7 +837,7 @@ class MessageTest(unittest.TestCase):
     self.assertEqual('oneof_uint32', m.WhichOneof('oneof_field'))
     self.assertTrue(m.HasField('oneof_uint32'))
 
-    m.oneof_string = u'foo'
+    m.oneof_string = 'foo'
     self.assertEqual('oneof_string', m.WhichOneof('oneof_field'))
     self.assertFalse(m.HasField('oneof_uint32'))
     self.assertTrue(m.HasField('oneof_string'))
@@ -977,7 +976,7 @@ class MessageTest(unittest.TestCase):
     in the value being converted to a Unicode string.
     """
     m = message_module.TestAllTypes()
-    m.optional_string = str('')
+    m.optional_string = ''
     self.assertIsInstance(m.optional_string, str)
 
   def testLongValuedSlice(self, message_module):
@@ -1005,7 +1004,7 @@ class MessageTest(unittest.TestCase):
     with self.assertRaises(NameError) as _:
       m.repeated_nested_enum.extend(a for i in range(10))  # pylint: disable=undefined-variable
 
-  FALSY_VALUES = [None, False, 0, 0.0, b'', u'', bytearray(), [], {}, set()]
+  FALSY_VALUES = [None, False, 0, 0.0, b'', '', bytearray(), [], {}, set()]
 
   def testExtendInt32WithNothing(self, message_module):
     """Test no-ops extending repeated int32 fields."""
@@ -1086,7 +1085,7 @@ class MessageTest(unittest.TestCase):
     m.repeated_string.extend('abc')
     self.assertSequenceEqual(['a', 'b', 'c'], m.repeated_string)
 
-  class TestIterable(object):
+  class TestIterable:
     """This iterable object mimics the behavior of numpy.array.
 
     __nonzero__ fails for length > 1, and returns bool(item[0]) for length == 1.
@@ -1149,7 +1148,7 @@ class MessageTest(unittest.TestCase):
     m.repeated_string.extend(MessageTest.TestIterable(['3', '4']))
     self.assertSequenceEqual(['', '1', '2', '3', '4'], m.repeated_string)
 
-  class TestIndex(object):
+  class TestIndex:
     """This index object mimics the behavior of numpy.int64 and other types."""
 
     def __init__(self, value=None):
@@ -1300,13 +1299,13 @@ class Proto2Test(unittest.TestCase):
     message.optional_bool = True
     message.optional_nested_message.bb = 15
 
-    self.assertTrue(message.HasField(u'optional_int32'))
+    self.assertTrue(message.HasField('optional_int32'))
     self.assertTrue(message.HasField('optional_bool'))
     self.assertTrue(message.HasField('optional_nested_message'))
 
     # Clearing the fields unsets them and resets their value to default.
     message.ClearField('optional_int32')
-    message.ClearField(u'optional_bool')
+    message.ClearField('optional_bool')
     message.ClearField('optional_nested_message')
 
     self.assertFalse(message.HasField('optional_int32'))
@@ -1542,7 +1541,7 @@ class Proto2Test(unittest.TestCase):
     self.assertEqual(0, len(message.repeated_float))
     self.assertEqual(42, message.default_int64)
 
-    message = unittest_pb2.TestAllTypes(optional_nested_enum=u'BAZ')
+    message = unittest_pb2.TestAllTypes(optional_nested_enum='BAZ')
     self.assertEqual(unittest_pb2.TestAllTypes.BAZ,
                      message.optional_nested_enum)
 
@@ -1564,7 +1563,7 @@ class Proto2Test(unittest.TestCase):
     # Both string/unicode field name keys should work.
     kwargs = {
         'optional_int32': 100,
-        u'optional_fixed32': 200,
+        'optional_fixed32': 200,
     }
     msg = unittest_pb2.TestAllTypes(**kwargs)
     self.assertEqual(100, msg.optional_int32)
@@ -1915,7 +1914,7 @@ class Proto3Test(unittest.TestCase):
   def testStringUnicodeConversionInMap(self):
     msg = map_unittest_pb2.TestMap()
 
-    unicode_obj = u'\u1234'
+    unicode_obj = '\u1234'
     bytes_obj = unicode_obj.encode('utf8')
 
     msg.map_string_string[bytes_obj] = bytes_obj
@@ -2489,24 +2488,24 @@ class Proto3Test(unittest.TestCase):
 
     # Test optional_string=u'😍' is accepted.
     serialized = unittest_proto3_arena_pb2.TestAllTypes(
-        optional_string=u'😍').SerializeToString()
+        optional_string='😍').SerializeToString()
     msg2 = unittest_proto3_arena_pb2.TestAllTypes()
     msg2.MergeFromString(serialized)
-    self.assertEqual(msg2.optional_string, u'😍')
+    self.assertEqual(msg2.optional_string, '😍')
 
-    msg = unittest_proto3_arena_pb2.TestAllTypes(optional_string=u'\ud001')
-    self.assertEqual(msg.optional_string, u'\ud001')
+    msg = unittest_proto3_arena_pb2.TestAllTypes(optional_string='\ud001')
+    self.assertEqual(msg.optional_string, '\ud001')
 
   def testSurrogatesInPython3(self):
     # Surrogates are rejected at setters in Python3.
     with self.assertRaises(ValueError):
-      unittest_proto3_arena_pb2.TestAllTypes(optional_string=u'\ud801\udc01')
+      unittest_proto3_arena_pb2.TestAllTypes(optional_string='\ud801\udc01')
     with self.assertRaises(ValueError):
       unittest_proto3_arena_pb2.TestAllTypes(optional_string=b'\xed\xa0\x81')
     with self.assertRaises(ValueError):
-      unittest_proto3_arena_pb2.TestAllTypes(optional_string=u'\ud801')
+      unittest_proto3_arena_pb2.TestAllTypes(optional_string='\ud801')
     with self.assertRaises(ValueError):
-      unittest_proto3_arena_pb2.TestAllTypes(optional_string=u'\ud801\ud801')
+      unittest_proto3_arena_pb2.TestAllTypes(optional_string='\ud801\ud801')
 
   def testCrashNullAA(self):
     self.assertEqual(
@@ -2539,7 +2538,7 @@ class ValidTypeNamesTest(unittest.TestCase):
                    'Repeated%sFieldContainer' % base_name)
     self.assertTrue(
         any(tp_name.endswith(v) for v in valid_names),
-        '%r does end with any of %r' % (tp_name, valid_names))
+        f'{tp_name!r} does end with any of {valid_names!r}')
 
     parts = tp_name.split('.')
     class_name = parts[-1]

--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -150,7 +150,7 @@ class GeneratedProtocolMessageType(type):
     _AddClassAttributesForNestedExtensions(descriptor, dictionary)
     _AddSlots(descriptor, dictionary)
 
-    superclass = super(GeneratedProtocolMessageType, cls)
+    superclass = super()
     new_class = superclass.__new__(cls, name, bases, dictionary)
     return new_class
 
@@ -201,7 +201,7 @@ class GeneratedProtocolMessageType(type):
     _AddMessageMethods(descriptor, cls)
     _AddPrivateHelperMethods(descriptor, cls)
 
-    superclass = super(GeneratedProtocolMessageType, cls)
+    superclass = super()
     superclass.__init__(name, bases, dictionary)
 
 
@@ -455,7 +455,7 @@ def _ReraiseTypeErrorWithFieldName(message_name, field_name):
   exc = sys.exc_info()[1]
   if len(exc.args) == 1 and type(exc) is TypeError:
     # simple TypeError; add field name to exception message
-    exc = TypeError('%s for field %s.%s' % (str(exc), message_name, field_name))
+    exc = TypeError(f'{str(exc)} for field {message_name}.{field_name}')
 
   # re-raise possibly-amended exception with original traceback:
   raise exc.with_traceback(sys.exc_info()[2])
@@ -475,7 +475,7 @@ def _AddInitMethod(message_descriptor, cls):
       try:
         return enum_type.values_by_name[value].number
       except KeyError:
-        raise ValueError('Enum type %s: unknown label "%s"' % (
+        raise ValueError('Enum type {}: unknown label "{}"'.format(
             enum_type.full_name, value))
     return value
 
@@ -1054,7 +1054,7 @@ def _AddSerializeToStringMethod(message_descriptor, cls):
     # Check if the message has all of its required fields set.
     if not self.IsInitialized():
       raise message_mod.EncodeError(
-          'Message %s is missing required fields: %s' % (
+          'Message {} is missing required fields: {}'.format(
           self.DESCRIPTOR.full_name, ','.join(self.FindInitializationErrors())))
     return self.SerializePartialToString(**kwargs)
   cls.SerializeToString = SerializeToString
@@ -1245,7 +1245,7 @@ def _AddIsInitializedMethod(message_descriptor, cls):
           if _IsMessageMapField(field):
             for key in value:
               element = value[key]
-              prefix = '%s[%s].' % (name, key)
+              prefix = f'{name}[{key}].'
               sub_errors = element.FindInitializationErrors()
               errors += [prefix + error for error in sub_errors]
           else:
@@ -1445,7 +1445,7 @@ def _AddPrivateHelperMethods(message_descriptor, cls):
   cls._UpdateOneofState = _UpdateOneofState
 
 
-class _Listener(object):
+class _Listener:
 
   """MessageListener implementation that a parent message registers with its
   child message.
@@ -1500,13 +1500,13 @@ class _OneofListener(_Listener):
         we receive Modified() messages.
       field: The descriptor of the field being set in the parent message.
     """
-    super(_OneofListener, self).__init__(parent_message)
+    super().__init__(parent_message)
     self._field = field
 
   def Modified(self):
     """Also updates the state of the containing oneof in the parent message."""
     try:
       self._parent_message_weakref._UpdateOneofState(self._field)
-      super(_OneofListener, self).Modified()
+      super().Modified()
     except ReferenceError:
       pass

--- a/python/google/protobuf/internal/reflection_test.py
+++ b/python/google/protobuf/internal/reflection_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Protocol Buffers - Google's data interchange format
 # Copyright 2008 Google Inc.  All rights reserved.
 # https://developers.google.com/protocol-buffers/
@@ -64,7 +63,7 @@ from google.protobuf import unittest_proto3_arena_pb2
 warnings.simplefilter('error', DeprecationWarning)
 
 
-class _MiniDecoder(object):
+class _MiniDecoder:
   """Decodes a stream of values from a string.
 
   Once upon a time we actually had a class called decoder.Decoder.  Then we
@@ -840,32 +839,32 @@ class ReflectionTest(unittest.TestCase):
 
     # Assignment of a unicode object to a field of type 'bytes' is not allowed.
     self.assertRaises(TypeError,
-                      setattr, proto, 'optional_bytes', u'unicode object')
+                      setattr, proto, 'optional_bytes', 'unicode object')
 
     # Check that the default value is of python's 'unicode' type.
     self.assertEqual(type(proto.optional_string), str)
 
-    proto.optional_string = str('Testing')
-    self.assertEqual(proto.optional_string, str('Testing'))
+    proto.optional_string = 'Testing'
+    self.assertEqual(proto.optional_string, 'Testing')
 
     # Assign a value of type 'str' which can be encoded in UTF-8.
-    proto.optional_string = str('Testing')
-    self.assertEqual(proto.optional_string, str('Testing'))
+    proto.optional_string = 'Testing'
+    self.assertEqual(proto.optional_string, 'Testing')
 
     # Try to assign a 'bytes' object which contains non-UTF-8.
     self.assertRaises(ValueError,
                       setattr, proto, 'optional_string', b'a\x80a')
     # No exception: Assign already encoded UTF-8 bytes to a string field.
-    utf8_bytes = u'Тест'.encode('utf-8')
+    utf8_bytes = 'Тест'.encode()
     proto.optional_string = utf8_bytes
     # No exception: Assign the a non-ascii unicode object.
-    proto.optional_string = u'Тест'
+    proto.optional_string = 'Тест'
     # No exception thrown (normal str assignment containing ASCII).
     proto.optional_string = 'abc'
 
   def testBytesInTextFormat(self, message_module):
     proto = message_module.TestAllTypes(optional_bytes=b'\x00\x7f\x80\xff')
-    self.assertEqual(u'optional_bytes: "\\000\\177\\200\\377"\n', str(proto))
+    self.assertEqual('optional_bytes: "\\000\\177\\200\\377"\n', str(proto))
 
   def testEmptyNestedMessage(self, message_module):
     proto = message_module.TestAllTypes()
@@ -1154,7 +1153,7 @@ class Proto2ReflectionTest(unittest.TestCase):
                      proto.default_import_enum)
 
     proto = unittest_pb2.TestExtremeDefaultValues()
-    self.assertEqual(u'\u1234', proto.utf8_string)
+    self.assertEqual('\u1234', proto.utf8_string)
 
   def testHasFieldWithUnknownFieldName(self):
     proto = unittest_pb2.TestAllTypes()
@@ -2058,7 +2057,7 @@ class Proto2ReflectionTest(unittest.TestCase):
     extension_message = message_set_extensions_pb2.TestMessageSetExtension2
     extension = extension_message.message_set_extension
 
-    test_utf8 = u'Тест'
+    test_utf8 = 'Тест'
     test_utf8_bytes = test_utf8.encode('utf-8')
 
     # 'Test' in another language, using UTF-8 charset.

--- a/python/google/protobuf/internal/test_util.py
+++ b/python/google/protobuf/internal/test_util.py
@@ -81,7 +81,7 @@ def SetAllNonLazyFields(message):
   message.optional_float    = 111
   message.optional_double   = 112
   message.optional_bool     = True
-  message.optional_string   = u'115'
+  message.optional_string   = '115'
   message.optional_bytes    = b'116'
 
   if IsProto2(message):
@@ -96,8 +96,8 @@ def SetAllNonLazyFields(message):
   if IsProto2(message):
     message.optional_import_enum = unittest_import_pb2.IMPORT_BAZ
 
-  message.optional_string_piece = u'124'
-  message.optional_cord = u'125'
+  message.optional_string_piece = '124'
+  message.optional_cord = '125'
 
   #
   # Repeated fields.
@@ -116,7 +116,7 @@ def SetAllNonLazyFields(message):
   message.repeated_float.append(211)
   message.repeated_double.append(212)
   message.repeated_bool.append(True)
-  message.repeated_string.append(u'215')
+  message.repeated_string.append('215')
   message.repeated_bytes.append(b'216')
 
   if IsProto2(message):
@@ -131,8 +131,8 @@ def SetAllNonLazyFields(message):
   if IsProto2(message):
     message.repeated_import_enum.append(unittest_import_pb2.IMPORT_BAR)
 
-  message.repeated_string_piece.append(u'224')
-  message.repeated_cord.append(u'225')
+  message.repeated_string_piece.append('224')
+  message.repeated_cord.append('225')
 
   # Add a second one of each field and set value by index.
   message.repeated_int32.append(0)
@@ -148,7 +148,7 @@ def SetAllNonLazyFields(message):
   message.repeated_float.append(0)
   message.repeated_double.append(0)
   message.repeated_bool.append(True)
-  message.repeated_string.append(u'0')
+  message.repeated_string.append('0')
   message.repeated_bytes.append(b'0')
   message.repeated_int32[1] = 301
   message.repeated_int64[1] = 302
@@ -163,7 +163,7 @@ def SetAllNonLazyFields(message):
   message.repeated_float[1] = 311
   message.repeated_double[1] = 312
   message.repeated_bool[1] = False
-  message.repeated_string[1] = u'315'
+  message.repeated_string[1] = '315'
   message.repeated_bytes[1] = b'316'
 
   if IsProto2(message):
@@ -179,8 +179,8 @@ def SetAllNonLazyFields(message):
   if IsProto2(message):
     message.repeated_import_enum.append(unittest_import_pb2.IMPORT_BAZ)
 
-  message.repeated_string_piece.append(u'324')
-  message.repeated_cord.append(u'325')
+  message.repeated_string_piece.append('324')
+  message.repeated_cord.append('325')
 
   #
   # Fields that have defaults.
@@ -250,7 +250,7 @@ def SetAllExtensions(message):
   extensions[pb2.optional_float_extension] = 111
   extensions[pb2.optional_double_extension] = 112
   extensions[pb2.optional_bool_extension] = True
-  extensions[pb2.optional_string_extension] = u'115'
+  extensions[pb2.optional_string_extension] = '115'
   extensions[pb2.optional_bytes_extension] = b'116'
 
   extensions[pb2.optionalgroup_extension].a = 117
@@ -266,8 +266,8 @@ def SetAllExtensions(message):
   extensions[pb2.optional_foreign_enum_extension] = pb2.FOREIGN_BAZ
   extensions[pb2.optional_import_enum_extension] = import_pb2.IMPORT_BAZ
 
-  extensions[pb2.optional_string_piece_extension] = u'124'
-  extensions[pb2.optional_cord_extension] = u'125'
+  extensions[pb2.optional_string_piece_extension] = '124'
+  extensions[pb2.optional_cord_extension] = '125'
 
   #
   # Repeated fields.
@@ -286,7 +286,7 @@ def SetAllExtensions(message):
   extensions[pb2.repeated_float_extension].append(211)
   extensions[pb2.repeated_double_extension].append(212)
   extensions[pb2.repeated_bool_extension].append(True)
-  extensions[pb2.repeated_string_extension].append(u'215')
+  extensions[pb2.repeated_string_extension].append('215')
   extensions[pb2.repeated_bytes_extension].append(b'216')
 
   extensions[pb2.repeatedgroup_extension].add().a = 217
@@ -299,8 +299,8 @@ def SetAllExtensions(message):
   extensions[pb2.repeated_foreign_enum_extension].append(pb2.FOREIGN_BAR)
   extensions[pb2.repeated_import_enum_extension].append(import_pb2.IMPORT_BAR)
 
-  extensions[pb2.repeated_string_piece_extension].append(u'224')
-  extensions[pb2.repeated_cord_extension].append(u'225')
+  extensions[pb2.repeated_string_piece_extension].append('224')
+  extensions[pb2.repeated_cord_extension].append('225')
 
   # Append a second one of each field.
   extensions[pb2.repeated_int32_extension].append(301)
@@ -316,7 +316,7 @@ def SetAllExtensions(message):
   extensions[pb2.repeated_float_extension].append(311)
   extensions[pb2.repeated_double_extension].append(312)
   extensions[pb2.repeated_bool_extension].append(False)
-  extensions[pb2.repeated_string_extension].append(u'315')
+  extensions[pb2.repeated_string_extension].append('315')
   extensions[pb2.repeated_bytes_extension].append(b'316')
 
   extensions[pb2.repeatedgroup_extension].add().a = 317
@@ -329,8 +329,8 @@ def SetAllExtensions(message):
   extensions[pb2.repeated_foreign_enum_extension].append(pb2.FOREIGN_BAZ)
   extensions[pb2.repeated_import_enum_extension].append(import_pb2.IMPORT_BAZ)
 
-  extensions[pb2.repeated_string_piece_extension].append(u'324')
-  extensions[pb2.repeated_cord_extension].append(u'325')
+  extensions[pb2.repeated_string_piece_extension].append('324')
+  extensions[pb2.repeated_cord_extension].append('325')
 
   #
   # Fields with defaults.
@@ -349,19 +349,19 @@ def SetAllExtensions(message):
   extensions[pb2.default_float_extension] = 411
   extensions[pb2.default_double_extension] = 412
   extensions[pb2.default_bool_extension] = False
-  extensions[pb2.default_string_extension] = u'415'
+  extensions[pb2.default_string_extension] = '415'
   extensions[pb2.default_bytes_extension] = b'416'
 
   extensions[pb2.default_nested_enum_extension] = pb2.TestAllTypes.FOO
   extensions[pb2.default_foreign_enum_extension] = pb2.FOREIGN_FOO
   extensions[pb2.default_import_enum_extension] = import_pb2.IMPORT_FOO
 
-  extensions[pb2.default_string_piece_extension] = u'424'
+  extensions[pb2.default_string_piece_extension] = '424'
   extensions[pb2.default_cord_extension] = '425'
 
   extensions[pb2.oneof_uint32_extension] = 601
   extensions[pb2.oneof_nested_message_extension].bb = 602
-  extensions[pb2.oneof_string_extension] = u'603'
+  extensions[pb2.oneof_string_extension] = '603'
   extensions[pb2.oneof_bytes_extension] = b'604'
 
 
@@ -405,7 +405,7 @@ def ExpectAllFieldsAndExtensionsInOrder(serialized):
   expected = b''.join(expected_strings)
 
   if expected != serialized:
-    raise ValueError('Expected %r, found %r' % (expected, serialized))
+    raise ValueError(f'Expected {expected!r}, found {serialized!r}')
 
 
 def ExpectAllFieldsSet(test_case, message):

--- a/python/google/protobuf/internal/testing_refleaks.py
+++ b/python/google/protobuf/internal/testing_refleaks.py
@@ -61,7 +61,7 @@ class LocalTestResult(unittest.TestResult):
     pass
 
 
-class ReferenceLeakCheckerMixin(object):
+class ReferenceLeakCheckerMixin:
   """A mixin class for TestCase, which checks reference counts."""
 
   NB_RUNS = 3
@@ -79,8 +79,8 @@ class ReferenceLeakCheckerMixin(object):
     self._saved_pickle_registry = copyreg.dispatch_table.copy()
 
     # Run the test twice, to warm up the instance attributes.
-    super(ReferenceLeakCheckerMixin, self).run(result=result)
-    super(ReferenceLeakCheckerMixin, self).run(result=result)
+    super().run(result=result)
+    super().run(result=result)
 
     oldrefcount = 0
     local_result = LocalTestResult(result)
@@ -89,7 +89,7 @@ class ReferenceLeakCheckerMixin(object):
     refcount_deltas = []
     while len(refcount_deltas) < self.NB_RUNS:
       oldrefcount = self._getRefcounts()
-      super(ReferenceLeakCheckerMixin, self).run(result=local_result)
+      super().run(result=local_result)
       newrefcount = self._getRefcounts()
       # If the GC was able to collect some objects after the call to run() that
       # it could not collect before the call, then the counts won't match.

--- a/python/google/protobuf/internal/text_format_test.py
+++ b/python/google/protobuf/internal/text_format_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Protocol Buffers - Google's data interchange format
 # Copyright 2008 Google Inc.  All rights reserved.
 # https://developers.google.com/protocol-buffers/
@@ -108,7 +107,7 @@ class TextFormatMessageToStringTests(TextFormatBase):
     message.repeated_double.append(1.23e22)
     message.repeated_double.append(1.23e-18)
     message.repeated_string.append('\000\001\a\b\f\n\r\t\v\\\'"')
-    message.repeated_string.append(u'\u00fc\ua71f')
+    message.repeated_string.append('\u00fc\ua71f')
     self.CompareToGoldenText(
         self.RemoveRedundantZeros(text_format.MessageToString(message)),
         'repeated_int64: -9223372036854775808\n'
@@ -226,7 +225,7 @@ class TextFormatMessageToStringTests(TextFormatBase):
       pass
 
     message = message_module.TestAllTypes()
-    message.repeated_string.append(UnicodeSub(u'\u00fc\ua71f'))
+    message.repeated_string.append(UnicodeSub('\u00fc\ua71f'))
     self.CompareToGoldenText(
         text_format.MessageToString(message),
         'repeated_string: "\\303\\274\\352\\234\\237"\n')
@@ -303,7 +302,7 @@ class TextFormatMessageToStringTests(TextFormatBase):
     message.repeated_double.append(1.23e22)
     message.repeated_double.append(1.23e-18)
     message.repeated_string.append('\000\001\a\b\f\n\r\t\v\\\'"')
-    message.repeated_string.append(u'\u00fc\ua71f')
+    message.repeated_string.append('\u00fc\ua71f')
     self.CompareToGoldenText(
         self.RemoveRedundantZeros(text_format.MessageToString(
             message, as_one_line=True)),
@@ -324,7 +323,7 @@ class TextFormatMessageToStringTests(TextFormatBase):
     message.repeated_double.append(1.23e22)
     message.repeated_double.append(1.23e-18)
     message.repeated_string.append('\000\001\a\b\f\n\r\t\v\\\'"')
-    message.repeated_string.append(u'\u00fc\ua71f')
+    message.repeated_string.append('\u00fc\ua71f')
 
     # Test as_utf8 = False.
     wire_text = text_format.MessageToString(message,
@@ -343,13 +342,13 @@ class TextFormatMessageToStringTests(TextFormatBase):
     r = text_format.Parse(wire_text, parsed_message)
     self.assertIs(r, parsed_message)
     self.assertEqual(message, parsed_message,
-                     '\n%s != %s' % (message, parsed_message))
+                     f'\n{message} != {parsed_message}')
 
   def testPrintRawUtf8String(self, message_module):
     message = message_module.TestAllTypes()
-    message.repeated_string.append(u'\u00fc\t\ua71f')
+    message.repeated_string.append('\u00fc\t\ua71f')
     text = text_format.MessageToString(message, as_utf8=True)
-    golden_unicode = u'repeated_string: "\u00fc\\t\ua71f"\n'
+    golden_unicode = 'repeated_string: "\u00fc\\t\ua71f"\n'
     golden_text = golden_unicode
     # MessageToString always returns a native str.
     self.CompareToGoldenText(text, golden_text)
@@ -439,7 +438,7 @@ class TextFormatMessageToStringTests(TextFormatBase):
     self.assertEqual('c: 123\n', str(message))
 
   def testMessageToStringUnicode(self, message_module):
-    golden_unicode = u'Á short desçription and a 🍌.'
+    golden_unicode = 'Á short desçription and a 🍌.'
     golden_bytes = golden_unicode.encode('utf-8')
     message = message_module.TestAllTypes()
     message.optional_string = golden_unicode
@@ -453,7 +452,7 @@ class TextFormatMessageToStringTests(TextFormatBase):
     self.CompareToGoldenText(text, golden_message)
 
   def testMessageToStringASCII(self, message_module):
-    golden_unicode = u'Á short desçription and a 🍌.'
+    golden_unicode = 'Á short desçription and a 🍌.'
     golden_bytes = golden_unicode.encode('utf-8')
     message = message_module.TestAllTypes()
     message.optional_string = golden_unicode
@@ -592,7 +591,7 @@ class TextFormatMessageToStringTests(TextFormatBase):
     inner_msg = message_module.TestAllTypes()
     inner_msg.optional_int32 = 101
     inner_msg.optional_double = 102.0
-    inner_msg.optional_string = u'hello'
+    inner_msg.optional_string = 'hello'
     inner_msg.optional_bytes = b'103'
     inner_msg.optional_nested_message.bb = 105
     inner_data = inner_msg.SerializeToString()
@@ -639,7 +638,7 @@ class TextFormatMessageToTextBytesTests(TextFormatBase):
 
   def testRawUtf8RoundTrip(self, message_module):
     message = message_module.TestAllTypes()
-    message.repeated_string.append(u'\u00fc\t\ua71f')
+    message.repeated_string.append('\u00fc\t\ua71f')
     utf8_text = text_format.MessageToBytes(message, as_utf8=True)
     golden_bytes = b'repeated_string: "\xc3\xbc\\t\xea\x9c\x9f"\n'
     self.CompareToGoldenText(utf8_text, golden_bytes)
@@ -652,7 +651,7 @@ class TextFormatMessageToTextBytesTests(TextFormatBase):
 
   def testEscapedUtf8ASCIIRoundTrip(self, message_module):
     message = message_module.TestAllTypes()
-    message.repeated_string.append(u'\u00fc\t\ua71f')
+    message.repeated_string.append('\u00fc\t\ua71f')
     ascii_text = text_format.MessageToBytes(message)  # as_utf8=False default
     golden_bytes = b'repeated_string: "\\303\\274\\t\\352\\234\\237"\n'
     self.CompareToGoldenText(ascii_text, golden_bytes)
@@ -697,13 +696,13 @@ class TextFormatParserTests(TextFormatBase):
       test_util.ExpectAllFieldsSet(self, message)
 
     msg2 = message_module.TestAllTypes()
-    text = (u'optional_string: "café"')
+    text = ('optional_string: "café"')
     text_format.Merge(text, msg2)
-    self.assertEqual(msg2.optional_string, u'café')
+    self.assertEqual(msg2.optional_string, 'café')
     msg2.Clear()
-    self.assertEqual(msg2.optional_string, u'')
+    self.assertEqual(msg2.optional_string, '')
     text_format.Parse(text, msg2)
-    self.assertEqual(msg2.optional_string, u'café')
+    self.assertEqual(msg2.optional_string, 'café')
 
   def testParseDoubleToFloat(self, message_module):
     message = message_module.TestAllTypes()
@@ -735,8 +734,8 @@ class TextFormatParserTests(TextFormatBase):
     self.assertEqual(1.23e-18, message.repeated_double[2])
     self.assertEqual('\000\001\a\b\f\n\r\t\v\\\'"', message.repeated_string[0])
     self.assertEqual('foocorgegrault', message.repeated_string[1])
-    self.assertEqual(u'\u00fc\ua71f', message.repeated_string[2])
-    self.assertEqual(u'\u00fc', message.repeated_string[3])
+    self.assertEqual('\u00fc\ua71f', message.repeated_string[2])
+    self.assertEqual('\u00fc', message.repeated_string[3])
 
   def testParseTrailingCommas(self, message_module):
     message = message_module.TestAllTypes()
@@ -750,8 +749,8 @@ class TextFormatParserTests(TextFormatBase):
     self.assertEqual(100, message.repeated_int64[0])
     self.assertEqual(200, message.repeated_int64[1])
     self.assertEqual(300, message.repeated_int64[2])
-    self.assertEqual(u'one', message.repeated_string[0])
-    self.assertEqual(u'two', message.repeated_string[1])
+    self.assertEqual('one', message.repeated_string[0])
+    self.assertEqual('two', message.repeated_string[1])
 
   def testParseRepeatedScalarShortFormat(self, message_module):
     message = message_module.TestAllTypes()
@@ -764,8 +763,8 @@ class TextFormatParserTests(TextFormatBase):
     self.assertEqual(100, message.repeated_int64[0])
     self.assertEqual(200, message.repeated_int64[1])
     self.assertEqual(300, message.repeated_int64[2])
-    self.assertEqual(u'one', message.repeated_string[0])
-    self.assertEqual(u'two', message.repeated_string[1])
+    self.assertEqual('one', message.repeated_string[0])
+    self.assertEqual('two', message.repeated_string[1])
 
   def testParseRepeatedMessageShortFormat(self, message_module):
     message = message_module.TestAllTypes()
@@ -878,7 +877,7 @@ class TextFormatParserTests(TextFormatBase):
   # itself for string fields.  It also demonstrates escaped binary data.
   # The ur"" string prefix is unfortunately missing from Python 3
   # so we resort to double escaping our \s so that they come through.
-  _UNICODE_SAMPLE = u"""
+  _UNICODE_SAMPLE = """
       optional_bytes: 'Á short desçription'
       optional_string: 'Á short desçription'
       repeated_bytes: '\\303\\201 short des\\303\\247ription'
@@ -886,10 +885,10 @@ class TextFormatParserTests(TextFormatBase):
       repeated_string: '\\xd0\\x9f\\xd1\\x80\\xd0\\xb8\\xd0\\xb2\\xd0\\xb5\\xd1\\x82'
       """
   _BYTES_SAMPLE = _UNICODE_SAMPLE.encode('utf-8')
-  _GOLDEN_UNICODE = u'Á short desçription'
+  _GOLDEN_UNICODE = 'Á short desçription'
   _GOLDEN_BYTES = _GOLDEN_UNICODE.encode('utf-8')
   _GOLDEN_BYTES_1 = b'\x12\x34\x56\x78\x90\xab\xcd\xef'
-  _GOLDEN_STR_0 = u'Привет'
+  _GOLDEN_STR_0 = 'Привет'
 
   def testParseUnicode(self, message_module):
     m = message_module.TestAllTypes()
@@ -940,7 +939,7 @@ class TextFormatParserTests(TextFormatBase):
 
   def testFromUnicodeLines(self, message_module):
     m = message_module.TestAllTypes()
-    text_format.ParseLines(self._UNICODE_SAMPLE.split(u'\n'), m)
+    text_format.ParseLines(self._UNICODE_SAMPLE.split('\n'), m)
     self.assertEqual(m.optional_bytes, self._GOLDEN_BYTES)
     self.assertEqual(m.optional_string, self._GOLDEN_UNICODE)
     self.assertEqual(m.repeated_bytes[0], self._GOLDEN_BYTES)
@@ -1049,7 +1048,7 @@ class OnlyWorksWithProto2RightNowTests(TextFormatBase):
     message = unittest_pb2.TestAllTypes()
     message.optional_int32 = 101
     message.optional_double = 102.0
-    message.optional_string = u'hello'
+    message.optional_string = 'hello'
     message.optional_bytes = b'103'
     message.optionalgroup.a = 104
     message.optional_nested_message.bb = 105
@@ -1281,8 +1280,8 @@ class OnlyWorksWithProto2RightNowTests(TextFormatBase):
       message.map_string_string[letter] = 'dummy'
     for letter in reversed(string.ascii_uppercase[0:13]):
       message.map_string_string[letter] = 'dummy'
-    golden = ''.join(('map_string_string {\n  key: "%c"\n  value: "dummy"\n}\n'
-                      % (letter,) for letter in string.ascii_uppercase))
+    golden = ''.join('map_string_string {\n  key: "%c"\n  value: "dummy"\n}\n'
+                      % (letter,) for letter in string.ascii_uppercase)
     self.CompareToGoldenText(text_format.MessageToString(message), golden)
 
   # TODO(teboring): In c/137553523, not serializing default value for map entry
@@ -2325,7 +2324,7 @@ class PrettyPrinterTest(TextFormatBase):
     def printer(m, indent, as_one_line):
       if m.DESCRIPTOR == message_module.TestAllTypes.NestedMessage.DESCRIPTOR:
         line_deliminator = (' ' if as_one_line else '\n') + ' ' * indent
-        return 'My lucky number is:%s%s' % (line_deliminator, m.bb)
+        return f'My lucky number is:{line_deliminator}{m.bb}'
       return None
 
     message = message_module.TestAllTypes()

--- a/python/google/protobuf/internal/type_checkers.py
+++ b/python/google/protobuf/internal/type_checkers.py
@@ -101,7 +101,7 @@ def GetTypeChecker(field):
 # subclassing builtin types and doing weird things.  We're not trying to
 # protect against malicious clients here, just people accidentally shooting
 # themselves in the foot in obvious ways.
-class TypeChecker(object):
+class TypeChecker:
 
   """Type checker used to catch type errors as early as possible
   when the client is setting scalar fields in protocol messages.
@@ -132,7 +132,7 @@ class TypeCheckerWithDefault(TypeChecker):
     return self._default_value
 
 
-class BoolValueChecker(object):
+class BoolValueChecker:
   """Type checker used for bool fields."""
 
   def CheckValue(self, proposed_value):
@@ -150,7 +150,7 @@ class BoolValueChecker(object):
 
 # IntValueChecker and its subclasses perform integer type-checks
 # and bounds-checks.
-class IntValueChecker(object):
+class IntValueChecker:
 
   """Checker used for integer fields.  Performs type-check and range check."""
 
@@ -173,7 +173,7 @@ class IntValueChecker(object):
     return 0
 
 
-class EnumValueChecker(object):
+class EnumValueChecker:
 
   """Checker used for enum fields.  Performs type-check and range check."""
 
@@ -193,7 +193,7 @@ class EnumValueChecker(object):
     return self._enum_type.values[0].number
 
 
-class UnicodeValueChecker(object):
+class UnicodeValueChecker:
 
   """Checker used for string fields.
 
@@ -226,7 +226,7 @@ class UnicodeValueChecker(object):
     return proposed_value
 
   def DefaultValue(self):
-    return u""
+    return ""
 
 
 class Int32ValueChecker(IntValueChecker):
@@ -258,7 +258,7 @@ _INF = float('inf')
 _NEG_INF = float('-inf')
 
 
-class DoubleValueChecker(object):
+class DoubleValueChecker:
   """Checker used for double fields.
 
   Performs type-check and range check.

--- a/python/google/protobuf/internal/unknown_fields_test.py
+++ b/python/google/protobuf/internal/unknown_fields_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Protocol Buffers - Google's data interchange format
 # Copyright 2008 Google Inc.  All rights reserved.
 # https://developers.google.com/protocol-buffers/

--- a/python/google/protobuf/internal/well_known_types.py
+++ b/python/google/protobuf/internal/well_known_types.py
@@ -58,7 +58,7 @@ _SECONDS_PER_DAY = 24 * 3600
 _DURATION_SECONDS_MAX = 315576000000
 
 
-class Any(object):
+class Any:
   """Class for Any Message type."""
 
   __slots__ = ()
@@ -67,9 +67,9 @@ class Any(object):
            deterministic=None):
     """Packs the specified message into current Any message."""
     if len(type_url_prefix) < 1 or type_url_prefix[-1] != '/':
-      self.type_url = '%s/%s' % (type_url_prefix, msg.DESCRIPTOR.full_name)
+      self.type_url = f'{type_url_prefix}/{msg.DESCRIPTOR.full_name}'
     else:
-      self.type_url = '%s%s' % (type_url_prefix, msg.DESCRIPTOR.full_name)
+      self.type_url = f'{type_url_prefix}{msg.DESCRIPTOR.full_name}'
     self.value = msg.SerializeToString(deterministic=deterministic)
 
   def Unpack(self, msg):
@@ -95,7 +95,7 @@ _EPOCH_DATETIME_AWARE = datetime.datetime.fromtimestamp(
     0, tz=datetime.timezone.utc)
 
 
-class Timestamp(object):
+class Timestamp:
   """Class for Timestamp message type."""
 
   __slots__ = ()
@@ -140,7 +140,7 @@ class Timestamp(object):
       ValueError: On parsing problems.
     """
     if not isinstance(value, str):
-      raise ValueError('Timestamp JSON value not a string: {!r}'.format(value))
+      raise ValueError(f'Timestamp JSON value not a string: {value!r}')
     timezone_offset = value.find('Z')
     if timezone_offset == -1:
       timezone_offset = value.find('+')
@@ -160,14 +160,14 @@ class Timestamp(object):
       nano_value = time_value[point_position + 1:]
     if 't' in second_value:
       raise ValueError(
-          'time data \'{0}\' does not match format \'%Y-%m-%dT%H:%M:%S\', '
+          'time data \'{}\' does not match format \'%Y-%m-%dT%H:%M:%S\', '
           'lowercase \'t\' is not accepted'.format(second_value))
     date_object = datetime.datetime.strptime(second_value, _TIMESTAMPFOMAT)
     td = date_object - datetime.datetime(1970, 1, 1)
     seconds = td.seconds + td.days * _SECONDS_PER_DAY
     if len(nano_value) > 9:
       raise ValueError(
-          'Failed to parse Timestamp: nanos {0} more than '
+          'Failed to parse Timestamp: nanos {} more than '
           '9 fractional digits.'.format(nano_value))
     if nano_value:
       nanos = round(float('0.' + nano_value) * 1e9)
@@ -177,13 +177,13 @@ class Timestamp(object):
     if value[timezone_offset] == 'Z':
       if len(value) != timezone_offset + 1:
         raise ValueError('Failed to parse timestamp: invalid trailing'
-                         ' data {0}.'.format(value))
+                         ' data {}.'.format(value))
     else:
       timezone = value[timezone_offset:]
       pos = timezone.find(':')
       if pos == -1:
         raise ValueError(
-            'Invalid timezone offset value: {0}.'.format(timezone))
+            f'Invalid timezone offset value: {timezone}.')
       if timezone[0] == '+':
         seconds -= (int(timezone[1:pos])*60+int(timezone[pos+1:]))*60
       else:
@@ -271,7 +271,7 @@ class Timestamp(object):
     self.nanos = dt.microsecond * _NANOS_PER_MICROSECOND
 
 
-class Duration(object):
+class Duration:
   """Class for Duration message type."""
 
   __slots__ = ()
@@ -320,10 +320,10 @@ class Duration(object):
       ValueError: On parsing problems.
     """
     if not isinstance(value, str):
-      raise ValueError('Duration JSON value not a string: {!r}'.format(value))
+      raise ValueError(f'Duration JSON value not a string: {value!r}')
     if len(value) < 1 or value[-1] != 's':
       raise ValueError(
-          'Duration must end with letter "s": {0}.'.format(value))
+          f'Duration must end with letter "s": {value}.')
     try:
       pos = value.find('.')
       if pos == -1:
@@ -332,15 +332,15 @@ class Duration(object):
       else:
         seconds = int(value[:pos])
         if value[0] == '-':
-          nanos = int(round(float('-0{0}'.format(value[pos: -1])) *1e9))
+          nanos = int(round(float(f'-0{value[pos: -1]}') *1e9))
         else:
-          nanos = int(round(float('0{0}'.format(value[pos: -1])) *1e9))
+          nanos = int(round(float(f'0{value[pos: -1]}') *1e9))
       _CheckDurationValid(seconds, nanos)
       self.seconds = seconds
       self.nanos = nanos
     except ValueError as e:
       raise ValueError(
-          'Couldn\'t parse duration: {0} : {1}.'.format(value, e))
+          f'Couldn\'t parse duration: {value} : {e}.')
 
   def ToNanoseconds(self):
     """Converts a Duration to nanoseconds."""
@@ -406,11 +406,11 @@ class Duration(object):
 def _CheckDurationValid(seconds, nanos):
   if seconds < -_DURATION_SECONDS_MAX or seconds > _DURATION_SECONDS_MAX:
     raise ValueError(
-        'Duration is not valid: Seconds {0} must be in range '
+        'Duration is not valid: Seconds {} must be in range '
         '[-315576000000, 315576000000].'.format(seconds))
   if nanos <= -_NANOS_PER_SECOND or nanos >= _NANOS_PER_SECOND:
     raise ValueError(
-        'Duration is not valid: Nanos {0} must be in range '
+        'Duration is not valid: Nanos {} must be in range '
         '[-999999999, 999999999].'.format(nanos))
   if (nanos < 0 and seconds > 0) or (nanos > 0 and seconds < 0):
     raise ValueError(
@@ -471,7 +471,7 @@ def _GetStructValue(struct_value):
     raise ValueError('Value not set')
 
 
-class Struct(object):
+class Struct:
   """Class for Struct message type."""
 
   __slots__ = ()
@@ -524,7 +524,7 @@ class Struct(object):
 collections.abc.MutableMapping.register(Struct)
 
 
-class ListValue(object):
+class ListValue:
   """Class for ListValue message type."""
 
   __slots__ = ()

--- a/python/google/protobuf/internal/well_known_types_test.py
+++ b/python/google/protobuf/internal/well_known_types_test.py
@@ -569,7 +569,7 @@ class AnyTest(unittest.TestCase):
     msg_descriptor = msg.DESCRIPTOR
     all_types = unittest_pb2.TestAllTypes()
     all_descriptor = all_types.DESCRIPTOR
-    all_types.repeated_string.append(u'\u00fc\ua71f')
+    all_types.repeated_string.append('\u00fc\ua71f')
     # Packs to Any.
     msg.value.Pack(all_types)
     self.assertEqual(msg.value.type_url,

--- a/python/google/protobuf/internal/wire_format_test.py
+++ b/python/google/protobuf/internal/wire_format_test.py
@@ -196,7 +196,7 @@ class WireFormatTest(unittest.TestCase):
     self.assertEqual(10, wire_format.StringByteSize(
         5, b'\xd0\xa2\xd0\xb5\xd1\x81\xd1\x82'.decode('utf-8')))
 
-    class MockMessage(object):
+    class MockMessage:
       def __init__(self, byte_size):
         self.byte_size = byte_size
       def ByteSize(self):

--- a/python/google/protobuf/message.py
+++ b/python/google/protobuf/message.py
@@ -51,7 +51,7 @@ class EncodeError(Error):
   pass
 
 
-class Message(object):
+class Message:
 
   """Abstract base class for protocol messages.
 

--- a/python/google/protobuf/message_factory.py
+++ b/python/google/protobuf/message_factory.py
@@ -144,7 +144,7 @@ def _InternalCreateMessageClass(descriptor):
 
 # Deprecated. Please use GetMessageClass() or GetMessageClassesForFiles()
 # method above instead.
-class MessageFactory(object):
+class MessageFactory:
   """Factory for creating Proto2 messages from descriptors in a pool."""
 
   def __init__(self, pool=None):

--- a/python/google/protobuf/service.py
+++ b/python/google/protobuf/service.py
@@ -48,7 +48,7 @@ class RpcException(Exception):
   pass
 
 
-class Service(object):
+class Service:
 
   """Abstract base interface for protocol-buffer-based RPC services.
 
@@ -117,7 +117,7 @@ class Service(object):
     raise NotImplementedError
 
 
-class RpcController(object):
+class RpcController:
 
   """An RpcController mediates a single method call.
 
@@ -200,7 +200,7 @@ class RpcController(object):
     raise NotImplementedError
 
 
-class RpcChannel(object):
+class RpcChannel:
 
   """Abstract interface for an RPC channel.
 

--- a/python/google/protobuf/service_reflection.py
+++ b/python/google/protobuf/service_reflection.py
@@ -103,7 +103,7 @@ class GeneratedServiceStubType(GeneratedServiceType):
         dictionary[_DESCRIPTOR_KEY] must contain a ServiceDescriptor object
         describing this protocol service type.
     """
-    super(GeneratedServiceStubType, cls).__init__(name, bases, dictionary)
+    super().__init__(name, bases, dictionary)
     # Don't do anything if this class doesn't have a descriptor. This happens
     # when a service stub is subclassed.
     if GeneratedServiceStubType._DESCRIPTOR_KEY not in dictionary:
@@ -114,7 +114,7 @@ class GeneratedServiceStubType(GeneratedServiceType):
     service_stub_builder.BuildServiceStub(cls)
 
 
-class _ServiceBuilder(object):
+class _ServiceBuilder:
 
   """This class constructs a protocol service class using a service descriptor.
 
@@ -238,7 +238,7 @@ class _ServiceBuilder(object):
     callback(None)
 
 
-class _ServiceStubBuilder(object):
+class _ServiceStubBuilder:
 
   """Constructs a protocol service stub class using a service descriptor.
 

--- a/python/google/protobuf/symbol_database.py
+++ b/python/google/protobuf/symbol_database.py
@@ -196,8 +196,7 @@ class SymbolDatabase():
       """Walk a message Descriptor and recursively yields all message names."""
       yield desc
       for msg_desc in desc.nested_types:
-        for nested_desc in _GetAllMessages(msg_desc):
-          yield nested_desc
+        yield from _GetAllMessages(msg_desc)
 
     result = {}
     for file_name in files:

--- a/python/google/protobuf/text_format.py
+++ b/python/google/protobuf/text_format.py
@@ -81,12 +81,12 @@ class ParseError(Error):
     if message is not None and line is not None:
       loc = str(line)
       if column is not None:
-        loc += ':{0}'.format(column)
-      message = '{0} : {1}'.format(loc, message)
+        loc += f':{column}'
+      message = f'{loc} : {message}'
     if message is not None:
-      super(ParseError, self).__init__(message)
+      super().__init__(message)
     else:
-      super(ParseError, self).__init__()
+      super().__init__()
     self._line = line
     self._column = column
 
@@ -97,7 +97,7 @@ class ParseError(Error):
     return self._column
 
 
-class TextWriter(object):
+class TextWriter:
 
   def __init__(self, as_utf8):
     self._writer = io.StringIO()
@@ -344,7 +344,7 @@ WIRETYPE_LENGTH_DELIMITED = 2
 WIRETYPE_START_GROUP = 3
 
 
-class _Printer(object):
+class _Printer:
   """Text format printer for protocol message."""
 
   def __init__(
@@ -424,7 +424,7 @@ class _Printer(object):
     if packed_message:
       packed_message.MergeFromString(message.value)
       colon = ':' if self.force_colon else ''
-      self.out.write('%s[%s]%s ' % (self.indent * ' ', message.type_url, colon))
+      self.out.write('{}[{}]{} '.format(self.indent * ' ', message.type_url, colon))
       self._PrintMessageFieldValue(packed_message)
       self.out.write(' ' if self.as_one_line else '\n')
       return True
@@ -704,7 +704,7 @@ def Parse(text,
   Raises:
     ParseError: On text parsing problems.
   """
-  return ParseLines(text.split(b'\n' if isinstance(text, bytes) else u'\n'),
+  return ParseLines(text.split(b'\n' if isinstance(text, bytes) else '\n'),
                     message,
                     allow_unknown_extension,
                     allow_field_number,
@@ -742,7 +742,7 @@ def Merge(text,
     ParseError: On text parsing problems.
   """
   return MergeLines(
-      text.split(b'\n' if isinstance(text, bytes) else u'\n'),
+      text.split(b'\n' if isinstance(text, bytes) else '\n'),
       message,
       allow_unknown_extension,
       allow_field_number,
@@ -818,7 +818,7 @@ def MergeLines(lines,
   return parser.MergeLines(lines, message)
 
 
-class _Parser(object):
+class _Parser:
   """Text format parser for protocol message."""
 
   def __init__(self,
@@ -1081,7 +1081,7 @@ class _Parser(object):
 
     while not tokenizer.TryConsume(end_token):
       if tokenizer.AtEnd():
-        raise tokenizer.ParseErrorPreviousToken('Expected "%s".' % (end_token,))
+        raise tokenizer.ParseErrorPreviousToken(f'Expected "{end_token}".')
       self._MergeField(tokenizer, sub_message)
 
     if is_map_entry:
@@ -1275,7 +1275,7 @@ class _Parser(object):
     tokenizer.Consume(']')
 
 
-class Tokenizer(object):
+class Tokenizer:
   """Protocol buffer text representation tokenizer.
 
   This class handles the lower level string parsing by splitting it into
@@ -1557,10 +1557,10 @@ class Tokenizer(object):
     """
     text = self.token
     if len(text) < 1 or text[0] not in _QUOTES:
-      raise self.ParseError('Expected string but found: %r' % (text,))
+      raise self.ParseError(f'Expected string but found: {text!r}')
 
     if len(text) < 2 or text[-1] != text[0]:
-      raise self.ParseError('String missing ending quote: %r' % (text,))
+      raise self.ParseError(f'String missing ending quote: {text!r}')
 
     try:
       result = text_encoding.CUnescape(text[1:-1])

--- a/python/python_version.py
+++ b/python/python_version.py
@@ -45,7 +45,7 @@ class PythonVersionTest(unittest.TestCase):
       return
     self.assertTrue(
         sys.version.startswith(exp),
-        'Expected Python %s but found Python %s' % (exp, sys.version))
+        f'Expected Python {exp} but found Python {sys.version}')
 
 
 if __name__ == '__main__':

--- a/python/setup.py
+++ b/python/setup.py
@@ -242,7 +242,7 @@ class TestConformanceCmd(_build_py):
     # Python 2.6 dodges these extra failures.
     os.environ['CONFORMANCE_PYTHON_EXTRA_FAILURES'] = (
         '--failure_list failure_list_python-post26.txt')
-    cmd = 'bazel test %s' % (TestConformanceCmd.target,)
+    cmd = f'bazel test {TestConformanceCmd.target}'
     subprocess.check_call(cmd, shell=True)
 
 
@@ -260,7 +260,7 @@ def _GetFlagValues(flag_long, flag_short):
   flag_res = [re.compile(r'--?%s(=(.*))?' %
                          (flag_long[:-1] if expect_value else flag_long))]
   if flag_short:
-    flag_res.append(re.compile(r'-%s(.*)?' % (flag_short,)))
+    flag_res.append(re.compile(fr'-{flag_short}(.*)?'))
 
   flag_match = None
   for arg in sys.argv:


### PR DESCRIPTION
This change removes code that was needed in older versions of python and it also updates existing code to make use of new language features.

pyupgrade was run with the --py3-only --py37-plus flags to ensure that the code still works on our oldest supported python version.

The IOError was changed to OSError (also by pyupgrade), because the in python3.3 many exception classes have been merged into OSError. See https://github.com/asottile/pyupgrade/issues/141.

Closes: #12896