### PR TITLE
Update utf8_range to the latest version

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -71,8 +71,8 @@ def protobuf_deps():
         _github_archive(
             name = "utf8_range",
             repo = "https://github.com/protocolbuffers/utf8_range",
-            commit = "de0b4a8ff9b5d4c98108bdfe723291a33c52c54f",
-            sha256 = "5da960e5e5d92394c809629a03af3c7709d2d3d0ca731dacb3a9fb4bf28f7702",
+            commit = "d863bc33e15cba6d873c878dcca9e6fe52b2f8cb",
+            sha256 = "568988b5f7261ca181468dba38849fabf59dd9200fb2ed4b2823da187ef84d8c",
         )
 
     if not native.existing_rule("rules_cc"):


### PR DESCRIPTION
Picks up an OSS build fix for unused function CodepointSkipBackwards: https://github.com/protocolbuffers/utf8_range/commit/d863bc33e15cba6d873c878dcca9e6fe52b2f8cb