### PR TITLE
bazel: Get rid of exec_tools.

### DIFF
--- a/build_defs/internal_shell.bzl
+++ b/build_defs/internal_shell.bzl
@@ -32,7 +32,7 @@ def inline_sh_binary(
     native.genrule(
         name = name + "_genrule",
         srcs = srcs,
-        exec_tools = tools,
+        tools = tools,
         outs = [name + ".sh"],
         cmd = "cat <<'EOF' >$(OUTS)\n#!/bin/bash -exu\n%s\nEOF\n" % cmd,
         visibility = ["//visibility:private"],
@@ -77,7 +77,7 @@ def inline_sh_test(
     native.genrule(
         name = name + "_genrule",
         srcs = srcs,
-        exec_tools = tools,
+        tools = tools,
         outs = [name + ".sh"],
         cmd = "cat <<'EOF' >$(OUTS)\n#!/bin/bash -exu\n%s\nEOF\n" % cmd,
         visibility = ["//visibility:private"],

--- a/objectivec/BUILD.bazel
+++ b/objectivec/BUILD.bazel
@@ -42,7 +42,7 @@ genrule(
         for wkt in _OBJC_WKT_NAMES
         for ext in _OBJC_EXTS
     ]),
-    exec_tools = ["//:protoc"],
+    tools = ["//:protoc"],
     tags = ["manual"],
 )
 

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -139,7 +139,7 @@ genrule(
             --proto_path=$$(dirname $$(dirname $$(dirname $(location any.proto)))) \
             $(SRCS)
     """,
-    exec_tools = ["//:protoc"],
+    tools = ["//:protoc"],
     visibility = ["//visibility:private"],
 )
 


### PR DESCRIPTION
Bazel has removed this attribute in bazelbuild/bazel@c061e57a7004a88eeb2f84d094d9a88b56c146b6.