### PR TITLE
adding provide to php composer.json

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -8,6 +8,9 @@
   "require": {
     "php": ">=7.0.0"
   },
+  "provide": {
+    "ext-protobuf": "*"
+  },
   "require-dev": {
     "phpunit/phpunit": ">=5.0.0 <8.5.27"
   },


### PR DESCRIPTION
Adding composer config to allow the native protobuf extension to provide ext-protobuf.

This allows libraries to require at least one protobuf implementation. If the extension is not available, it can be provided by the native package. If the extension is available but the native package is required, the native will be installed.

Importantly, for libraries which require at least one of them to be installed, composer will complain if neither is available.