### PR TITLE
Clean up staleness tests.

### DIFF
--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -30,21 +30,28 @@ jobs:
         with:
           ref: ${{ inputs.safe-checkout || matrix.branch}}
 
-      # For commit-based tests, simply run the bazel query to make sure it works.  This should be
-      # identical to the step below, except for the xargs piece that runs bazel test.
-      - name: Check that staleness tests are queryable
-        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'pull_request' || github.event_name == 'push' }}
-        uses: protocolbuffers/protobuf-ci/bazel-docker@v1
-        with:
-          image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:6.0.0-6361b3a6e5c97e9951d03a4de28542fc45f1adab
-          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
-          bazel-cache: staleness_check/${{ matrix.branch}}_${{ matrix.os.value }}
-          bash: bazel query 'attr(tags, "staleness_test", //...)'
+      - name: Mark runs associated with commits
+        if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
+        run: echo "COMMIT_TRIGGERED_RUN=1" >> $GITHUB_ENV
+
+      - name: Mark runs from the main branch
+        if: ${{ github.base_ref == 'main' || github.ref == 'refs/heads/main' }}
+        run: echo "MAIN_RUN=1" >> $GITHUB_ENV
 
       - name: Run all staleness tests
-        if: ${{ github.event_name != 'pull_request_target' && github.event_name != 'pull_request' && github.event_name != 'push' }}
-        uses: protocolbuffers/protobuf-ci/bazel-docker@v1
-        with:
-          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
-          bazel-cache: staleness_check/${{ matrix.branch}}_${{ matrix.os.value }}
-          bash: bazel query 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS
+        # Run all tests if either of the following is true, otherwise simply run the query to make
+        # sure it continues to work:
+        # 1) If this is not a commit-based run it means it's scheduled or manually dispatched. In
+        #    this case we want to make sure there are no stale files.
+        # 2) Release branches don't work with automated commits (see b/287117570).  Until this is
+        #    fixed, we want to run the tests to force manual regeneration when necessary.
+        #
+        # In branches where automatic updates work as post-submits, we don't want to run staleness
+        # tests along with user changes.  Any stale files will be automatically fixed in a follow-up
+        # commit.
+        run: |
+          if [[ -z $COMMIT_TRIGGERED_RUN || -z $MAIN_RUN ]]; then
+            bazel query 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS
+          else
+            bazel query 'attr(tags, "staleness_test", //...)'
+          fi


### PR DESCRIPTION
Our automation can't currently update release branches, so we need to enable staleness tests as presubmits to force manual regeneration.

PiperOrigin-RevId: 540094169