### PR TITLE
Add JRuby 9.4 tests and require Ruby version >=2.7 

### DIFF
--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -21,8 +21,6 @@ jobs:
           - { name: Ruby 3.0, ruby: ruby-3.0.2, bazel: 5.1.1}
           - { name: Ruby 3.1, ruby: ruby-3.1.0, bazel: 5.1.1}
           - { name: Ruby 3.2, ruby: ruby-3.2.0, bazel: 5.1.1}
-          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1}
-          - { name: JRuby 9.3, ruby: jruby-9.3.10.0, bazel: 5.1.1}
           - { name: JRuby 9.4, ruby: jruby-9.4.3.0, bazel: 5.1.1}
           - { name: Ruby 2.7 (Bazel6), ruby: ruby-2.7.0, bazel: 6.0.0}
           - { name: JRuby 9.4 (Bazel6), ruby: jruby-9.4.3.0, bazel: 6.0.0}
@@ -113,8 +111,6 @@ jobs:
           - { name: Ruby 3.0, ruby: ruby-3.0.2, bazel: 5.1.1}
           - { name: Ruby 3.1, ruby: ruby-3.1.0, bazel: 5.1.1}
           - { name: Ruby 3.2, ruby: ruby-3.2.0, bazel: 5.1.1}
-          - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1}
-          - { name: JRuby 9.3, ruby: jruby-9.3.10.0, bazel: 5.1.1}
           - { name: JRuby 9.4, ruby: jruby-9.4.3.0, bazel: 5.1.1}
           - { name: Ruby 2.7 (Bazel6), ruby: ruby-2.7.0, bazel: 6.0.0}
           - { name: JRuby 9.4 (Bazel6), ruby: jruby-9.4.3.0, bazel: 6.0.0}

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -22,9 +22,10 @@ jobs:
           - { name: Ruby 3.1, ruby: ruby-3.1.0, bazel: 5.1.1}
           - { name: Ruby 3.2, ruby: ruby-3.2.0, bazel: 5.1.1}
           - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1}
-          - { name: JRuby 9.3, ruby: jruby-9.3.4.0, bazel: 5.1.1}
+          - { name: JRuby 9.3, ruby: jruby-9.3.10.0, bazel: 5.1.1}
+          - { name: JRuby 9.4, ruby: jruby-9.4.3.0, bazel: 5.1.1}
           - { name: Ruby 2.7 (Bazel6), ruby: ruby-2.7.0, bazel: 6.0.0}
-          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0}
+          - { name: JRuby 9.4 (Bazel6), ruby: jruby-9.4.3.0, bazel: 6.0.0}
 
     name: Linux ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -113,9 +114,10 @@ jobs:
           - { name: Ruby 3.1, ruby: ruby-3.1.0, bazel: 5.1.1}
           - { name: Ruby 3.2, ruby: ruby-3.2.0, bazel: 5.1.1}
           - { name: JRuby 9.2, ruby: jruby-9.2.20.1, bazel: 5.1.1}
-          - { name: JRuby 9.3, ruby: jruby-9.3.4.0, bazel: 5.1.1}
+          - { name: JRuby 9.3, ruby: jruby-9.3.10.0, bazel: 5.1.1}
+          - { name: JRuby 9.4, ruby: jruby-9.4.3.0, bazel: 5.1.1}
           - { name: Ruby 2.7 (Bazel6), ruby: ruby-2.7.0, bazel: 6.0.0}
-          - { name: JRuby 9.2 (Bazel6), ruby: jruby-9.2.20.1, bazel: 6.0.0}
+          - { name: JRuby 9.4 (Bazel6), ruby: jruby-9.4.3.0, bazel: 6.0.0}
     name: Install ${{ matrix.name }}
     runs-on: ubuntu-latest
     steps:

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -110,8 +110,8 @@ def protobuf_deps():
         _github_archive(
             name = "rules_ruby",
             repo = "https://github.com/protocolbuffers/rules_ruby",
-            commit = "5cf6ff74161d7f985b9bf86bb3c5fb16cef6337b",
-            sha256 = "c88dd69eb50fcfd7fbc5d7db79adc6631ef0e1d80b3c94efe33ac5ee3ccc37f7",
+            commit = "8fca842a3006c3d637114aba4f6bf9695bb3a432",
+            sha256 = "2619f9a23cee6f6a198d9ef284b6f6cbc901545ee9a9aac9ffa6b83dbf17cf0c",
         )
 
     if not native.existing_rule("rules_jvm_external"):

--- a/ruby/compatibility_tests/v3.0.0/tests/repeated_field_test.rb
+++ b/ruby/compatibility_tests/v3.0.0/tests/repeated_field_test.rb
@@ -8,7 +8,7 @@ class RepeatedFieldTest < Test::Unit::TestCase
   def test_acts_like_enumerator
     m = TestMessage.new
     (Enumerable.instance_methods - TestMessage.new.repeated_string.methods).each do |method_name|
-      assert_equal "does not respond to #{method_name}", m.repeated_string.respond_to?(method_name), true
+      assert_respond_to m.repeated_string, method_name
     end
   end
 
@@ -20,8 +20,10 @@ class RepeatedFieldTest < Test::Unit::TestCase
       :iter_for_each_with_index, :dimensions, :copy_data, :copy_data_simple,
       :nitems, :iter_for_reverse_each, :indexes, :append, :prepend]
     arr_methods -= [:union, :difference, :filter!]
-    arr_methods -= [:intersection, :deconstruct] # ruby 2.7 methods we can ignore
-    arr_methods -= [:intersect?] # ruby 3.1 methods we can ignore
+    # ruby 2.7 methods we can ignore
+    arr_methods -= [:intersection, :deconstruct, :resolve_feature_path]
+    # ruby 3.1 methods we can ignore
+    arr_methods -= [:intersect?]
     arr_methods.each do |method_name|
       assert_respond_to m.repeated_string, method_name
     end

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     s.files     += Dir.glob('ext/**/*')
     s.extensions= ["ext/google/protobuf_c/extconf.rb"]
     s.add_development_dependency "rake-compiler-dock", "= 1.2.1"  end
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.7'
   s.add_development_dependency "rake-compiler", "~> 1.1.0"
   s.add_development_dependency "test-unit", '~> 3.0', '>= 3.0.9'
 end

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -20,8 +20,10 @@ class RepeatedFieldTest < Test::Unit::TestCase
       :iter_for_each_with_index, :dimensions, :copy_data, :copy_data_simple,
       :nitems, :iter_for_reverse_each, :indexes, :append, :prepend]
     arr_methods -= [:union, :difference, :filter!]
-    arr_methods -= [:intersection, :deconstruct] # ruby 2.7 methods we can ignore
-    arr_methods -= [:intersect?] # ruby 3.1 methods we can ignore
+    # ruby 2.7 methods we can ignore
+    arr_methods -= [:intersection, :deconstruct, :resolve_feature_path]
+    # ruby 3.1 methods we can ignore
+    arr_methods -= [:intersect?]
     arr_methods.each do |method_name|
       assert_respond_to m.repeated_string, method_name
     end


### PR DESCRIPTION
This drops support for JRuby 9.2 and 9.3 after adding JRuby 9.4 to the test matrix. This backports 59e19a7.

Fixes https://github.com/protocolbuffers/protobuf/issues/13307
