### PR TITLE
Python: stop using backward compatiblity timezones

### DIFF
--- a/python/google/protobuf/internal/well_known_types_test.py
+++ b/python/google/protobuf/internal/well_known_types_test.py
@@ -26,12 +26,12 @@ from google.protobuf import unittest_pb2
 try:
   # New module in Python 3.9:
   import zoneinfo  # pylint:disable=g-import-not-at-top
-  _TZ_JAPAN = zoneinfo.ZoneInfo('Japan')
-  _TZ_PACIFIC = zoneinfo.ZoneInfo('US/Pacific')
+  _TZ_JAPAN = zoneinfo.ZoneInfo('Asia/Tokyo')
+  _TZ_PACIFIC = zoneinfo.ZoneInfo('America/Los_Angeles')
   has_zoneinfo = True
 except ImportError:
-  _TZ_JAPAN = datetime.timezone(datetime.timedelta(hours=9), 'Japan')
-  _TZ_PACIFIC = datetime.timezone(datetime.timedelta(hours=-8), 'US/Pacific')
+  _TZ_JAPAN = datetime.timezone(datetime.timedelta(hours=9), 'Asia/Tokyo')
+  _TZ_PACIFIC = datetime.timezone(datetime.timedelta(hours=-8), 'America/Los_Angeles')
   has_zoneinfo = False
 
 


### PR DESCRIPTION
The 'Japan' and 'US/Pacific' timezones used in Python tests are backward compatibility timezones (defined in the backward file of tzdata) and might not be available on all systems. For instance Debian recently split those timezones in a tzdata-legacy package.

Update the tests to the use the canonical name of the timezones instead, that is respectively 'Asia/Tokyo' and 'America/Los_Angeles'.