### PR TITLE
Cherry-pick: Set `PROTOBUF_EXPORT` on `InternalOutOfLineDeleteMessageLite()`

### DIFF
--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -863,7 +863,7 @@ void RepeatedPtrFieldBase::MergeFrom<std::string>(
     const RepeatedPtrFieldBase& from);
 
 
-void InternalOutOfLineDeleteMessageLite(MessageLite* message);
+PROTOBUF_EXPORT void InternalOutOfLineDeleteMessageLite(MessageLite* message);
 
 template <typename GenericType>
 class GenericTypeHandler {


### PR DESCRIPTION
This function needs to be visible to generated code, so this CL ensures that it's exported on libprotobuf.so.

PiperOrigin-RevId: 573980166