### PR TITLE
Move linkage monitor check as part of Bazel build

### DIFF
--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Run Linkage Monitor test
         uses: protocolbuffers/protobuf-ci/bazel-docker@v1
         with:
-          image: ${{ matrix.image }}
+          image: us-docker.pkg.dev/protobuf-build/containers/test/linux/java:8-03a376b5d6ef66f827fc307716e3b841cc26b709
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
-          bazel-cache: java_linux/${{ matrix.version }}
+          bazel-cache: java_linux/8
           bazel: test --test_output=all //java:linkage_monitor --spawn_strategy=standalone
 
   protobuf-bom:

--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -57,23 +57,13 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: ${{ inputs.safe-checkout }}
-      - name: Build protoc
-        id: build-protoc
-        uses: protocolbuffers/protobuf-ci/cross-compile-protoc@v1
+      - name: Run Linkage Monitor test
+        uses: protocolbuffers/protobuf-ci/bazel-docker@v1
         with:
-          image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:5.1.1-6361b3a6e5c97e9951d03a4de28542fc45f1adab
+          image: ${{ matrix.image }}
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
-          architecture: linux-x86_64
-      - name: Move protoc into place and clean up
-        run: |
-          mv ${{ steps.build-protoc.outputs.protoc }} protoc
-          sudo rm -rf _build
-      - name: Run Linkage Monitor Bazel test
-        run: |
-          # --spawn_strategy=standalone is needed to save files in local Maven
-          # repositories during dependency resolution.
-          bazelisk test --sandbox_debug --subcommands  //java:linkage_monitor --spawn_strategy=standalone
-          echo "Linkage Monitor test passed"
+          bazel-cache: java_linux/${{ matrix.version }}
+          bazel: test --sandbox_debug --subcommands  //java:linkage_monitor --spawn_strategy=standalone
 
   protobuf-bom:
     name: Protobuf Maven BOM

--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -68,14 +68,12 @@ jobs:
         run: |
           mv ${{ steps.build-protoc.outputs.protoc }} protoc
           sudo rm -rf _build
-      - name: Install snapshot version locally
+      - name: Run Linkage Monitor Bazel test
         run: |
-          cd java
-          mvn -e -B -Dhttps.protocols=TLSv1.2 install -Dmaven.test.skip=true
-      - name: Download Linkage Monitor
-        run: curl -v -O "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-latest-all-deps.jar"
-      - name: Fails if there's new linkage errors compared with baseline
-        run: java -Xmx2048m -jar linkage-monitor-latest-all-deps.jar com.google.cloud:libraries-bom
+          # --spawn_strategy=standalone is needed to save files in local Maven
+          # repositories during dependency resolution.
+          bazelisk test --sandbox_debug --subcommands  //java:linkage_monitor --spawn_strategy=standalone
+          echo "Linkage Monitor test passed"
 
   protobuf-bom:
     name: Protobuf Maven BOM

--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -63,7 +63,7 @@ jobs:
           image: ${{ matrix.image }}
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: java_linux/${{ matrix.version }}
-          bazel: test --sandbox_debug --subcommands  //java:linkage_monitor --spawn_strategy=standalone
+          bazel: test --test_output=all //java:linkage_monitor --spawn_strategy=standalone
 
   protobuf-bom:
     name: Protobuf Maven BOM

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -8,13 +8,16 @@ sh_test(
         ":linkage_monitor.sh",
     ],
     data = [
-        ":bom",
+        # Making the Maven modules available in the sandbox
         ":core",
         ":kotlin",
         ":kotlin-lite",
         ":lite",
         ":util",
         "//:protoc",
+        # Making this test depends on the code change in core and util
+        "//java/core:dist_files",
+        "//java/util",
     ] + glob([
         "pom.xml",
         "*/pom.xml",

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
 # Run Linkage Monitor
 sh_test(
     name = "linkage_monitor",
-    size = "small",
+    size = "large",
     srcs = [
         ":linkage_monitor.sh",
     ],

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -1,5 +1,26 @@
 load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
 
+# Run Linkage Monitor
+sh_test(
+    name = "linkage_monitor",
+    size = "small",
+    srcs = [
+        ":linkage_monitor.sh",
+    ],
+    data = [
+        ":bom",
+        ":core",
+        ":kotlin",
+        ":kotlin-lite",
+        ":lite",
+        ":util",
+        "//:protoc",
+    ] + glob([
+        "pom.xml",
+        "*/pom.xml",
+    ]),
+)
+
 test_suite(
     name = "tests",
     tests = [

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -4,6 +4,11 @@ load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
 sh_test(
     name = "linkage_monitor",
     size = "large",
+    tags = [
+        # Exclude this target from wildcard expansion (//...) because it may
+        # take unnecessary time.
+        "manual",
+    ],
     srcs = [
         ":linkage_monitor.sh",
     ],

--- a/java/core/generate-sources-build.xml
+++ b/java/core/generate-sources-build.xml
@@ -1,4 +1,4 @@
-<project name="generate-sources">
+    <project name="generate-sources">
     <echo message="Running protoc ..."/>
     <mkdir dir="${generated.sources.dir}"/>
     <exec executable="${protoc}">

--- a/java/core/generate-sources-build.xml
+++ b/java/core/generate-sources-build.xml
@@ -1,4 +1,4 @@
-    <project name="generate-sources">
+<project name="generate-sources">
     <echo message="Running protoc ..."/>
     <mkdir dir="${generated.sources.dir}"/>
     <exec executable="${protoc}">

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -16,7 +16,7 @@ echo "Maven command: $(which mvn)"
 
 echo "protoc command:$(which protoc); $(protoc --version)"
 
-mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install -Dmaven.test.skip=true -Dprotoc=protoc
+mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install -Dmaven.test.skip=true -Dprotoc="${RUNFILES_DIR}/com_google_protobuf/protoc"
 
 curl -v -O "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-latest-all-deps.jar"
 

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -4,14 +4,6 @@ set -e
 
 cd java
 
-echo "list of files here:"
-
-ls -alt
-
-echo "list of files in core:"
-
-ls -alt core/
-
 echo "Maven command: $(which mvn)"
 
 protoc_location="${RUNFILES_DIR}/com_google_protobuf/protoc"

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -5,6 +5,7 @@ set -e
 cd java
 
 echo "Maven command: $(which mvn)"
+mvn --version
 
 protoc_location="${RUNFILES_DIR}/com_google_protobuf/protoc"
 if [ ! -x "${protoc_location}" ]; then

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -14,13 +14,17 @@ ls -alt core/
 
 echo "Maven command: $(which mvn)"
 
-echo "protoc command:$(which protoc); $(protoc --version)"
+protoc_location="${RUNFILES_DIR}/com_google_protobuf/protoc"
+if [ ! -x "${protoc_location}" ]; then
+  echo "${protoc_location} is not found or not executable"
+  exit 1
+fi
 
 mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install \
     -Dmaven.test.skip=true \
     -Dprotobuf.basedir="../" \
-    -Dprotoc="${RUNFILES_DIR}/com_google_protobuf/protoc" \
+    -Dprotoc="${protoc_location}"
 
 curl -v -O "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-latest-all-deps.jar"
 
-java -Xmx2048m -jar linkage-monitor-latest-all-deps.jar com.google.cloud:google-cloud-shared-dependencies
+java -Xmx2048m -jar linkage-monitor-latest-all-deps.jar com.google.cloud:first-party-dependencies

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -4,9 +4,13 @@ set -e
 
 cd java
 
+echo "Running Linkage Monitor check"
+
 echo "Maven command: $(which mvn)"
 mvn --version
 
+# This script runs within the Bazel's sandbox directory and uses protoc
+# generated within the Bazel project.
 protoc_location="${RUNFILES_DIR}/com_google_protobuf/protoc"
 if [ ! -x "${protoc_location}" ]; then
   echo "${protoc_location} is not found or not executable"
@@ -18,6 +22,12 @@ mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install \
     -Dprotobuf.basedir="../" \
     -Dprotoc="${protoc_location}"
 
+echo "Installed the artifacts to local Maven repository"
+
 curl -v -O "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-latest-all-deps.jar"
 
+echo "Running linkage-monitor-latest-all-deps.jar."
+
 java -Xmx2048m -jar linkage-monitor-latest-all-deps.jar com.google.cloud:first-party-dependencies
+
+echo "Finished running Linkage Monitor check"

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+echo "Argument1 $1"
+echo "Argument2 $2"
+
+cd java
+
+echo "list of files here:"
+
+ls -alt
+
+echo "list of files in core:"
+
+ls -alt core/
+
+echo "Maven command; $(which mvn)"
+
+mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install -Dmaven.test.skip=true
+
+curl -v -O "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-latest-all-deps.jar"
+
+java -Xmx2048m -jar linkage-monitor-latest-all-deps.jar com.google.cloud:libraries-bom

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -16,8 +16,11 @@ echo "Maven command: $(which mvn)"
 
 echo "protoc command:$(which protoc); $(protoc --version)"
 
-mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install -Dmaven.test.skip=true -Dprotoc="${RUNFILES_DIR}/com_google_protobuf/protoc"
+mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install \
+    -Dmaven.test.skip=true \
+    -Dprotobuf.basedir="../" \
+    -Dprotoc="${RUNFILES_DIR}/com_google_protobuf/protoc" \
 
 curl -v -O "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-latest-all-deps.jar"
 
-java -Xmx2048m -jar linkage-monitor-latest-all-deps.jar com.google.cloud:libraries-bom
+java -Xmx2048m -jar linkage-monitor-latest-all-deps.jar com.google.cloud:google-cloud-shared-dependencies

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -17,6 +17,8 @@ fi
 
 cd java
 
+# Linkage Monitor requires the artifacts to be available in local Maven
+# repository.
 mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 clean generate-sources install \
     -Dmaven.test.skip=true \
     -Dprotobuf.basedir="../.." \
@@ -28,6 +30,9 @@ curl -v -O "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor
 
 echo "Running linkage-monitor-latest-all-deps.jar."
 
+# The generated libraries in google-cloud-shared-dependencies would detect
+# incompatible changes via Linkage Monitor
+# https://github.com/googleapis/sdk-platform-java/tree/main/java-shared-dependencies
 java -Xmx2048m -jar linkage-monitor-latest-all-deps.jar com.google.cloud:google-cloud-shared-dependencies
 
 echo "Finished running Linkage Monitor check"

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -28,6 +28,6 @@ curl -v -O "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor
 
 echo "Running linkage-monitor-latest-all-deps.jar."
 
-java -Xmx2048m -jar linkage-monitor-latest-all-deps.jar com.google.cloud:first-party-dependencies
+java -Xmx2048m -jar linkage-monitor-latest-all-deps.jar com.google.cloud:google-cloud-shared-dependencies
 
 echo "Finished running Linkage Monitor check"

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-cd java
-
 echo "Running Linkage Monitor check"
 
 echo "Maven command: $(which mvn)"
@@ -16,6 +14,8 @@ if [ ! -x "${protoc_location}" ]; then
   echo "${protoc_location} is not found or not executable"
   exit 1
 fi
+
+cd java
 
 mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install \
     -Dmaven.test.skip=true \

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -17,7 +17,7 @@ fi
 
 cd java
 
-mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install \
+mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 generate-sources install \
     -Dmaven.test.skip=true \
     -Dprotobuf.basedir="../" \
     -Dprotoc="${protoc_location}"

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -9,7 +9,7 @@ mvn --version
 
 # This script runs within the Bazel's sandbox directory and uses protoc
 # generated within the Bazel project.
-protoc_location="${RUNFILES_DIR}/com_google_protobuf/protoc"
+protoc_location=$(realpath "${RUNFILES_DIR}/com_google_protobuf/protoc")
 if [ ! -x "${protoc_location}" ]; then
   echo "${protoc_location} is not found or not executable"
   exit 1
@@ -17,9 +17,9 @@ fi
 
 cd java
 
-mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 generate-sources install \
+mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 clean generate-sources install \
     -Dmaven.test.skip=true \
-    -Dprotobuf.basedir="../" \
+    -Dprotobuf.basedir="../.." \
     -Dprotoc="${protoc_location}"
 
 echo "Installed the artifacts to local Maven repository"

--- a/java/linkage_monitor.sh
+++ b/java/linkage_monitor.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-echo "Argument1 $1"
-echo "Argument2 $2"
-
 cd java
 
 echo "list of files here:"
@@ -15,9 +12,11 @@ echo "list of files in core:"
 
 ls -alt core/
 
-echo "Maven command; $(which mvn)"
+echo "Maven command: $(which mvn)"
 
-mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install -Dmaven.test.skip=true
+echo "protoc command:$(which protoc); $(protoc --version)"
+
+mvn --projects "bom,core,util" -e -B -Dhttps.protocols=TLSv1.2 install -Dmaven.test.skip=true -Dprotoc=protoc
 
 curl -v -O "https://storage.googleapis.com/cloud-opensource-java-linkage-monitor/linkage-monitor-latest-all-deps.jar"
 


### PR DESCRIPTION
Fixes https://github.com/protocolbuffers/protobuf/issues/12912

Moving the Linkage Monitor check to Bazel, so that the result is cached.