### PR TITLE
CMake: Fix abseil_dll target name when using find_package(absl)

### DIFF
--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -39,9 +39,19 @@ set(_protobuf_FIND_ABSL "if(NOT TARGET absl::strings)\n  find_package(absl CONFI
 
 if (BUILD_SHARED_LIBS AND MSVC)
   # On MSVC Abseil is bundled into a single DLL.
-  set(protobuf_ABSL_USED_TARGETS abseil_dll)
-
-  set(protobuf_ABSL_USED_TEST_TARGETS abseil_test_dll)
+  # This condition is necessary as of abseil 20230125.3 when abseil is consumed via add_subdirectory,
+  # the abseil_dll target  is named abseil_dll, while if abseil is consumed via find_package, the target
+  # is called absl::abseil_dll
+  # Once https://github.com/abseil/abseil-cpp/pull/1466 is merged and released in the minimum version of 
+  # abseil required by protobuf, it is possible to always link absl::abseil_dll and absl::abseil_test_dll
+  # and remove the if
+  if(protobuf_ABSL_PROVIDER STREQUAL "package")
+    set(protobuf_ABSL_USED_TARGETS absl::abseil_dll)
+    set(protobuf_ABSL_USED_TEST_TARGETS absl::abseil_test_dll)
+  else()
+    set(protobuf_ABSL_USED_TARGETS abseil_dll)
+    set(protobuf_ABSL_USED_TEST_TARGETS abseil_test_dll)
+  endif()
 else()
   set(protobuf_ABSL_USED_TARGETS
     absl::absl_check


### PR DESCRIPTION
This additional if  is necessary as of abseil 20230125.3 when abseil is consumed via add_subdirectory,
the abseil_dll target  is named abseil_dll, while if abseil is consumed via find_package, the target is called `absl::abseil_dll` . 

Once https://github.com/abseil/abseil-cpp/pull/1466 is merged and released in the minimum version of  abseil required by protobuf, it is possible to always link `absl::abseil_dll` and `absl::abseil_test_dll` and remove the if.

You may wonder how linking worked at all before when `protobuf_ABSL_PROVIDER STREQUAL "package"`, as `abseil_dll` was not an imported target defined by `find_package(absl)`. The reason behind this is that if a name that is not an imported target is passed to `target_link_libraries`, it is just regarded as a C++ library name. So, in the end the `abseil_dll` library was correctly linked, simply all the transitive usage requirements defined by the `absl::abseil_dll` target were not propagated, that could lead to compilation errors if abseil was compiled with the `ABSL_PROPAGATE_CXX_STD` CMake option enabled.