### PR TITLE
chore(zlib.BUILD): use @platforms instead of @bazel_tools

### DIFF
--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -58,7 +58,7 @@ cc_library(
     ] + _ZLIB_HEADERS,
     hdrs = _ZLIB_PREFIXED_HEADERS,
     copts = select({
-        "@bazel_tools//src/conditions:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": [
             "-Wno-deprecated-non-prototype",
             "-Wno-unused-variable",


### PR DESCRIPTION
Closes https://github.com/protocolbuffers/protobuf/issues/13250