### PR TITLE
Fix signedness comparison warning

### DIFF
--- a/src/google/protobuf/compiler/retention.cc
+++ b/src/google/protobuf/compiler/retention.cc
@@ -233,7 +233,7 @@ void StripSourceCodeInfo(std::vector<std::vector<int>>& stripped_paths,
   old_locations.resize(locations->size());
   locations->ExtractSubrange(0, locations->size(), old_locations.data());
   locations->Reserve(old_locations.size() - indices_to_delete.size());
-  for (int i = 0; i < old_locations.size(); ++i) {
+  for (size_t i = 0; i < old_locations.size(); ++i) {
     if (indices_to_delete.contains(i)) {
       delete old_locations[i];
     } else {


### PR DESCRIPTION
Fixes the following compiler warning:

```
external/com_google_protobuf/src/google/protobuf/compiler/retention.cc:236:21: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<google::protobuf::SourceCodeInfo_Location*>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
```