### PR TITLE
cleanup(cmake): prefer target over global options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,6 @@ if(protobuf_DEPRECATED_CMAKE_SUBDIRECTORY_USAGE)
   get_filename_component(protobuf_SOURCE_DIR ${protobuf_SOURCE_DIR} DIRECTORY)
 endif()
 
-# The Intel compiler isn't able to deal with noinline member functions of
-# template classes defined in headers.  As such it spams the output with
-#   warning #2196: routine is both "inline" and "noinline"
-# This silences that warning.
-if (CMAKE_CXX_COMPILER_ID MATCHES Intel)
-  string(APPEND CMAKE_CXX_FLAGS " -diag-disable=2196")
-endif()
-
 # Options
 option(protobuf_INSTALL "Install protobuf binaries and files" ON)
 option(protobuf_BUILD_TESTS "Build tests" ON)
@@ -130,12 +122,6 @@ if(protobuf_VERBOSE)
   message(STATUS "]")
 endif()
 
-add_definitions(-DGOOGLE_PROTOBUF_CMAKE_BUILD)
-
-if (protobuf_DISABLE_RTTI)
-  add_definitions(-DGOOGLE_PROTOBUF_NO_RTTI=1)
-endif()
-
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmaketest.map
 "{
   global:
@@ -192,10 +178,6 @@ if (protobuf_WITH_ZLIB)
   endif (ZLIB_FOUND)
 endif (protobuf_WITH_ZLIB)
 
-if (HAVE_ZLIB)
-  add_definitions(-DHAVE_ZLIB)
-endif (HAVE_ZLIB)
-
 # We need to link with libatomic on systems that do not have builtin atomics, or
 # don't have builtin support for 8 byte atomics
 set(protobuf_LINK_LIBATOMIC false)
@@ -251,30 +233,6 @@ endif (protobuf_BUILD_SHARED_LIBS)
 SET(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 if (MSVC)
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # Build with multiple processes
-    add_compile_options(/MP)
-  endif()
-  # Set source file and execution character sets to UTF-8
-  add_compile_options(/utf-8)
-  # MSVC warning suppressions
-  add_compile_options(
-    /wd4065 # switch statement contains 'default' but no 'case' labels
-    /wd4146 # unary minus operator applied to unsigned type
-    /wd4244 # 'conversion' conversion from 'type1' to 'type2', possible loss of data
-    /wd4251 # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
-    /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
-    /wd4305 # 'identifier' : truncation from 'type1' to 'type2'
-    /wd4307 # 'operator' : integral constant overflow
-    /wd4309 # 'conversion' : truncation of constant value
-    /wd4334 # 'operator' : result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
-    /wd4355 # 'this' : used in base member initializer list
-    /wd4506 # no definition for inline function 'function'
-    /wd4800 # 'type' : forcing value to bool 'true' or 'false' (performance warning)
-    /wd4996 # The compiler encountered a deprecated declaration.
-  )
-  # Allow big object
-  add_compile_options(/bigobj)
   string(REPLACE "/" "\\" PROTOBUF_SOURCE_WIN32_PATH ${protobuf_SOURCE_DIR})
   string(REPLACE "/" "\\" PROTOBUF_BINARY_WIN32_PATH ${protobuf_BINARY_DIR})
   string(REPLACE "." ","  protobuf_RC_FILEVERSION "${protobuf_VERSION}")
@@ -322,10 +280,6 @@ include_directories(
   ${ZLIB_INCLUDE_DIRECTORIES}
   ${protobuf_BINARY_DIR}
   ${protobuf_SOURCE_DIR}/src)
-
-if (protobuf_UNICODE)
-  add_definitions(-DUNICODE -D_UNICODE)
-endif (protobuf_UNICODE)
 
 set(protobuf_ABSL_PROVIDER "module" CACHE STRING "Provider of absl library")
 set_property(CACHE protobuf_ABSL_PROVIDER PROPERTY STRINGS "module" "package")

--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -1,6 +1,7 @@
 # CMake definitions for libprotobuf_lite (the "lite" C++ protobuf runtime).
 
 include(${protobuf_SOURCE_DIR}/src/file_lists.cmake)
+include(${protobuf_SOURCE_DIR}/cmake/protobuf-configure-target.cmake)
 
 add_library(libprotobuf-lite ${protobuf_SHARED_OR_STATIC}
   ${libprotobuf_lite_srcs}
@@ -24,7 +25,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
 endif()
 target_include_directories(libprotobuf-lite PUBLIC ${protobuf_SOURCE_DIR}/src)
 target_link_libraries(libprotobuf-lite PUBLIC ${protobuf_ABSL_USED_TARGETS})
-target_compile_features(libprotobuf-lite PUBLIC cxx_std_14)
+protobuf_configure_target(libprotobuf-lite)
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf-lite
     PUBLIC  PROTOBUF_USE_DLLS

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -1,6 +1,7 @@
 # CMake definitions for libprotobuf (the "full" C++ protobuf runtime).
 
 include(${protobuf_SOURCE_DIR}/src/file_lists.cmake)
+include(${protobuf_SOURCE_DIR}/cmake/protobuf-configure-target.cmake)
 
 add_library(libprotobuf ${protobuf_SHARED_OR_STATIC}
   ${libprotobuf_srcs}
@@ -27,7 +28,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
 endif()
 target_include_directories(libprotobuf PUBLIC ${protobuf_SOURCE_DIR}/src)
 target_link_libraries(libprotobuf PUBLIC ${protobuf_ABSL_USED_TARGETS})
-target_compile_features(libprotobuf PUBLIC cxx_std_14)
+protobuf_configure_target(libprotobuf)
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf
     PUBLIC  PROTOBUF_USE_DLLS

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -1,6 +1,7 @@
 # CMake definitions for libprotoc (the protobuf compiler library).
 
 include(${protobuf_SOURCE_DIR}/src/file_lists.cmake)
+include(${protobuf_SOURCE_DIR}/cmake/protobuf-configure-target.cmake)
 
 add_library(libprotoc ${protobuf_SHARED_OR_STATIC}
   ${libprotoc_srcs}
@@ -17,7 +18,7 @@ if(protobuf_HAVE_LD_VERSION_SCRIPT)
 endif()
 target_link_libraries(libprotoc PRIVATE libprotobuf)
 target_link_libraries(libprotoc PUBLIC ${protobuf_ABSL_USED_TARGETS})
-target_compile_features(libprotoc PUBLIC cxx_std_14)
+protobuf_configure_target(libprotoc)
 if(protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotoc
     PUBLIC  PROTOBUF_USE_DLLS

--- a/cmake/protobuf-configure-target.cmake
+++ b/cmake/protobuf-configure-target.cmake
@@ -1,0 +1,78 @@
+# Protocol Buffers - Google's data interchange format
+# Copyright 2013 Google LLC  All rights reserved.
+# https://developers.google.com/protocol-buffers/
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Refactors configuration options set on all Protobuf targets
+function(protobuf_configure_target target)
+    target_compile_features("${target}" PUBLIC cxx_std_14)
+    if (MSVC)
+        # Build with multiple processes
+        target_compile_options("${target}" PRIVATE /MP)
+        # Set source file and execution character sets to UTF-8
+        target_compile_options("${target}" PRIVATE /utf-8)
+        # MSVC warning suppressions
+        target_compile_options("${target}" PRIVATE
+            /wd4065 # switch statement contains 'default' but no 'case' labels
+            /wd4146 # unary minus operator applied to unsigned type
+            /wd4244 # 'conversion' conversion from 'type1' to 'type2', possible loss of data
+            /wd4251 # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
+            /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
+            /wd4305 # 'identifier' : truncation from 'type1' to 'type2'
+            /wd4307 # 'operator' : integral constant overflow
+            /wd4309 # 'conversion' : truncation of constant value
+            /wd4334 # 'operator' : result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
+            /wd4355 # 'this' : used in base member initializer list
+            /wd4506 # no definition for inline function 'function'
+            /wd4800 # 'type' : forcing value to bool 'true' or 'false' (performance warning)
+            /wd4996 # The compiler encountered a deprecated declaration.
+        )
+        # Allow big object
+        target_compile_options("${target}" PRIVATE /bigobj)
+    endif ()
+    if (protobuf_UNICODE)
+        target_compile_definitions("${target}" PRIVATE -DUNICODE -D_UNICODE)
+    endif ()
+    target_compile_definitions("${target}" PRIVATE -DGOOGLE_PROTOBUF_CMAKE_BUILD)
+
+    if (protobuf_DISABLE_RTTI)
+      target_compile_definitions("${target}" PRIVATE -DGOOGLE_PROTOBUF_NO_RTTI=1)
+    endif()
+
+    # The Intel compiler isn't able to deal with noinline member functions of
+    # template classes defined in headers.  As such it spams the output with
+    #   warning #2196: routine is both "inline" and "noinline"
+    # This silences that warning.
+    if (CMAKE_CXX_COMPILER_ID MATCHES Intel)
+        target_compile_options("${target}" PRIVATE -diag-disable=2196)
+    endif()
+
+    if (HAVE_ZLIB)
+        target_compile_definitions("${target}" PRIVATE -DHAVE_ZLIB)
+    endif ()
+endfunction ()


### PR DESCRIPTION
In CMake >= 3.0 it is more idiomatic to set per-target compiler options than global compiler settings. I have kept these options and defines as `PRIVATE` so they won't be exported with the target.