### PR TITLE
ruby: return 0 from shared_convert.c in failure cases

### DIFF
--- a/ruby/ext/google/protobuf_c/shared_convert.c
+++ b/ruby/ext/google/protobuf_c/shared_convert.c
@@ -35,6 +35,7 @@ bool shared_Msgval_IsEqual(upb_MessageValue val1, upb_MessageValue val2,
       return shared_Message_Equal(val1.msg_val, val2.msg_val, msgdef, status);
     default:
       upb_Status_SetErrorMessage(status, "Internal error, unexpected type");
+      return 0;
   }
 }
 
@@ -60,5 +61,6 @@ uint64_t shared_Msgval_GetHash(upb_MessageValue val, upb_CType type,
       return shared_Message_Hash(val.msg_val, msgdef, seed, status);
     default:
       upb_Status_SetErrorMessage(status, "Internal error, unexpected type");
+      return 0;
   }
 }

--- a/ruby/ext/google/protobuf_c/shared_message.c
+++ b/ruby/ext/google/protobuf_c/shared_message.c
@@ -32,6 +32,7 @@ uint64_t shared_Message_Hash(const upb_Message* msg, const upb_MessageDef* m,
   } else {
     upb_Arena_Free(arena);
     upb_Status_SetErrorMessage(status, "Error calculating hash");
+    return 0;
   }
 }
 
@@ -61,5 +62,6 @@ bool shared_Message_Equal(const upb_Message* m1, const upb_Message* m2,
   } else {
     upb_Arena_Free(arena_tmp);
     upb_Status_SetErrorMessage(status, "Error comparing messages");
+    return 0;
   }
 }


### PR DESCRIPTION
Functions declared as returning a value must return a value, otherwise the return value is undefined.
This fixes building protobuf with -Werror=return-type