### PR TITLE
Update Kotlin compiler to escape package names

### DIFF
--- a/src/google/protobuf/compiler/java/message.cc
+++ b/src/google/protobuf/compiler/java/message.cc
@@ -1338,8 +1338,7 @@ void ImmutableMessageGenerator::GenerateTopLevelKotlinMembers(
       "message",
       EscapeKotlinKeywords(name_resolver_->GetClassName(descriptor_, true)),
       "message_kt",
-      EscapeKotlinKeywords(
-          name_resolver_->GetKotlinExtensionsClassName(descriptor_)));
+      name_resolver_->GetKotlinExtensionsClassNameEscaped(descriptor_));
 
   for (int i = 0; i < descriptor_->nested_type_count(); i++) {
     if (IsMapEntry(descriptor_->nested_type(i))) continue;

--- a/src/google/protobuf/compiler/java/message_lite.cc
+++ b/src/google/protobuf/compiler/java/message_lite.cc
@@ -864,8 +864,7 @@ void ImmutableMessageLiteGenerator::GenerateTopLevelKotlinMembers(
       "message",
       EscapeKotlinKeywords(name_resolver_->GetClassName(descriptor_, true)),
       "message_kt",
-      EscapeKotlinKeywords(
-          name_resolver_->GetKotlinExtensionsClassName(descriptor_)));
+      name_resolver_->GetKotlinExtensionsClassNameEscaped(descriptor_));
 
   for (int i = 0; i < descriptor_->nested_type_count(); i++) {
     if (IsMapEntry(descriptor_->nested_type(i))) continue;

--- a/src/google/protobuf/compiler/java/name_resolver.cc
+++ b/src/google/protobuf/compiler/java/name_resolver.cc
@@ -365,6 +365,19 @@ std::string ClassNameResolver::GetKotlinExtensionsClassName(
                           descriptor->file(), true, true, true);
 }
 
+std::string ClassNameResolver::GetKotlinExtensionsClassNameEscaped(
+    const Descriptor* descriptor) {
+  std::string name_without_package = ClassNameWithoutPackageKotlin(descriptor);
+  std::string full_name = GetClassFullName(name_without_package,
+                                           descriptor->file(), true, true, true);
+  std::string name_without_package_suffix = absl::StrCat(".", name_without_package, "Kt");
+  size_t package_end = full_name.rfind(name_without_package_suffix);
+  if (package_end != std::string::npos) {
+    return absl::StrCat("`", full_name.substr(0, package_end), "`", name_without_package_suffix);
+  }
+  return full_name;
+}
+
 std::string ClassNameResolver::GetJavaMutableClassName(
     const Descriptor* descriptor) {
   return GetJavaClassFullName(ClassNameWithoutPackage(descriptor, false),

--- a/src/google/protobuf/compiler/java/name_resolver.h
+++ b/src/google/protobuf/compiler/java/name_resolver.h
@@ -125,6 +125,7 @@ class ClassNameResolver {
   std::string GetJavaImmutableClassName(const ServiceDescriptor* descriptor);
   std::string GetKotlinFactoryName(const Descriptor* descriptor);
   std::string GetKotlinExtensionsClassName(const Descriptor* descriptor);
+  std::string GetKotlinExtensionsClassNameEscaped(const Descriptor* descriptor);
   std::string GetJavaMutableClassName(const Descriptor* descriptor);
   std::string GetJavaMutableClassName(const EnumDescriptor* descriptor);
   std::string GetJavaMutableClassName(const ServiceDescriptor* descriptor);


### PR DESCRIPTION
The current Kotlin code generator creates code which fails to compile with imports like:

```
syntax = "proto3";
package net.example.v1;
message Sample {
  string net = 1;
}
```

This results in a condition where 'net' is ambiguous in some cases (could refer to the field or the package). To avoid these issues, the code generator should enclose package paths in backticks:

```
net.example.v1.SampleKt => `net.example.v1`.SampleKt
```

Fixes #13182.