### PR TITLE
Handle BUILD_TYPE=None in protobuf-module.cmake

### DIFF
--- a/cmake/protobuf-module.cmake.in
+++ b/cmake/protobuf-module.cmake.in
@@ -153,6 +153,10 @@ if(NOT Protobuf_PROTOC_EXECUTABLE AND TARGET protobuf::protoc)
     get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
       IMPORTED_LOCATION_NOCONFIG)
   endif()
+  if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
+    get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
+      IMPORTED_LOCATION_NONE)
+  endif()
 endif()
 
 # Version info variable


### PR DESCRIPTION
Fixes Protobuf_PROTOC_EXECUTABLE being undefined in that case.