### PR TITLE
Fix pyi top level messages/enums in public imports

### DIFF
--- a/src/google/protobuf/compiler/python/pyi_generator.cc
+++ b/src/google/protobuf/compiler/python/pyi_generator.cc
@@ -283,13 +283,13 @@ void PyiGenerator::PrintImports() const {
     std::string module_name = StrippedModuleName(public_dep->name());
     // Top level messages in public imports
     for (int i = 0; i < public_dep->message_type_count(); ++i) {
-      printer_->Print("from $module$ import $message_class$\n", "module",
+      printer_->Print("from $module$ import $message_class$ as $message_class$\n", "module",
                       module_name, "message_class",
                       public_dep->message_type(i)->name());
     }
     // Top level enums for public imports
     for (int i = 0; i < public_dep->enum_type_count(); ++i) {
-      printer_->Print("from $module$ import $enum_class$\n", "module",
+      printer_->Print("from $module$ import $enum_class$ as $enum_class$\n", "module",
                       module_name, "enum_class",
                       public_dep->enum_type(i)->name());
     }


### PR DESCRIPTION
According to PEP 484 https://peps.python.org/pep-0484/#stub-files
> Modules and variables imported into the stub are not considered exported from the stub unless the import uses the import ... as ... form or the equivalent from ... import ... as ... form.

