### PR TITLE
Add dependency on absl::layout, and explicitly include absl layout includes

### DIFF
--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -331,6 +331,7 @@ cc_library(
         ":arena_cleanup",
         ":string_block",
         "//src/google/protobuf/stubs:lite",
+        "@com_google_absl//absl/container:layout",
         "@com_google_absl//absl/log:absl_check",
         "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/synchronization",

--- a/src/google/protobuf/arena.cc
+++ b/src/google/protobuf/arena.cc
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include "absl/base/attributes.h"
+#include "absl/container/internal/layout.h"
 #include "absl/synchronization/mutex.h"
 #include "google/protobuf/arena_allocation_policy.h"
 #include "google/protobuf/arenaz_sampler.h"


### PR DESCRIPTION
This header was transitively included from (deprecated) absl cord includes.

PiperOrigin-RevId: 562008066