### PR TITLE
Removed compatibility code for PHP <8.0

### DIFF
--- a/.github/workflows/test_php.yml
+++ b/.github/workflows/test_php.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Run tests
         uses: protocolbuffers/protobuf-ci/docker@v1
         with:
-          image: us-docker.pkg.dev/protobuf-build/containers/test/linux/php-aarch64:0cc100b6e03d14c1e8f71ae794dc162ed122fe31@sha256:77b70feba68dced1f0fd21b52a08d3d2e0c5c797bfe68435a0038ce87ecfd310
+          image: us-docker.pkg.dev/protobuf-build/containers/test/linux/php-aarch64@sha256:77ff9fdec867bbfb290ee0b10d8b7a3e5e434155daa5ec93de7341c7592b858d
           platform: linux/arm64
           skip-staleness-check: true
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}

--- a/php/ext/google/protobuf/array.c
+++ b/php/ext/google/protobuf/array.c
@@ -677,11 +677,7 @@ void Array_ModuleInit() {
   h = &RepeatedField_object_handlers;
   memcpy(h, &std_object_handlers, sizeof(zend_object_handlers));
   h->dtor_obj = RepeatedField_destructor;
-#if PHP_VERSION_ID < 80000
-  h->compare_objects = RepeatedField_compare_objects;
-#else
   h->compare = RepeatedField_compare_objects;
-#endif
   h->clone_obj = RepeatedField_clone_obj;
   h->get_properties = RepeatedField_GetProperties;
   h->get_property_ptr_ptr = RepeatedField_GetPropertyPtrPtr;

--- a/php/ext/google/protobuf/array.c
+++ b/php/ext/google/protobuf/array.c
@@ -118,7 +118,7 @@ static int RepeatedField_compare_objects(zval *rf1, zval *rf2) {
  *
  *   $rf2 = clone $rf1;
  */
-static zend_object *RepeatedField_clone_obj(PROTO_VAL *object) {
+static zend_object *RepeatedField_clone_obj(zend_object *object) {
   RepeatedField* intern = PROTO_VAL_P(object);
   upb_Arena *arena = Arena_Get(&intern->arena);
   upb_Array *clone = upb_Array_New(arena, intern->type.type);
@@ -135,12 +135,12 @@ static zend_object *RepeatedField_clone_obj(PROTO_VAL *object) {
   return Z_OBJ_P(&ret);
 }
 
-static HashTable *RepeatedField_GetProperties(PROTO_VAL *object) {
+static HashTable *RepeatedField_GetProperties(zend_object *object) {
   return NULL;  // We do not have a properties table.
 }
 
-static zval *RepeatedField_GetPropertyPtrPtr(PROTO_VAL *object,
-                                             PROTO_STR *member,
+static zval *RepeatedField_GetPropertyPtrPtr(zend_object *object,
+                                             zend_string *member,
                                              int type, void **cache_slot) {
   return NULL;  // We don't offer direct references to our properties.
 }
@@ -459,7 +459,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_append, 0, 0, 1)
   ZEND_ARG_INFO(0, newval)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetExists, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetExists, 0, 0, _IS_BOOL, 0)
   ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
 
@@ -467,16 +467,16 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_offsetGet, 0, 0, IS_MI
   ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetSet, 0, 2, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetSet, 0, 2, IS_VOID, 0)
   ZEND_ARG_INFO(0, index)
   ZEND_ARG_INFO(0, newval)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetUnset, 0, 0, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetUnset, 0, 0, IS_VOID, 0)
   ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_count, 0, 0, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_count, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_getIterator, 0, 0, Traversable, 0)
@@ -633,13 +633,13 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_key, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_next, 0, 0, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_next, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_valid, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_valid, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_rewind, 0, 0, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_rewind, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry repeated_field_iter_methods[] = {

--- a/php/ext/google/protobuf/array.c
+++ b/php/ext/google/protobuf/array.c
@@ -119,7 +119,7 @@ static int RepeatedField_compare_objects(zval *rf1, zval *rf2) {
  *   $rf2 = clone $rf1;
  */
 static zend_object *RepeatedField_clone_obj(zend_object *object) {
-  RepeatedField* intern = PROTO_VAL_P(object);
+  RepeatedField* intern = (RepeatedField*)object;
   upb_Arena *arena = Arena_Get(&intern->arena);
   upb_Array *clone = upb_Array_New(arena, intern->type.type);
   size_t n = upb_Array_Size(intern->array);

--- a/php/ext/google/protobuf/map.c
+++ b/php/ext/google/protobuf/map.c
@@ -133,7 +133,7 @@ static int MapField_compare_objects(zval *map1, zval *map2) {
  *
  *   $map2 = clone $map1;
  */
-static zend_object *MapField_clone_obj(PROTO_VAL *object) {
+static zend_object *MapField_clone_obj(zend_object *object) {
   MapField* intern = PROTO_VAL_P(object);
   upb_Arena *arena = Arena_Get(&intern->arena);
   upb_Map *clone =
@@ -151,12 +151,12 @@ static zend_object *MapField_clone_obj(PROTO_VAL *object) {
   return Z_OBJ_P(&ret);
 }
 
-static zval *Map_GetPropertyPtrPtr(PROTO_VAL *object, PROTO_STR *member,
+static zval *Map_GetPropertyPtrPtr(zend_object *object, zend_string *member,
                                    int type, void **cache_slot) {
   return NULL;  // We don't offer direct references to our properties.
 }
 
-static HashTable *Map_GetProperties(PROTO_VAL *object) {
+static HashTable *Map_GetProperties(zend_object *object) {
   return NULL;  // We do not have a properties table.
 }
 
@@ -458,23 +458,23 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_offsetGet, 0, 0, IS_MI
   ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetSet, 0, 2, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetSet, 0, 2, IS_VOID, 0)
   ZEND_ARG_INFO(0, index)
   ZEND_ARG_INFO(0, newval)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetUnset, 0, 0, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetUnset, 0, 0, IS_VOID, 0)
   ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetExists, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_offsetExists, 0, 0, _IS_BOOL, 0)
   ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_getIterator, 0, 0, Traversable, 0)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_count, 0, 0, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_count, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry MapField_methods[] = {
@@ -624,7 +624,7 @@ PHP_METHOD(MapFieldIter, valid) {
   RETURN_BOOL(!done);
 }
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_rewind, 0, 0, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_rewind, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_current, 0, 0, IS_MIXED, 0)
@@ -633,10 +633,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_key, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_next, 0, 0, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_next, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
-PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_valid, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_valid, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry map_field_iter_methods[] = {

--- a/php/ext/google/protobuf/map.c
+++ b/php/ext/google/protobuf/map.c
@@ -674,11 +674,7 @@ void Map_ModuleInit() {
   h = &MapField_object_handlers;
   memcpy(h, &std_object_handlers, sizeof(zend_object_handlers));
   h->dtor_obj = MapField_destructor;
-#if PHP_VERSION_ID < 80000
-  h->compare_objects = MapField_compare_objects;
-#else
   h->compare = MapField_compare_objects;
-#endif
   h->clone_obj = MapField_clone_obj;
   h->get_properties = Map_GetProperties;
   h->get_property_ptr_ptr = Map_GetPropertyPtrPtr;

--- a/php/ext/google/protobuf/map.c
+++ b/php/ext/google/protobuf/map.c
@@ -134,7 +134,7 @@ static int MapField_compare_objects(zval *map1, zval *map2) {
  *   $map2 = clone $map1;
  */
 static zend_object *MapField_clone_obj(zend_object *object) {
-  MapField* intern = PROTO_VAL_P(object);
+  MapField* intern = (MapField*)object;
   upb_Arena *arena = Arena_Get(&intern->arena);
   upb_Map *clone =
       upb_Map_New(arena, intern->type.key_type, intern->type.val_type.type);

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -110,10 +110,10 @@ static void Message_dtor(zend_object* obj) {
  *
  * Helper function to look up a field given a member name (as a string).
  */
-static const upb_FieldDef *get_field(Message *msg, PROTO_STR *member) {
+static const upb_FieldDef *get_field(Message *msg, zend_string *member) {
   const upb_MessageDef *m = msg->desc->msgdef;
-  const upb_FieldDef *f =
-      upb_MessageDef_FindFieldByNameWithSize(m, PROTO_STRVAL_P(member), PROTO_STRLEN_P(member));
+  const upb_FieldDef *f = upb_MessageDef_FindFieldByNameWithSize(
+      m, ZSTR_VAL(member), ZSTR_LEN(member));
 
   if (!f) {
     zend_throw_exception_ex(NULL, 0, "No such property %s.",
@@ -283,7 +283,7 @@ static int Message_compare_objects(zval *m1, zval *m2) {
  *       return isset($this->optional_int32);
  *   }
  */
-static int Message_has_property(PROTO_VAL *obj, PROTO_STR *member,
+static int Message_has_property(zend_object *obj, zend_string *member,
                                 int has_set_exists,
                                 void **cache_slot) {
   Message* intern = PROTO_VAL_P(obj);
@@ -318,7 +318,7 @@ static int Message_has_property(PROTO_VAL *obj, PROTO_STR *member,
  *       unset($this->optional_int32);
  *   }
  */
-static void Message_unset_property(PROTO_VAL *obj, PROTO_STR *member,
+static void Message_unset_property(zend_object *obj, zend_string *member,
                                    void **cache_slot) {
   Message* intern = PROTO_VAL_P(obj);
   const upb_FieldDef *f = get_field(intern, member);
@@ -355,7 +355,7 @@ static void Message_unset_property(PROTO_VAL *obj, PROTO_STR *member,
  * We lookup the field and return the scalar, RepeatedField, or MapField for
  * this field.
  */
-static zval *Message_read_property(PROTO_VAL *obj, PROTO_STR *member,
+static zval *Message_read_property(zend_object *obj, zend_string *member,
                                    int type, void **cache_slot, zval *rv) {
   Message* intern = PROTO_VAL_P(obj);
   const upb_FieldDef *f = get_field(intern, member);
@@ -386,9 +386,9 @@ static zval *Message_read_property(PROTO_VAL *obj, PROTO_STR *member,
  * The C extension version of checkInt32() doesn't actually check anything, so
  * we perform all checking and conversion in this function.
  */
-static PROTO_RETURN_VAL Message_write_property(
-    PROTO_VAL *obj, PROTO_STR *member, zval *val, void **cache_slot) {
-  Message* intern = PROTO_VAL_P(obj);
+static zval *Message_write_property(zend_object *obj, zend_string *member,
+                                    zval *val, void **cache_slot) {
+  Message *intern = PROTO_VAL_P(obj);
   const upb_FieldDef *f = get_field(intern, member);
 
   if (f && Message_set(intern, f, val)) {
@@ -413,7 +413,7 @@ static PROTO_RETURN_VAL Message_write_property(
  * reference to our internal properties. We don't support this, so we return
  * NULL.
  */
-static zval *Message_get_property_ptr_ptr(PROTO_VAL *object, PROTO_STR *member,
+static zval *Message_get_property_ptr_ptr(zend_object *object, zend_string *member,
                                           int type,
                                           void **cache_slot) {
   return NULL;  // We do not have a properties table.
@@ -426,7 +426,7 @@ static zval *Message_get_property_ptr_ptr(PROTO_VAL *object, PROTO_STR *member,
  *
  *   $msg2 = clone $msg;
  */
-static zend_object *Message_clone_obj(PROTO_VAL *object) {
+static zend_object *Message_clone_obj(zend_object *object) {
   Message* intern = PROTO_VAL_P(object);
   upb_MiniTable *t = upb_MessageDef_MiniTable(intern->desc->msgdef);
   upb_Message *clone = upb_Message_New(t, Arena_Get(&intern->arena));
@@ -445,7 +445,7 @@ static zend_object *Message_clone_obj(PROTO_VAL *object) {
  * Object handler for the get_properties event in PHP. This returns a HashTable
  * of our internal properties. We don't support this, so we return NULL.
  */
-static HashTable *Message_get_properties(PROTO_VAL *object) {
+static HashTable *Message_get_properties(zend_object *object) {
   return NULL;  // We don't offer direct references to our properties.
 }
 

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -392,17 +392,9 @@ static zval *Message_write_property(zend_object *obj, zend_string *member,
   const upb_FieldDef *f = get_field(intern, member);
 
   if (f && Message_set(intern, f, val)) {
-#if PHP_VERSION_ID < 70400
-    return;
-#else
     return val;
-#endif
   } else {
-#if PHP_VERSION_ID < 70400
-    return;
-#else
     return &EG(error_zval);
-#endif
   }
 }
 
@@ -1423,11 +1415,7 @@ void Message_ModuleInit() {
 
   memcpy(h, &std_object_handlers, sizeof(zend_object_handlers));
   h->dtor_obj = Message_dtor;
-#if PHP_VERSION_ID < 80000
-  h->compare_objects = Message_compare_objects;
-#else
   h->compare = Message_compare_objects;
-#endif
   h->read_property = Message_read_property;
   h->write_property = Message_write_property;
   h->has_property = Message_has_property;

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -286,7 +286,7 @@ static int Message_compare_objects(zval *m1, zval *m2) {
 static int Message_has_property(zend_object *obj, zend_string *member,
                                 int has_set_exists,
                                 void **cache_slot) {
-  Message* intern = PROTO_VAL_P(obj);
+  Message* intern = (Message*)obj;
   const upb_FieldDef *f = get_field(intern, member);
 
   if (!f) return 0;
@@ -320,7 +320,7 @@ static int Message_has_property(zend_object *obj, zend_string *member,
  */
 static void Message_unset_property(zend_object *obj, zend_string *member,
                                    void **cache_slot) {
-  Message* intern = PROTO_VAL_P(obj);
+  Message* intern = (Message*)obj;
   const upb_FieldDef *f = get_field(intern, member);
 
   if (!f) return;
@@ -357,7 +357,7 @@ static void Message_unset_property(zend_object *obj, zend_string *member,
  */
 static zval *Message_read_property(zend_object *obj, zend_string *member,
                                    int type, void **cache_slot, zval *rv) {
-  Message* intern = PROTO_VAL_P(obj);
+  Message* intern = (Message*)obj;
   const upb_FieldDef *f = get_field(intern, member);
 
   if (!f) return &EG(uninitialized_zval);
@@ -388,7 +388,7 @@ static zval *Message_read_property(zend_object *obj, zend_string *member,
  */
 static zval *Message_write_property(zend_object *obj, zend_string *member,
                                     zval *val, void **cache_slot) {
-  Message *intern = PROTO_VAL_P(obj);
+  Message* intern = (Message*)obj;
   const upb_FieldDef *f = get_field(intern, member);
 
   if (f && Message_set(intern, f, val)) {
@@ -427,7 +427,7 @@ static zval *Message_get_property_ptr_ptr(zend_object *object, zend_string *memb
  *   $msg2 = clone $msg;
  */
 static zend_object *Message_clone_obj(zend_object *object) {
-  Message* intern = PROTO_VAL_P(object);
+  Message* intern = (Message*)object;
   upb_MiniTable *t = upb_MessageDef_MiniTable(intern->desc->msgdef);
   upb_Message *clone = upb_Message_New(t, Arena_Get(&intern->arena));
 

--- a/php/ext/google/protobuf/protobuf.c
+++ b/php/ext/google/protobuf/protobuf.c
@@ -264,18 +264,10 @@ const upb_MessageDef *NameMap_GetMessage(zend_class_entry *ce) {
       zend_hash_find_ptr(&PROTOBUF_G(name_msg_cache), ce->name);
 
   if (!ret && ce->create_object && ce != PROTOBUF_G(constructing_class)) {
-#if PHP_VERSION_ID < 80000
-    zval tmp;
-    zval zv;
-    ZVAL_OBJ(&tmp, ce->create_object(ce));
-    zend_call_method_with_0_params(&tmp, ce, NULL, "__construct", &zv);
-    zval_ptr_dtor(&tmp);
-#else
     zval zv;
     zend_object *tmp = ce->create_object(ce);
     zend_call_method_with_0_params(tmp, ce, NULL, "__construct", &zv);
     OBJ_RELEASE(tmp);
-#endif
     zval_ptr_dtor(&zv);
     ret = zend_hash_find_ptr(&PROTOBUF_G(name_msg_cache), ce->name);
   }

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -47,22 +47,6 @@ upb_DefPool *get_global_symtab();
         ZEND_BEGIN_ARG_INFO_EX(name, return_reference, required_num_args, allow_null)
 #endif
 
-#ifndef IS_VOID
-#define IS_VOID 99
-#endif
-
-#ifndef IS_MIXED
-#define IS_MIXED 99
-#endif
-
-#ifndef _IS_BOOL
-#define _IS_BOOL 99
-#endif
-
-#ifndef IS_LONG
-#define IS_LONG 99
-#endif
-
 ZEND_BEGIN_ARG_INFO(arginfo_void, 0)
 ZEND_END_ARG_INFO()
 

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -38,63 +38,6 @@
 
 upb_DefPool *get_global_symtab();
 
-#if PHP_VERSION_ID < 70300
-#define GC_ADDREF(h) ++GC_REFCOUNT(h)
-#define GC_DELREF(h) --GC_REFCOUNT(h)
-#endif
-
-// Since php 7.4, the write_property() object handler now returns the assigned
-// value (after possible type coercions) rather than void.
-// https://github.com/php/php-src/blob/PHP-7.4.0/UPGRADING.INTERNALS#L171-L173
-#if PHP_VERSION_ID < 70400
-#define PROTO_RETURN_VAL void
-#else
-#define PROTO_RETURN_VAL zval*
-#endif
-
-// Since php 8.0, the Object Handlers API was changed to receive zend_object*
-// instead of zval* and zend_string* instead of zval* for property names.
-// https://github.com/php/php-src/blob/php-8.0.0beta1/UPGRADING.INTERNALS#L37-L39
-#if PHP_VERSION_ID < 80000
-#define PROTO_VAL zval
-#define PROTO_STR zval
-#define PROTO_VAL_P(obj) (void*)Z_OBJ_P(obj)
-#define PROTO_STRVAL_P(obj) Z_STRVAL_P(obj)
-#define PROTO_STRLEN_P(obj) Z_STRLEN_P(obj)
-#define ZVAL_OBJ_COPY(z, o) do { ZVAL_OBJ(z, o); GC_ADDREF(o); } while (0)
-#define RETVAL_OBJ_COPY(r) ZVAL_OBJ_COPY(return_value, r)
-#define RETURN_OBJ_COPY(r) do { RETVAL_OBJ_COPY(r); return; } while (0)
-#define RETURN_COPY(zv) do { ZVAL_COPY(return_value, zv); return; } while (0)
-#define RETURN_COPY_VALUE(zv) do { ZVAL_COPY_VALUE(return_value, zv); return; } while (0)
-#else
-#define PROTO_VAL zend_object
-#define PROTO_STR zend_string
-#define PROTO_VAL_P(obj) (void*)(obj)
-#define PROTO_STRVAL_P(obj) ZSTR_VAL(obj)
-#define PROTO_STRLEN_P(obj) ZSTR_LEN(obj)
-#endif
-
-// In PHP 8.1, several old interfaces are removed:
-// https://github.com/php/php-src/blob/14f599ea7def7c7a59c40aff763ce8b105573e7a/UPGRADING.INTERNALS#L27-L31
-//
-// We now use the new interfaces (zend_ce_arrayaccess and zend_ce_countable).
-// However we have to polyfill zend_ce_countable, which was only introduced in
-// PHP 7.2.0.
-#if PHP_VERSION_ID < 70200
-#define zend_ce_countable spl_ce_Countable
-#define ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(name, return_reference, required_num_args, class_name, allow_null) \
-        ZEND_BEGIN_ARG_INFO_EX(name, return_reference, required_num_args, allow_null)
-#endif
-
-// polyfill for ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX, which changes between 7.1 and 7.2
-#if PHP_VERSION_ID < 70200
-#define PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, allow_null) \
-        ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, /*class_name*/ 0, allow_null)
-#else
-#define PROTOBUF_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, allow_null) \
-        ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, allow_null)
-#endif
-
 // In PHP 8.1, mismatched tentative return types emit a deprecation notice.
 // https://wiki.php.net/rfc/internal_method_return_types
 //


### PR DESCRIPTION
Now that we have dropped support for old PHP, we can remove this compatibility layer, which will simplify the code.