### PR TITLE
PHP: Fix read and write of float and double on big endian platforms

### DIFF
--- a/php/src/Google/Protobuf/Internal/GPBWire.php
+++ b/php/src/Google/Protobuf/Internal/GPBWire.php
@@ -241,7 +241,7 @@ class GPBWire
         if (!$input->readRaw(4, $data)) {
             return false;
         }
-        $value = unpack('f', $data)[1];
+        $value = unpack('g', $data)[1];
         return true;
     }
 
@@ -251,7 +251,7 @@ class GPBWire
         if (!$input->readRaw(8, $data)) {
             return false;
         }
-        $value = unpack('d', $data)[1];
+        $value = unpack('e', $data)[1];
         return true;
     }
 
@@ -360,13 +360,13 @@ class GPBWire
 
     public static function writeFloat(&$output, $value)
     {
-        $data = pack("f", $value);
+        $data = pack("g", $value);
         return $output->writeRaw($data, 4);
     }
 
     public static function writeDouble(&$output, $value)
     {
-        $data = pack("d", $value);
+        $data = pack("e", $value);
         return $output->writeRaw($data, 8);
     }
 


### PR DESCRIPTION
Change the pack/unpack format codes 'f' -> 'g' and 'd' -> 'e' which ensure little endian format is used on the wire regardless of machine endianness. This allows the php composer and conformance tests to pass on big endian platforms and should not change any behavior on little endian platforms.

According to the PHP documentation, 'g' and 'e' were added in PHP versions 7.0.15 and 7.1.1.