### PR TITLE
Support non ascii commandline args

### DIFF
--- a/build_defs/cpp_opts.bzl
+++ b/build_defs/cpp_opts.bzl
@@ -35,6 +35,7 @@ LINK_OPTS = select({
     "//build_defs:config_msvc": [
         # Suppress linker warnings about files with no symbols defined.
         "-ignore:4221",
+        "/utf-8",
     ],
     "@platforms//os:macos": [
         "-lpthread",


### PR DESCRIPTION
Using none ASCII chars for protoc on Windows are not handled well.
This adresses argument file at a location where either directory, or filename contains Unicode chars.

Specifically because MsBuild tool saves argument file in with the UserName appended to the .rsp file.
https://github.com/dotnet/msbuild/pull/9232

But in general we should really handle if none ascii chars are in the path.