### PR TITLE
constexpr causes undefined references

### DIFF
--- a/src/google/protobuf/message.cc
+++ b/src/google/protobuf/message.cc
@@ -189,7 +189,7 @@ static std::string InitializationErrorStringImpl(const MessageLite& msg) {
   return DownCast<const Message&>(msg).InitializationErrorString();
 }
 
-constexpr MessageLite::DescriptorMethods Message::kDescriptorMethods = {
+const MessageLite::DescriptorMethods Message::kDescriptorMethods = {
     GetTypeNameImpl,
     InitializationErrorStringImpl,
 };


### PR DESCRIPTION
It looks to me like the build is currently failing with undefined references to kDescriptorMethods?

This change fixes the issue for me at least.