### PR TITLE
Cherry-pick recent changes from the upb repo

### DIFF
--- a/upb/bazel/upb_proto_library.bzl
+++ b/upb/bazel/upb_proto_library.bzl
@@ -153,7 +153,7 @@ def _cc_library_func(ctx, name, hdrs, srcs, copts, includes, dep_ccinfos):
         cc_toolchain = toolchain,
         compilation_outputs = compilation_outputs,
         linking_contexts = linking_contexts,
-        disallow_dynamic_library = cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "targets_windows"),
+        disallow_dynamic_library = cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "targets_windows") or not cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "supports_dynamic_linker"),
     )
 
     return CcInfo(

--- a/upb/python/dist/dist.bzl
+++ b/upb/python/dist/dist.bzl
@@ -22,6 +22,7 @@ def _get_suffix(limited_api, python_version, cpu):
             python_version += "m"
         abis = {
             "darwin_arm64": "darwin",
+            "darwin_x86_64": "darwin",
             "darwin": "darwin",
             "osx-x86_64": "darwin",
             "osx-aarch_64": "darwin",

--- a/upb/python/message.c
+++ b/upb/python/message.c
@@ -1216,7 +1216,7 @@ static PyObject* PyUpb_Message_MergeInternal(PyObject* self, PyObject* arg,
   if (!serialized) return NULL;
   PyObject* ret = PyUpb_Message_MergeFromString(self, serialized);
   Py_DECREF(serialized);
-  Py_DECREF(ret);
+  Py_XDECREF(ret);
   Py_RETURN_NONE;
 }
 

--- a/upb/upb/mini_descriptor/internal/encode.hpp
+++ b/upb/upb/mini_descriptor/internal/encode.hpp
@@ -43,49 +43,51 @@ class MtDataEncoder {
   MtDataEncoder() : appender_(&encoder_) {}
 
   bool StartMessage(uint64_t msg_mod) {
-    return appender_([=](char* buf) {
+    return appender_([this, msg_mod](char* buf) {
       return upb_MtDataEncoder_StartMessage(&encoder_, buf, msg_mod);
     });
   }
 
   bool PutField(upb_FieldType type, uint32_t field_num, uint64_t field_mod) {
-    return appender_([=](char* buf) {
+    return appender_([this, type, field_num, field_mod](char* buf) {
       return upb_MtDataEncoder_PutField(&encoder_, buf, type, field_num,
                                         field_mod);
     });
   }
 
   bool StartOneof() {
-    return appender_([=](char* buf) {
+    return appender_([this](char* buf) {
       return upb_MtDataEncoder_StartOneof(&encoder_, buf);
     });
   }
 
   bool PutOneofField(uint32_t field_num) {
-    return appender_([=](char* buf) {
+    return appender_([this, field_num](char* buf) {
       return upb_MtDataEncoder_PutOneofField(&encoder_, buf, field_num);
     });
   }
 
   bool StartEnum() {
-    return appender_(
-        [=](char* buf) { return upb_MtDataEncoder_StartEnum(&encoder_, buf); });
+    return appender_([this](char* buf) {
+      return upb_MtDataEncoder_StartEnum(&encoder_, buf);
+    });
   }
 
   bool PutEnumValue(uint32_t enum_value) {
-    return appender_([=](char* buf) {
+    return appender_([this, enum_value](char* buf) {
       return upb_MtDataEncoder_PutEnumValue(&encoder_, buf, enum_value);
     });
   }
 
   bool EndEnum() {
-    return appender_(
-        [=](char* buf) { return upb_MtDataEncoder_EndEnum(&encoder_, buf); });
+    return appender_([this](char* buf) {
+      return upb_MtDataEncoder_EndEnum(&encoder_, buf);
+    });
   }
 
   bool EncodeExtension(upb_FieldType type, uint32_t field_num,
                        uint64_t field_mod) {
-    return appender_([=](char* buf) {
+    return appender_([this, type, field_num, field_mod](char* buf) {
       return upb_MtDataEncoder_EncodeExtension(&encoder_, buf, type, field_num,
                                                field_mod);
     });
@@ -93,14 +95,14 @@ class MtDataEncoder {
 
   bool EncodeMap(upb_FieldType key_type, upb_FieldType val_type,
                  uint64_t key_mod, uint64_t val_mod) {
-    return appender_([=](char* buf) {
+    return appender_([this, key_type, val_type, key_mod, val_mod](char* buf) {
       return upb_MtDataEncoder_EncodeMap(&encoder_, buf, key_type, val_type,
                                          key_mod, val_mod);
     });
   }
 
   bool EncodeMessageSet() {
-    return appender_([=](char* buf) {
+    return appender_([this](char* buf) {
       return upb_MtDataEncoder_EncodeMessageSet(&encoder_, buf);
     });
   }


### PR DESCRIPTION
I merged a handful of PRs on the upb repo after upb moved into the protobuf repo. This PR cherry-picks them here so that they will not be lost.

```
commit 7afb426a5ace6f6e76ac2144960363379a1be08d
Author: Keith Smiley <keithbsmiley@gmail.com>
Date:   Thu Sep 7 11:36:01 2023 -0700

    [bazel] Fix disallowing dylibs on darwin (#1180)
    
    Since this bazel commit
    https://github.com/bazelbuild/bazel/commit/ec5553352f2f661d39ac4cf665dd9b3c779e614c
    building dylibs like the ones in this rule on darwin platforms has been
    unsupported. This feature is a default C++ toolchain feature to indicate
    this. In bazel 7.x these dylibs will fail to link if they are still
    built. As far as I can tell in the tests even if they are built they are
    never used on macOS.
    
    Co-authored-by: Adam Cozzette <acozzette@google.com>

commit 72decab5eca0110548b0c805275fffab562aebde
Author: Keith Smiley <keithbsmiley@gmail.com>
Date:   Thu Sep 7 09:42:20 2023 -0700

    Add missing darwin_x86_64 CPU (#1181)
    
    This CPU is often used when cross compiling from M1 machines. I'm also
    hoping we can remove the legacy 'darwin' CPU.

commit ccadaf3196bda975dec5ed2aac8a78e75ab51c1b
Author: messense <messense@icloud.com>
Date:   Fri Sep 8 00:28:54 2023 +0800

    Fix `PyUpb_Message_MergeInternal` segfault (#1338)
    
    when `PyUpb_Message_MergeFromString` returns `NULL`, currently
    `PyUpb_Message_MergeInternal` will call `Py_DECREF` on `NULL`
    which results in a segmentation fault.
    
    This patch switches to `Py_XDECREF` to fix the segfault.

commit 2a5724d86ea81e0c2a0f8d10db274821c8bb6656
Author: Kevin Greene <kgreenek@gmail.com>
Date:   Wed Sep 6 16:46:35 2023 -0700

    Fix lambda capture compiler error with c++20 (#1502)
    
    When compiling with C++20, the following error is produced:
    
    ```
    upb/mini_table.hpp:63:22: note: add explicit 'this' or '*this' capture
    upb/mini_table.hpp: In lambda function:
    upb/mini_table.hpp:71:22: error: implicit capture of 'this' via '[=]' is deprecated in C++20 [-Werror=deprecated]
       71 |     return appender_([=](char* buf) {
    ```
    
    In C++20, it is no longer allowed to implicitly capture 'this' in a
    lambda using [=].
    
    This commit explicitly captures required values in the appropriate
    lambdas and removes all uses of [=] with lambdas.
```