### PR TITLE
Fix unnecessary switching of map representation for DiscardUnknownFields

### DIFF
--- a/src/google/protobuf/reflection_ops.cc
+++ b/src/google/protobuf/reflection_ops.cc
@@ -327,14 +327,14 @@ void ReflectionOps::DiscardUnknownFields(Message* message) {
       continue;
     }
     // Discard the unknown fields in maps that contain message values.
-    if (field->is_map() && IsMapValueMessageTyped(field)) {
-      const MapFieldBase* map_field =
-          reflection->MutableMapData(message, field);
-      if (map_field->IsMapValid()) {
+    const MapFieldBase* map_field = field->is_map() ?
+        reflection->MutableMapData(message, field) : nullptr;
+    if (map_field != nullptr && map_field->IsMapValid())  {
+      if (IsMapValueMessageTyped(field)) {
         MapIterator iter(message, field);
         MapIterator end(message, field);
         for (map_field->MapBegin(&iter), map_field->MapEnd(&end); iter != end;
-             ++iter) {
+              ++iter) {
           iter.MutableValueRef()->MutableMessageValue()->DiscardUnknownFields();
         }
       }


### PR DESCRIPTION
When unknown fields are discarded using reflection in reflection_ops.cc, unnecessary switching of the internal map representation is triggered.

A map<int,int> field cannot have unknown fields. However, in the current code the check used is

if (field->IsMap() && IsMapValueMessageTyped(field)) {
  // Discard map field 
} else {
  // Discard repeated message field
}

This means that the code proceeds discarding unknown fields for each mapentry using the RepeatedPtrField of MapEntry representation of the map. Causing unnecessary work and unnecessary, potentially big, memory allocation. This PR fixes this.

See also issue https://github.com/protocolbuffers/protobuf/issues/13222

This is also a bug fix. When a map<int, MyProto> is in a dirty state, previously it would be skipped. After this change it will correctly use the repeated path to clean the MyProto sub-entries