### PR TITLE
Fixed Document `cmake --build` to `cmake --build .`

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -17,7 +17,7 @@ protobuf requires C++14 or newer, sometimes you will need to explicitly override
 this.  For example, the following:
 
     cmake . -DCMAKE_CXX_STANDARD=14
-    cmake --build
+    cmake --build .
 
 will build protobuf using C++14 (see [CXX_STANDARD](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html#prop_tgt:CXX_STANDARD){.external} for all available options).
 


### PR DESCRIPTION
`cmake --build` This command needs to specify the directory.

```
Usage: cmake --build <dir>             [options] [-- [native-options]]
       cmake --build --preset <preset> [options] [-- [native-options]]
Options:
  <dir>          = Project binary directory to be built.
```