### PR TITLE
Bump mac PHP version to 8.2 to fix non-hermetic breakages.

### DIFF
--- a/.github/workflows/test_php.yml
+++ b/.github/workflows/test_php.yml
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
-        version: ['8.0']
+        version: ['8.2']
 
     name: MacOS PHP ${{ matrix.version }}
     runs-on: macos-12


### PR DESCRIPTION
This was likely either a change in macos or the github runners

PiperOrigin-RevId: 580245853

This is a backport of 62f4888