### PR TITLE
Add GOOGLE_LOG_DISABLE to allow dropping file paths and log messages

### DIFF
--- a/src/google/protobuf/stubs/common.cc
+++ b/src/google/protobuf/stubs/common.cc
@@ -260,6 +260,13 @@ void LogFinisher::operator=(LogMessage& other) {
   other.Finish();
 }
 
+#ifdef GOOGLE_LOG_DISABLE
+// This is never instantiated, it's just used for
+// PROTOBUF_EAT_STREAM_PARAMETERS to have an object of the correct type on the
+// LHS of the unused part of the ternary operator.
+std::ostream* g_swallow_stream;
+#endif  // GOOGLE_LOG_DISABLE
+
 }  // namespace internal
 
 LogHandler* SetLogHandler(LogHandler* new_func) {


### PR DESCRIPTION
Added `GOOGLE_LOG_DISABLE` flag to allow clients to decide whether or not to drop file paths and log messages.

- This does not affect the existing code and behaviors at all since the added code is only getting compiled when `GOOGLE_LOG_DISABLE` flag is defined.
- Once `GOOGLE_LOG_DISABLE` is defined (regardless of its value), all parameters including `__FILE__` and log message passed to `GOOGLE_LOG` will be dropped even without evaluating the passed parameters.
- On the client side, one will pass this definition `GOOGLE_LOG_DISABLE=1` down to the protobuf library. This way it will drop all file paths and log messages for security purposes.
- Tested locally and verified the file paths and log messages are not exposed at all when passed `GOOGLE_LOG_DISABLE=1`.