### PR TITLE
Cherry-pick: Include .inc files directly instead of through a filegroup

### DIFF
--- a/upb/port/BUILD
+++ b/upb/port/BUILD
@@ -14,7 +14,15 @@ cc_library(
         "vsnprintf_compat.h",
     ],
     copts = UPB_DEFAULT_COPTS,
-    textual_hdrs = [":inc"],
+    textual_hdrs = [
+        # We must list the headers explicitly here instead of relying on the
+        # :inc filegroup below. gRPC auto-generates various build configs from
+        # the Bazel graph, and this logic does not know how to handle
+        # filegroups. We might be able to replace these headers with just
+        # ":inc" after gRPC starts using upb's CMake build.
+        "def.inc",
+        "undef.inc",
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
gRPC auto-generates CMake and other build configs from the Bazel build graph, but the logic for doing this does not know how to handle filegroups. This change works around that problem by making the `:port` target refer directly to the `.inc` files instead of going through a filegroup. This solution is not ideal but I think it's probably the best way to unblock progress for now.

PiperOrigin-RevId: 578333954