### PR TITLE
Disable Bzlmod explicitly in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,3 +26,7 @@ build:ubsan --copt=-DUNDEFINED_SANITIZER=1
 # Workaround for the fact that Bazel links with $CC, not $CXX
 # https://github.com/bazelbuild/bazel/issues/11122#issuecomment-613746748
 build:ubsan --copt=-fno-sanitize=function --copt=-fno-sanitize=vptr
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/protocolbuffers/protobuf/issues/14313
+common --noenable_bzlmod

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,3 @@
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/protocolbuffers/protobuf/issues/14313
+


### PR DESCRIPTION
This will help make sure [Bazel Downstream Pipeline](https://github.com/bazelbuild/continuous-integration/blob/master/docs/downstream-testing.md) is green after enabling Bzlmod at Bazel@HEAD

See https://github.com/bazelbuild/bazel/issues/18958#issuecomment-1749058780

Related https://github.com/protocolbuffers/protobuf/issues/14313