### PR TITLE
Parsing array of varints optimizations

### DIFF
--- a/src/google/protobuf/parse_context.cc
+++ b/src/google/protobuf/parse_context.cc
@@ -465,27 +465,33 @@ const char* VarintParser(void* object, const char* ptr, ParseContext* ctx) {
 
 const char* PackedInt32Parser(void* object, const char* ptr,
                               ParseContext* ctx) {
-  return VarintParser<int32_t, false>(object, ptr, ctx);
+  return ctx->ReadPackedVarint<int32_t, false>(ptr, 
+                               static_cast<RepeatedField<int32_t>*>(object));
 }
 const char* PackedUInt32Parser(void* object, const char* ptr,
                                ParseContext* ctx) {
-  return VarintParser<uint32_t, false>(object, ptr, ctx);
+  return ctx->ReadPackedVarint<uint32_t, false>(ptr, 
+                               static_cast<RepeatedField<uint32_t>*>(object));
 }
 const char* PackedInt64Parser(void* object, const char* ptr,
                               ParseContext* ctx) {
-  return VarintParser<int64_t, false>(object, ptr, ctx);
+  return ctx->ReadPackedVarint<int64_t, false>(ptr, 
+                               static_cast<RepeatedField<int64_t>*>(object));
 }
 const char* PackedUInt64Parser(void* object, const char* ptr,
                                ParseContext* ctx) {
-  return VarintParser<uint64_t, false>(object, ptr, ctx);
+  return ctx->ReadPackedVarint<uint64_t, false>(ptr, 
+                               static_cast<RepeatedField<uint64_t>*>(object));
 }
 const char* PackedSInt32Parser(void* object, const char* ptr,
                                ParseContext* ctx) {
-  return VarintParser<int32_t, true>(object, ptr, ctx);
+  return ctx->ReadPackedVarint<int32_t, true>(ptr, 
+                               static_cast<RepeatedField<int32_t>*>(object));
 }
 const char* PackedSInt64Parser(void* object, const char* ptr,
                                ParseContext* ctx) {
-  return VarintParser<int64_t, true>(object, ptr, ctx);
+  return ctx->ReadPackedVarint<int64_t, true>(ptr, 
+                               static_cast<RepeatedField<int64_t>*>(object));
 }
 
 const char* PackedEnumParser(void* object, const char* ptr, ParseContext* ctx) {

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -2117,8 +2117,8 @@ const char* EpsCopyInputStream::ReadPackedVarint(const char* ptr,
                                                  RepeatedField<T>* out) {
   int size = ReadSize(&ptr);
   GOOGLE_PROTOBUF_PARSER_ASSERT(ptr);
-  GOOGLE_DCHECK(buffer_end_ != 0);
-  GOOGLE_DCHECK_GE(size, 0);
+  ABSL_DCHECK(buffer_end_ != 0);
+  ABSL_DCHECK_GE(size, 0);
   int chunk_size = 1 + (buffer_end_ - ptr); // +1 because buffer_end_ points 
                                             // to the last byte, and not past 
                                             // the buffer end
@@ -2130,9 +2130,9 @@ const char* EpsCopyInputStream::ReadPackedVarint(const char* ptr,
        ptr = ReadPackedVarintArray<T, sign>(ptr, chunk_size, out);
        if (ptr == nullptr) return nullptr;
        overrun = (ptr - buffer_end_) - 1;
-       GOOGLE_DCHECK(overrun >= 0 && overrun <= kSlopBytes && overrun < size);
+       ABSL_DCHECK(overrun >= 0 && overrun <= kSlopBytes && overrun < size);
        size -= overrun + chunk_size;
-       GOOGLE_DCHECK_GE(size, 0);
+       ABSL_DCHECK_GE(size, 0);
     } 
     
     if (size <= kSlopBytes) {
@@ -2155,12 +2155,12 @@ const char* EpsCopyInputStream::ReadPackedVarint(const char* ptr,
     ptr = Next();
     if (ptr == nullptr) return nullptr;
 
-    GOOGLE_DCHECK(buffer_end_ != 0);
+    ABSL_DCHECK(buffer_end_ != 0);
     ptr += overrun;
     chunk_size = 1 + (buffer_end_ - ptr);
   }
 
-  GOOGLE_DCHECK_GE(size, 0);
+  ABSL_DCHECK_GE(size, 0);
 
   auto end = ptr + size;
   ptr = ReadPackedVarintArray<T, sign>(ptr, size, out);


### PR DESCRIPTION
This PR has the changes for parsing array of varints. Most of the changes originate in the `ReadPackedVarint` and `ReadPackedVarintArray` functions. The core of optimizations is to break the one-at-a-time parsing in the original code into a series of steps to leverage SIMD instructions.