### PR TITLE
Expand lunit visibility to enable moving lua directory

### DIFF
--- a/third_party/lunit/BUILD.bazel
+++ b/third_party/lunit/BUILD.bazel
@@ -3,5 +3,8 @@ exports_files(
         "console.lua",
         "lunit.lua",
     ],
-    visibility = ["//upb/lua:__pkg__"],
+    visibility = [
+        "//lua:__pkg__",
+        "//upb/lua:__pkg__",
+    ],
 )


### PR DESCRIPTION
We will soon be moving the upb/lua directory up to the top level, so this commit updates lunit's visibility to enable that.