### PR TITLE
fix python code generation compatibility with Cython

### DIFF
--- a/src/google/protobuf/compiler/python/generator.cc
+++ b/src/google/protobuf/compiler/python/generator.cc
@@ -1199,8 +1199,8 @@ void PrintDescriptorOptionsFixingCode(absl::string_view descriptor,
   // Reset the _options to None thus DescriptorBase.GetOptions() can
   // parse _options again after extensions are registered.
   printer->Print(
-      "$descriptor$._options = None\n"
-      "$descriptor$._serialized_options = $serialized_value$\n",
+      "_globals['$descriptor$']._options = None\n"
+      "_globals['$descriptor$']._serialized_options = $serialized_value$\n",
       "descriptor", descriptor, "serialized_value", options);
 }
 }  // namespace


### PR DESCRIPTION
This is a follow-up to https://github.com/protocolbuffers/protobuf/pull/11011/

The generation is still not compatible with Cython when maps are used.

For example, this protobuf file:

```proto
syntax = "proto3";

message Foo {
    map<string, string> bar = 1;
}
```

Will generate:

```py
...
_globals = globals()
_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'a_pb2', _globals)
if _descriptor._USE_C_DESCRIPTORS == False:

  DESCRIPTOR._options = None
  _FOO_BARENTRY._options = None
  _FOO_BARENTRY._serialized_options = b'8\001'
  _globals['_FOO']._serialized_start=11
  _globals['_FOO']._serialized_end=88
  _globals['_FOO_BARENTRY']._serialized_start=46
  _globals['_FOO_BARENTRY']._serialized_end=88
```

The `_FOO_BARENTRY` variable is not defined anywhere and confuses cython. We can see the `_globals` used below, it is simply missing for the first two lines using `_FOO_BARENTRY`.

If possible, i would love to have this fix in the next 24 release, instead of having to wait for the 25 release.