### PR TITLE
Improve .NET debugging of Protobuf messages

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -123,6 +123,7 @@ void MessageGenerator::Generate(io::Printer* printer) {
   AddDeprecatedFlag(printer);
   AddSerializableAttribute(printer);
 
+  printer->Print("[global::System.Diagnostics.DebuggerDisplay(\"{ToString(),nq}\")]\n");
   printer->Print(
     vars,
     "$access_level$ sealed partial class $class_name$ : ");

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -123,7 +123,7 @@ void MessageGenerator::Generate(io::Printer* printer) {
   AddDeprecatedFlag(printer);
   AddSerializableAttribute(printer);
 
-  printer->Print("[global::System.Diagnostics.DebuggerDisplay(\"{ToString(),nq}\")]\n");
+  printer->Print("[global::System.Diagnostics.DebuggerDisplayAttribute(\"{ToString(),nq}\")]\n");
   printer->Print(
     vars,
     "$access_level$ sealed partial class $class_name$ : ");


### PR DESCRIPTION
Generated .NET protobuf messages override `ToString` and return JSON. By default, the .NET debugger displays the result from `ToString` and wraps it in curly braces, e.g. `{{ "Message": "Hello world" }}`. The double curly braces is an ugly result. People expecting JSON here are confused.

This PR adds a [DebuggerDisplayAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.debuggerdisplayattribute?view=net-7.0) to generated messages. The attribute tells the debugger to not quote the ToString value with `nq`.

Before:
![image](https://github.com/protocolbuffers/protobuf/assets/303201/b1cc5f45-4064-4ba0-b266-8894ca0f35c8)

After:
![image](https://github.com/protocolbuffers/protobuf/assets/303201/70f6ffc0-9421-428d-bc22-ead7aa82c37f)

I haven't touched the protoc compiler in a long time. I'm guessing I need to build it and then run it to regenerate the checked-in code. I don't suppose someone else could do that? It would save me a lot of time 😬 