### PR TITLE
Fix jruby encoding in new thread

### DIFF
--- a/ruby/src/main/java/com/google/protobuf/jruby/Utils.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/Utils.java
@@ -36,7 +36,9 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import java.math.BigInteger;
+import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
+import org.jcodings.specific.UTF8Encoding;
 import org.jruby.*;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.ext.bigdecimal.RubyBigDecimal;
@@ -141,12 +143,12 @@ public class Utils {
           throw createInvalidTypeError(context, "boolean", fieldName, value);
         break;
       case BYTES:
-        value = validateAndEncodeString(context, "bytes", fieldName, value, "Encoding::ASCII_8BIT");
+        value = validateAndEncodeString(context, "bytes", fieldName, value, ASCIIEncoding.INSTANCE);
         break;
       case STRING:
         value =
             validateAndEncodeString(
-                context, "string", fieldName, symToString(value), "Encoding::UTF_8");
+                context, "string", fieldName, symToString(value), UTF8Encoding.INSTANCE);
         break;
       case MESSAGE:
         if (value.getMetaClass() != typeClass) {
@@ -383,11 +385,11 @@ public class Utils {
       String fieldType,
       String fieldName,
       IRubyObject value,
-      String encoding) {
+      Encoding encoding) {
     if (!(value instanceof RubyString))
       throw createInvalidTypeError(context, fieldType, fieldName, value);
 
-    value = ((RubyString) value).encode(context, context.runtime.evalScriptlet(encoding));
+    value = ((RubyString) value).encode(context, context.runtime.getEncodingService().convertEncodingToRubyEncoding(encoding));
     value.setFrozen(true);
     return value;
   }


### PR DESCRIPTION
In jruby `runtime.evalScriptlet('Encoding::UTF_8')` can be broken under a newly created thread, which can cause protobuf encoding to fail. For example: https://github.com/ntkme/sass-embedded-host-ruby/actions/runs/5108602231/jobs/9182569583#step:5:544

It real issue seems to be in jruby itself. A bug report with minimal reproduction has been filed at https://github.com/jruby/jruby/issues/7820

This PR fixes the problem by effectively replacing `runtime.evalScriptlet('Encoding::UTF_8')` with `runtime.getEncodingService().convertEncodingToRubyEncoding(org.jcodings.specific.UTF8Encoding.INSTANCE)`, which works on all threads.
