### PR TITLE
Fix 13736 error on upb compilation with Clang

### DIFF
--- a/upb/BUILD
+++ b/upb/BUILD
@@ -91,7 +91,7 @@ cc_library(
     hdrs = [
         "upb.hpp",
     ],
-    copts = UPB_DEFAULT_COPTS,
+    copts = UPB_DEFAULT_COPTS + ["-Wno-gnu-offsetof-extensions"],
     deprecation = "use upb:base and/or upb:mem instead",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
When compiling upb Clang will emit a warning like this: `error: defining a type within '__builtin_offsetof' is a Clang extension [-Werror,-Wgnu-offsetof-extensions]` as shown in issue #13736.

This commit fixes that error by adding the compiler flag '-Wno-gnu-offsetof-extensions' which suppresses the warning/error.