### PR TITLE
Set top level permissions to read only on GitHub Workflows

### DIFF
--- a/.github/workflows/clear_caches.yml
+++ b/.github/workflows/clear_caches.yml
@@ -8,6 +8,9 @@ on:
   # manual
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   bazel-repository-cache:
     strategy:

--- a/.github/workflows/forked_pr_workflow_check.yml
+++ b/.github/workflows/forked_pr_workflow_check.yml
@@ -17,6 +17,9 @@ on:
     paths:
       - '.github/workflows/**'
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check PR source

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -7,6 +7,9 @@ on:
         required: true
         description: "The SHA key for the commit we want to run over"
         type: string
+        
+permissions:
+  contents: read
 
 jobs:
   linux:

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -8,6 +8,9 @@ on:
         description: "The SHA key for the commit we want to run over"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     name: Linux

--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -8,6 +8,9 @@ on:
         description: "The SHA key for the commit we want to run over"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     strategy:

--- a/.github/workflows/test_objectivec.yml
+++ b/.github/workflows/test_objectivec.yml
@@ -8,6 +8,9 @@ on:
         description: "The SHA key for the commit we want to run over"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   xcode:
     strategy:

--- a/.github/workflows/test_php.yml
+++ b/.github/workflows/test_php.yml
@@ -8,6 +8,9 @@ on:
         description: "The SHA key for the commit we want to run over"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     strategy:

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -8,6 +8,9 @@ on:
         description: "The SHA key for the commit we want to run over"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     strategy:

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -8,6 +8,9 @@ on:
         description: "The SHA key for the commit we want to run over"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     strategy:

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -63,7 +63,7 @@ jobs:
     if: |
       (github.event_name != 'pull_request' &&
        github.event_name != 'pull_request_target' &&
-       github.event.repository.full_name == 'protocolbuffers/protobuf') ||
+       github.event.repository.full_name == 'joycebrum/protobuf') ||
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == 'protocolbuffers/protobuf') ||
       (github.event_name == 'pull_request_target' &&

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -49,6 +49,9 @@ on:
 
   # manual
   workflow_dispatch:
+  
+permissions:
+  contents: read
 
 jobs:
   check-tag:

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -8,6 +8,9 @@ on:
         description: "The SHA key for the commit we want to run over"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     name: Linux


### PR DESCRIPTION
Hi, here is Joyce from Google again.

I'd like starting suggesting the [Token-Permission check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) fix.

Let me know if I might be missing any permission. Thanks!

### Security Reason

This is needed because, by default, github grants write-all permission to all workflows, which could be exploit by an attacker in case of a compromised workflow. Limiting permissions is a simple and effective way to also limit the impact of an eventual compromised workflow.

Thus, it is both a recommendation from [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and the [Github](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) to always use credentials that are minimally scoped.


