### PR TITLE
feat(cmake): require at least C++14

### DIFF
--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -24,6 +24,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
 endif()
 target_include_directories(libprotobuf-lite PUBLIC ${protobuf_SOURCE_DIR}/src)
 target_link_libraries(libprotobuf-lite PUBLIC ${protobuf_ABSL_USED_TARGETS})
+target_compile_features(libprotobuf-lite PUBLIC cxx_std_14)
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf-lite
     PUBLIC  PROTOBUF_USE_DLLS

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -27,6 +27,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
 endif()
 target_include_directories(libprotobuf PUBLIC ${protobuf_SOURCE_DIR}/src)
 target_link_libraries(libprotobuf PUBLIC ${protobuf_ABSL_USED_TARGETS})
+target_compile_features(libprotobuf PUBLIC cxx_std_14)
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf
     PUBLIC  PROTOBUF_USE_DLLS

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -17,6 +17,7 @@ if(protobuf_HAVE_LD_VERSION_SCRIPT)
 endif()
 target_link_libraries(libprotoc PRIVATE libprotobuf)
 target_link_libraries(libprotoc PUBLIC ${protobuf_ABSL_USED_TARGETS})
+target_compile_features(libprotoc PUBLIC cxx_std_14)
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotoc
     PUBLIC  PROTOBUF_USE_DLLS


### PR DESCRIPTION
This will require C++14 (or higher) for the `libproto*` targets **and** anything that links them.  If multiple dependencies have different C++ requirements, CMake will use the maximum version.  It does not work with pkg-config, and does not work if the downstream dependency forcibly downgrades the compiler to C++11 (or lower).  But prevents many problems.  Note that if Abseil was compiled with C++17 it will require C++17 and that will propagate through Protobuf.