### PR TITLE
Conformance test runner big endian fixes

### DIFF
--- a/conformance/conformance_test_runner.cc
+++ b/conformance/conformance_test_runner.cc
@@ -65,6 +65,7 @@
 #include <future>
 #include <vector>
 
+#include "google/protobuf/endian.h"
 #include "absl/log/absl_log.h"
 #include "absl/strings/str_format.h"
 #include "conformance/conformance.pb.h"
@@ -155,7 +156,8 @@ void ForkPipeRunner::RunTest(const std::string &test_name,
   }
   current_test_name_ = test_name;
 
-  uint32_t len = request.size();
+  uint32_t len = internal::little_endian::FromHost(
+      static_cast<uint32_t>(request.size()));
   CheckedWrite(write_fd_, &len, sizeof(uint32_t));
   CheckedWrite(write_fd_, request.c_str(), request.size());
 
@@ -190,6 +192,7 @@ void ForkPipeRunner::RunTest(const std::string &test_name,
     return;
   }
 
+  len = internal::little_endian::ToHost(len);
   response->resize(len);
   CheckedRead(read_fd_, (void *)response->c_str(), len);
 }


### PR DESCRIPTION
Add some missing endian conversions so that the conformance tests can be run on big endian platforms.

The message length value created by the conformance test runner is little endian according to the comments in the file but actually was sent in the native endianness of the host. I was able to run the java, python, ruby, php and csharp test executables and they all expect little endian length values so those tests would hang on big endian machines. Only the cpp test executable was using native endian so it has been changed to expect little endian too.

Also change the fixed32 and fixed64 functions in binary_json_conformance_test_suite.cc to send the data as little endian which fixes some failures in the python conformance tests on big endian platforms.