### PR TITLE
Update reference to missing function JsonStringToBinary()

### DIFF
--- a/src/google/protobuf/json/json.h
+++ b/src/google/protobuf/json/json.h
@@ -92,8 +92,8 @@ inline absl::Status MessageToJsonString(const Message& message,
   return MessageToJsonString(message, output, PrintOptions());
 }
 
-// Converts from JSON to protobuf message. This is a simple wrapper of
-// JsonStringToBinary(). It will use the DescriptorPool of the passed-in
+// Converts from JSON to protobuf message. This works equivalently to
+// JsonToBinaryStream(). It will use the DescriptorPool of the passed-in
 // message to resolve Any types.
 //
 // Please note that non-OK statuses are not a stable output of this API and


### PR DESCRIPTION
Also tweaked the "simple wrapper" language since the implementation does not appear to delegate to JsonToBinaryStream() directly.