### PR TITLE
Add support for options in CRuby, JRuby and FFI

### DIFF
--- a/ruby/ext/google/protobuf_c/glue.c
+++ b/ruby/ext/google/protobuf_c/glue.c
@@ -19,3 +19,35 @@ google_protobuf_FileDescriptorProto* FileDescriptorProto_parse(
   return google_protobuf_FileDescriptorProto_parse(serialized_file_proto,
                                                    length, arena);
 }
+
+char* EnumDescriptor_serialized_options(const upb_EnumDef* enumdef, size_t *size) {
+  const google_protobuf_EnumOptions* opts = upb_EnumDef_Options(enumdef);
+  upb_Arena* arena = upb_Arena_New();
+  char* serialized = google_protobuf_EnumOptions_serialize(opts, arena, size);
+  upb_Arena_Free(arena);
+  return serialized;
+}
+
+char* FileDescriptor_serialized_options(const upb_FileDef* filedef, size_t *size) {
+  const google_protobuf_FileOptions* opts = upb_FileDef_Options(filedef);
+  upb_Arena* arena = upb_Arena_New();
+  char* serialized = google_protobuf_FileOptions_serialize(opts, arena, size);
+  upb_Arena_Free(arena);
+  return serialized;
+}
+
+char* Descriptor_serialized_options(const upb_MessageDef* msgdef, size_t *size) {
+  const google_protobuf_MessageOptions* opts = upb_MessageDef_Options(msgdef);
+  upb_Arena* arena = upb_Arena_New();
+  char* serialized = google_protobuf_MessageOptions_serialize(opts, arena, size);
+  upb_Arena_Free(arena);
+  return serialized;
+}
+
+char* OneOfDescriptor_serialized_options(const upb_OneofDef* oneofdef, size_t *size) {
+  const google_protobuf_OneofOptions* opts = upb_OneofDef_Options(oneofdef);
+  upb_Arena* arena = upb_Arena_New();
+  char* serialized = google_protobuf_OneofOptions_serialize(opts, arena, size);
+  upb_Arena_Free(arena);
+  return serialized;
+}

--- a/ruby/ext/google/protobuf_c/glue.c
+++ b/ruby/ext/google/protobuf_c/glue.c
@@ -42,3 +42,9 @@ char* OneOfDescriptor_serialized_options(const upb_OneofDef* oneofdef, size_t *s
   char* serialized = google_protobuf_OneofOptions_serialize(opts, arena, size);
   return serialized;
 }
+
+char* FieldDescriptor_serialized_options(const upb_FieldDef* fielddef, size_t *size, upb_Arena *arena) {
+  const google_protobuf_FieldOptions* opts = upb_FieldDef_Options(fielddef);
+  char* serialized = google_protobuf_FieldOptions_serialize(opts, arena, size);
+  return serialized;
+}

--- a/ruby/ext/google/protobuf_c/glue.c
+++ b/ruby/ext/google/protobuf_c/glue.c
@@ -14,40 +14,31 @@
 upb_Arena* Arena_create() { return upb_Arena_Init(NULL, 0, &upb_alloc_global); }
 
 google_protobuf_FileDescriptorProto* FileDescriptorProto_parse(
-    const char* serialized_file_proto, size_t length) {
-  upb_Arena* arena = Arena_create();
+    const char* serialized_file_proto, size_t length, upb_Arena *arena) {
   return google_protobuf_FileDescriptorProto_parse(serialized_file_proto,
                                                    length, arena);
 }
 
-char* EnumDescriptor_serialized_options(const upb_EnumDef* enumdef, size_t *size) {
+char* EnumDescriptor_serialized_options(const upb_EnumDef* enumdef, size_t *size, upb_Arena *arena) {
   const google_protobuf_EnumOptions* opts = upb_EnumDef_Options(enumdef);
-  upb_Arena* arena = upb_Arena_New();
   char* serialized = google_protobuf_EnumOptions_serialize(opts, arena, size);
-  upb_Arena_Free(arena);
   return serialized;
 }
 
-char* FileDescriptor_serialized_options(const upb_FileDef* filedef, size_t *size) {
+char* FileDescriptor_serialized_options(const upb_FileDef* filedef, size_t *size, upb_Arena *arena) {
   const google_protobuf_FileOptions* opts = upb_FileDef_Options(filedef);
-  upb_Arena* arena = upb_Arena_New();
   char* serialized = google_protobuf_FileOptions_serialize(opts, arena, size);
-  upb_Arena_Free(arena);
   return serialized;
 }
 
-char* Descriptor_serialized_options(const upb_MessageDef* msgdef, size_t *size) {
+char* Descriptor_serialized_options(const upb_MessageDef* msgdef, size_t *size, upb_Arena *arena) {
   const google_protobuf_MessageOptions* opts = upb_MessageDef_Options(msgdef);
-  upb_Arena* arena = upb_Arena_New();
   char* serialized = google_protobuf_MessageOptions_serialize(opts, arena, size);
-  upb_Arena_Free(arena);
   return serialized;
 }
 
-char* OneOfDescriptor_serialized_options(const upb_OneofDef* oneofdef, size_t *size) {
+char* OneOfDescriptor_serialized_options(const upb_OneofDef* oneofdef, size_t *size, upb_Arena *arena) {
   const google_protobuf_OneofOptions* opts = upb_OneofDef_Options(oneofdef);
-  upb_Arena* arena = upb_Arena_New();
   char* serialized = google_protobuf_OneofOptions_serialize(opts, arena, size);
-  upb_Arena_Free(arena);
   return serialized;
 }

--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -573,9 +573,6 @@ static VALUE Map_freeze(VALUE _self) {
 }
 
 /*
- * call-seq:
- *     Map.internal_deep_freeze => self
- *
  * Deep freezes the map and values recursively.
  * Internal use only.
  */
@@ -591,7 +588,7 @@ static VALUE Map_internal_deep_freeze(VALUE _self) {
 
       while (upb_Map_Next(self->map, &key, &val, &iter)) {
         VALUE val_val = Convert_UpbToRuby(val, self->value_type_info, self->arena);
-        rb_funcall(val_val, rb_intern("internal_deep_freeze"), 0);
+        Message_internal_deep_freeze(val_val);
       }
     }
   }
@@ -685,8 +682,6 @@ void Map_register(VALUE module) {
   rb_define_method(klass, "clone", Map_dup, 0);
   rb_define_method(klass, "==", Map_eq, 1);
   rb_define_method(klass, "freeze", Map_freeze, 0);
-  rb_define_private_method(klass, "internal_deep_freeze",
-                          Map_internal_deep_freeze, 0);
   rb_define_method(klass, "hash", Map_hash, 0);
   rb_define_method(klass, "to_h", Map_to_h, 0);
   rb_define_method(klass, "inspect", Map_inspect, 0);

--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -576,7 +576,7 @@ static VALUE Map_freeze(VALUE _self) {
  * Deep freezes the map and values recursively.
  * Internal use only.
  */
-static VALUE Map_internal_deep_freeze(VALUE _self) {
+VALUE Map_internal_deep_freeze(VALUE _self) {
   Map* self = ruby_to_Map(_self);
 
   if (!RB_OBJ_FROZEN(_self)) {

--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -578,21 +578,16 @@ static VALUE Map_freeze(VALUE _self) {
  */
 VALUE Map_internal_deep_freeze(VALUE _self) {
   Map* self = ruby_to_Map(_self);
+  Map_freeze(_self);
+  if (self->value_type_info.type == kUpb_CType_Message) {
+    size_t iter = kUpb_Map_Begin;
+    upb_MessageValue key, val;
 
-  if (!RB_OBJ_FROZEN(_self)) {
-    Map_freeze(_self);
-
-    if (self->value_type_info.type == kUpb_CType_Message) {
-      size_t iter = kUpb_Map_Begin;
-      upb_MessageValue key, val;
-
-      while (upb_Map_Next(self->map, &key, &val, &iter)) {
-        VALUE val_val = Convert_UpbToRuby(val, self->value_type_info, self->arena);
-        Message_internal_deep_freeze(val_val);
-      }
+    while (upb_Map_Next(self->map, &key, &val, &iter)) {
+      VALUE val_val = Convert_UpbToRuby(val, self->value_type_info, self->arena);
+      Message_internal_deep_freeze(val_val);
     }
   }
-
   return _self;
 }
 

--- a/ruby/ext/google/protobuf_c/map.h
+++ b/ruby/ext/google/protobuf_c/map.h
@@ -38,4 +38,7 @@ extern VALUE cMap;
 // Call at startup to register all types in this module.
 void Map_register(VALUE module);
 
+// Recursively freeze map
+VALUE Map_internal_deep_freeze(VALUE _self);
+
 #endif  // RUBY_PROTOBUF_MAP_H_

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -874,8 +874,10 @@ static VALUE Message_internal_deep_freeze(VALUE _self) {
       VALUE field = Message_getfield(_self, f);
 
       if (field != Qnil) {
-        if (upb_FieldDef_IsMap(f) || upb_FieldDef_IsRepeated(f)) {
-          rb_funcall(field, rb_intern("internal_deep_freeze"), 0);
+        if (upb_FieldDef_IsMap(f) {
+          Map_internal_deep_freeze(field);
+        } else if (upb_FieldDef_IsRepeated(f)) {
+          RepeatedField_internal_deep_freeze(field);
         } else if (upb_FieldDef_IsSubMessage(f)) {
           Message_internal_deep_freeze(field);
         }

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -863,7 +863,7 @@ static VALUE Message_freeze(VALUE _self) {
  * Deep freezes the message object recursively.
  * Internal use only.
  */
-static VALUE Message_internal_deep_freeze(VALUE _self) {
+VALUE Message_internal_deep_freeze(VALUE _self) {
   Message* self = ruby_to_Message(_self);
   if (!RB_OBJ_FROZEN(_self)) {
     Message_freeze(_self);
@@ -874,7 +874,7 @@ static VALUE Message_internal_deep_freeze(VALUE _self) {
       VALUE field = Message_getfield(_self, f);
 
       if (field != Qnil) {
-        if (upb_FieldDef_IsMap(f) {
+        if (upb_FieldDef_IsMap(f)) {
           Map_internal_deep_freeze(field);
         } else if (upb_FieldDef_IsRepeated(f)) {
           RepeatedField_internal_deep_freeze(field);

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -865,26 +865,23 @@ static VALUE Message_freeze(VALUE _self) {
  */
 VALUE Message_internal_deep_freeze(VALUE _self) {
   Message* self = ruby_to_Message(_self);
-  if (!RB_OBJ_FROZEN(_self)) {
-    Message_freeze(_self);
+  Message_freeze(_self);
 
-    int n = upb_MessageDef_FieldCount(self->msgdef);
-    for (int i = 0; i < n; i++) {
-      const upb_FieldDef* f = upb_MessageDef_Field(self->msgdef, i);
-      VALUE field = Message_getfield(_self, f);
+  int n = upb_MessageDef_FieldCount(self->msgdef);
+  for (int i = 0; i < n; i++) {
+    const upb_FieldDef* f = upb_MessageDef_Field(self->msgdef, i);
+    VALUE field = Message_getfield(_self, f);
 
-      if (field != Qnil) {
-        if (upb_FieldDef_IsMap(f)) {
-          Map_internal_deep_freeze(field);
-        } else if (upb_FieldDef_IsRepeated(f)) {
-          RepeatedField_internal_deep_freeze(field);
-        } else if (upb_FieldDef_IsSubMessage(f)) {
-          Message_internal_deep_freeze(field);
-        }
+    if (field != Qnil) {
+      if (upb_FieldDef_IsMap(f)) {
+        Map_internal_deep_freeze(field);
+      } else if (upb_FieldDef_IsRepeated(f)) {
+        RepeatedField_internal_deep_freeze(field);
+      } else if (upb_FieldDef_IsSubMessage(f)) {
+        Message_internal_deep_freeze(field);
       }
     }
   }
-
   return _self;
 }
 

--- a/ruby/ext/google/protobuf_c/message.h
+++ b/ruby/ext/google/protobuf_c/message.h
@@ -76,6 +76,9 @@ VALUE MessageOrEnum_GetDescriptor(VALUE klass);
 // Decodes a Message from a byte sequence.
 VALUE Message_decode_bytes(int size, const char *bytes, int options, VALUE klass, bool freeze);
 
+// Recursively freeze message
+VALUE Message_internal_deep_freeze(VALUE _self);
+
 // Call at startup to register all types in this module.
 void Message_register(VALUE protobuf);
 

--- a/ruby/ext/google/protobuf_c/message.h
+++ b/ruby/ext/google/protobuf_c/message.h
@@ -73,6 +73,9 @@ VALUE build_module_from_enumdesc(VALUE _enumdesc);
 // module.
 VALUE MessageOrEnum_GetDescriptor(VALUE klass);
 
+// Decodes a Message from a byte sequence.
+VALUE Message_decode_bytes(int size, const char *bytes, int options, VALUE klass, bool freeze);
+
 // Call at startup to register all types in this module.
 void Message_register(VALUE protobuf);
 

--- a/ruby/ext/google/protobuf_c/repeated_field.c
+++ b/ruby/ext/google/protobuf_c/repeated_field.c
@@ -491,7 +491,7 @@ static VALUE RepeatedField_freeze(VALUE _self) {
  * Deep freezes the repeated field and values recursively.
  * Internal use only.
  */
-static VALUE RepeatedField_internal_deep_freeze(VALUE _self) {
+VALUE RepeatedField_internal_deep_freeze(VALUE _self) {
   RepeatedField* self = ruby_to_RepeatedField(_self);
 
   if (!RB_OBJ_FROZEN(_self)) {

--- a/ruby/ext/google/protobuf_c/repeated_field.c
+++ b/ruby/ext/google/protobuf_c/repeated_field.c
@@ -488,9 +488,6 @@ static VALUE RepeatedField_freeze(VALUE _self) {
 }
 
 /*
- * call-seq:
- *     RepeatedField.internal_deep_freeze => self
- *
  * Deep freezes the repeated field and values recursively.
  * Internal use only.
  */
@@ -507,7 +504,7 @@ static VALUE RepeatedField_internal_deep_freeze(VALUE _self) {
       for (i = 0; i < size; i++) {
         upb_MessageValue msgval = upb_Array_Get(self->array, i);
         VALUE val = Convert_UpbToRuby(msgval, self->type_info, self->arena);
-        rb_funcall(val, rb_intern("internal_deep_freeze"), 0);
+        Message_internal_deep_freeze(val);
       }
     }
   }
@@ -658,8 +655,6 @@ void RepeatedField_register(VALUE module) {
   rb_define_method(klass, "==", RepeatedField_eq, 1);
   rb_define_method(klass, "to_ary", RepeatedField_to_ary, 0);
   rb_define_method(klass, "freeze", RepeatedField_freeze, 0);
-  rb_define_private_method(klass, "internal_deep_freeze",
-                          RepeatedField_internal_deep_freeze, 0);
   rb_define_method(klass, "hash", RepeatedField_hash, 0);
   rb_define_method(klass, "+", RepeatedField_plus, 1);
   rb_define_method(klass, "concat", RepeatedField_concat, 1);

--- a/ruby/ext/google/protobuf_c/repeated_field.c
+++ b/ruby/ext/google/protobuf_c/repeated_field.c
@@ -493,22 +493,16 @@ static VALUE RepeatedField_freeze(VALUE _self) {
  */
 VALUE RepeatedField_internal_deep_freeze(VALUE _self) {
   RepeatedField* self = ruby_to_RepeatedField(_self);
-
-  if (!RB_OBJ_FROZEN(_self)) {
-    RepeatedField_freeze(_self);
-
-    if (self->type_info.type == kUpb_CType_Message) {
-      int size = upb_Array_Size(self->array);
-      int i;
-
-      for (i = 0; i < size; i++) {
-        upb_MessageValue msgval = upb_Array_Get(self->array, i);
-        VALUE val = Convert_UpbToRuby(msgval, self->type_info, self->arena);
-        Message_internal_deep_freeze(val);
-      }
+  RepeatedField_freeze(_self);
+  if (self->type_info.type == kUpb_CType_Message) {
+    int size = upb_Array_Size(self->array);
+    int i;
+    for (i = 0; i < size; i++) {
+      upb_MessageValue msgval = upb_Array_Get(self->array, i);
+      VALUE val = Convert_UpbToRuby(msgval, self->type_info, self->arena);
+      Message_internal_deep_freeze(val);
     }
   }
-
   return _self;
 }
 

--- a/ruby/ext/google/protobuf_c/repeated_field.h
+++ b/ruby/ext/google/protobuf_c/repeated_field.h
@@ -35,4 +35,7 @@ extern VALUE cRepeatedField;
 // Call at startup to register all types in this module.
 void RepeatedField_register(VALUE module);
 
+// Recursively freeze RepeatedField.
+VALUE RepeatedField_internal_deep_freeze(VALUE _self);
+
 #endif  // RUBY_PROTOBUF_REPEATED_FIELD_H_

--- a/ruby/lib/google/protobuf/descriptor_dsl.rb
+++ b/ruby/lib/google/protobuf/descriptor_dsl.rb
@@ -450,11 +450,6 @@ module Google
           @enum_proto.value << enum_value_proto
         end
       end
-
-      def self.decode_options(klass, serialized_options)
-        options = klass.decode(serialized_options)
-        options.send(:internal_deep_freeze)
-      end
     end
 
     # Re-open the class (the rest of the class is implemented in C)
@@ -463,56 +458,6 @@ module Google
         builder = Internal::Builder.new(self)
         builder.instance_eval(&block)
         builder.build
-      end
-    end
-
-    # Re-open the class (the rest of the class is implemented in C)
-    class Descriptor
-      def options
-        @options ||= Google::Protobuf::Internal.decode_options(
-          Google::Protobuf::MessageOptions,
-          serialized_options
-        )
-      end
-    end
-
-    # Re-open the class (the rest of the class is implemented in C)
-    class FileDescriptor
-      def options
-        @options ||= Google::Protobuf::Internal.decode_options(
-          Google::Protobuf::FileOptions,
-          serialized_options
-        )
-      end
-    end
-
-    # Re-open the class (the rest of the class is implemented in C)
-    class FieldDescriptor
-      def options
-        @options ||= Google::Protobuf::Internal.decode_options(
-          Google::Protobuf::FieldOptions,
-          serialized_options
-        )
-      end
-    end
-
-    # Re-open the class (the rest of the class is implemented in C)
-    class EnumDescriptor
-      def options
-        @options ||= Google::Protobuf::Internal.decode_options(
-          Google::Protobuf::EnumOptions,
-          serialized_options
-        )
-      end
-    end
-
-    # Re-open the class (the rest of the class is implemented in C)
-    class OneofDescriptor
-      def options
-        @options ||= Google::Protobuf::Internal.decode_options(
-          Google::Protobuf::OneofOptions,
-          serialized_options
-        )
       end
     end
   end

--- a/ruby/lib/google/protobuf/descriptor_dsl.rb
+++ b/ruby/lib/google/protobuf/descriptor_dsl.rb
@@ -450,6 +450,7 @@ module Google
           @enum_proto.value << enum_value_proto
         end
       end
+
     end
 
     # Re-open the class (the rest of the class is implemented in C)

--- a/ruby/lib/google/protobuf/ffi/descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/descriptor.rb
@@ -136,6 +136,12 @@ module Google
       def pool
         @descriptor_pool
       end
+
+      def serialized_options
+        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+        buffer = Google::Protobuf::FFI.message_options(self, size_ptr)
+        buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze
+      end
     end
 
     class FFI
@@ -146,6 +152,7 @@ module Google
       attach_function :get_message_fullname, :upb_MessageDef_FullName,                [Descriptor], :string
       attach_function :get_mini_table,       :upb_MessageDef_MiniTable,               [Descriptor], MiniTable.ptr
       attach_function :oneof_count,          :upb_MessageDef_OneofCount,              [Descriptor], :int
+      attach_function :message_options,      :Descriptor_serialized_options,          [Descriptor, :pointer], :pointer
       attach_function :get_well_known_type,  :upb_MessageDef_WellKnownType,           [Descriptor], WellKnown
       attach_function :message_def_syntax,   :upb_MessageDef_Syntax,                  [Descriptor], Syntax
       attach_function :find_msg_def_by_name, :upb_MessageDef_FindByNameWithSize,      [Descriptor, :string, :size_t, :FieldDefPointer, :OneofDefPointer], :bool

--- a/ruby/lib/google/protobuf/ffi/descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/descriptor.rb
@@ -96,9 +96,12 @@ module Google
       end
 
       def options
-        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
-        buffer = Google::Protobuf::FFI.message_options(self, size_ptr)
-        Google::Protobuf::MessageOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
+        @options ||= begin
+          size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+          temporary_arena = Google::Protobuf::FFI.create_arena
+          buffer = Google::Protobuf::FFI.message_options(self, size_ptr, temporary_arena)
+          Google::Protobuf::MessageOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
+        end
       end
 
       private
@@ -152,7 +155,7 @@ module Google
       attach_function :get_message_fullname, :upb_MessageDef_FullName,                [Descriptor], :string
       attach_function :get_mini_table,       :upb_MessageDef_MiniTable,               [Descriptor], MiniTable.ptr
       attach_function :oneof_count,          :upb_MessageDef_OneofCount,              [Descriptor], :int
-      attach_function :message_options,      :Descriptor_serialized_options,          [Descriptor, :pointer], :pointer
+      attach_function :message_options,      :Descriptor_serialized_options,          [Descriptor, :pointer, Internal::Arena], :pointer
       attach_function :get_well_known_type,  :upb_MessageDef_WellKnownType,           [Descriptor], WellKnown
       attach_function :message_def_syntax,   :upb_MessageDef_Syntax,                  [Descriptor], Syntax
       attach_function :find_msg_def_by_name, :upb_MessageDef_FindByNameWithSize,      [Descriptor, :string, :size_t, :FieldDefPointer, :OneofDefPointer], :bool

--- a/ruby/lib/google/protobuf/ffi/descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/descriptor.rb
@@ -138,6 +138,7 @@ module Google
         message = OBJECT_CACHE.get(msg.address)
         if message.nil?
           message = descriptor.msgclass.send(:private_constructor, arena, msg: msg)
+          message.send :internal_deep_freeze if frozen?
         end
         message
       end

--- a/ruby/lib/google/protobuf/ffi/descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/descriptor.rb
@@ -95,6 +95,12 @@ module Google
         @msg_class ||= build_message_class
       end
 
+      def options
+        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+        buffer = Google::Protobuf::FFI.message_options(self, size_ptr)
+        Google::Protobuf::MessageOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
+      end
+
       private
 
       extend Google::Protobuf::Internal::Convert
@@ -135,12 +141,6 @@ module Google
 
       def pool
         @descriptor_pool
-      end
-
-      def serialized_options
-        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
-        buffer = Google::Protobuf::FFI.message_options(self, size_ptr)
-        buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze
       end
     end
 

--- a/ruby/lib/google/protobuf/ffi/descriptor_pool.rb
+++ b/ruby/lib/google/protobuf/ffi/descriptor_pool.rb
@@ -15,7 +15,7 @@ module Google
       attach_function :lookup_enum,           :upb_DefPool_FindEnumByName,    [:DefPool, :string], EnumDescriptor
       attach_function :lookup_msg,            :upb_DefPool_FindMessageByName, [:DefPool, :string], Descriptor
       # FileDescriptorProto
-      attach_function :parse,                 :FileDescriptorProto_parse, [:binary_string, :size_t], :FileDescriptorProto
+      attach_function :parse,                 :FileDescriptorProto_parse,     [:binary_string, :size_t, Internal::Arena], :FileDescriptorProto
     end
     class DescriptorPool
       attr :descriptor_pool
@@ -35,7 +35,8 @@ module Google
         memBuf = ::FFI::MemoryPointer.new(:char, file_contents.bytesize)
         # Insert the data
         memBuf.put_bytes(0, file_contents)
-        file_descriptor_proto = Google::Protobuf::FFI.parse memBuf, file_contents.bytesize
+        temporary_arena = Google::Protobuf::FFI.create_arena
+        file_descriptor_proto = Google::Protobuf::FFI.parse memBuf, file_contents.bytesize, temporary_arena
         raise ArgumentError.new("Unable to parse FileDescriptorProto") if file_descriptor_proto.null?
 
         status = Google::Protobuf::FFI::Status.new

--- a/ruby/lib/google/protobuf/ffi/enum_descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/enum_descriptor.rb
@@ -80,9 +80,12 @@ module Google
       end
 
       def options
-        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
-        buffer = Google::Protobuf::FFI.enum_options(self, size_ptr)
-        Google::Protobuf::EnumOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
+        @options ||= begin
+          size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+          temporary_arena = Google::Protobuf::FFI.create_arena
+          buffer = Google::Protobuf::FFI.enum_options(self, size_ptr, temporary_arena)
+          Google::Protobuf::EnumOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
+        end
       end
 
       private
@@ -158,7 +161,7 @@ module Google
       attach_function :enum_value_by_name,        :upb_EnumDef_FindValueByNameWithSize,[EnumDescriptor, :string, :size_t], :EnumValueDef
       attach_function :enum_value_by_number,      :upb_EnumDef_FindValueByNumber,      [EnumDescriptor, :int], :EnumValueDef
       attach_function :get_enum_fullname,         :upb_EnumDef_FullName,               [EnumDescriptor], :string
-      attach_function :enum_options,              :EnumDescriptor_serialized_options,  [EnumDescriptor, :pointer], :pointer
+      attach_function :enum_options,              :EnumDescriptor_serialized_options,  [EnumDescriptor, :pointer, Internal::Arena], :pointer
       attach_function :enum_value_by_index,       :upb_EnumDef_Value,                  [EnumDescriptor, :int], :EnumValueDef
       attach_function :enum_value_count,          :upb_EnumDef_ValueCount,             [EnumDescriptor], :int
       attach_function :enum_name,                 :upb_EnumValueDef_Name,              [:EnumValueDef], :string

--- a/ruby/lib/google/protobuf/ffi/enum_descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/enum_descriptor.rb
@@ -19,7 +19,7 @@ module Google
         prepend Google::Protobuf::Internal::TypeSafety
         include Google::Protobuf::Internal::PointerHelper
 
-        # @param value [Arena] Arena to convert to an FFI native type
+        # @param value [EnumDescriptor] EnumDescriptor to convert to an FFI native type
         # @param _ [Object] Unused
         def to_native(value, _)
           value.instance_variable_get(:@enum_def) || ::FFI::Pointer::NULL
@@ -111,6 +111,12 @@ module Google
         end
       end
 
+      def serialized_options
+        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+        buffer = Google::Protobuf::FFI.enum_options(self, size_ptr)
+        buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze
+      end
+
       def build_enum_module
         descriptor = self
         dynamic_module = Module.new do
@@ -152,6 +158,7 @@ module Google
       attach_function :enum_value_by_name,        :upb_EnumDef_FindValueByNameWithSize,[EnumDescriptor, :string, :size_t], :EnumValueDef
       attach_function :enum_value_by_number,      :upb_EnumDef_FindValueByNumber,      [EnumDescriptor, :int], :EnumValueDef
       attach_function :get_enum_fullname,         :upb_EnumDef_FullName,               [EnumDescriptor], :string
+      attach_function :enum_options,              :EnumDescriptor_serialized_options,  [EnumDescriptor, :pointer], :pointer
       attach_function :enum_value_by_index,       :upb_EnumDef_Value,                  [EnumDescriptor, :int], :EnumValueDef
       attach_function :enum_value_count,          :upb_EnumDef_ValueCount,             [EnumDescriptor], :int
       attach_function :enum_name,                 :upb_EnumValueDef_Name,              [:EnumValueDef], :string

--- a/ruby/lib/google/protobuf/ffi/enum_descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/enum_descriptor.rb
@@ -79,6 +79,12 @@ module Google
         @module
       end
 
+      def options
+        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+        buffer = Google::Protobuf::FFI.enum_options(self, size_ptr)
+        Google::Protobuf::EnumOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
+      end
+
       private
 
       def initialize(enum_def, descriptor_pool)
@@ -109,12 +115,6 @@ module Google
         else
           Google::Protobuf::FFI.enum_number(enum_value)
         end
-      end
-
-      def serialized_options
-        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
-        buffer = Google::Protobuf::FFI.enum_options(self, size_ptr)
-        buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze
       end
 
       def build_enum_module

--- a/ruby/lib/google/protobuf/ffi/field_descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/field_descriptor.rb
@@ -206,6 +206,15 @@ module Google
         end
       end
 
+      def options
+        @options ||= begin
+          size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+          temporary_arena = Google::Protobuf::FFI.create_arena
+          buffer = Google::Protobuf::FFI.field_options(self, size_ptr, temporary_arena)
+          Google::Protobuf::FieldOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
+        end
+      end
+
       private
 
       def initialize(field_def, descriptor_pool)
@@ -289,21 +298,22 @@ module Google
       attach_function :get_field_by_number,  :upb_MessageDef_FindFieldByNumber,      [Descriptor, :uint32_t], FieldDescriptor
 
       # FieldDescriptor
-      attach_function :get_containing_message_def, :upb_FieldDef_ContainingType,     [FieldDescriptor], Descriptor
-      attach_function :get_c_type,                 :upb_FieldDef_CType,              [FieldDescriptor], CType
-      attach_function :get_default,                :upb_FieldDef_Default,            [FieldDescriptor], MessageValue.by_value
-      attach_function :get_subtype_as_enum,        :upb_FieldDef_EnumSubDef,         [FieldDescriptor], EnumDescriptor
-      attach_function :get_has_presence,           :upb_FieldDef_HasPresence,        [FieldDescriptor], :bool
-      attach_function :is_map,                     :upb_FieldDef_IsMap,              [FieldDescriptor], :bool
-      attach_function :is_repeated,                :upb_FieldDef_IsRepeated,         [FieldDescriptor], :bool
-      attach_function :is_sub_message,             :upb_FieldDef_IsSubMessage,       [FieldDescriptor], :bool
-      attach_function :get_json_name,              :upb_FieldDef_JsonName,           [FieldDescriptor], :string
-      attach_function :get_label,                  :upb_FieldDef_Label,              [FieldDescriptor], Label
-      attach_function :get_subtype_as_message,     :upb_FieldDef_MessageSubDef,      [FieldDescriptor], Descriptor
-      attach_function :get_full_name,              :upb_FieldDef_Name,               [FieldDescriptor], :string
-      attach_function :get_number,                 :upb_FieldDef_Number,             [FieldDescriptor], :uint32_t
-      attach_function :get_type,                   :upb_FieldDef_Type,               [FieldDescriptor], FieldType
-      attach_function :file_def_by_raw_field_def,  :upb_FieldDef_File,               [:pointer], :FileDef
+      attach_function :field_options,              :FieldDescriptor_serialized_options, [FieldDescriptor, :pointer, Internal::Arena], :pointer
+      attach_function :get_containing_message_def, :upb_FieldDef_ContainingType,        [FieldDescriptor], Descriptor
+      attach_function :get_c_type,                 :upb_FieldDef_CType,                 [FieldDescriptor], CType
+      attach_function :get_default,                :upb_FieldDef_Default,               [FieldDescriptor], MessageValue.by_value
+      attach_function :get_subtype_as_enum,        :upb_FieldDef_EnumSubDef,            [FieldDescriptor], EnumDescriptor
+      attach_function :get_has_presence,           :upb_FieldDef_HasPresence,           [FieldDescriptor], :bool
+      attach_function :is_map,                     :upb_FieldDef_IsMap,                 [FieldDescriptor], :bool
+      attach_function :is_repeated,                :upb_FieldDef_IsRepeated,            [FieldDescriptor], :bool
+      attach_function :is_sub_message,             :upb_FieldDef_IsSubMessage,          [FieldDescriptor], :bool
+      attach_function :get_json_name,              :upb_FieldDef_JsonName,              [FieldDescriptor], :string
+      attach_function :get_label,                  :upb_FieldDef_Label,                 [FieldDescriptor], Label
+      attach_function :get_subtype_as_message,     :upb_FieldDef_MessageSubDef,         [FieldDescriptor], Descriptor
+      attach_function :get_full_name,              :upb_FieldDef_Name,                  [FieldDescriptor], :string
+      attach_function :get_number,                 :upb_FieldDef_Number,                [FieldDescriptor], :uint32_t
+      attach_function :get_type,                   :upb_FieldDef_Type,                  [FieldDescriptor], FieldType
+      attach_function :file_def_by_raw_field_def,  :upb_FieldDef_File,                  [:pointer], :FileDef
     end
   end
 end

--- a/ruby/lib/google/protobuf/ffi/file_descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/file_descriptor.rb
@@ -46,12 +46,10 @@ module Google
         Google::Protobuf::FFI.file_def_name(@file_def)
       end
 
-      private
-
-      def serialized_options
+      def options
         size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
         buffer = Google::Protobuf::FFI.file_options(@file_def, size_ptr)
-        buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze
+        Google::Protobuf::FileOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
       end
     end
   end

--- a/ruby/lib/google/protobuf/ffi/file_descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/file_descriptor.rb
@@ -12,7 +12,9 @@ module Google
       attach_function :file_def_name,   :upb_FileDef_Name,   [:FileDef], :string
       attach_function :file_def_syntax, :upb_FileDef_Syntax, [:FileDef], Syntax
       attach_function :file_def_pool,   :upb_FileDef_Pool,   [:FileDef], :DefPool
+      attach_function :file_options,    :FileDescriptor_serialized_options,  [:FileDef, :pointer], :pointer
     end
+
     class FileDescriptor
       attr :descriptor_pool, :file_def
 
@@ -42,6 +44,14 @@ module Google
 
       def name
         Google::Protobuf::FFI.file_def_name(@file_def)
+      end
+
+      private
+
+      def serialized_options
+        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+        buffer = Google::Protobuf::FFI.file_options(@file_def, size_ptr)
+        buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze
       end
     end
   end

--- a/ruby/lib/google/protobuf/ffi/map.rb
+++ b/ruby/lib/google/protobuf/ffi/map.rb
@@ -269,6 +269,19 @@ module Google
 
       include Google::Protobuf::Internal::Convert
 
+      def internal_deep_freeze
+        unless frozen?
+          freeze
+          if value_type == :message
+            internal_iterator do |iterator|
+              value_message_value = Google::Protobuf::FFI.map_value(@map_ptr, iterator)
+              convert_upb_to_ruby(value_message_value, value_type, descriptor, arena).send :internal_deep_freeze
+            end
+          end
+        end
+        self
+      end
+
       def internal_iterator
         iter = ::FFI::MemoryPointer.new(:size_t, 1)
         iter.write(:size_t, Google::Protobuf::FFI::Upb_Map_Begin)

--- a/ruby/lib/google/protobuf/ffi/map.rb
+++ b/ruby/lib/google/protobuf/ffi/map.rb
@@ -270,13 +270,11 @@ module Google
       include Google::Protobuf::Internal::Convert
 
       def internal_deep_freeze
-        unless frozen?
-          freeze
-          if value_type == :message
-            internal_iterator do |iterator|
-              value_message_value = Google::Protobuf::FFI.map_value(@map_ptr, iterator)
-              convert_upb_to_ruby(value_message_value, value_type, descriptor, arena).send :internal_deep_freeze
-            end
+        freeze
+        if value_type == :message
+          internal_iterator do |iterator|
+            value_message_value = Google::Protobuf::FFI.map_value(@map_ptr, iterator)
+            convert_upb_to_ruby(value_message_value, value_type, descriptor, arena).send :internal_deep_freeze
           end
         end
         self

--- a/ruby/lib/google/protobuf/ffi/message.rb
+++ b/ruby/lib/google/protobuf/ffi/message.rb
@@ -632,6 +632,7 @@ module Google
             repeated_field = OBJECT_CACHE.get(array.address)
             if repeated_field.nil?
               repeated_field = RepeatedField.send(:construct_for_field, field, @arena, array: array)
+              repeated_field.send :internal_deep_freeze if frozen?
             end
             repeated_field
           end
@@ -644,6 +645,7 @@ module Google
             map_field = OBJECT_CACHE.get(map.address)
             if map_field.nil?
               map_field = Google::Protobuf::Map.send(:construct_for_field, field, @arena, map: map)
+              map_field.send :internal_deep_freeze if frozen?
             end
             map_field
           end

--- a/ruby/lib/google/protobuf/ffi/message.rb
+++ b/ruby/lib/google/protobuf/ffi/message.rb
@@ -294,13 +294,11 @@ module Google
           include Google::Protobuf::Internal::Convert
 
           def internal_deep_freeze
-            unless frozen?
-              freeze
-              self.class.descriptor.each do |field_descriptor|
-                next if field_descriptor.has_presence? && !Google::Protobuf::FFI.get_message_has(@msg, field_descriptor)
-                if field_descriptor.map? or field_descriptor.repeated? or field_descriptor.sub_message?
-                  get_field(field_descriptor).send :internal_deep_freeze
-                end
+            freeze
+            self.class.descriptor.each do |field_descriptor|
+              next if field_descriptor.has_presence? && !Google::Protobuf::FFI.get_message_has(@msg, field_descriptor)
+              if field_descriptor.map? or field_descriptor.repeated? or field_descriptor.sub_message?
+                get_field(field_descriptor).send :internal_deep_freeze
               end
             end
             self

--- a/ruby/lib/google/protobuf/ffi/oneof_descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/oneof_descriptor.rb
@@ -53,6 +53,12 @@ module Google
         nil
       end
 
+      def options
+        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+        buffer = Google::Protobuf::FFI.oneof_options(self, size_ptr)
+        Google::Protobuf::OneofOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
+      end
+
       private
 
       def initialize(oneof_def, descriptor_pool)
@@ -64,14 +70,6 @@ module Google
         instance = allocate
         instance.send(:initialize, oneof_def, descriptor_pool)
         instance
-      end
-
-      def serialized_options
-        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
-        buffer = Google::Protobuf::FFI.oneof_options(self, size_ptr)
-        return_value = buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze
-        $stderr.puts return_value
-        return_value
       end
     end
 

--- a/ruby/lib/google/protobuf/ffi/oneof_descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/oneof_descriptor.rb
@@ -54,9 +54,12 @@ module Google
       end
 
       def options
-        size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
-        buffer = Google::Protobuf::FFI.oneof_options(self, size_ptr)
-        Google::Protobuf::OneofOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
+        @options ||= begin
+          size_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+          temporary_arena = Google::Protobuf::FFI.create_arena
+          buffer = Google::Protobuf::FFI.oneof_options(self, size_ptr, temporary_arena)
+          Google::Protobuf::OneofOptions.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze).send(:internal_deep_freeze)
+       end
       end
 
       private
@@ -75,18 +78,18 @@ module Google
 
     class FFI
       # MessageDef
-      attach_function :get_oneof_by_name,    :upb_MessageDef_FindOneofByNameWithSize, [Descriptor, :string, :size_t], OneofDescriptor
-      attach_function :get_oneof_by_index,   :upb_MessageDef_Oneof,                   [Descriptor, :int], OneofDescriptor
+      attach_function :get_oneof_by_name,        :upb_MessageDef_FindOneofByNameWithSize, [Descriptor, :string, :size_t], OneofDescriptor
+      attach_function :get_oneof_by_index,       :upb_MessageDef_Oneof,                   [Descriptor, :int], OneofDescriptor
 
       # OneofDescriptor
-      attach_function :get_oneof_name,           :upb_OneofDef_Name,          [OneofDescriptor], :string
-      attach_function :get_oneof_field_count,    :upb_OneofDef_FieldCount,    [OneofDescriptor], :int
-      attach_function :get_oneof_field_by_index, :upb_OneofDef_Field,         [OneofDescriptor, :int], FieldDescriptor
-      attach_function :get_oneof_containing_type,:upb_OneofDef_ContainingType,[:pointer], Descriptor
-      attach_function :oneof_options,            :OneOfDescriptor_serialized_options,[OneofDescriptor, :pointer], :pointer
+      attach_function :get_oneof_name,           :upb_OneofDef_Name,                      [OneofDescriptor], :string
+      attach_function :get_oneof_field_count,    :upb_OneofDef_FieldCount,                [OneofDescriptor], :int
+      attach_function :get_oneof_field_by_index, :upb_OneofDef_Field,                     [OneofDescriptor, :int], FieldDescriptor
+      attach_function :get_oneof_containing_type,:upb_OneofDef_ContainingType,            [:pointer], Descriptor
+      attach_function :oneof_options,            :OneOfDescriptor_serialized_options,     [OneofDescriptor, :pointer, Internal::Arena], :pointer
 
       # FieldDescriptor
-      attach_function :real_containing_oneof,      :upb_FieldDef_RealContainingOneof,[FieldDescriptor], OneofDescriptor
+      attach_function :real_containing_oneof,    :upb_FieldDef_RealContainingOneof,       [FieldDescriptor], OneofDescriptor
     end
   end
 end

--- a/ruby/lib/google/protobuf/ffi/repeated_field.rb
+++ b/ruby/lib/google/protobuf/ffi/repeated_field.rb
@@ -253,12 +253,10 @@ module Google
       attr :name, :arena, :array, :type, :descriptor
 
       def internal_deep_freeze
-        unless frozen?
-          freeze
-          if type == :message
-            each do |element|
-              element.send :internal_deep_freeze
-            end
+        freeze
+        if type == :message
+          each do |element|
+            element.send :internal_deep_freeze
           end
         end
         self

--- a/ruby/lib/google/protobuf/ffi/repeated_field.rb
+++ b/ruby/lib/google/protobuf/ffi/repeated_field.rb
@@ -5,8 +5,6 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-require 'forwardable'
-
 #
 # This class makes RepeatedField act (almost-) like a Ruby Array.
 # It has convenience methods that extend the core C or Java based
@@ -15,7 +13,7 @@ require 'forwardable'
 # This is a best-effort to mirror Array behavior.  Two comments:
 #  1) patches always welcome :)
 #  2) if performance is an issue, feel free to rewrite the method
-#     in jruby and C.  The source code has plenty of examples
+#     in C.  The source code has plenty of examples
 #
 # KNOWN ISSUES
 #   - #[]= doesn't allow less used approaches such as `arr[1, 2] = 'fizz'`
@@ -35,19 +33,6 @@ module Google
     end
 
     class RepeatedField
-      extend Forwardable
-      # NOTE:  using delegators rather than method_missing to make the
-      #        relationship explicit instead of implicit
-      def_delegators :to_ary,
-        :&, :*, :-, :'<=>',
-        :assoc, :bsearch, :bsearch_index, :combination, :compact, :count,
-        :cycle, :dig, :drop, :drop_while, :eql?, :fetch, :find_index, :flatten,
-        :include?, :index, :inspect, :join,
-        :pack, :permutation, :product, :pretty_print, :pretty_print_cycle,
-        :rassoc, :repeated_combination, :repeated_permutation, :reverse,
-        :rindex, :rotate, :sample, :shuffle, :shelljoin,
-        :to_s, :transpose, :uniq, :|
-
       include Enumerable
 
       ##
@@ -262,127 +247,22 @@ module Google
         push(*other.to_a)
       end
 
-      def first(n=nil)
-        if n.nil?
-          return self[0]
-        elsif n < 0
-          raise ArgumentError, "negative array size"
-        else
-          return self[0...n]
-        end
-      end
-
-
-      def last(n=nil)
-        if n.nil?
-          return self[-1]
-        elsif n < 0
-          raise ArgumentError, "negative array size"
-        else
-          start = [self.size-n, 0].max
-          return self[start...self.size]
-        end
-      end
-
-
-      def pop(n=nil)
-        if n
-          results = []
-          n.times{ results << pop_one }
-          return results
-        else
-          return pop_one
-        end
-      end
-
-
-      def empty?
-        self.size == 0
-      end
-
-      # array aliases into enumerable
-      alias_method :each_index, :each_with_index
-      alias_method :slice, :[]
-      alias_method :values_at, :select
-      alias_method :map, :collect
-
-
-      class << self
-        def define_array_wrapper_method(method_name)
-          define_method(method_name) do |*args, &block|
-            arr = self.to_a
-            result = arr.send(method_name, *args)
-            self.replace(arr)
-            return result if result
-            return block ? block.call : result
-          end
-        end
-        private :define_array_wrapper_method
-
-
-        def define_array_wrapper_with_result_method(method_name)
-          define_method(method_name) do |*args, &block|
-            # result can be an Enumerator, Array, or nil
-            # Enumerator can sometimes be returned if a block is an optional argument and it is not passed in
-            # nil usually specifies that no change was made
-            result = self.to_a.send(method_name, *args, &block)
-            if result
-              new_arr = result.to_a
-              self.replace(new_arr)
-              if result.is_a?(Enumerator)
-                # generate a fresh enum; rewinding the exiting one, in Ruby 2.2, will
-                # reset the enum with the same length, but all the #next calls will
-                # return nil
-                result = new_arr.to_enum
-                # generate a wrapper enum so any changes which occur by a chained
-                # enum can be captured
-                ie = ProxyingEnumerator.new(self, result)
-                result = ie.to_enum
-              end
-            end
-            result
-          end
-        end
-        private :define_array_wrapper_with_result_method
-      end
-
-
-      %w(delete delete_at shift slice! unshift).each do |method_name|
-        define_array_wrapper_method(method_name)
-      end
-
-
-      %w(collect! compact! delete_if fill flatten! insert reverse!
-        rotate! select! shuffle! sort! sort_by! uniq!).each do |method_name|
-        define_array_wrapper_with_result_method(method_name)
-      end
-      alias_method :keep_if, :select!
-      alias_method :map!, :collect!
-      alias_method :reject!, :delete_if
-
-
-      # propagates changes made by user of enumerator back to the original repeated field.
-      # This only applies in cases where the calling function which created the enumerator,
-      # such as #sort!, modifies itself rather than a new array, such as #sort
-      class ProxyingEnumerator < Struct.new(:repeated_field, :external_enumerator)
-        def each(*args, &block)
-          results = []
-          external_enumerator.each_with_index do |val, i|
-            result = yield(val)
-            results << result
-            #nil means no change occurred from yield; usually occurs when #to_a is called
-            if result
-              repeated_field[i] = result if result != val
-            end
-          end
-          results
-        end
-      end
-
       private
       include Google::Protobuf::Internal::Convert
 
       attr :name, :arena, :array, :type, :descriptor
+
+      def internal_deep_freeze
+        unless frozen?
+          freeze
+          if type == :message
+            each do |element|
+              element.send :internal_deep_freeze
+            end
+          end
+        end
+        self
+      end
 
       def internal_push(*elements)
         elements.each do |element|
@@ -501,3 +381,5 @@ module Google
     end
   end
 end
+
+require 'google/protobuf/repeated_field'

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyDescriptor.java
@@ -32,6 +32,7 @@
 
 package com.google.protobuf.jruby;
 
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
@@ -158,11 +159,13 @@ public class RubyDescriptor extends RubyObject {
     return Helpers.nullToNil(oneofDescriptors.get(Utils.symToString(name)), context.nil);
   }
 
-  @JRubyMethod(name = "serialized_options")
-  public IRubyObject serializedOptions(ThreadContext context) {
-    IRubyObject wrapped = RubyString.newString(context.runtime, descriptor.getOptions().toByteString().toByteArray());
-    wrapped.setFrozen(true);
-    return wrapped;
+  @JRubyMethod
+  public IRubyObject options(ThreadContext context) {
+    RubyDescriptorPool pool = (RubyDescriptorPool) RubyDescriptorPool.generatedPool(null, null);
+    RubyDescriptor messageOptionsDescriptor = (RubyDescriptor) pool.lookup(context, context.runtime.newString("google.protobuf.MessageOptions"));
+    RubyClass messageOptionsClass = (RubyClass) messageOptionsDescriptor.msgclass(context);
+    RubyMessage msg = (RubyMessage) messageOptionsClass.newInstance(context, Block.NULL_BLOCK);
+    return msg.decodeBytes(context, msg, CodedInputStream.newInstance(descriptor.getOptions().toByteString().toByteArray()), /*freeze*/ true);
   }
 
   protected FieldDescriptor getField(String name) {

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyDescriptor.java
@@ -158,6 +158,13 @@ public class RubyDescriptor extends RubyObject {
     return Helpers.nullToNil(oneofDescriptors.get(Utils.symToString(name)), context.nil);
   }
 
+  @JRubyMethod(name = "serialized_options")
+  public IRubyObject serializedOptions(ThreadContext context) {
+    IRubyObject wrapped = RubyString.newString(context.runtime, descriptor.getOptions().toByteString().toByteArray());
+    wrapped.setFrozen(true);
+    return wrapped;
+  }
+
   protected FieldDescriptor getField(String name) {
     return descriptor.findFieldByName(name);
   }

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyEnumDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyEnumDescriptor.java
@@ -42,7 +42,6 @@ import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyObject;
-import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Block;

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyEnumDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyEnumDescriptor.java
@@ -41,6 +41,7 @@ import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyObject;
+import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Block;
@@ -124,6 +125,12 @@ public class RubyEnumDescriptor extends RubyObject {
     return RubyFileDescriptor.getRubyFileDescriptor(context, descriptor);
   }
 
+  @JRubyMethod(name = "serialized_options")
+  public IRubyObject serializedOptions(ThreadContext context) {
+    IRubyObject wrapped = RubyString.newString(context.runtime, descriptor.getOptions().toByteString().toByteArray());
+    wrapped.setFrozen(true);
+    return wrapped;
+  }
   public boolean isValidValue(ThreadContext context, IRubyObject value) {
     EnumValueDescriptor enumValue;
 

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyEnumDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyEnumDescriptor.java
@@ -32,6 +32,7 @@
 
 package com.google.protobuf.jruby;
 
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.DescriptorProtos.EnumDescriptorProto;
 import com.google.protobuf.Descriptors.EnumDescriptor;
 import com.google.protobuf.Descriptors.EnumValueDescriptor;
@@ -125,11 +126,13 @@ public class RubyEnumDescriptor extends RubyObject {
     return RubyFileDescriptor.getRubyFileDescriptor(context, descriptor);
   }
 
-  @JRubyMethod(name = "serialized_options")
-  public IRubyObject serializedOptions(ThreadContext context) {
-    IRubyObject wrapped = RubyString.newString(context.runtime, descriptor.getOptions().toByteString().toByteArray());
-    wrapped.setFrozen(true);
-    return wrapped;
+  @JRubyMethod
+  public IRubyObject options(ThreadContext context) {
+    RubyDescriptorPool pool = (RubyDescriptorPool) RubyDescriptorPool.generatedPool(null, null);
+    RubyDescriptor enumOptionsDescriptor = (RubyDescriptor) pool.lookup(context, context.runtime.newString("google.protobuf.EnumOptions"));
+    RubyClass enumOptionsClass = (RubyClass) enumOptionsDescriptor.msgclass(context);
+    RubyMessage msg = (RubyMessage) enumOptionsClass.newInstance(context, Block.NULL_BLOCK);
+    return msg.decodeBytes(context, msg, CodedInputStream.newInstance(descriptor.getOptions().toByteString().toByteArray()), /*freeze*/ true);
   }
   public boolean isValidValue(ThreadContext context, IRubyObject value) {
     EnumValueDescriptor enumValue;

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyFieldDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyFieldDescriptor.java
@@ -38,6 +38,7 @@ import com.google.protobuf.LegacyDescriptorsUtil.LegacyFileDescriptor;
 import org.jruby.*;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyFieldDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyFieldDescriptor.java
@@ -32,6 +32,7 @@
 
 package com.google.protobuf.jruby;
 
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.LegacyDescriptorsUtil.LegacyFileDescriptor;
 import org.jruby.*;
@@ -229,6 +230,14 @@ public class RubyFieldDescriptor extends RubyObject {
   public IRubyObject setValue(ThreadContext context, IRubyObject message, IRubyObject value) {
     ((RubyMessage) message).setField(context, descriptor, value);
     return context.nil;
+  }
+
+  @JRubyMethod
+  public IRubyObject options(ThreadContext context) {
+    RubyDescriptor fieldOptionsDescriptor = (RubyDescriptor) pool.lookup(context, context.runtime.newString("google.protobuf.FieldOptions"));
+    RubyClass fieldOptionsClass = (RubyClass) fieldOptionsDescriptor.msgclass(context);
+    RubyMessage msg = (RubyMessage) fieldOptionsClass.newInstance(context, Block.NULL_BLOCK);
+    return msg.decodeBytes(context, msg, CodedInputStream.newInstance(descriptor.getOptions().toByteString().toByteArray()), /*freeze*/ true);
   }
 
   protected void setDescriptor(

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyFileDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyFileDescriptor.java
@@ -106,6 +106,13 @@ public class RubyFileDescriptor extends RubyObject {
     }
   }
 
+  @JRubyMethod(name = "serialized_options")
+  public IRubyObject serializedOptions(ThreadContext context) {
+    IRubyObject wrapped = RubyString.newString(context.runtime, fileDescriptor.getOptions().toByteString().toByteArray());
+    wrapped.setFrozen(true);
+    return wrapped;
+  }
+
   private static RubyClass cFileDescriptor;
 
   private FileDescriptor fileDescriptor;

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyFileDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyFileDescriptor.java
@@ -32,6 +32,7 @@
 
 package com.google.protobuf.jruby;
 
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.GenericDescriptor;
 import com.google.protobuf.LegacyDescriptorsUtil.LegacyFileDescriptor;
@@ -106,11 +107,13 @@ public class RubyFileDescriptor extends RubyObject {
     }
   }
 
-  @JRubyMethod(name = "serialized_options")
-  public IRubyObject serializedOptions(ThreadContext context) {
-    IRubyObject wrapped = RubyString.newString(context.runtime, fileDescriptor.getOptions().toByteString().toByteArray());
-    wrapped.setFrozen(true);
-    return wrapped;
+  @JRubyMethod
+  public IRubyObject options(ThreadContext context) {
+    RubyDescriptorPool pool = (RubyDescriptorPool) RubyDescriptorPool.generatedPool(null, null);
+    RubyDescriptor fileOptionsDescriptor = (RubyDescriptor) pool.lookup(context, context.runtime.newString("google.protobuf.FileOptions"));
+    RubyClass fileOptionsClass = (RubyClass) fileOptionsDescriptor.msgclass(context);
+    RubyMessage msg = (RubyMessage) fileOptionsClass.newInstance(context, Block.NULL_BLOCK);
+    return msg.decodeBytes(context, msg, CodedInputStream.newInstance(fileDescriptor.getOptions().toByteString().toByteArray()), /*freeze*/ true);
   }
 
   private static RubyClass cFileDescriptor;

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
@@ -373,12 +373,10 @@ public class RubyMap extends RubyObject {
   }
 
   protected IRubyObject deepFreeze(ThreadContext context) {
-    if (!isFrozen()) {
-      setFrozen(true);
-      if (valueType == FieldDescriptor.Type.MESSAGE) {
-        for (IRubyObject key : table.keySet()) {
-          ((RubyMessage)table.get(key)).deepFreeze(context);
-        }
+    setFrozen(true);
+    if (valueType == FieldDescriptor.Type.MESSAGE) {
+      for (IRubyObject key : table.keySet()) {
+        ((RubyMessage)table.get(key)).deepFreeze(context);
       }
     }
     return this;

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
@@ -372,6 +372,19 @@ public class RubyMap extends RubyObject {
     return RubyHash.newHash(context.runtime, mapForHash, context.nil);
   }
 
+  @JRubyMethod(name = "internal_deep_freeze", visibility = org.jruby.runtime.Visibility.PRIVATE)
+  protected IRubyObject deepFreeze(ThreadContext context) {
+    if (!isFrozen()) {
+      setFrozen(true);
+      if (valueType == FieldDescriptor.Type.MESSAGE) {
+        for (IRubyObject key : table.keySet()) {
+          ((RubyMessage)table.get(key)).deepFreeze(context);
+        }
+      }
+    }
+    return this;
+  }
+
   // Used by Google::Protobuf.deep_copy but not exposed directly.
   protected IRubyObject deepCopy(ThreadContext context) {
     RubyMap newMap = newThisType(context);

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
@@ -372,7 +372,6 @@ public class RubyMap extends RubyObject {
     return RubyHash.newHash(context.runtime, mapForHash, context.nil);
   }
 
-  @JRubyMethod(name = "internal_deep_freeze", visibility = org.jruby.runtime.Visibility.PRIVATE)
   protected IRubyObject deepFreeze(ThreadContext context) {
     if (!isFrozen()) {
       setFrozen(true);

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
@@ -817,17 +817,15 @@ public class RubyMessage extends RubyObject {
   }
 
   protected IRubyObject deepFreeze(ThreadContext context) {
-    if (!isFrozen()) {
-      setFrozen(true);
-      for (FieldDescriptor fdef : descriptor.getFields()) {
-        if (fdef.isMapField()) {
-          ((RubyMap) fields.get(fdef)).deepFreeze(context);
-        } else if (fdef.isRepeated()) {
-          this.getRepeatedField(context, fdef).deepFreeze(context);
-        } else if (fields.containsKey(fdef)) {
-          if (fdef.getType() == FieldDescriptor.Type.MESSAGE) {
-            ((RubyMessage) fields.get(fdef)).deepFreeze(context);
-          }
+    setFrozen(true);
+    for (FieldDescriptor fdef : descriptor.getFields()) {
+      if (fdef.isMapField()) {
+        ((RubyMap) fields.get(fdef)).deepFreeze(context);
+      } else if (fdef.isRepeated()) {
+        this.getRepeatedField(context, fdef).deepFreeze(context);
+      } else if (fields.containsKey(fdef)) {
+        if (fdef.getType() == FieldDescriptor.Type.MESSAGE) {
+          ((RubyMessage) fields.get(fdef)).deepFreeze(context);
         }
       }
     }

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
@@ -628,7 +628,10 @@ public class RubyMessage extends RubyObject {
         input.setRecursionLimit(((RubyNumeric) recursionLimit).getIntValue());
       }
     }
+    return decodeBytes(context, ret, input, /*freeze*/ false);
+  }
 
+  public static IRubyObject decodeBytes(ThreadContext context, RubyMessage ret, CodedInputStream input, boolean freeze) {
     try {
       ret.builder.mergeFrom(input);
     } catch (Exception e) {
@@ -658,7 +661,9 @@ public class RubyMessage extends RubyObject {
                 }
               });
     }
-
+    if (freeze) {
+      ret.deepFreeze(context);
+    }
     return ret;
   }
 
@@ -811,7 +816,6 @@ public class RubyMessage extends RubyObject {
     return ret;
   }
 
-  @JRubyMethod(name = "internal_deep_freeze", visibility = org.jruby.runtime.Visibility.PRIVATE)
   protected IRubyObject deepFreeze(ThreadContext context) {
     if (!isFrozen()) {
       setFrozen(true);

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyOneofDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyOneofDescriptor.java
@@ -1,5 +1,6 @@
 package com.google.protobuf.jruby;
 
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
 import java.util.ArrayList;
@@ -67,11 +68,13 @@ public class RubyOneofDescriptor extends RubyObject {
     return context.nil;
   }
 
-  @JRubyMethod(name = "serialized_options")
-  public IRubyObject serializedOptions(ThreadContext context) {
-    IRubyObject wrapped = RubyString.newString(context.runtime, descriptor.getOptions().toByteString().toByteArray());
-    wrapped.setFrozen(true);
-    return wrapped;
+  @JRubyMethod
+  public IRubyObject options(ThreadContext context) {
+    RubyDescriptorPool pool = (RubyDescriptorPool) RubyDescriptorPool.generatedPool(null, null);
+    RubyDescriptor oneofOptionsDescriptor = (RubyDescriptor) pool.lookup(context, context.runtime.newString("google.protobuf.OneofOptions"));
+    RubyClass oneofOptionsClass = (RubyClass) oneofOptionsDescriptor.msgclass(context);
+    RubyMessage msg = (RubyMessage) oneofOptionsClass.newInstance(context, Block.NULL_BLOCK);
+    return msg.decodeBytes(context, msg, CodedInputStream.newInstance(descriptor.getOptions().toByteString().toByteArray()), /*freeze*/ true);
   }
 
   protected Collection<RubyFieldDescriptor> getFields() {

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyOneofDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyOneofDescriptor.java
@@ -10,6 +10,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
+import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Block;
@@ -64,6 +65,13 @@ public class RubyOneofDescriptor extends RubyObject {
       block.yieldSpecific(context, field);
     }
     return context.nil;
+  }
+
+  @JRubyMethod(name = "serialized_options")
+  public IRubyObject serializedOptions(ThreadContext context) {
+    IRubyObject wrapped = RubyString.newString(context.runtime, descriptor.getOptions().toByteString().toByteArray());
+    wrapped.setFrozen(true);
+    return wrapped;
   }
 
   protected Collection<RubyFieldDescriptor> getFields() {

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyOneofDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyOneofDescriptor.java
@@ -11,7 +11,6 @@ import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
-import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Block;

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
@@ -358,7 +358,6 @@ public class RubyRepeatedField extends RubyObject {
     return storage.inspect();
   }
 
-  @JRubyMethod(name = "internal_deep_freeze", visibility = org.jruby.runtime.Visibility.PRIVATE)
   protected IRubyObject deepFreeze(ThreadContext context) {
     if (!isFrozen()) {
       setFrozen(true);

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
@@ -359,12 +359,10 @@ public class RubyRepeatedField extends RubyObject {
   }
 
   protected IRubyObject deepFreeze(ThreadContext context) {
-    if (!isFrozen()) {
-      setFrozen(true);
-      if (fieldType == FieldDescriptor.Type.MESSAGE) {
-        for (int i = 0; i < size(); i++) {
-          ((RubyMessage)storage.eltInternal(i)).deepFreeze(context);
-        }
+    setFrozen(true);
+    if (fieldType == FieldDescriptor.Type.MESSAGE) {
+      for (int i = 0; i < size(); i++) {
+        ((RubyMessage)storage.eltInternal(i)).deepFreeze(context);
       }
     }
     return this;

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
@@ -111,6 +111,7 @@ public class RubyRepeatedField extends RubyObject {
    */
   @JRubyMethod(name = "[]=")
   public IRubyObject indexSet(ThreadContext context, IRubyObject index, IRubyObject value) {
+    testFrozen("Can't set index in frozen repeated field");
     int arrIndex = normalizeArrayIndex(index);
     value = Utils.checkType(context, fieldType, name, value, (RubyModule) typeClass);
     IRubyObject defaultValue = defaultValue(context);
@@ -183,6 +184,7 @@ public class RubyRepeatedField extends RubyObject {
       required = 1,
       rest = true)
   public IRubyObject push(ThreadContext context, IRubyObject[] args) {
+    testFrozen("Can't push frozen repeated field");
     for (int i = 0; i < args.length; i++) {
       IRubyObject val = args[i];
       if (fieldType != FieldDescriptor.Type.MESSAGE || !val.isNil()) {
@@ -199,6 +201,7 @@ public class RubyRepeatedField extends RubyObject {
    */
   @JRubyMethod(visibility = org.jruby.runtime.Visibility.PRIVATE)
   public IRubyObject pop_one(ThreadContext context) {
+    testFrozen("Can't pop frozen repeated field");
     IRubyObject ret = this.storage.last();
     this.storage.remove(ret);
     return ret;
@@ -212,6 +215,7 @@ public class RubyRepeatedField extends RubyObject {
    */
   @JRubyMethod
   public IRubyObject replace(ThreadContext context, IRubyObject list) {
+    testFrozen("Can't replace frozen repeated field");
     RubyArray arr = (RubyArray) list;
     checkArrayElementType(context, arr);
     this.storage = arr;
@@ -226,6 +230,7 @@ public class RubyRepeatedField extends RubyObject {
    */
   @JRubyMethod
   public IRubyObject clear(ThreadContext context) {
+    testFrozen("Can't clear frozen repeated field");
     this.storage.clear();
     return this;
   }
@@ -274,6 +279,7 @@ public class RubyRepeatedField extends RubyObject {
    */
   @JRubyMethod
   public IRubyObject concat(ThreadContext context, IRubyObject list) {
+    testFrozen("Can't concat frozen repeated field");
     if (list instanceof RubyArray) {
       checkArrayElementType(context, (RubyArray) list);
       this.storage.addAll((RubyArray) list);
@@ -350,6 +356,19 @@ public class RubyRepeatedField extends RubyObject {
   @JRubyMethod
   public IRubyObject inspect() {
     return storage.inspect();
+  }
+
+  @JRubyMethod(name = "internal_deep_freeze", visibility = org.jruby.runtime.Visibility.PRIVATE)
+  protected IRubyObject deepFreeze(ThreadContext context) {
+    if (!isFrozen()) {
+      setFrozen(true);
+      if (fieldType == FieldDescriptor.Type.MESSAGE) {
+        for (int i = 0; i < size(); i++) {
+          ((RubyMessage)storage.eltInternal(i)).deepFreeze(context);
+        }
+      }
+    }
+    return this;
   }
 
   // Java API

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -732,25 +732,6 @@ module BasicTest
           Google::Protobuf::UninterpretedOption.new
       end
     end
-
-    def test_message_deep_freeze
-      message = TestDeprecatedMessage.new
-
-      nested_message_2 = TestMessage2.new
-
-      message.map_string_msg["message"] = TestMessage2.new
-      message.repeated_msg.push(TestMessage2.new)
-
-      message.send(:internal_deep_freeze)
-
-      assert_raise FrozenError do
-        message.map_string_msg["message"].foo = "bar"
-      end
-
-      assert_raise FrozenError do
-        message.repeated_msg[0].foo = "bar"
-      end
-    end
   end
 
   def test_oneof_fields_respond_to? # regression test for issue 9202

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -699,21 +699,21 @@ module BasicTest
     def test_file_descriptor_options
       file_descriptor = TestMessage.descriptor.file_descriptor
 
-      assert_equal file_descriptor.options.class, Google::Protobuf::FileOptions
+      assert_instance_of Google::Protobuf::FileOptions, file_descriptor.options
       assert file_descriptor.options.deprecated
     end
 
     def test_descriptor_options
       descriptor = TestDeprecatedMessage.descriptor
 
-      assert_equal descriptor.options.class, Google::Protobuf::MessageOptions
+      assert_instance_of Google::Protobuf::MessageOptions, descriptor.options
       assert descriptor.options.deprecated
     end
 
     def test_enum_descriptor_options
       enum_descriptor = TestDeprecatedEnum.descriptor
 
-      assert_equal enum_descriptor.options.class, Google::Protobuf::EnumOptions
+      assert_instance_of Google::Protobuf::EnumOptions, enum_descriptor.options
       assert enum_descriptor.options.deprecated
     end
 
@@ -721,7 +721,7 @@ module BasicTest
       descriptor = TestDeprecatedMessage.descriptor
       oneof_descriptor = descriptor.lookup_oneof("test_deprecated_message_oneof")
 
-      assert_equal oneof_descriptor.options.class, Google::Protobuf::OneofOptions
+      assert_instance_of Google::Protobuf::OneofOptions, oneof_descriptor.options
     end
 
     def test_options_deep_freeze

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -703,6 +703,13 @@ module BasicTest
       assert file_descriptor.options.deprecated
     end
 
+    def test_field_descriptor_options
+      field_descriptor = TestDeprecatedMessage.descriptor.lookup("foo")
+
+      assert_instance_of Google::Protobuf::FieldOptions, field_descriptor.options
+      assert field_descriptor.options.deprecated
+    end
+
     def test_descriptor_options
       descriptor = TestDeprecatedMessage.descriptor
 

--- a/ruby/tests/basic_test.proto
+++ b/ruby/tests/basic_test.proto
@@ -73,7 +73,7 @@ message TestMessage2 {
 message TestDeprecatedMessage {
   option deprecated = true;
 
-  optional int32 foo = 1;
+  optional int32 foo = 1 [deprecated = true];
 
   oneof test_deprecated_message_oneof {
     string a = 2;


### PR DESCRIPTION
Rewrrte and extension of #12828, with additional work for JRuby. Partially fixes #1198 by adding support for custom options. Handling of extensions will be handled in a follow up.

Also includes these unrelated fixes:
* Removes code echo between `google/protobuf/repeated_field.rb` and `google/protobuf/ffi/repeated_field.rb` by `require`'ing the former in the latter.
* Adds missing calles to `testFrozen()` from methods of `RepeatedField` under JRuby that mutate.
* Various typos in comments.