### PR TITLE
[c++] Expose TextFormatParse allow_unknown_enum parse option

### DIFF
--- a/src/google/protobuf/text_format.h
+++ b/src/google/protobuf/text_format.h
@@ -729,6 +729,14 @@ class PROTOBUF_EXPORT TextFormat {
     // if possible.
     void AllowUnknownField(bool allow) { allow_unknown_field_ = allow; }
 
+    // When an unknown enum value is met, parsing will fail if this option is
+    // set to false (the default). If true, unknown enums will be ignored and
+    // a warning message will be generated.
+    // Beware! Setting this option true may hide some errors (e.g. spelling
+    // error on enum name). This allows data loss; unlike binary format, text
+    // format cannot preserve unknown enums.  Avoid using this option
+    // if possible.
+    void AllowUnknownEnum(bool allow) { allow_unknown_enum_ = allow; }
 
     void AllowFieldNumber(bool allow) { allow_field_number_ = allow; }
 

--- a/src/google/protobuf/text_format_unittest.cc
+++ b/src/google/protobuf/text_format_unittest.cc
@@ -2602,6 +2602,20 @@ TEST(TextFormatUnknownFieldTest, TestUnknownExtension) {
   EXPECT_FALSE(parser.ParseFromString("unknown_field: 1", &proto));
 }
 
+TEST(TextFormatUnknownFieldTest, TestUnknownEnum) {
+  protobuf_unittest::TestAllTypes proto;
+  TextFormat::Parser parser;
+  std::string message_with_bad_enum =
+      "repeated_nested_enum: BAR_BAD\n"
+      "repeated_nested_enum: BAR\n";
+  // Unknown enums are not permitted by default.
+  EXPECT_FALSE(parser.ParseFromString(message_with_bad_enum, &proto));
+
+  parser.AllowUnknownEnum(true);
+  EXPECT_TRUE(parser.ParseFromString(message_with_bad_enum, &proto));
+  ASSERT_EQ(proto.repeated_nested_enum_size(), 1);
+  EXPECT_EQ(proto.repeated_nested_enum(0), protobuf_unittest::TestAllTypes::BAR);
+}
 
 TEST(TextFormatFloatingPointTest, PreservesNegative0) {
   proto3_unittest::TestAllTypes in_message;


### PR DESCRIPTION
Allow text format parser to allow unknown enum values. This is useful when dealing with code that needs to compatible with different commits.