### PR TITLE
feat: add protons extension

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -486,3 +486,8 @@ with info about your project (name and website) so we can add an entry for you.
 
     *   Website: https://square.github.io/wire/
     *   Extensions: 1185
+
+1.  Protons
+
+    *   Website: https://github.com/ipfs/protons
+    *   Extensions: 1186


### PR DESCRIPTION
Adds an extension id to the registry for use by the [protons](https://www.npmjs.com/package/protons) protobuf encoder/decoder.