### PR TITLE
Cherry-picked Python tests and updated upb dep

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -151,7 +151,7 @@ def protobuf_deps():
         _github_archive(
             name = "upb",
             repo = "https://github.com/protocolbuffers/upb",
-            commit = "455cfdb8ae60a1763e6d924e36851c6897a781bb",
-            sha256 = "2c8b4e961c38fcc7c58e8aca807cc3cc5190f42afdf39551ce49812b130493de",
+            commit = "5afd8ccb253d408483782ec19f0090a82d10ba1d",
+            sha256 = "0e3ce017e0636023fe9cd67c6fb513dfd534bad5d43b3a16a9141c3b58822435",
             patches = ["@com_google_protobuf//build_defs:upb.patch"],
         )

--- a/python/google/protobuf/internal/factory_test1.proto
+++ b/python/google/protobuf/internal/factory_test1.proto
@@ -52,6 +52,7 @@ message Factory1Message {
   optional NestedFactory1Message nested_factory_1_message = 3;
   optional int32 scalar_value = 4;
   repeated string list_value = 5;
+  map<string, string> map_field = 6;
 
   extensions 1000 to max;
 }

--- a/python/google/protobuf/internal/message_factory_test.py
+++ b/python/google/protobuf/internal/message_factory_test.py
@@ -33,6 +33,7 @@
 __author__ = 'matthewtoia@google.com (Matt Toia)'
 
 import unittest
+import gc
 
 from google.protobuf import descriptor_pb2
 from google.protobuf.internal import api_implementation
@@ -284,6 +285,30 @@ class MessageFactoryTest(unittest.TestCase):
     self.assertEqual(234, m.Extensions[ext1].setting)
     self.assertEqual(345, m.Extensions[ext2].setting)
 
+
+  def testOndemandCreateMetaClass(self):
+    def loadFile():
+      f = descriptor_pb2.FileDescriptorProto.FromString(
+        factory_test1_pb2.DESCRIPTOR.serialized_pb)
+      return message_factory.GetMessages([f])
+
+    messages = loadFile()
+    data = factory_test1_pb2.Factory1Message()
+    data.map_field['hello'] = 'welcome'
+    # Force GC to collect. UPB python will clean up the map entry class.
+    # cpp extension and pure python will still keep the map entry class.
+    gc.collect()
+    message = messages['google.protobuf.python.internal.Factory1Message']()
+    message.ParseFromString(data.SerializeToString())
+    value = message.map_field
+    values = [
+        # The entry class will be created on demand in upb python.
+        value.GetEntryClass()(key=k, value=value[k]) for k in sorted(value)
+    ]
+    gc.collect()
+    self.assertEqual(1, len(values))
+    self.assertEqual('hello', values[0].key)
+    self.assertEqual('welcome', values[0].value)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This is a cherry-pick of https://github.com/protocolbuffers/protobuf/commit/b1c4c65658c9f116ad804610c191371f92b9e318, which was committed before the protobuf/upb repo split. The upb portion of that change was already cherry-picked. This PR cherry-picks the tests, and updates the upb dep so that these tests can pass.