### PR TITLE
Cherry-pick JSON parser fix to 24.x

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -19,8 +19,8 @@ jobs:
         config:
           - { name: Optimized, flags: --config=opt }
           - { name: Debug, flags: --config=dbg }
-          - { name: ASAN, flags: --config=asan }
-          - { name: MSAN, flags: --config=docker-msan }
+          - { name: ASAN, flags: --config=asan, runner: ubuntu-22-large }
+          - { name: MSAN, flags: --config=docker-msan, runner: ubuntu-22-large }
           - { name: TSAN, flags: --config=tsan }
           - { name: UBSAN, flags: --config=ubsan }
           - { name: No-RTTI, flags: --cxxopt=-fno-rtti }
@@ -37,7 +37,7 @@ jobs:
             targets: "//src/... //src/google/protobuf/compiler:protoc_aarch64_test"
             image: "us-docker.pkg.dev/protobuf-build/containers/test/linux/emulation:aarch64-222e7e87028b7098e088f5ca7cae06d32f483eb5"
     name: Linux ${{ matrix.config.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.runner || 'ubuntu-latest' }}
     steps:
       - name: Checkout pending changes
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/src/google/protobuf/io/test_zero_copy_stream.h
+++ b/src/google/protobuf/io/test_zero_copy_stream.h
@@ -32,12 +32,12 @@
 #define GOOGLE_PROTOBUF_IO_TEST_ZERO_COPY_STREAM_H__
 
 #include <deque>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "absl/log/absl_check.h"
-#include "absl/types/optional.h"
 #include "google/protobuf/io/zero_copy_stream.h"
 
 // Must be included last.
@@ -60,18 +60,22 @@ class TestZeroCopyInputStream final : public ZeroCopyInputStream {
   TestZeroCopyInputStream(const TestZeroCopyInputStream& other)
       : ZeroCopyInputStream(),
         buffers_(other.buffers_),
-        last_returned_buffer_(other.last_returned_buffer_),
+        last_returned_buffer_(
+            other.last_returned_buffer_
+                ? std::make_unique<std::string>(*other.last_returned_buffer_)
+                : nullptr),
         byte_count_(other.byte_count_) {}
 
   bool Next(const void** data, int* size) override {
     ABSL_CHECK(data) << "data must not be null";
     ABSL_CHECK(size) << "size must not be null";
-    last_returned_buffer_ = absl::nullopt;
+    last_returned_buffer_ = nullptr;
 
     // We are done
     if (buffers_.empty()) return false;
 
-    last_returned_buffer_ = std::move(buffers_.front());
+    last_returned_buffer_ =
+        std::make_unique<std::string>(std::move(buffers_.front()));
     buffers_.pop_front();
     *data = last_returned_buffer_->data();
     *size = static_cast<int>(last_returned_buffer_->size());
@@ -81,19 +85,19 @@ class TestZeroCopyInputStream final : public ZeroCopyInputStream {
 
   void BackUp(int count) override {
     ABSL_CHECK_GE(count, 0) << "count must not be negative";
-    ABSL_CHECK(last_returned_buffer_.has_value())
+    ABSL_CHECK(last_returned_buffer_ != nullptr)
         << "The last call was not a successful Next()";
     ABSL_CHECK_LE(count, last_returned_buffer_->size())
         << "count must be within bounds of last buffer";
     buffers_.push_front(
         last_returned_buffer_->substr(last_returned_buffer_->size() - count));
-    last_returned_buffer_ = absl::nullopt;
+    last_returned_buffer_ = nullptr;
     byte_count_ -= count;
   }
 
   bool Skip(int count) override {
     ABSL_CHECK_GE(count, 0) << "count must not be negative";
-    last_returned_buffer_ = absl::nullopt;
+    last_returned_buffer_ = nullptr;
     while (true) {
       if (count == 0) return true;
       if (buffers_.empty()) return false;
@@ -119,7 +123,9 @@ class TestZeroCopyInputStream final : public ZeroCopyInputStream {
   // move them to `last_returned_buffer_`. It makes it simpler to keep track of
   // the state of the object. The extra cost is not relevant for testing.
   std::deque<std::string> buffers_;
-  absl::optional<std::string> last_returned_buffer_;
+  // absl::optional could work here, but std::unique_ptr makes it more likely
+  // for sanitizers to detect if the string is used after it is destroyed.
+  std::unique_ptr<std::string> last_returned_buffer_;
   int64_t byte_count_ = 0;
 };
 

--- a/src/google/protobuf/json/BUILD.bazel
+++ b/src/google/protobuf/json/BUILD.bazel
@@ -41,6 +41,7 @@ cc_test(
         "//src/google/protobuf:cc_test_protos",
         "//src/google/protobuf:port_def",
         "//src/google/protobuf/io",
+        "//src/google/protobuf/io:test_zero_copy_stream",
         "//src/google/protobuf/util:json_format_cc_proto",
         "//src/google/protobuf/util:json_format_proto3_cc_proto",
         "//src/google/protobuf/util:type_resolver_util",

--- a/src/google/protobuf/json/internal/parser.cc
+++ b/src/google/protobuf/json/internal/parser.cc
@@ -1296,7 +1296,7 @@ absl::Status ParseMessage(JsonLexer& lex, const Desc<Traits>& desc,
           }
         }
 
-        return ParseField<Traits>(lex, desc, name.value.AsView(), msg);
+        return ParseField<Traits>(lex, desc, name.value.ToString(), msg);
       });
 }
 }  // namespace

--- a/src/google/protobuf/json/json_test.cc
+++ b/src/google/protobuf/json/json_test.cc
@@ -49,6 +49,7 @@
 #include "absl/strings/string_view.h"
 #include "google/protobuf/descriptor_database.h"
 #include "google/protobuf/dynamic_message.h"
+#include "google/protobuf/io/test_zero_copy_stream.h"
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl_lite.h"
 #include "google/protobuf/util/json_format.pb.h"
@@ -73,6 +74,7 @@ using ::proto3::TestMap;
 using ::proto3::TestMessage;
 using ::proto3::TestOneof;
 using ::proto3::TestWrapper;
+using ::testing::ContainsRegex;
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 using ::testing::Not;
@@ -1352,6 +1354,24 @@ TEST_P(JsonTest, ClearPreExistingRepeatedInJsonValues) {
   (*s.mutable_fields())["hello"].set_string_value("world");
   ASSERT_OK(JsonStringToMessage("{}", &s));
   EXPECT_THAT(s.fields(), IsEmpty());
+}
+
+TEST(JsonErrorTest, FieldNameAndSyntaxErrorInSeparateChunks) {
+  std::unique_ptr<TypeResolver> resolver{
+      google::protobuf::util::NewTypeResolverForDescriptorPool(
+          "type.googleapis.com", DescriptorPool::generated_pool())};
+  io::internal::TestZeroCopyInputStream input_stream(
+      {"{\"bool_value\":", "5}"});
+  std::string result;
+  io::StringOutputStream output_stream(&result);
+  absl::Status s = JsonToBinaryStream(
+      resolver.get(), "type.googleapis.com/proto3.TestMessage", &input_stream,
+      &output_stream, ParseOptions{});
+  ASSERT_FALSE(s.ok());
+  EXPECT_THAT(
+      s.message(),
+      ContainsRegex("invalid *JSON *in *type.googleapis.com/proto3.TestMessage "
+                    "*@ *bool_value"));
 }
 
 }  // namespace


### PR DESCRIPTION
This PR also backports a change to use large runners for ASAN and MSAN builds.