### PR TITLE
Add a release flag to disambiguate between release and local config_s…

### DIFF
--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -1,8 +1,14 @@
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 package(default_visibility = ["//visibility:public"])
 
 filegroup(name = "empty")
+
+bool_flag(
+    name = "release",
+    build_setting_default = False,
+)
 
 TOOLCHAINS = {
     "osx-x86_64": "cc-compiler-osx-x86_64",
@@ -19,7 +25,7 @@ TOOLCHAINS = {
 
 cc_toolchain_suite(
     name = "clang_suite",
-    toolchains = TOOLCHAINS
+    toolchains = TOOLCHAINS,
 )
 
 [
@@ -50,8 +56,8 @@ cc_toolchain_config(
 
 cc_toolchain_config(
     name = "linux-aarch_64-config",
-    sysroot = "/opt/manylinux/2014/aarch64",
     linker_path = "/usr/bin/ld",
+    sysroot = "/opt/manylinux/2014/aarch64",
     target_cpu = "aarch64",
     target_full_name = "aarch64-linux-gnu",
 )

--- a/toolchain/toolchains.bazelrc
+++ b/toolchain/toolchains.bazelrc
@@ -1,4 +1,5 @@
 build:cross_config --crosstool_top=//toolchain:clang_suite
+build:cross_config --//toolchain:release=true
 build:cross_config --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 
 build:linux-aarch_64 --config=cross_config --cpu=linux-aarch_64


### PR DESCRIPTION
…ettings.

This flag will be set in UPB which will be submitted separately due to version skew between repos.

This attempts to fix the following error from local and release settings both matching.
```
ERROR: /workspace/_build/out/external/upb/python/dist/BUILD.bazel:251:9: Illegal ambiguous match on configurable attribute "platform" in @upb//python/dist:binary_wheel:
@upb//python/dist:linux_x86_64_local
@upb//python/dist:windows_x86_64
Multiple matches are not allowed unless one is unambiguously more specialized or they resolve to the same value. See https://bazel.build/reference/be/functions#select.
```
This is a cherry-pick of https://github.com/protocolbuffers/protobuf/commit/22e845e279bd79ad013bff4b79660b8c8b72d935.

PiperOrigin-RevId: 553184373