### PR TITLE
refactor: relocate ruby targets under the //ruby package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,7 @@ load("@rules_java//java:defs.bzl", "java_lite_proto_library", "java_proto_librar
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
 load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
-load(":protobuf.bzl", "internal_objc_proto_library", "internal_php_proto_library", "internal_py_proto_library", "internal_ruby_proto_library")
+load(":protobuf.bzl", "internal_objc_proto_library", "internal_php_proto_library", "internal_py_proto_library")
 
 licenses(["notice"])
 
@@ -148,17 +148,6 @@ filegroup(
     ],
     deprecation = "Prefer :well_known_type_protos instead.",
     visibility = ["//visibility:public"],
-)
-
-internal_ruby_proto_library(
-    name = "well_known_ruby_protos",
-    srcs = [":well_known_protos"],
-    default_runtime = "",
-    includes = ["src"],
-    visibility = [
-        "//conformance:__pkg__",
-        "//ruby:__subpackages__",
-    ],
 )
 
 ################################################################################
@@ -522,33 +511,6 @@ internal_php_proto_library(
         "//conformance:__pkg__",
         "//php:__subpackages__",
     ],
-)
-
-internal_ruby_proto_library(
-    name = "test_messages_proto2_ruby_proto",
-    testonly = 1,
-    srcs = ["//src/google/protobuf:test_messages_proto2.proto"],
-    includes = ["src/google/protobuf"],
-    visibility = [
-        "//conformance:__pkg__",
-        "//ruby:__subpackages__",
-    ],
-)
-
-internal_ruby_proto_library(
-    name = "test_messages_proto3_ruby_proto",
-    testonly = 1,
-    srcs = ["//src/google/protobuf:test_messages_proto3.proto"],
-    includes = [
-        "src/google/protobuf",
-        # The above must come first.
-        "src",
-    ],
-    visibility = [
-        "//conformance:__pkg__",
-        "//ruby:__subpackages__",
-    ],
-    deps = [":well_known_ruby_protos"],
 )
 
 filegroup(

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -2,7 +2,8 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "objc_library")
 load("@rules_ruby//ruby:defs.bzl", "ruby_binary")
-load("//:protobuf.bzl", "internal_csharp_proto_library", "internal_objc_proto_library", "internal_php_proto_library", "internal_py_proto_library", "internal_ruby_proto_library")
+load("//ruby:defs.bzl", "internal_ruby_proto_library")
+load("//:protobuf.bzl", "internal_csharp_proto_library", "internal_objc_proto_library", "internal_php_proto_library", "internal_py_proto_library")
 load("//build_defs:internal_shell.bzl", "inline_sh_binary")
 load(
     "@rules_pkg//:mappings.bzl",

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -2,7 +2,6 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load("@rules_python//python:defs.bzl", "py_library")
-load("@rules_ruby//ruby:defs.bzl", "ruby_library")
 
 def _GetPath(ctx, path):
     if ctx.label.workspace_root:
@@ -272,6 +271,9 @@ _proto_gen = rule(
     implementation = _proto_gen_impl,
 )
 
+# Expose for //ruby
+internal_only_proto_gen = _proto_gen
+
 def _internal_gen_well_known_protos_java_impl(ctx):
     args = ctx.actions.args()
 
@@ -485,63 +487,6 @@ def internal_objc_proto_library(
         # works.  See https://github.com/bazelbuild/bazel/issues/12897.
         tags = ["manual"],
         target_compatible_with = ["@platforms//os:osx"],
-        **kwargs
-    )
-
-def internal_ruby_proto_library(
-        name,
-        srcs = [],
-        deps = [],
-        includes = ["."],
-        default_runtime = "@com_google_protobuf//ruby:protobuf",
-        protoc = "@com_google_protobuf//:protoc",
-        testonly = None,
-        visibility = ["//visibility:public"],
-        **kwargs):
-    """Bazel rule to create a Ruby protobuf library from proto source files
-
-    NOTE: the rule is only an internal workaround to generate protos. The
-    interface may change and the rule may be removed when bazel has introduced
-    the native rule.
-
-    Args:
-      name: the name of the ruby_proto_library.
-      srcs: the .proto files to compile.
-      deps: a list of dependency labels; must be a internal_ruby_proto_library.
-      includes: a string indicating the include path of the .proto files.
-      default_runtime: the RubyProtobuf runtime
-      protoc: the label of the protocol compiler to generate the sources.
-      testonly: common rule attribute (see:
-          https://bazel.build/reference/be/common-definitions#common-attributes)
-      visibility: the visibility of the generated files.
-      **kwargs: other keyword arguments that are passed to ruby_library.
-
-    """
-
-    # Note: we need to run the protoc build twice to get separate targets for
-    # the generated header and the source files.
-    _proto_gen(
-        name = name + "_genproto",
-        srcs = srcs,
-        deps = [s + "_genproto" for s in deps],
-        langs = ["ruby"],
-        includes = includes,
-        protoc = protoc,
-        testonly = testonly,
-        visibility = visibility,
-        tags = ["manual"],
-    )
-
-    deps = []
-    if default_runtime:
-        deps.append(default_runtime)
-    ruby_library(
-        name = name,
-        srcs = [name + "_genproto"],
-        deps = deps,
-        testonly = testonly,
-        visibility = visibility,
-        includes = includes,
         **kwargs
     )
 

--- a/ruby/BUILD.bazel
+++ b/ruby/BUILD.bazel
@@ -6,10 +6,47 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_ruby//ruby:defs.bzl", "ruby_library")
-load("//build_defs:internal_shell.bzl", "inline_sh_binary")
-load("//:protobuf.bzl", "internal_ruby_proto_library")
+load(":defs.bzl", "internal_ruby_proto_library")
 load("//conformance:defs.bzl", "conformance_test")
 load("//:protobuf_version.bzl", "PROTOBUF_RUBY_VERSION")
+
+internal_ruby_proto_library(
+    name = "well_known_ruby_protos",
+    srcs = ["//:well_known_protos"],
+    default_runtime = "",
+    includes = ["src"],
+    visibility = [
+        "//conformance:__pkg__",
+        "//ruby:__subpackages__",
+    ],
+)
+
+internal_ruby_proto_library(
+    name = "test_messages_proto2_ruby_proto",
+    testonly = 1,
+    srcs = ["//src/google/protobuf:test_messages_proto2.proto"],
+    includes = ["src/google/protobuf"],
+    visibility = [
+        "//conformance:__pkg__",
+        "//ruby:__subpackages__",
+    ],
+)
+
+internal_ruby_proto_library(
+    name = "test_messages_proto3_ruby_proto",
+    testonly = 1,
+    srcs = ["//src/google/protobuf:test_messages_proto3.proto"],
+    includes = [
+        "src/google/protobuf",
+        # The above must come first.
+        "src",
+    ],
+    visibility = [
+        "//conformance:__pkg__",
+        "//ruby:__subpackages__",
+    ],
+    deps = [":well_known_ruby_protos"],
+)
 
 ################################################################################
 # Ruby Runtime
@@ -105,7 +142,7 @@ genrule(
         "//ruby/lib/google:copy_jar",
         "//ruby/lib/google:dist_files",
         "//ruby/ext/google/protobuf_c:dist_files",
-        "//:well_known_ruby_protos",
+        "//ruby:well_known_ruby_protos",
         "google-protobuf.gemspec",
     ],
     outs = ["google-protobuf-" + PROTOBUF_RUBY_VERSION + "-java.gem"],
@@ -119,7 +156,7 @@ genrule(
         for utf in $(execpaths @utf8_range//:utf8_range_srcs) $(execpath @utf8_range//:LICENSE); do
             mv "tmp/$$utf" "tmp/ruby/ext/google/protobuf_c/third_party/utf8_range"
         done
-        for wkt in $(execpaths //:well_known_ruby_protos); do
+        for wkt in $(execpaths //ruby:well_known_ruby_protos); do
             mv "tmp/$$wkt" "tmp/ruby/lib/google/protobuf/"
         done
         mv "tmp/$(execpath //ruby/lib/google:copy_jar)" "tmp/ruby/lib/google"
@@ -141,7 +178,7 @@ genrule(
     srcs = [
         "@utf8_range//:utf8_range_srcs",
         "@utf8_range//:LICENSE",
-        "//:well_known_ruby_protos",
+        "//ruby:well_known_ruby_protos",
         "//ruby/ext/google/protobuf_c:dist_files",
         "//ruby/lib/google:dist_files",
         "google-protobuf.gemspec",
@@ -157,7 +194,7 @@ genrule(
         for utf in $(execpaths @utf8_range//:utf8_range_srcs) $(execpath @utf8_range//:LICENSE); do
             mv "tmp/$$utf" "tmp/ruby/ext/google/protobuf_c/third_party/utf8_range"
         done
-        for wkt in $(execpaths //:well_known_ruby_protos); do
+        for wkt in $(execpaths //ruby:well_known_ruby_protos); do
             mv "tmp/$$wkt" "tmp/ruby/lib/google/protobuf/"
         done
         cd tmp/ruby
@@ -198,7 +235,7 @@ internal_ruby_proto_library(
     visibility = [
         "//ruby:__subpackages__",
     ],
-    deps = ["//:well_known_ruby_protos"],
+    deps = ["//ruby:well_known_ruby_protos"],
 )
 
 conformance_test(

--- a/ruby/compatibility_tests/v3.0.0/tests/BUILD.bazel
+++ b/ruby/compatibility_tests/v3.0.0/tests/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_ruby//ruby:defs.bzl", "ruby_test")
-load("//:protobuf.bzl", "internal_ruby_proto_library")
+load("//ruby:defs.bzl", "internal_ruby_proto_library")
 
 internal_ruby_proto_library(
     name = "test_ruby_protos",

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -1,0 +1,64 @@
+"""Definition of ruby rules for Bazel
+
+These are in the //ruby subpackage to avoid leaking a dependency on the
+protocolbuffers/rules_ruby fork to Bazel users who don't use ruby.
+"""
+load("@rules_ruby//ruby:defs.bzl", "ruby_library")
+load("//:protobuf.bzl", "internal_only_proto_gen")
+
+def internal_ruby_proto_library(
+        name,
+        srcs = [],
+        deps = [],
+        includes = ["."],
+        default_runtime = "@com_google_protobuf//ruby:protobuf",
+        protoc = "@com_google_protobuf//:protoc",
+        testonly = None,
+        visibility = ["//visibility:public"],
+        **kwargs):
+    """Bazel rule to create a Ruby protobuf library from proto source files
+
+    NOTE: the rule is only an internal workaround to generate protos. The
+    interface may change and the rule may be removed when bazel has introduced
+    the native rule.
+
+    Args:
+      name: the name of the ruby_proto_library.
+      srcs: the .proto files to compile.
+      deps: a list of dependency labels; must be a internal_ruby_proto_library.
+      includes: a string indicating the include path of the .proto files.
+      default_runtime: the RubyProtobuf runtime
+      protoc: the label of the protocol compiler to generate the sources.
+      testonly: common rule attribute (see:
+          https://bazel.build/reference/be/common-definitions#common-attributes)
+      visibility: the visibility of the generated files.
+      **kwargs: other keyword arguments that are passed to ruby_library.
+
+    """
+
+    # Note: we need to run the protoc build twice to get separate targets for
+    # the generated header and the source files.
+    internal_only_proto_gen(
+        name = name + "_genproto",
+        srcs = srcs,
+        deps = [s + "_genproto" for s in deps],
+        langs = ["ruby"],
+        includes = includes,
+        protoc = protoc,
+        testonly = testonly,
+        visibility = visibility,
+        tags = ["manual"],
+    )
+
+    deps = []
+    if default_runtime:
+        deps.append(default_runtime)
+    ruby_library(
+        name = name,
+        srcs = [name + "_genproto"],
+        deps = deps,
+        testonly = testonly,
+        visibility = visibility,
+        includes = includes,
+        **kwargs
+    )

--- a/ruby/lib/google/BUILD.bazel
+++ b/ruby/lib/google/BUILD.bazel
@@ -78,7 +78,7 @@ ruby_library(
     }),
     includes = ["ruby/lib"],
     visibility = ["//ruby:__pkg__"],
-    deps = ["//:well_known_ruby_protos"] + select({
+    deps = ["//ruby:well_known_ruby_protos"] + select({
         "//ruby:ffi_enabled": [
             "@protobuf_bundle//:ffi",
             "@protobuf_bundle//:ffi-compiler",


### PR DESCRIPTION
Fixes #14569

Note, this is a breaking change for Bazel users who depended on the labels of the `ruby_library` targets of the well-known-protos