### PR TITLE
`Printer`: Include Abseil's `str_cat.h` for `absl::AlphaNum`

### DIFF
--- a/src/google/protobuf/io/printer.h
+++ b/src/google/protobuf/io/printer.h
@@ -50,6 +50,7 @@
 #include "absl/functional/function_ref.h"
 #include "absl/log/absl_check.h"
 #include "absl/meta/type_traits.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"


### PR DESCRIPTION
No need to touch Bazel/CMake files, as they already depend on Abseil strings.

PiperOrigin-RevId: 564640299