### PR TITLE
Add weakref tests for python messages + fix for upb implementation

### DIFF
--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -2734,5 +2734,52 @@ class OversizeProtosTest(unittest.TestCase):
     msg.ParseFromString(self.GenerateNestedProto(101))
 
 
+@_parameterized.named_parameters(('_proto2', unittest_pb2),
+                                ('_proto3', unittest_proto3_arena_pb2))
+class WeakRefMessageTest(unittest.TestCase):
+  def testWeakRefable(self, message_module):
+    """
+    Test that Message objects can have weakrefs created from them.
+    """
+    import weakref
+
+    message = message_module.TestAllTypes()
+    try:
+      weakref.ref(message)
+    except TypeError as e:
+      self.fail(e)
+
+  def testProperWeakRef(self, message_module):
+    """
+    Test that proper weakref semantics are implemented for Message objects, and that
+    distinct objects of the same Message class have independent weakrefs.
+    """
+    import weakref
+
+    message1 = message_module.TestAllTypes()
+    message1_1 = message1
+
+    message2 = message_module.TestAllTypes()
+
+    ref2 = weakref.ref(message2)
+
+    ref1 = weakref.ref(message1)
+
+    self.assertIs(ref1(), message1)
+
+    del message1
+
+    self.assertIs(ref1(), message1_1)
+
+    del message1_1
+
+    self.assertIsNone(ref1())
+
+    self.assertIs(ref2(), message2)
+
+    del message2
+    self.assertIsNone(ref2())
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/python/message.c
+++ b/python/message.c
@@ -189,6 +189,7 @@ typedef struct PyUpb_Message {
   // name->obj dict for non-present msg/map/repeated, NULL if none.
   PyUpb_WeakMap* unset_subobj_map;
   int version;
+  PyObject* weakreflist;
 } PyUpb_Message;
 
 static PyObject* PyUpb_Message_GetAttr(PyObject* _self, PyObject* attr);
@@ -780,6 +781,10 @@ void PyUpb_Message_SetConcreteSubobj(PyObject* _self, const upb_FieldDef* f,
 
 static void PyUpb_Message_Dealloc(PyObject* _self) {
   PyUpb_Message* self = (void*)_self;
+
+  if (self->weakreflist != NULL) {
+    PyObject_ClearWeakRefs(_self);
+  }
 
   if (PyUpb_Message_IsStub(self)) {
     PyUpb_Message_CacheDelete((PyObject*)self->ptr.parent,
@@ -1782,6 +1787,8 @@ PyObject* PyUpb_MessageMeta_DoCreateClass(PyObject* py_descriptor,
   }
 
   PyObject* ret = cpython_bits.type_new(state->message_meta_type, args, NULL);
+  ((PyTypeObject*)(ret))->tp_weaklistoffset =
+      offsetof(PyUpb_Message, weakreflist);
   Py_DECREF(args);
   if (!ret) return NULL;
 


### PR DESCRIPTION
This exposes a regression with the upb implementation where the python message objects are not weakref-able.

See also: https://github.com/protocolbuffers/protobuf/issues/13727