### PR TITLE
Enable building PHP extension on Windows

### DIFF
--- a/php/BUILD.bazel
+++ b/php/BUILD.bazel
@@ -148,6 +148,7 @@ pkg_files(
   ]) + [
     "//:LICENSE",
     "ext/google/protobuf/config.m4",
+    "ext/google/protobuf/config.w32",
     "ext/google/protobuf/wkt.inc",
   ],
 )

--- a/php/ext/google/protobuf/config.w32
+++ b/php/ext/google/protobuf/config.w32
@@ -1,0 +1,14 @@
+ARG_ENABLE("protobuf", "whether to enable Protobuf extension", "no");
+
+if (PHP_PROTOBUF != "no") {
+
+  var PHP_PROTOBUF_SRC_ARRAY = glob(configure_module_dirname + "/third_party/utf8_range/*.c");
+  var PHP_PROTOBUF_SOURCES=" ";
+  for (var i=0; i<PHP_PROTOBUF_SRC_ARRAY.length; ++i) {
+    var basename = FSO.GetFileName(PHP_PROTOBUF_SRC_ARRAY[i]);
+    PHP_PROTOBUF_SOURCES = PHP_PROTOBUF_SOURCES + " " + basename;
+  }
+  ADD_SOURCES(configure_module_dirname + "/third_party/utf8_range", PHP_PROTOBUF_SOURCES, "PROTOBUF");
+  ADD_FLAG("CFLAGS_PROTOBUF", "/I" + configure_module_dirname + "/third_party/utf8_range");
+  EXTENSION("protobuf", "arena.c array.c convert.c def.c map.c message.c names.c php-upb.c protobuf.c");
+}


### PR DESCRIPTION
This PR adds a config.w32 for the PHP extension and includes it in the tgz for PECL.
I used this to build php_protobuf.dll for PHP 8.2.7. 
See https://github.com/phalcon/cphalcon/issues/16318#issuecomment-1592534432 for the request to build the extension and the result.

Please review and merge.