### PR TITLE
Breaking Change: protoc: require that reserved names are identifiers

### DIFF
--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -1793,10 +1793,11 @@ bool Parser::ParseReservedName(std::string* name,
   int col = input_->current().column;
   DO(ConsumeString(name, error_message));
   if (!io::Tokenizer::IsIdentifier(*name)) {
-    RecordWarning(
+    RecordError(
         line, col,
         absl::StrFormat("Reserved name \"%s\" is not a valid identifier.",
                         *name));
+    return false;
   }
   return true;
 }

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -1745,7 +1745,7 @@ TEST_F(ParseErrorTest, EnumReservedMissingQuotes) {
 }
 
 TEST_F(ParseErrorTest, EnumReservedInvalidIdentifier) {
-  ExpectHasWarnings(
+  ExpectHasErrors(
       R"pb(
       enum TestEnum {
         FOO = 1;
@@ -1783,7 +1783,7 @@ TEST_F(ParseErrorTest, ReservedMissingQuotes) {
 }
 
 TEST_F(ParseErrorTest, ReservedInvalidIdentifier) {
-  ExpectHasWarnings(
+  ExpectHasErrors(
       R"pb(
       message Foo {
         reserved "foo bar";


### PR DESCRIPTION
This changes the current warnings into errors. In the previous PR (#10586), we downgraded these to warnings with the decision that they could be upgraded back to errors in a future major version.

Now that v24.0 is on the cusp of release, this seemed like a reasonable time to change it to error.

Resolves #6335 and #4558.