### PR TITLE
Remove <iostream> from the common.h header

### DIFF
--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -13,7 +13,6 @@
 #define GOOGLE_PROTOBUF_COMMON_H__
 
 #include <algorithm>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
<iostream> embeds a global constructor (to initialize std::cout and such), typically `static ios_base::Init __ioinit;` in libstdc++).

This header is not directly necessary in the common header and has a small impact on every compilation unit that includes it.

As an example, removing that header dependency in turns suppresses 33 global constructors from the firefox core library libxul.