### PR TITLE
Add Protobuf extension number for DTDL option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -476,3 +476,8 @@ with info about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/clly/proto-telemetry
     *   Extensions: 1182
+
+1.  Digital Twins Definition Language (DTDL)
+
+    *   Website: https://github.com/Azure/opendigitaltwins-dtdl
+    *   Extensions: 1183


### PR DESCRIPTION
This option will be used by extensions to the [Digital Twins Definition Language](https://github.com/Azure/opendigitaltwins-dtdl) to support Protobuf serialization.