### PR TITLE
Explicitly delete the destructor for the internal `Rep` structure.

### DIFF
--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -459,6 +459,9 @@ class RepeatedField final
       Element unused;
     };
     Element* elements() { return reinterpret_cast<Element*>(this + 1); }
+
+    // Avoid 'implicitly deleted dtor' warnings on certain compilers.
+    ~Rep() = delete;
   };
   static PROTOBUF_CONSTEXPR const size_t kRepHeaderSize = sizeof(Rep);
 


### PR DESCRIPTION
MSVC compilers generate warnings that the default destructor is implicitly deleted, which causes errors on /W1. While this is a pedantic warning (error), we can easily make the deletion explicit to avoid these warnings.

PiperOrigin-RevId: 547548886