### PR TITLE
Remove unneeded temporary copy in MutableRepeatedFieldRef::(Add|Set)

### DIFF
--- a/src/google/protobuf/reflection.h
+++ b/src/google/protobuf/reflection.h
@@ -339,6 +339,11 @@ class PROTOBUF_EXPORT RepeatedFieldAccessor {
         Get(data, index, static_cast<Value*>(&scratch_space))));
   }
 
+  template <typename T>
+  void Set(Field* data, int index, const typename RefTypeTraits<T>::AccessorValueType& value) const {
+    Set(data, index, static_cast<const Value*>(&value));
+  }
+
   template <typename T, typename ValueType>
   void Set(Field* data, int index, const ValueType& value) const {
     typedef typename RefTypeTraits<T>::AccessorValueType ActualType;
@@ -351,6 +356,11 @@ class PROTOBUF_EXPORT RepeatedFieldAccessor {
     // we make a copy to get a temporary ActualType object and use it.
     ActualType tmp = static_cast<ActualType>(value);
     Set(data, index, static_cast<const Value*>(&tmp));
+  }
+
+  template <typename T>
+  void Add(Field* data, const typename RefTypeTraits<T>::AccessorValueType& value) const {
+    Add(data, static_cast<const Value*>(&value));
   }
 
   template <typename T, typename ValueType>


### PR DESCRIPTION
If `ValueType` and `ActualType` are the same, there's no need for a temporary.
This patch should speed up `MutableRepeatedFieldRef<std::string>::Add()` and `MutableRepeatedFieldRef<std::string>::Set()`.

### Notes

This patch does not affect `MutableRepeatedFieldRef<Message>`.

Performance improvement for other non-string `MutableRepeatedFieldRef` instantiations is negligible.

For constant strings and new (empty) messages, `MutableRepeatedFieldRef<std::string>:Add`, becomes as efficient as `Reflection::AddString`. Both create 1 copy of the string: the former in [`RepeatedPtrFieldStringAccessor::ConvertToT`](https://github.com/protocolbuffers/protobuf/blob/4a24a29780835addf10a2a21fe1f7d80c78f8a64/src/google/protobuf/reflection_internal.h#L313) and the latter copies the string into parameter.

For temporary/moved strings `AddString` is still preferable, because it moves the string into its parameter and then [moves it into the allocated string](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/generated_message_reflection.cc#L2027), while `MutableRepeatedFieldRef::Add` always creates a copy (see above).

For reused (previously filled and cleared) messages `AddString` is also preferrable, because it [reuses previously allocated strings](https://github.com/protocolbuffers/protobuf/blob/4a24a29780835addf10a2a21fe1f7d80c78f8a64/src/google/protobuf/repeated_ptr_field.h#L231C5-L234C6), while `MutableRepeatedFieldRef::Add` [deletes them](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/repeated_ptr_field.h#L465C7-L465C52).

### Benchmark

```proto3
// test.proto
syntax = "proto3";

message TestMessage {
    repeated string str = 1;
};
```

```cpp
// main.cpp
#include "proto/test.pb.h"

#include <google/protobuf/message.h>
#include <google/protobuf/reflection.h>

#include <chrono>
#include <string>
#include <iostream>

const std::string& GetStr() {
    static const std::string s(32, 'a');  A medium-sized string, large enough to prevent SSO (with SSO construction of the temporary is much cheaper)
    return s;
}

void Fill(google::protobuf::Message* msg, bool useFieldRef, size_t nElems) {
    auto reflection = msg->GetReflection();
    auto fd = msg->GetDescriptor()->FindFieldByNumber(1);
    if (useFieldRef) {
        auto fieldRef = reflection->GetMutableRepeatedFieldRef<std::string>(msg, fd);
        for (size_t i = 0; i < nElems; ++i) {
            fieldRef.Add(GetStr());
        }
    } else {
        for (size_t i = 0; i < nElems; ++i) {
            reflection->AddString(msg, fd, GetStr());
        }
    }
}

void BenchmarkFillEmptyMessage(bool useFieldRef, size_t nElems, size_t nIters) {
    auto t1 = std::chrono::high_resolution_clock::now();
    for (size_t i = 0; i < nIters; ++i) {
        TestMessage msg;
        Fill(&msg, useFieldRef, nElems);
    }
    auto t2 = std::chrono::high_resolution_clock::now();
    std::cout << "Using field ref: " << (useFieldRef ? "yes" : "no") << ", time per iteration: " << std::chrono::nanoseconds(t2 - t1).count() / nIters << " ns" << std::endl;
}

int main() {
    size_t nElems, nIters;
    std::cin >> nElems >> nIters;
    BenchmarkFillEmptyMessage(false, nElems, nIters);
    BenchmarkFillEmptyMessage(true, nElems, nIters);
}
```

On my machine, results with nElems = 1000 and nIters = 100000 are as follows:
<details>
In both cases `main.cpp` was compiled by clang++-14 with `-O2`, libprotobuf and other support libraries are built with `-DCMAKE_BUILD_TYPE=Release`
</details>

- Before this patch (at 4a24a29780835addf10a2a21fe1f7d80c78f8a64):
  ```
  Using field ref: no, time per iteration: 79602 ns
  Using field ref: yes, time per iteration: 97629 ns
  ```
- With the patch applied:
  ```
  Using field ref: no, time per iteration: 78579 ns
  Using field ref: yes, time per iteration: 79588 ns
  ```