### PR TITLE
Fix gcc compilation error about non virtual destructor

### DIFF
--- a/src/google/protobuf/map_field.h
+++ b/src/google/protobuf/map_field.h
@@ -324,7 +324,7 @@ class PROTOBUF_EXPORT MapFieldBase : public MapFieldBaseForParse {
 
  protected:
   // "protected" stops users from deleting a `MapFieldBase *`
-  ~MapFieldBase();
+  virtual ~MapFieldBase();
 
  public:
   // Returns reference to internal repeated field. Data written using


### PR DESCRIPTION
gcc is complaining that MapFieldBase has virtual methods but non-virtual destructor.