### PR TITLE
Only substitute prefixes during installation setup.

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -78,7 +78,10 @@ foreach(_header ${protobuf_HEADERS})
   elseif (_find_nosrc GREATER -1)
     set(_from_dir "${protobuf_SOURCE_DIR}")
   endif()
-  string(REPLACE "${_from_dir}" "" _header ${_header})
+  # On some platforms `_form_dir` ends up being just "protobuf", which can
+  # easily match multiple times in our paths.  We force it to only replace
+  # prefixes to avoid this case.
+  string(REGEX REPLACE "^${_from_dir}" "" _header ${_header})
   get_filename_component(_extract_from "${_from_dir}/${_header}" ABSOLUTE)
   get_filename_component(_extract_name ${_header} NAME)
   get_filename_component(_extract_to "${CMAKE_INSTALL_INCLUDEDIR}/${_header}" DIRECTORY)


### PR DESCRIPTION
This caused an issue on some platforms where `protobuf/java/core/src/main/java/com/google/protobuf/java_features.proto` was getting turned into the invalid path `java/core/src/main/java/com/google/java_features.proto`.

Fixes #14862

PiperOrigin-RevId: 586478133