### PR TITLE
Add JRuby 9.3 and 9.4 to the test matrix under both Bazel versions.

### DIFF
--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -21,10 +21,13 @@ jobs:
           - { name: Ruby 3.0, ruby: ruby-3.0.2, bazel: 5.1.1}
           - { name: Ruby 3.1, ruby: ruby-3.1.0, bazel: 5.1.1}
           - { name: Ruby 3.2, ruby: ruby-3.2.0, bazel: 5.1.1}
-          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1}
-          - { name: JRuby 9.3, ruby: jruby-9.3.4.0, bazel: 5.1.1}
+          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1} # To be removed
+          - { name: JRuby 9.3, ruby: jruby-9.3.10.0, bazel: 5.1.1}
+          - { name: JRuby 9.4, ruby: jruby-9.4.3.0, bazel: 5.1.1}
           - { name: Ruby 2.7 (Bazel6), ruby: ruby-2.7.0, bazel: 6.0.0}
-          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0}
+          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0} # To be removed
+          - { name: JRuby 9.3 (Bazel6), ruby: jruby-9.3.10.0, bazel: 6.0.0}
+          - { name: JRuby 9.4 (Bazel6), ruby: jruby-9.4.3.0, bazel: 6.0.0}
 
     name: Linux ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -112,10 +115,13 @@ jobs:
           - { name: Ruby 3.0, ruby: ruby-3.0.2, bazel: 5.1.1}
           - { name: Ruby 3.1, ruby: ruby-3.1.0, bazel: 5.1.1}
           - { name: Ruby 3.2, ruby: ruby-3.2.0, bazel: 5.1.1}
-          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1}
-          - { name: JRuby 9.3, ruby: jruby-9.3.4.0, bazel: 5.1.1}
+          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1} # To be removed
+          - { name: JRuby 9.3, ruby: jruby-9.3.10.0, bazel: 5.1.1}
+          - { name: JRuby 9.4, ruby: jruby-9.4.3.0, bazel: 5.1.1}
           - { name: Ruby 2.7 (Bazel6), ruby: ruby-2.7.0, bazel: 6.0.0}
-          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0}
+          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0}  # To be removed
+          - { name: JRuby 9.3 (Bazel6), ruby: jruby-9.3.10.0, bazel: 6.0.0}
+          - { name: JRuby 9.4 (Bazel6), ruby: jruby-9.4.3.0, bazel: 6.0.0}
     name: Install ${{ matrix.name }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Prepare for 9.2 to be removed. Also bump 9.3 to patch level 10.