### PR TITLE
Add JRuby 9.3 and 9.4 to the test matrix under both Bazel versions.

### DIFF
--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -21,12 +21,10 @@ jobs:
           - { name: Ruby 3.0, ruby: ruby-3.0.2, bazel: 5.1.1}
           - { name: Ruby 3.1, ruby: ruby-3.1.0, bazel: 5.1.1}
           - { name: Ruby 3.2, ruby: ruby-3.2.0, bazel: 5.1.1}
-          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1} # To be removed
+          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1}
           - { name: JRuby 9.3, ruby: jruby-9.3.10.0, bazel: 5.1.1}
           - { name: JRuby 9.4, ruby: jruby-9.4.3.0, bazel: 5.1.1}
           - { name: Ruby 2.7 (Bazel6), ruby: ruby-2.7.0, bazel: 6.0.0}
-          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0} # To be removed
-          - { name: JRuby 9.3 (Bazel6), ruby: jruby-9.3.10.0, bazel: 6.0.0}
           - { name: JRuby 9.4 (Bazel6), ruby: jruby-9.4.3.0, bazel: 6.0.0}
 
     name: Linux ${{ matrix.name }}
@@ -115,12 +113,10 @@ jobs:
           - { name: Ruby 3.0, ruby: ruby-3.0.2, bazel: 5.1.1}
           - { name: Ruby 3.1, ruby: ruby-3.1.0, bazel: 5.1.1}
           - { name: Ruby 3.2, ruby: ruby-3.2.0, bazel: 5.1.1}
-          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1} # To be removed
+          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1}
           - { name: JRuby 9.3, ruby: jruby-9.3.10.0, bazel: 5.1.1}
           - { name: JRuby 9.4, ruby: jruby-9.4.3.0, bazel: 5.1.1}
           - { name: Ruby 2.7 (Bazel6), ruby: ruby-2.7.0, bazel: 6.0.0}
-          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0}  # To be removed
-          - { name: JRuby 9.3 (Bazel6), ruby: jruby-9.3.10.0, bazel: 6.0.0}
           - { name: JRuby 9.4 (Bazel6), ruby: jruby-9.4.3.0, bazel: 6.0.0}
     name: Install ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -21,10 +21,13 @@ jobs:
           - { name: Ruby 3.0, ruby: ruby-3.0.2, bazel: 5.1.1}
           - { name: Ruby 3.1, ruby: ruby-3.1.0, bazel: 5.1.1}
           - { name: Ruby 3.2, ruby: ruby-3.2.0, bazel: 5.1.1}
-          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1}
-          - { name: JRuby 9.3, ruby: jruby-9.3.4.0, bazel: 5.1.1}
+          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1} # To be removed
+          - { name: JRuby 9.3, ruby: jruby-9.3.10.0, bazel: 5.1.1}
+          - { name: JRuby 9.4, ruby: jruby-9.4.3.0, bazel: 5.1.1}
           - { name: Ruby 2.7 (Bazel6), ruby: ruby-2.7.0, bazel: 6.0.0}
-          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0}
+          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0} # To be removed
+          - { name: JRuby 9.3 (Bazel6), ruby: jruby-9.3.10.0, bazel: 6.0.0}
+          - { name: JRuby 9.4 (Bazel6), ruby: jruby-9.4.3.0, bazel: 6.0.0}
 
     name: Linux ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -112,10 +115,13 @@ jobs:
           - { name: Ruby 3.0, ruby: ruby-3.0.2, bazel: 5.1.1}
           - { name: Ruby 3.1, ruby: ruby-3.1.0, bazel: 5.1.1}
           - { name: Ruby 3.2, ruby: ruby-3.2.0, bazel: 5.1.1}
-          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1}
-          - { name: JRuby 9.3, ruby: jruby-9.3.4.0, bazel: 5.1.1}
+          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1} # To be removed
+          - { name: JRuby 9.3, ruby: jruby-9.3.10.0, bazel: 5.1.1}
+          - { name: JRuby 9.4, ruby: jruby-9.4.3.0, bazel: 5.1.1}
           - { name: Ruby 2.7 (Bazel6), ruby: ruby-2.7.0, bazel: 6.0.0}
-          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0}
+          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0}  # To be removed
+          - { name: JRuby 9.3 (Bazel6), ruby: jruby-9.3.10.0, bazel: 6.0.0}
+          - { name: JRuby 9.4 (Bazel6), ruby: jruby-9.4.3.0, bazel: 6.0.0}
     name: Install ${{ matrix.name }}
     runs-on: ubuntu-latest
     steps:

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -110,8 +110,8 @@ def protobuf_deps():
         _github_archive(
             name = "rules_ruby",
             repo = "https://github.com/protocolbuffers/rules_ruby",
-            commit = "5cf6ff74161d7f985b9bf86bb3c5fb16cef6337b",
-            sha256 = "c88dd69eb50fcfd7fbc5d7db79adc6631ef0e1d80b3c94efe33ac5ee3ccc37f7",
+            commit = "8fca842a3006c3d637114aba4f6bf9695bb3a432",
+            sha256 = "2619f9a23cee6f6a198d9ef284b6f6cbc901545ee9a9aac9ffa6b83dbf17cf0c",
         )
 
     if not native.existing_rule("rules_jvm_external"):

--- a/ruby/compatibility_tests/v3.0.0/tests/repeated_field_test.rb
+++ b/ruby/compatibility_tests/v3.0.0/tests/repeated_field_test.rb
@@ -8,7 +8,7 @@ class RepeatedFieldTest < Test::Unit::TestCase
   def test_acts_like_enumerator
     m = TestMessage.new
     (Enumerable.instance_methods - TestMessage.new.repeated_string.methods).each do |method_name|
-      assert_equal "does not respond to #{method_name}", m.repeated_string.respond_to?(method_name), true
+      assert_respond_to m.repeated_string, method_name
     end
   end
 
@@ -20,8 +20,10 @@ class RepeatedFieldTest < Test::Unit::TestCase
       :iter_for_each_with_index, :dimensions, :copy_data, :copy_data_simple,
       :nitems, :iter_for_reverse_each, :indexes, :append, :prepend]
     arr_methods -= [:union, :difference, :filter!]
-    arr_methods -= [:intersection, :deconstruct] # ruby 2.7 methods we can ignore
-    arr_methods -= [:intersect?] # ruby 3.1 methods we can ignore
+    # ruby 2.7 methods we can ignore
+    arr_methods -= [:intersection, :deconstruct, :resolve_feature_path]
+    # ruby 3.1 methods we can ignore
+    arr_methods -= [:intersect?]
     arr_methods.each do |method_name|
       assert_respond_to m.repeated_string, method_name
     end

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
@@ -74,6 +74,9 @@ public class RubyRepeatedField extends RubyObject {
   @JRubyMethod(required = 1, optional = 2)
   public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
     Ruby runtime = context.runtime;
+    // Workaround for https://github.com/jruby/jruby/issues/7851. Can be removed when JRuby 9.4.3.0
+    // is no longer supported.
+    if (args.length < 1) throw runtime.newArgumentError("Expected at least 1 argument");
     this.storage = runtime.newArray();
     IRubyObject ary = null;
     if (!(args[0] instanceof RubySymbol)) {
@@ -141,14 +144,20 @@ public class RubyRepeatedField extends RubyObject {
       } else if (arg instanceof RubyRange) {
         RubyRange range = ((RubyRange) arg);
 
-        int first = normalizeArrayIndex(range.first(context));
-        int last = normalizeArrayIndex(range.last(context));
+        boolean beginless = range.begin(context).isNil();
+        int first = normalizeArrayIndex(
+            beginless ? RubyNumeric.int2fix(context.runtime, 0)
+                : range.begin(context));
+        boolean endless = range.end(context).isNil();
+        int last = normalizeArrayIndex(
+            endless ? RubyNumeric.int2fix(context.runtime, -1)
+                : range.end(context));
 
         if (last - first < 0) {
           return context.runtime.newEmptyArray();
         }
-
-        return this.storage.subseq(first, last - first + (range.isExcludeEnd() ? 0 : 1));
+        boolean excludeEnd = range.isExcludeEnd() && !endless;
+        return this.storage.subseq(first, last - first + (excludeEnd ? 0 : 1));
       }
     }
     /* assume 2 arguments */

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -20,8 +20,10 @@ class RepeatedFieldTest < Test::Unit::TestCase
       :iter_for_each_with_index, :dimensions, :copy_data, :copy_data_simple,
       :nitems, :iter_for_reverse_each, :indexes, :append, :prepend]
     arr_methods -= [:union, :difference, :filter!]
-    arr_methods -= [:intersection, :deconstruct] # ruby 2.7 methods we can ignore
-    arr_methods -= [:intersect?] # ruby 3.1 methods we can ignore
+    # ruby 2.7 methods we can ignore
+    arr_methods -= [:intersection, :deconstruct, :resolve_feature_path]
+    # ruby 3.1 methods we can ignore
+    arr_methods -= [:intersect?]
     arr_methods.each do |method_name|
       assert_respond_to m.repeated_string, method_name
     end


### PR DESCRIPTION
Prepare for 9.2 to be removed.