### PR TITLE
feat: automate publishing releases to Bazel Central Registry

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -1,0 +1,9 @@
+# Bazel Central Registry
+
+When protobuf is released, we want it to be published to the
+Bazel Central Registry automatically:
+<https://registry.bazel.build>
+
+This folder contains configuration files to automate the publish step.
+See <https://github.com/bazel-contrib/publish-to-bcr/blob/main/templates/README.md>
+for authoritative documentation about these files.

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,4 @@
+# see https://github.com/bazel-contrib/publish-to-bcr/#a-note-on-release-automation
+fixedReleaser:
+  login: thesayyn
+  email: sahin@aspect.dev

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,22 @@
+{
+  "homepage": "https://github.com/protocolbuffers/protobuf",
+  "maintainers": [
+    {
+      "github": "comius",
+      "name": "Ivo List"
+    },
+    {
+      "email": "alex@aspect.dev",
+      "github": "alexeagle",
+      "name": "Alex Eagle"
+    },
+    {
+      "email": "sahin@aspect.dev",
+      "github": "thesayyn",
+      "name": "Şahin Yort"
+    }
+  ],
+  "repository": ["github:protocolbuffers/protobuf"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,24 @@
+matrix:
+  platform: ["debian10", "macos", "ubuntu2004"]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    build_targets:
+    - '@protobuf//:all'
+    - '@protobuf//java/core/...'
+    - '@protobuf//java/lite/...'
+    - '-@protobuf//:common_dist_files'
+    - '-@protobuf//:proto_api'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["centos7", "debian10", "macos", "ubuntu2004"]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      build_targets:
+      - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "**leave this alone**",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{VERSION}.zip"
+}


### PR DESCRIPTION
Note, it's also required that someone with sufficient permissions "installs" the Publish-to-BCR GitHub app to this repo.
FYI @thesayyn 

Fixes #14564 