### PR TITLE
Add versions files to hold Protobuf implementations versions.

### DIFF
--- a/src/file_lists.cmake
+++ b/src/file_lists.cmake
@@ -86,6 +86,7 @@ set(libprotobuf_srcs
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/message_differencer.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/time_util.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/type_resolver_util.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/versions.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_lite.cc
 )
@@ -199,6 +200,7 @@ set(libprotobuf_hdrs
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/type_resolver.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/util/type_resolver_util.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/varint_shuffle.h
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/versions.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format.h
   ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_lite.h
 )
@@ -680,6 +682,7 @@ set(protobuf_test_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/text_format_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/unknown_field_set_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/varint_shuffle_test.cc
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/versions_test.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/well_known_types_unittest.cc
   ${protobuf_SOURCE_DIR}/src/google/protobuf/wire_format_unittest.cc
 )

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -471,6 +471,7 @@ cc_library(
         "service.cc",
         "text_format.cc",
         "unknown_field_set.cc",
+        "versions.cc",
         "wire_format.cc",
     ],
     hdrs = [
@@ -500,6 +501,7 @@ cc_library(
         "service.h",
         "text_format.h",
         "unknown_field_set.h",
+        "versions.h",
         "wire_format.h",
     ],
     copts = COPTS,
@@ -1449,6 +1451,22 @@ cc_test(
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+cc_test(
+    name = "versions_test",
+    srcs = ["versions_test.cc"],
+    copts = COPTS + select({
+        "//build_defs:config_msvc": [],
+        "//conditions:default": [
+            "-Wno-deprecated-declarations",
+        ],
+    }),
+    deps = [
+         ":protobuf",
+         "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ]
 )
 
 cc_test(

--- a/src/google/protobuf/generated_message_tctable_impl.h
+++ b/src/google/protobuf/generated_message_tctable_impl.h
@@ -580,6 +580,9 @@ class PROTOBUF_EXPORT TcParser final {
   static const char* FastMlS1(PROTOBUF_TC_PARAM_DECL);
   static const char* FastMlS2(PROTOBUF_TC_PARAM_DECL);
 
+  // NOTE: Do not dedup RefAt by having one call the other with a const_cast. It
+  // causes ICEs of gcc 7.5.
+  // https://github.com/protocolbuffers/protobuf/issues/13715
   template <typename T>
   static inline T& RefAt(void* x, size_t offset) {
     T* target = reinterpret_cast<T*>(static_cast<char*>(x) + offset);
@@ -599,7 +602,20 @@ class PROTOBUF_EXPORT TcParser final {
 
   template <typename T>
   static inline const T& RefAt(const void* x, size_t offset) {
-    return RefAt<T>(const_cast<void*>(x), offset);
+    const T* target =
+        reinterpret_cast<const T*>(static_cast<const char*>(x) + offset);
+#if !defined(NDEBUG) && !(defined(_MSC_VER) && defined(_M_IX86))
+    // Check the alignment in debug mode, except in 32-bit msvc because it does
+    // not respect the alignment as expressed by `alignof(T)`
+    if (PROTOBUF_PREDICT_FALSE(
+            reinterpret_cast<uintptr_t>(target) % alignof(T) != 0)) {
+      AlignFail(std::integral_constant<size_t, alignof(T)>(),
+                reinterpret_cast<uintptr_t>(target));
+      // Explicit abort to let compilers know this code-path does not return
+      abort();
+    }
+#endif
+    return *target;
   }
 
   template <typename T, bool is_split>

--- a/src/google/protobuf/versions.cc
+++ b/src/google/protobuf/versions.cc
@@ -1,0 +1,49 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "google/protobuf/versions.h"
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/substitute.h"
+
+namespace google {
+namespace protobuf {
+namespace internal {
+
+std::string VersionString(int version, absl::string_view suffix) {
+  int major = version / 1000000;
+  int minor = (version / 1000) % 1000;
+  int micro = version % 1000;
+  return absl::Substitute("$0.$1.$2$3", major, minor, micro, suffix);
+}
+
+}
+}
+}

--- a/src/google/protobuf/versions.cc
+++ b/src/google/protobuf/versions.cc
@@ -44,6 +44,6 @@ std::string VersionString(int version, absl::string_view suffix) {
   return absl::Substitute("$0.$1.$2$3", major, minor, micro, suffix);
 }
 
-}
-}
-}
+}  // namespace internal
+}  // namespace protobuf
+}  // namespace google

--- a/src/google/protobuf/versions.h
+++ b/src/google/protobuf/versions.h
@@ -36,21 +36,29 @@
 #include "absl/strings/string_view.h"
 
 // Macros to be used by language generators to insert version information.
+// Although "main" is not a normal version suffix, it would be helpful for
+// code generators to discern the main version.
+//
+// Currently, it holds language versions only for C++, Java and Python,
+// but can be extended to other Protobuf languages.
+//
+// Usually, they should be updated automatically by Protobuf release
+// process.
 #define PROTOBUF_CPP_VERSION 4024000
-#define PROTOBUF_CPP_VERSION_SUFFIX "main"
+#define PROTOBUF_CPP_VERSION_SUFFIX "-main"
 
 #define PROTOBUF_JAVA_VERSION 3024000
-#define PROTOBUF_JAVA_VERSION_SUFFIX "main"
+#define PROTOBUF_JAVA_VERSION_SUFFIX "-main"
 
 #define PROTOBUF_PYTHON_VERSION 4024000
-#define PROTOBUF_PYTHON_VERSION_SUFFIX "main"
+#define PROTOBUF_PYTHON_VERSION_SUFFIX "-main"
 
 namespace google {
 namespace protobuf {
 namespace internal {
 
-// Gets the version string with suffix. For example, "4.24.0-dev".
-// version must be an integer in the form of
+// Gets the version string with version number and suffix.
+// For example, "4.24.0-dev". version must be an integer in the form of
 // {1 digit major}0{2 digits minor}0{2 digits micro}.
 // suffix can be empty or prefixed by "-".
 std::string VersionString(int version, absl::string_view suffix);

--- a/src/google/protobuf/versions.h
+++ b/src/google/protobuf/versions.h
@@ -1,0 +1,62 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2023 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GOOGLE_PROTOBUF_VERSIONS_H_
+#define GOOGLE_PROTOBUF_VERSIONS_H_
+
+#include <string>
+
+#include "absl/strings/string_view.h"
+
+// Macros to be used by language generators to insert version information.
+#define PROTOBUF_CPP_VERSION 4024000
+#define PROTOBUF_CPP_VERSION_SUFFIX "main"
+
+#define PROTOBUF_JAVA_VERSION 3024000
+#define PROTOBUF_JAVA_VERSION_SUFFIX "main"
+
+#define PROTOBUF_PYTHON_VERSION 4024000
+#define PROTOBUF_PYTHON_VERSION_SUFFIX "main"
+
+namespace google {
+namespace protobuf {
+namespace internal {
+
+// Gets the version string with suffix. For example, "4.24.0-dev".
+// version must be an integer in the form of
+// {1 digit major}0{2 digits minor}0{2 digits micro}.
+// suffix can be empty or prefixed by "-".
+std::string VersionString(int version, absl::string_view suffix);
+
+}  // namespace internal
+}  // namespace protobuf
+}  // namespace google
+
+#endif  // GOOGLE_PROTOBUF_VERSIONS_H_

--- a/src/google/protobuf/versions_test.cc
+++ b/src/google/protobuf/versions_test.cc
@@ -14,6 +14,7 @@ TEST(VersionsTest, VersionStringWithEmptySuffix) {
 TEST(VersionsTest, VersionStringWithDevSuffix) {
   EXPECT_EQ(VersionString(4024000, "-dev"), "4.24.0-dev");
 }
-}
-}
-}
+
+}  // namespace internal
+}  // namespace protobuf
+}  // namespace google

--- a/src/google/protobuf/versions_test.cc
+++ b/src/google/protobuf/versions_test.cc
@@ -1,3 +1,33 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #include "google/protobuf/versions.h"
 
 #include <gtest/gtest.h>

--- a/src/google/protobuf/versions_test.cc
+++ b/src/google/protobuf/versions_test.cc
@@ -1,0 +1,19 @@
+#include "google/protobuf/versions.h"
+
+#include <gtest/gtest.h>
+
+
+namespace google {
+namespace protobuf {
+namespace internal {
+
+TEST(VersionsTest, VersionStringWithEmptySuffix) {
+  EXPECT_EQ(VersionString(4024000, ""), "4.24.0");
+}
+
+TEST(VersionsTest, VersionStringWithDevSuffix) {
+  EXPECT_EQ(VersionString(4024000, "-dev"), "4.24.0-dev");
+}
+}
+}
+}


### PR DESCRIPTION
This will prepare for adding version numbers to Protobuf gencodes.

As a followup, update_version.py will be enhanced to catch the version updates to versions.h. After that, code generators can adopt them into the gencode.