### PR TITLE
[C#] Fix trimming warning in JSON formatter enum handling

### DIFF
--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <!-- If you update this, update the .csproj in the Docker file as well -->
 
   <PropertyGroup>
@@ -23,6 +23,10 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IsTrimmable>true</IsTrimmable>
+    <EnableAOTAnalyzer>true</EnableAOTAnalyzer>
+    <!-- Disable warnings about AOT and trimming features on older targets, e.g. netstandard2.0.
+         For now, continue to apply these features to these targets because some packages don't have a target that supports them -->
+    <NoWarn>$(NoWarn);NETSDK1195;NETSDK1210</NoWarn>	  
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -23,7 +23,6 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IsTrimmable>true</IsTrimmable>
-    <EnableAOTAnalyzer>true</EnableAOTAnalyzer>
     <!-- Disable warnings about AOT and trimming features on older targets, e.g. netstandard2.0.
          For now, continue to apply these features to these targets because some packages don't have a target that supports them -->
     <NoWarn>$(NoWarn);NETSDK1195;NETSDK1210</NoWarn>	  

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -968,8 +968,12 @@ namespace Google.Protobuf
 
             [UnconditionalSuppressMessage("Trimming", "IL2072",
                 Justification = "The field for the value must still be present. It will be returned by reflection, will be in this collection, and its name can be resolved.")]
+            [UnconditionalSuppressMessage("Trimming", "IL2067",
+                Justification = "The field for the value must still be present. It will be returned by reflection, will be in this collection, and its name can be resolved.")]
             internal static string GetOriginalName(object value)
             {
+                // Warnings are suppressed on this method. However, this code has been tested in an AOT app and verified that it works.
+                // Issue https://github.com/protocolbuffers/protobuf/issues/14788 discusses changes to guarantee that enum fields are never trimmed.
                 Dictionary<object, string> nameMapping = dictionaries.GetOrAdd(value.GetType(), static t => GetNameMapping(t));
 
                 // If this returns false, originalName will be null, which is what we want.

--- a/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs
@@ -104,6 +104,7 @@ namespace Google.Protobuf.Reflection
         /// the type that declares the method, and the second argument to the first parameter type of the method.
         /// </summary>
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Type parameter members are preserved with DynamicallyAccessedMembers on GeneratedClrTypeInfo.ctor clrType parameter.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Dynamic code won't call Type.MakeGenericType.")]
         internal static IExtensionReflectionHelper CreateExtensionHelper(Extension extension)
         {
 #if NET5_0_OR_GREATER
@@ -128,6 +129,7 @@ namespace Google.Protobuf.Reflection
         /// an object is pretty cheap.
         /// </summary>
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Type parameter members are preserved with DynamicallyAccessedMembers on GeneratedClrTypeInfo.ctor clrType parameter.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Dynamic code won't call Type.MakeGenericType.")]
         private static IReflectionHelper GetReflectionHelper(Type t1, Type t2)
         {
 #if NET5_0_OR_GREATER


### PR DESCRIPTION
There is a new trimming/AOT warning in JSON formatter enum handling. I have fixed it by suppressing the value.
I also tested the solution with the .NET 8 SDK and suppressed some other warnings that came up (they're already handled).

It would be great to include this fix in a 25.x release.