### PR TITLE
examples: fix deprecated ioutil package

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,4 @@
 # Ignore the bazel symlinks
 /bazel-*
+# ignore protoc generated files
+*.pb.go

--- a/examples/go/cmd/add_person/add_person.go
+++ b/examples/go/cmd/add_person/add_person.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -97,7 +96,7 @@ func main() {
 	fname := os.Args[1]
 
 	// Read the existing address book.
-	in, err := ioutil.ReadFile(fname)
+	in, err := os.ReadFile(fname)
 	if err != nil {
 		if os.IsNotExist(err) {
 			fmt.Printf("%s: File not found.  Creating new file.\n", fname)
@@ -126,7 +125,7 @@ func main() {
 	if err != nil {
 		log.Fatalln("Failed to encode address book:", err)
 	}
-	if err := ioutil.WriteFile(fname, out, 0644); err != nil {
+	if err := os.WriteFile(fname, out, 0644); err != nil {
 		log.Fatalln("Failed to write address book:", err)
 	}
 	// [END marshal_proto]

--- a/examples/go/cmd/list_people/list_people.go
+++ b/examples/go/cmd/list_people/list_people.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -47,7 +46,7 @@ func main() {
 
 	// [START unmarshal_proto]
 	// Read the existing address book.
-	in, err := ioutil.ReadFile(fname)
+	in, err := os.ReadFile(fname)
 	if err != nil {
 		log.Fatalln("Error reading file:", err)
 	}


### PR DESCRIPTION
This commit updates the deprecated ioutil functions (Write/ReadFile) to their os equivalents.

Additionally, also sets to ignore `*.pb.go` files that are generated by the Make commands (protoc compilations).