### PR TITLE
Add Descriptor to forbidden names in Java codegen

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/DescriptorMessageInfoFactory.java
+++ b/java/core/src/main/java/com/google/protobuf/DescriptorMessageInfoFactory.java
@@ -63,7 +63,8 @@ final class DescriptorMessageInfoFactory implements MessageInfoFactory {
               "InitializationErrorString",
               "UnknownFields",
               // obsolete. kept for backwards compatibility of generated code
-              "CachedSize"));
+              "CachedSize",
+              "Descriptor"));
 
   // Disallow construction - it's a singleton.
   private DescriptorMessageInfoFactory() {}

--- a/src/google/protobuf/compiler/java/names.cc
+++ b/src/google/protobuf/compiler/java/names.cc
@@ -74,6 +74,7 @@ bool IsForbidden(absl::string_view field_name) {
           "UnknownFields",
           // obsolete. kept for backwards compatibility of generated code
           "CachedSize",
+          "Descriptor",
       });
   return kForbiddenNames.contains(UnderscoresToCamelCase(field_name, true));
 }


### PR DESCRIPTION
Update the protoc Java plugin to add Descriptor to the list of forbidden names. This method isn't present in the inherited classes but rather the generated code for the Protobuf messages. Adding this to the forbidden names allows .proto files with fields named `descriptor` to be compiled (and accessed).

Fixes #14392.