### PR TITLE
Cherry-picked Python tests and updated upb dep

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -149,7 +149,7 @@ def protobuf_deps():
         _github_archive(
             name = "upb",
             repo = "https://github.com/protocolbuffers/upb",
-            commit = "52a1ddadc25ac426ade7d21e84f00ad1192c21d0",
-            sha256 = "d3f451979243fc12b110d4d98cb9f4328ff11c71cfd06c82e0a0904c37d50379",
+            commit = "e31cb02f73f7164f3d7f5c00ede94d64af116a47",
+            sha256 = "5851f065f82f0cb98eb305d59e9316565cfdd2d6de2921bdcf1438208874a8aa",
             patches = ["@com_google_protobuf//build_defs:upb.patch"],
         )

--- a/python/google/protobuf/internal/factory_test1.proto
+++ b/python/google/protobuf/internal/factory_test1.proto
@@ -52,6 +52,7 @@ message Factory1Message {
   optional NestedFactory1Message nested_factory_1_message = 3;
   optional int32 scalar_value = 4;
   repeated string list_value = 5;
+  map<string, string> map_field = 6;
 
   extensions 1000 to max;
 }

--- a/python/google/protobuf/internal/message_factory_test.py
+++ b/python/google/protobuf/internal/message_factory_test.py
@@ -33,6 +33,7 @@
 __author__ = 'matthewtoia@google.com (Matt Toia)'
 
 import unittest
+import gc
 
 from google.protobuf import descriptor_pb2
 from google.protobuf.internal import api_implementation
@@ -300,6 +301,30 @@ class MessageFactoryTest(unittest.TestCase):
     self.assertEqual(234, m.Extensions[ext1].setting)
     self.assertEqual(345, m.Extensions[ext2].setting)
 
+
+  def testOndemandCreateMetaClass(self):
+    def loadFile():
+      f = descriptor_pb2.FileDescriptorProto.FromString(
+        factory_test1_pb2.DESCRIPTOR.serialized_pb)
+      return message_factory.GetMessages([f])
+
+    messages = loadFile()
+    data = factory_test1_pb2.Factory1Message()
+    data.map_field['hello'] = 'welcome'
+    # Force GC to collect. UPB python will clean up the map entry class.
+    # cpp extension and pure python will still keep the map entry class.
+    gc.collect()
+    message = messages['google.protobuf.python.internal.Factory1Message']()
+    message.ParseFromString(data.SerializeToString())
+    value = message.map_field
+    values = [
+        # The entry class will be created on demand in upb python.
+        value.GetEntryClass()(key=k, value=value[k]) for k in sorted(value)
+    ]
+    gc.collect()
+    self.assertEqual(1, len(values))
+    self.assertEqual('hello', values[0].key)
+    self.assertEqual('welcome', values[0].value)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This is a cherry-pick of https://github.com/protocolbuffers/protobuf/commit/b1c4c65658c9f116ad804610c191371f92b9e318, which was committed before the protobuf/upb repo split. The upb portion of that change was already cherry-picked. This PR cherry-picks the tests, and updates the upb dep so that these tests can pass.