### PR TITLE
Pin frozen messages to their arena to prevent garbage collection.

### DIFF
--- a/ruby/lib/google/protobuf/ffi/internal/arena.rb
+++ b/ruby/lib/google/protobuf/ffi/internal/arena.rb
@@ -35,6 +35,7 @@ module Google
   module Protobuf
     module Internal
       class Arena
+        attr :pinned_messages
 
         # FFI Interface methods and setup
         extend ::FFI::DataConverter
@@ -59,6 +60,7 @@ module Google
 
         def initialize(pointer)
           @arena = ::FFI::AutoPointer.new(pointer, Google::Protobuf::FFI.method(:free_arena))
+          @pinned_messages = []
         end
 
         def fuse(other_arena)
@@ -66,6 +68,10 @@ module Google
           unless Google::Protobuf::FFI.fuse_arena(self, other_arena)
             raise RuntimeError.new "Unable to fuse arenas. This should never happen since Ruby does not use initial blocks"
           end
+        end
+
+        def pin(message)
+          pinned_messages.push message
         end
       end
     end

--- a/ruby/lib/google/protobuf/ffi/message.rb
+++ b/ruby/lib/google/protobuf/ffi/message.rb
@@ -83,6 +83,7 @@ module Google
           def freeze
             super
             @arena.pin self
+            self
           end
 
           def dup

--- a/ruby/lib/google/protobuf/ffi/message.rb
+++ b/ruby/lib/google/protobuf/ffi/message.rb
@@ -80,6 +80,11 @@ module Google
             instance
           end
 
+          def freeze
+            super
+            @arena.pin self
+          end
+
           def dup
             duplicate = self.class.private_constructor(@arena)
             mini_table = Google::Protobuf::FFI.get_mini_table(self.class.descriptor)


### PR DESCRIPTION
Fixes a class of flaky test failures observed only in the FFI implementation due to garbage collection in between calls to an accessors for a frozen field.