### PR TITLE
Cherry-picked Python tests and updated upb dep

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -149,7 +149,7 @@ def protobuf_deps():
         _github_archive(
             name = "upb",
             repo = "https://github.com/protocolbuffers/upb",
-            commit = "7af7938239bf027022e90438d4c6dbcdce007fb9",
-            sha256 = "99b44fe57266c897ca1d2af96e4ced314344d40f34f7f99d458ddcc76b56f827",
+            commit = "a71ec4b0e0c01ce2f02c461511302efe97d58727",
+            sha256 = "3ad3f339ca65fccbde566b6b8c56f23743cebac83eef4e047cfd924ce9ce08b6",
             patches = ["@com_google_protobuf//build_defs:upb.patch"],
         )

--- a/python/google/protobuf/internal/factory_test1.proto
+++ b/python/google/protobuf/internal/factory_test1.proto
@@ -52,6 +52,7 @@ message Factory1Message {
   optional NestedFactory1Message nested_factory_1_message = 3;
   optional int32 scalar_value = 4;
   repeated string list_value = 5;
+  map<string, string> map_field = 6;
 
   extensions 1000 to max;
 }

--- a/python/google/protobuf/internal/message_factory_test.py
+++ b/python/google/protobuf/internal/message_factory_test.py
@@ -33,6 +33,7 @@
 __author__ = 'matthewtoia@google.com (Matt Toia)'
 
 import unittest
+import gc
 
 from google.protobuf import descriptor_pb2
 from google.protobuf.internal import api_implementation
@@ -284,6 +285,30 @@ class MessageFactoryTest(unittest.TestCase):
     self.assertEqual(234, m.Extensions[ext1].setting)
     self.assertEqual(345, m.Extensions[ext2].setting)
 
+
+  def testOndemandCreateMetaClass(self):
+    def loadFile():
+      f = descriptor_pb2.FileDescriptorProto.FromString(
+        factory_test1_pb2.DESCRIPTOR.serialized_pb)
+      return message_factory.GetMessages([f])
+
+    messages = loadFile()
+    data = factory_test1_pb2.Factory1Message()
+    data.map_field['hello'] = 'welcome'
+    # Force GC to collect. UPB python will clean up the map entry class.
+    # cpp extension and pure python will still keep the map entry class.
+    gc.collect()
+    message = messages['google.protobuf.python.internal.Factory1Message']()
+    message.ParseFromString(data.SerializeToString())
+    value = message.map_field
+    values = [
+        # The entry class will be created on demand in upb python.
+        value.GetEntryClass()(key=k, value=value[k]) for k in sorted(value)
+    ]
+    gc.collect()
+    self.assertEqual(1, len(values))
+    self.assertEqual('hello', values[0].key)
+    self.assertEqual('welcome', values[0].value)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This is a cherry-pick of https://github.com/protocolbuffers/protobuf/commit/b1c4c65658c9f116ad804610c191371f92b9e318, which was committed before the protobuf/upb repo split. The upb portion of that change was already cherry-picked. This PR cherry-picks the tests, and updates the upb dep so that these tests can pass.