### PR TITLE
fix: typo inside docs/upb/design.md and docs/design/editions/edition-zero-features.md

### DIFF
--- a/docs/design/editions/edition-zero-features.md
+++ b/docs/design/editions/edition-zero-features.md
@@ -146,7 +146,7 @@ We also make some semantic changes:
 *   `proto3_optional` is rejected as a parse error (use the feature instead).
 
 Migrating from proto2/3 involves deleting all `optional`/`required` labels and
-adding `IMPLICT` and `LEGACY_REQUIURED` annotations where necessary.
+adding `IMPLICIT` and `LEGACY_REQUIURED` annotations where necessary.
 
 #### Alternatives
 

--- a/docs/upb/design.md
+++ b/docs/upb/design.md
@@ -288,7 +288,7 @@ Dart for a message with only primitive fields currently looks something like:
   _accessor = $pb.instance.registry.newMessageAccessor(desc);
 ```
 
-The implementation of `newMessageAccesor()` is mainly just a wrapper around
+The implementation of `newMessageAccessor()` is mainly just a wrapper around
 `upb_MiniTable_Build()`, which builds a MiniTable from a MiniDescriptor. In the
 code generator, the MiniDescriptor can be obtained from the
 `upb_MessageDef_MiniDescriptorEncode()` API; users should never need to encode a


### PR DESCRIPTION
Multiple typos has been fixed. 
- docs/upb/design.md -> line no 291: changed 'newMessageAccesor' to 'newMessageAccessor '
- docs/design/editions/edition-zero-features.md -> line no 149: changed 'implict' to 'implicit'