### PR TITLE
Bump mac PHP version to 8.2 to fix non-hermetic breakages.

### DIFF
--- a/.github/workflows/test_php.yml
+++ b/.github/workflows/test_php.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
-        version: ['8.0']
+        version: ['8.2']
         suffix: [ '', '-zts']
         test: ['test', 'test_c']
         exclude:


### PR DESCRIPTION
This was likely either a change in macos or the github runners

PiperOrigin-RevId: 580245853

This is a backport of https://github.com/protocolbuffers/protobuf/commit/62f48888247587eeee4f13ff0cc464d78b8e2d04