### PR TITLE
Use `omit` to skip ObjectCache tests when it is not in use.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,7 @@ local_repository(
 
 # Load common dependencies first to ensure we use the correct version
 load("//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS", "protobuf_deps")
+
 protobuf_deps()
 
 # Bazel platform rules.
@@ -63,23 +64,41 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
 rules_pkg_dependencies()
 
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+
 apple_rules_dependencies()
 
 # For `kt_jvm_library`
 load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+
 kotlin_repositories()
 
 load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+
 kt_register_toolchains()
 
 load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
+
 ruby_runtime("system_ruby")
+
 register_toolchains("@system_ruby//:toolchain")
 
+# Uncomment pairs of ruby_runtime() + register_toolchain() calls below to enable
+# local JRuby testing. Do not submit the changes (due to impact on test duration
+# for non JRuby builds due to downloading JRuby SDKs).
+#ruby_runtime("jruby-9.2")
+#
+#register_toolchains("@jruby-9.2//:toolchain")
+#
+#ruby_runtime("jruby-9.3")
+#
+#register_toolchains("@jruby-9.3//:toolchain")
+
 load("@system_ruby//:bundle.bzl", "ruby_bundle")
+
 ruby_bundle(
     name = "protobuf_bundle",
     srcs = ["//ruby:google-protobuf.gemspec"],
@@ -87,17 +106,20 @@ ruby_bundle(
 )
 
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
+
 upb_deps()
 
 load("@upb//bazel:system_python.bzl", "system_python")
+
 system_python(
     name = "system_python",
     minimum_python_version = "3.7",
 )
 
 load("@system_python//:pip.bzl", "pip_parse")
+
 pip_parse(
-    name="pip_deps",
+    name = "pip_deps",
     requirements = "@upb//python:requirements.txt",
     requirements_overrides = {
         "3.11": "@upb//python:requirements_311.txt",
@@ -105,9 +127,11 @@ pip_parse(
 )
 
 load("@pip_deps//:requirements.bzl", "install_deps")
+
 install_deps()
 
 load("@utf8_range//:workspace_deps.bzl", "utf8_range_deps")
+
 utf8_range_deps()
 
 http_archive(
@@ -118,6 +142,7 @@ http_archive(
 )
 
 load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+
 rules_fuzzing_dependencies()
 
 bind(
@@ -132,5 +157,7 @@ http_archive(
 )
 
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
+
 rules_rust_dependencies()
+
 rust_register_toolchains(edition = "2021")

--- a/ruby/tests/object_cache_test.rb
+++ b/ruby/tests/object_cache_test.rb
@@ -3,10 +3,7 @@ require 'test/unit'
 
 class PlatformTest < Test::Unit::TestCase
   def test_correct_implementation_for_platform
-    if RUBY_PLATFORM == "java"
-      return
-    end
-
+    omit('OBJECT_CACHE not defined') unless defined? Google::Protobuf::OBJECT_CACHE
     if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0') and Google::Protobuf::SIZEOF_LONG >= Google::Protobuf::SIZEOF_VALUE
       assert_instance_of Google::Protobuf::ObjectCache, Google::Protobuf::OBJECT_CACHE
     else
@@ -19,8 +16,8 @@ module ObjectCacheTestModule
   def test_try_add_returns_existing_value
     cache = self.create
 
-    keys = ["k1", "k2"]
-    vals = ["v1", "v2"]
+    keys = %w[k1 k2]
+    vals = %w[v1 v2]
     2.times do |i|
       assert_same vals[i], cache.try_add(keys[i], vals[i])
       assert_same vals[i], cache.get(keys[i])
@@ -32,7 +29,7 @@ module ObjectCacheTestModule
   def test_multithreaded_access
     cache = self.create
 
-    keys = ["k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7"]
+    keys = %w[k0 k1 k2 k3 k4 k5 k6 k7]
 
     threads = []
     100.times do |i|
@@ -48,12 +45,9 @@ module ObjectCacheTestModule
   end
 end
 
-if RUBY_PLATFORM == "java"
-  return
-end
-
 class ObjectCacheTest < Test::Unit::TestCase
   def create
+    omit('OBJECT_CACHE not defined') unless defined? Google::Protobuf::OBJECT_CACHE
     Google::Protobuf::ObjectCache.new
   end
 
@@ -62,6 +56,7 @@ end
 
 class LegacyObjectCacheTest < Test::Unit::TestCase
   def create
+    omit('OBJECT_CACHE not defined') unless defined? Google::Protobuf::OBJECT_CACHE
     Google::Protobuf::LegacyObjectCache.new
   end
 


### PR DESCRIPTION
Unblocks execution of these tests on JRuby FFI.

Automated reformatting of WORKSPACE with documentary comment to ease future debugging of JRuby tests locally.