### PR TITLE
Handle conflicting macros for FreeBSD

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -1030,6 +1030,19 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
 #undef TYPE_BOOL
 #endif  // __APPLE__
 
+#ifdef __FreeBSD__
+// Inconvenient macro names from /usr/include/sys/param.h.
+#pragma push_macro("TRUE")
+#undef TRUE
+#pragma push_macro("FALSE")
+#undef FALSE
+// Inconvenient macro names from /usr/include/sys/limits.h.
+#pragma push_macro("UID_MAX")
+#undef UID_MAX
+#pragma push_macro("GID_MAX")
+#undef GID_MAX
+#endif  // __FreeBSD__
+
 #if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
 // Don't let Objective-C Macros interfere with proto identifiers with the same
 // name.

--- a/src/google/protobuf/port_undef.inc
+++ b/src/google/protobuf/port_undef.inc
@@ -192,6 +192,13 @@
 #pragma pop_macro("TYPE_BOOL")
 #endif  // __APPLE__
 
+#ifdef __FreeBSD__
+#pragma pop_macro("TRUE")
+#pragma pop_macro("FALSE")
+#pragma pop_macro("UID_MAX")
+#pragma pop_macro("GID_MAX")
+#endif  // __FreeBSD__
+
 #if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
 #pragma pop_macro("DEBUG")
 #endif // defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)


### PR DESCRIPTION
The `unittest_proto3_bad_macros.proto` test is failing on FreeBSD due to the GID_MAX/UID_MAX macros. This is because `port_def.inc` is missing these entries (as well as TRUE/FALSE) for FreeBSD. This PR adds those missing macros.
See compile errors below:

```
[ 87%] Building CXX object CMakeFiles/tests.dir/src/google/protobuf/unittest_preserve_unknown_enum2.pb.cc.o
[ 87%] Building CXX object CMakeFiles/tests.dir/src/google/protobuf/unittest_proto3.pb.cc.o
[ 87%] Building CXX object CMakeFiles/tests.dir/src/google/protobuf/unittest_proto3_arena.pb.cc.o
[ 87%] Building CXX object CMakeFiles/tests.dir/src/google/protobuf/unittest_proto3_arena_lite.pb.cc.o
[ 88%] Building CXX object CMakeFiles/tests.dir/src/google/protobuf/unittest_proto3_bad_macros.pb.cc.o
In file included from /usr/home/jpb/protobuf/src/google/protobuf/unittest_proto3_bad_macros.pb.cc:4:
/usr/home/jpb/protobuf/src/google/protobuf/unittest_proto3_bad_macros.pb.h:71:15: error: expected unqualified-id
constexpr GID GID_MAX = static_cast<GID>(0);
              ^
/usr/include/sys/limits.h:85:18: note: expanded from macro 'GID_MAX'
#define GID_MAX         UINT_MAX        /* max value for a gid_t */
                        ^
/usr/include/sys/limits.h:59:18: note: expanded from macro 'UINT_MAX'
#define UINT_MAX        __UINT_MAX      /* max value for an unsigned int */
                        ^
/usr/include/x86/_limits.h:58:20: note: expanded from macro '__UINT_MAX'
#define __UINT_MAX      0xffffffff      /* max value for an unsigned int */
                        ^
In file included from /usr/home/jpb/protobuf/src/google/protobuf/unittest_proto3_bad_macros.pb.cc:4:
/usr/home/jpb/protobuf/src/google/protobuf/unittest_proto3_bad_macros.pb.h:102:15: error: expected unqualified-id
constexpr UID UID_MAX = static_cast<UID>(0);
              ^
/usr/include/sys/limits.h:86:18: note: expanded from macro 'UID_MAX'
#define UID_MAX         UINT_MAX        /* max value for a uid_t */
                        ^
/usr/include/sys/limits.h:59:18: note: expanded from macro 'UINT_MAX'
#define UINT_MAX        __UINT_MAX      /* max value for an unsigned int */
                        ^
/usr/include/x86/_limits.h:58:20: note: expanded from macro '__UINT_MAX'
#define __UINT_MAX      0xffffffff      /* max value for an unsigned int */
                        ^
2 errors generated.
gmake[2]: *** [CMakeFiles/tests.dir/build.make:2038: CMakeFiles/tests.dir/src/google/protobuf/unittest_proto3_bad_macros.pb.cc.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1178: CMakeFiles/tests.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```