### PR TITLE
protoc: support identifiers as reserved names in addition to string literals (only in editions)

### DIFF
--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -1773,12 +1773,19 @@ bool Parser::ParseReserved(DescriptorProto* message,
   // Parse the declaration.
   DO(Consume("reserved"));
   if (LookingAtType(io::Tokenizer::TYPE_STRING)) {
+    if (syntax_identifier_ == "editions") {
+      RecordError("Reserved names must be identifiers in editions, not string literals.");
+      return false;
+    }
     LocationRecorder location(message_location,
                               DescriptorProto::kReservedNameFieldNumber);
     location.StartAt(start_token);
     return ParseReservedNames(message, location);
-  } else if (LookingAtType(io::Tokenizer::TYPE_IDENTIFIER) && syntax_identifier_ == "editions") {
-    // As of first edition, we also accept identifiers instead of string literals.
+  } else if (LookingAtType(io::Tokenizer::TYPE_IDENTIFIER)) {
+    if (syntax_identifier_ != "editions") {
+      RecordError("Reserved names must be string literals. (Only editions supports identifiers.)");
+      return false;
+    }
     LocationRecorder location(message_location,
                               DescriptorProto::kReservedNameFieldNumber);
     location.StartAt(start_token);
@@ -1811,7 +1818,7 @@ bool Parser::ParseReservedNames(DescriptorProto* message,
                                 const LocationRecorder& parent_location) {
   do {
     LocationRecorder location(parent_location, message->reserved_name_size());
-    DO(ParseReservedName(message->add_reserved_name(), "Expected field name."));
+    DO(ParseReservedName(message->add_reserved_name(), "Expected field name string literal."));
   } while (TryConsume(","));
   DO(ConsumeEndOfDeclaration(";", &parent_location));
   return true;
@@ -1888,12 +1895,19 @@ bool Parser::ParseReserved(EnumDescriptorProto* proto,
   // Parse the declaration.
   DO(Consume("reserved"));
   if (LookingAtType(io::Tokenizer::TYPE_STRING)) {
+    if (syntax_identifier_ == "editions") {
+      RecordError("Reserved names must be identifiers in editions, not string literals.");
+      return false;
+    }
     LocationRecorder location(enum_location,
                               EnumDescriptorProto::kReservedNameFieldNumber);
     location.StartAt(start_token);
     return ParseReservedNames(proto, location);
-  } else if (LookingAtType(io::Tokenizer::TYPE_IDENTIFIER) && syntax_identifier_ == "editions") {
-    // As of first edition, we also accept identifiers instead of string literals.
+  } else if (LookingAtType(io::Tokenizer::TYPE_IDENTIFIER)) {
+    if (syntax_identifier_ != "editions") {
+      RecordError("Reserved names must be string literals. (Only editions supports identifiers.)");
+      return false;
+    }
     LocationRecorder location(enum_location,
                               EnumDescriptorProto::kReservedNameFieldNumber);
     location.StartAt(start_token);
@@ -1910,7 +1924,7 @@ bool Parser::ParseReservedNames(EnumDescriptorProto* proto,
                                 const LocationRecorder& parent_location) {
   do {
     LocationRecorder location(parent_location, proto->reserved_name_size());
-    DO(ParseReservedName(proto->add_reserved_name(), "Expected enum value."));
+    DO(ParseReservedName(proto->add_reserved_name(), "Expected enum value string literal."));
   } while (TryConsume(","));
   DO(ConsumeEndOfDeclaration(";", &parent_location));
   return true;

--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -1777,6 +1777,12 @@ bool Parser::ParseReserved(DescriptorProto* message,
                               DescriptorProto::kReservedNameFieldNumber);
     location.StartAt(start_token);
     return ParseReservedNames(message, location);
+  } else if (LookingAtType(io::Tokenizer::TYPE_IDENTIFIER) && syntax_identifier_ == "editions") {
+    // As of first edition, we also accept identifiers instead of string literals.
+    LocationRecorder location(message_location,
+                              DescriptorProto::kReservedNameFieldNumber);
+    location.StartAt(start_token);
+    return ParseReservedIdentifiers(message, location);
   } else {
     LocationRecorder location(message_location,
                               DescriptorProto::kReservedRangeFieldNumber);
@@ -1806,6 +1812,22 @@ bool Parser::ParseReservedNames(DescriptorProto* message,
   do {
     LocationRecorder location(parent_location, message->reserved_name_size());
     DO(ParseReservedName(message->add_reserved_name(), "Expected field name."));
+  } while (TryConsume(","));
+  DO(ConsumeEndOfDeclaration(";", &parent_location));
+  return true;
+}
+
+bool Parser::ParseReservedIdentifier(std::string* name,
+                               absl::string_view error_message) {
+  DO(ConsumeIdentifier(name, error_message));
+  return true;
+}
+
+bool Parser::ParseReservedIdentifiers(DescriptorProto* message,
+                                const LocationRecorder& parent_location) {
+  do {
+    LocationRecorder location(parent_location, message->reserved_name_size());
+    DO(ParseReservedIdentifier(message->add_reserved_name(), "Expected field name identifier."));
   } while (TryConsume(","));
   DO(ConsumeEndOfDeclaration(";", &parent_location));
   return true;
@@ -1870,6 +1892,12 @@ bool Parser::ParseReserved(EnumDescriptorProto* proto,
                               EnumDescriptorProto::kReservedNameFieldNumber);
     location.StartAt(start_token);
     return ParseReservedNames(proto, location);
+  } else if (LookingAtType(io::Tokenizer::TYPE_IDENTIFIER) && syntax_identifier_ == "editions") {
+    // As of first edition, we also accept identifiers instead of string literals.
+    LocationRecorder location(enum_location,
+                              EnumDescriptorProto::kReservedNameFieldNumber);
+    location.StartAt(start_token);
+    return ParseReservedIdentifiers(proto, location);
   } else {
     LocationRecorder location(enum_location,
                               EnumDescriptorProto::kReservedRangeFieldNumber);
@@ -1883,6 +1911,16 @@ bool Parser::ParseReservedNames(EnumDescriptorProto* proto,
   do {
     LocationRecorder location(parent_location, proto->reserved_name_size());
     DO(ParseReservedName(proto->add_reserved_name(), "Expected enum value."));
+  } while (TryConsume(","));
+  DO(ConsumeEndOfDeclaration(";", &parent_location));
+  return true;
+}
+
+bool Parser::ParseReservedIdentifiers(EnumDescriptorProto* proto,
+                                const LocationRecorder& parent_location) {
+  do {
+    LocationRecorder location(parent_location, proto->reserved_name_size());
+    DO(ParseReservedIdentifier(proto->add_reserved_name(), "Expected enum value identifier."));
   } while (TryConsume(","));
   DO(ConsumeEndOfDeclaration(";", &parent_location));
   return true;

--- a/src/google/protobuf/compiler/parser.h
+++ b/src/google/protobuf/compiler/parser.h
@@ -403,12 +403,17 @@ class PROTOBUF_EXPORT Parser {
   bool ParseReservedNames(DescriptorProto* message,
                           const LocationRecorder& parent_location);
   bool ParseReservedName(std::string* name, absl::string_view error_message);
+  bool ParseReservedIdentifiers(DescriptorProto* message,
+                                const LocationRecorder& parent_location);
+  bool ParseReservedIdentifier(std::string* name, absl::string_view error_message);
   bool ParseReservedNumbers(DescriptorProto* message,
                             const LocationRecorder& parent_location);
   bool ParseReserved(EnumDescriptorProto* message,
                      const LocationRecorder& message_location);
   bool ParseReservedNames(EnumDescriptorProto* message,
                           const LocationRecorder& parent_location);
+  bool ParseReservedIdentifiers(EnumDescriptorProto* message,
+                                const LocationRecorder& parent_location);
   bool ParseReservedNumbers(EnumDescriptorProto* message,
                             const LocationRecorder& parent_location);
 

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -869,6 +869,22 @@ TEST_F(ParseMessageTest, ReservedNames) {
       "}");
 }
 
+TEST_F(ParseMessageTest, ReservedIdentifiers) {
+  ExpectParsesTo(
+      "edition = \"2023\";\n"
+      "message TestMessage {\n"
+      "  reserved foo, bar;\n"
+      "}\n",
+
+      "syntax: \"editions\" "
+      "edition: \"2023\" "
+      "message_type {"
+      "  name: \"TestMessage\""
+      "  reserved_name: \"foo\""
+      "  reserved_name: \"bar\""
+      "}");
+}
+
 TEST_F(ParseMessageTest, ExtensionRange) {
   ExpectParsesTo(
       "message TestMessage {\n"
@@ -1227,6 +1243,24 @@ TEST_F(ParseEnumTest, ReservedNames) {
       "}");
 }
 
+TEST_F(ParseEnumTest, ReservedIdentifiers) {
+  ExpectParsesTo(
+      "edition = \"2023\";\n"
+      "enum TestEnum {\n"
+      "  FOO = 0;\n"
+      "  reserved foo, bar;\n"
+      "}\n",
+
+      "syntax: \"editions\" "
+      "edition: \"2023\" "
+      "enum_type {"
+      "  name: \"TestEnum\""
+      "  value { name:\"FOO\" number:0 }"
+      "  reserved_name: \"foo\""
+      "  reserved_name: \"bar\""
+      "}");
+}
+
 // ===================================================================
 
 typedef ParserTest ParseServiceTest;
@@ -1498,6 +1532,42 @@ TEST_F(ParseErrorTest, DuplicateJsonName) {
       "  optional uint32 foo = 1 [json_name=\"a\",json_name=\"b\"];\n"
       "}\n",
       "1:41: Already set option \"json_name\".\n");
+}
+
+TEST_F(ParseErrorTest, MsgReservedIdentifierOnlyInEditions) {
+  ExpectHasErrors(
+      "message TestMessage {\n"
+      "  reserved foo, bar;\n"
+      "}\n",
+      "1:11: Expected field name or number range.\n");
+}
+
+TEST_F(ParseErrorTest, MsgReservedIdentifierCantMixWithStrings) {
+  ExpectHasErrors(
+      "edition = \"2023\";\n"
+      "message TestMessage {\n"
+      "  reserved foo, \"bar\";\n"
+      "}\n",
+      "2:16: Expected field name identifier.\n");
+}
+
+TEST_F(ParseErrorTest, EnumReservedIdentifierOnlyInEditions) {
+  ExpectHasErrors(
+      "enum TestEnum {\n"
+      "  FOO = 0;\n"
+      "  reserved foo, bar;\n"
+      "}\n",
+      "2:11: Expected enum value or number range.\n");
+}
+
+TEST_F(ParseErrorTest, EnumReservedIdentifierCantMixWithStrings) {
+  ExpectHasErrors(
+      "edition = \"2023\";\n"
+      "enum TestEnum {\n"
+      "  FOO = 0;\n"
+      "  reserved foo, \"bar\";\n"
+      "}\n",
+      "3:16: Expected enum value identifier.\n");
 }
 
 TEST_F(ParseErrorTest, EnumValueOutOfRange) {

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -1539,16 +1539,15 @@ TEST_F(ParseErrorTest, MsgReservedIdentifierOnlyInEditions) {
       "message TestMessage {\n"
       "  reserved foo, bar;\n"
       "}\n",
-      "1:11: Expected field name or number range.\n");
+      "1:11: Reserved names must be string literals. (Only editions supports identifiers.)\n");
 }
-
-TEST_F(ParseErrorTest, MsgReservedIdentifierCantMixWithStrings) {
+TEST_F(ParseErrorTest, MsgReservedNameStringNotInEditions) {
   ExpectHasErrors(
       "edition = \"2023\";\n"
       "message TestMessage {\n"
-      "  reserved foo, \"bar\";\n"
+      "  reserved \"foo\", \"bar\";\n"
       "}\n",
-      "2:16: Expected field name identifier.\n");
+      "2:11: Reserved names must be identifiers in editions, not string literals.\n");
 }
 
 TEST_F(ParseErrorTest, EnumReservedIdentifierOnlyInEditions) {
@@ -1557,17 +1556,16 @@ TEST_F(ParseErrorTest, EnumReservedIdentifierOnlyInEditions) {
       "  FOO = 0;\n"
       "  reserved foo, bar;\n"
       "}\n",
-      "2:11: Expected enum value or number range.\n");
+      "2:11: Reserved names must be string literals. (Only editions supports identifiers.)\n");
 }
-
-TEST_F(ParseErrorTest, EnumReservedIdentifierCantMixWithStrings) {
+TEST_F(ParseErrorTest, EnumReservedNameStringNotInEditions) {
   ExpectHasErrors(
       "edition = \"2023\";\n"
       "enum TestEnum {\n"
       "  FOO = 0;\n"
-      "  reserved foo, \"bar\";\n"
+      "  reserved \"foo\", \"bar\";\n"
       "}\n",
-      "3:16: Expected enum value identifier.\n");
+      "3:11: Reserved names must be identifiers in editions, not string literals.\n");
 }
 
 TEST_F(ParseErrorTest, EnumValueOutOfRange) {
@@ -1769,13 +1767,14 @@ TEST_F(ParseErrorTest, EnumValueMissingNumber) {
       "1:5: Missing numeric value for enum constant.\n");
 }
 
+// NB: with editions, this would be accepted and would reserve a value name of "max"
 TEST_F(ParseErrorTest, EnumReservedStandaloneMaxNotAllowed) {
   ExpectHasErrors(
       "enum TestEnum {\n"
       "  FOO = 1;\n"
       "  reserved max;\n"
       "}\n",
-      "2:11: Expected enum value or number range.\n");
+      "2:11: Reserved names must be string literals. (Only editions supports identifiers.)\n");
 }
 
 TEST_F(ParseErrorTest, EnumReservedMixNameAndNumber) {
@@ -1785,6 +1784,15 @@ TEST_F(ParseErrorTest, EnumReservedMixNameAndNumber) {
       "  reserved 10, \"foo\";\n"
       "}\n",
       "2:15: Expected enum number range.\n");
+}
+TEST_F(ParseErrorTest, EnumReservedMixNameAndNumberEditions) {
+  ExpectHasErrors(
+      "edition = \"2023\";\n"
+      "enum TestEnum {\n"
+      "  FOO = 1;\n"
+      "  reserved 10, foo;\n"
+      "}\n",
+      "3:15: Expected enum number range.\n");
 }
 
 TEST_F(ParseErrorTest, EnumReservedPositiveNumberOutOfRange) {
@@ -1811,7 +1819,7 @@ TEST_F(ParseErrorTest, EnumReservedMissingQuotes) {
       "  FOO = 1;\n"
       "  reserved foo;\n"
       "}\n",
-      "2:11: Expected enum value or number range.\n");
+      "2:11: Reserved names must be string literals. (Only editions supports identifiers.)\n");
 }
 
 TEST_F(ParseErrorTest, EnumReservedInvalidIdentifier) {
@@ -1828,12 +1836,13 @@ TEST_F(ParseErrorTest, EnumReservedInvalidIdentifier) {
 // -------------------------------------------------------------------
 // Reserved field number errors
 
+// NB: with editions, this would be accepted and would reserve a field name of "max"
 TEST_F(ParseErrorTest, ReservedStandaloneMaxNotAllowed) {
   ExpectHasErrors(
       "message Foo {\n"
       "  reserved max;\n"
       "}\n",
-      "1:11: Expected field name or number range.\n");
+      "1:11: Reserved names must be string literals. (Only editions supports identifiers.)\n");
 }
 
 TEST_F(ParseErrorTest, ReservedMixNameAndNumber) {
@@ -1843,13 +1852,21 @@ TEST_F(ParseErrorTest, ReservedMixNameAndNumber) {
       "}\n",
       "1:15: Expected field number range.\n");
 }
+TEST_F(ParseErrorTest, ReservedMixNameAndNumberEditions) {
+  ExpectHasErrors(
+      "edition = \"2023\";\n"
+      "message Foo {\n"
+      "  reserved 10, foo;\n"
+      "}\n",
+      "2:15: Expected field number range.\n");
+}
 
 TEST_F(ParseErrorTest, ReservedMissingQuotes) {
   ExpectHasErrors(
       "message Foo {\n"
       "  reserved foo;\n"
       "}\n",
-      "1:11: Expected field name or number range.\n");
+      "1:11: Reserved names must be string literals. (Only editions supports identifiers.)\n");
 }
 
 TEST_F(ParseErrorTest, ReservedInvalidIdentifier) {


### PR DESCRIPTION
This addresses #13440.

@mkruskal-google, I saw you are assigned the above issue. I hope it's okay that I took a stab at it.