### PR TITLE
add protoc-gen-proto to third_party.md

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -89,6 +89,7 @@ These are projects we know about implementing Protocol Buffers for other program
 * PHP: https://code.google.com/p/pb4php/
 * PHP: https://github.com/allegro/php-protobuf/
 * PHP: https://github.com/chobie/php-protocolbuffers
+* Protobuf: https://github.com/mycroftjr/protoc-gen-proto
 * Prolog: http://www.swi-prolog.org/pldoc/package/protobufs.html
 * Purescript: https://github.com/xc-jp/purescript-protobuf
 * Python: https://github.com/protocolbuffers/protobuf (Google-official implementation)


### PR DESCRIPTION
Only handles proto2 syntax atm, but I couldn't find any other implementation of something that seemed rather simple and sometimes useful, to integrate with third-party tools meant to run directly on .proto files.

Example usage: `protoc Example.proto --descriptor_set_in file_descriptor_set.pb --proto_out .`