### PR TITLE
Add missing field initializers

### DIFF
--- a/src/google/protobuf/compiler/cpp/parse_function_generator.cc
+++ b/src/google/protobuf/compiler/cpp/parse_function_generator.cc
@@ -310,7 +310,7 @@ static NumToEntryTable MakeNumToEntryTable(
       if (fnum - last_skip_entry_start > 96) start_new_block = true;
     }
     if (start_new_block) {
-      num_to_entry_table.blocks.push_back(SkipEntryBlock{fnum});
+      num_to_entry_table.blocks.push_back(SkipEntryBlock{fnum, {}});
       block = &num_to_entry_table.blocks.back();
       start_new_block = false;
     }

--- a/src/google/protobuf/generated_message_bases.cc
+++ b/src/google/protobuf/generated_message_bases.cc
@@ -95,7 +95,7 @@ void ZeroFieldsBase::InternalSwap(ZeroFieldsBase* other) {
 }
 
 const Message::ClassData* ZeroFieldsBase::GetClassData() const {
-  static constexpr ClassData data = {&MergeImpl};
+  static constexpr ClassData data = {&MergeImpl, nullptr};
   return &data;
 }
 

--- a/src/google/protobuf/generated_message_reflection.cc
+++ b/src/google/protobuf/generated_message_reflection.cc
@@ -3221,7 +3221,7 @@ const internal::TcParseTableBase* Reflection::CreateTcParseTableReflectionOnly()
   void* p = ::operator new(sizeof(Table));
   auto* full_table = ::new (p)
       Table{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, schema_.default_instance_, nullptr},
-            {{{&internal::TcParser::ReflectionParseLoop, {}}}}};
+            {{{&internal::TcParser::ReflectionParseLoop, {}}}}, {}, {}};
   ABSL_DCHECK_EQ(static_cast<void*>(&full_table->header),
                  static_cast<void*>(full_table));
   return &full_table->header;


### PR DESCRIPTION
When compiling with clang and -Werror I need to disable `-Wmissing-field-initializers`, otherwise it does not compile. Example:
```
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_gen.cc:528:48: error: missing field 'entries' initializer [-Werror,-Wmissing-field-initializers]
  528 |       num_to_entry_table.blocks.push_back({fnum});
      |                                                ^
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_gen.cc:743:69: error: missing field 'google::protobuf::internal::TailCallTableInfo::AuxEntry::(anonymous union at bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_nowkt/google/protobuf/generated_message_tctable_gen.h:121:5)' initializer [-Werror,-Wmissing-field-initializers]
  743 |     aux_entries[kInlinedStringAuxIdx] = {kInlinedStringDonatedOffset};
      |                                                                     ^
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_gen.cc:753:54: error: missing field 'google::protobuf::internal::TailCallTableInfo::AuxEntry::(anonymous union at bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_nowkt/google/protobuf/generated_message_tctable_gen.h:121:5)' initializer [-Werror,-Wmissing-field-initializers]
  753 |       aux_entries[kSplitOffsetAuxIdx] = {kSplitOffset};
      |                                                      ^
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_gen.cc:754:52: error: missing field 'google::protobuf::internal::TailCallTableInfo::AuxEntry::(anonymous union at bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_nowkt/google/protobuf/generated_message_tctable_gen.h:121:5)' initializer [-Werror,-Wmissing-field-initializers]
  754 |       aux_entries[kSplitSizeAuxIdx] = {kSplitSizeof};
      |                                                    ^
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_gen.cc:765:25: error: missing field 'inlined_string_idx' initializer [-Werror,-Wmissing-field-initializers]
  765 |                     : -1});
      |                         ^
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_gen.cc:779:50: error: missing field 'google::protobuf::internal::TailCallTableInfo::AuxEntry::(anonymous union at bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_nowkt/google/protobuf/generated_message_tctable_gen.h:121:5)' initializer [-Werror,-Wmissing-field-initializers]
  779 |             aux_entries.push_back({kCreateInArena});
      |                                                  ^
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_gen.cc:793:44: error: missing field 'google::protobuf::internal::TailCallTableInfo::AuxEntry::(anonymous union at bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_nowkt/google/protobuf/generated_message_tctable_gen.h:121:5)' initializer [-Werror,-Wmissing-field-initializers]
  793 |             aux_entries.push_back({kNothing});
      |                                            ^
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_gen.cc:841:44: error: missing field 'google::protobuf::internal::TailCallTableInfo::AuxEntry::(anonymous union at bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_nowkt/google/protobuf/generated_message_tctable_gen.h:121:5)' initializer [-Werror,-Wmissing-field-initializers]
  841 |       aux_entries.push_back({kNumericOffset});

```

I went ahead and added default initializers where the compiler said they are missing.