### PR TITLE
Adding DLL export/import tags to generated public upb API

### DIFF
--- a/upb_generator/bootstrap_compiler.bzl
+++ b/upb_generator/bootstrap_compiler.bzl
@@ -67,7 +67,7 @@ def _stage0_proto_staleness_test(name, base_dir, src_files, src_rules, strip_pre
             "$(location " + _protoc + ") " +
             "-I$(GENDIR)/" + strip_prefix + " " + _extra_proto_path +
             "--plugin=protoc-gen-upb=$(location " + _upbc("upb", 0) + ") " +
-	    "--upb_out=dllexport_decl=TEST_DLL,bootstrap_upb:$(@D)/bootstrap_generated_sources/" + base_dir + "stage0 " +
+            "--upb_out=bootstrap_upb:$(@D)/bootstrap_generated_sources/" + base_dir + "stage0 " +
             " ".join(src_files),
     )
 

--- a/upb_generator/bootstrap_compiler.bzl
+++ b/upb_generator/bootstrap_compiler.bzl
@@ -67,7 +67,7 @@ def _stage0_proto_staleness_test(name, base_dir, src_files, src_rules, strip_pre
             "$(location " + _protoc + ") " +
             "-I$(GENDIR)/" + strip_prefix + " " + _extra_proto_path +
             "--plugin=protoc-gen-upb=$(location " + _upbc("upb", 0) + ") " +
-	    "--upb_out=dllexport_tag=TEST_DLL,bootstrap_upb:$(@D)/bootstrap_generated_sources/" + base_dir + "stage0 " +
+	    "--upb_out=dllexport_decl=TEST_DLL,bootstrap_upb:$(@D)/bootstrap_generated_sources/" + base_dir + "stage0 " +
             " ".join(src_files),
     )
 

--- a/upb_generator/bootstrap_compiler.bzl
+++ b/upb_generator/bootstrap_compiler.bzl
@@ -67,7 +67,7 @@ def _stage0_proto_staleness_test(name, base_dir, src_files, src_rules, strip_pre
             "$(location " + _protoc + ") " +
             "-I$(GENDIR)/" + strip_prefix + " " + _extra_proto_path +
             "--plugin=protoc-gen-upb=$(location " + _upbc("upb", 0) + ") " +
-            "--upb_out=bootstrap_upb:$(@D)/bootstrap_generated_sources/" + base_dir + "stage0 " +
+	    "--upb_out=dllexport_tag=TEST_DLL,bootstrap_upb:$(@D)/bootstrap_generated_sources/" + base_dir + "stage0 " +
             " ".join(src_files),
     )
 

--- a/upb_generator/common.cc
+++ b/upb_generator/common.cc
@@ -59,8 +59,8 @@ std::string MessageInitName(upb::MessageDefPtr descriptor) {
   return MessageInit(descriptor.full_name());
 }
 
-void EmitDllExportMacros(absl::string_view dllexport_tag, Output& output) {
-  if (dllexport_tag.length()) {
+void EmitDllExportMacros(absl::string_view dllexport_decl, Output& output) {
+  if (dllexport_decl.length()) {
     output(
         "#if !defined $0\n"
         "#if defined $0_EXPORT\n"
@@ -71,7 +71,7 @@ void EmitDllExportMacros(absl::string_view dllexport_tag, Output& output) {
         "#define $0\n"
         "#endif\n"
         "#endif\n\n",
-        dllexport_tag);    
+        dllexport_decl);    
   }
 }
 

--- a/upb_generator/common.cc
+++ b/upb_generator/common.cc
@@ -59,22 +59,6 @@ std::string MessageInitName(upb::MessageDefPtr descriptor) {
   return MessageInit(descriptor.full_name());
 }
 
-void EmitDllExportMacros(absl::string_view dllexport_decl, Output& output) {
-  if (dllexport_decl.length()) {
-    output(
-        "#if !defined $0\n"
-        "#if defined $0_EXPORT\n"
-        "#define $0 __declspec(dll_export)\n"
-        "#elif defined $0_IMPORT\n"
-        "#define $0 __declspec(dll_import)\n"
-        "#else\n"
-        "#define $0\n"
-        "#endif\n"
-        "#endif\n\n",
-        dllexport_decl);    
-  }
-}
-
 std::string PadSuffix(absl::string_view tag) {
   return tag.length() ? absl::StrCat(tag, " ") : std::string(tag);
 }

--- a/upb_generator/common.cc
+++ b/upb_generator/common.cc
@@ -59,6 +59,26 @@ std::string MessageInitName(upb::MessageDefPtr descriptor) {
   return MessageInit(descriptor.full_name());
 }
 
+void EmitDllExportMacros(absl::string_view dllexport_tag, Output& output) {
+  if (dllexport_tag.length()) {
+    output(
+        "#if !defined $0\n"
+        "#if defined $0_EXPORT\n"
+        "#define $0 __declspec(dll_export)\n"
+        "#elif defined $0_IMPORT\n"
+        "#define $0 __declspec(dll_import)\n"
+        "#else\n"
+        "#define $0\n"
+        "#endif\n"
+        "#endif\n\n",
+        dllexport_tag);    
+  }
+}
+
+std::string PadSuffix(absl::string_view tag) {
+  return tag.length() ? absl::StrCat(tag, " ") : std::string(tag);
+}
+
 std::string MessageName(upb::MessageDefPtr descriptor) {
   return ToCIdent(descriptor.full_name());
 }

--- a/upb_generator/common.cc
+++ b/upb_generator/common.cc
@@ -59,8 +59,8 @@ std::string MessageInitName(upb::MessageDefPtr descriptor) {
   return MessageInit(descriptor.full_name());
 }
 
-std::string PadSuffix(absl::string_view tag) {
-  return tag.length() ? absl::StrCat(tag, " ") : std::string(tag);
+std::string PadPrefix(absl::string_view tag) {
+  return tag.empty() ? "": absl::StrCat(" ", tag);
 }
 
 std::string MessageName(upb::MessageDefPtr descriptor) {

--- a/upb_generator/common.h
+++ b/upb_generator/common.h
@@ -9,6 +9,7 @@
 #define UPB_GENERATOR_COMMON_H
 
 #include <vector>
+#include <string>
 
 #include "absl/strings/str_replace.h"
 #include "absl/strings/substitute.h"
@@ -60,10 +61,12 @@ std::string ToPreproc(absl::string_view str);
 void EmitFileWarning(absl::string_view name, Output& output);
 std::string MessageInit(absl::string_view full_name);
 std::string MessageInitName(upb::MessageDefPtr descriptor);
+void EmitDllExportMacros(absl::string_view dllexport_tag, Output& output);
 std::string MessageName(upb::MessageDefPtr descriptor);
 std::string FileLayoutName(upb::FileDefPtr file);
 std::string MiniTableHeaderFilename(upb::FileDefPtr file);
 std::string CApiHeaderFilename(upb::FileDefPtr file);
+std::string PadSuffix(absl::string_view tag);
 
 std::string EnumInit(upb::EnumDefPtr descriptor);
 

--- a/upb_generator/common.h
+++ b/upb_generator/common.h
@@ -65,7 +65,7 @@ std::string MessageName(upb::MessageDefPtr descriptor);
 std::string FileLayoutName(upb::FileDefPtr file);
 std::string MiniTableHeaderFilename(upb::FileDefPtr file);
 std::string CApiHeaderFilename(upb::FileDefPtr file);
-std::string PadSuffix(absl::string_view tag);
+std::string PadPrefix(absl::string_view tag);
 
 std::string EnumInit(upb::EnumDefPtr descriptor);
 

--- a/upb_generator/common.h
+++ b/upb_generator/common.h
@@ -61,7 +61,7 @@ std::string ToPreproc(absl::string_view str);
 void EmitFileWarning(absl::string_view name, Output& output);
 std::string MessageInit(absl::string_view full_name);
 std::string MessageInitName(upb::MessageDefPtr descriptor);
-void EmitDllExportMacros(absl::string_view dllexport_tag, Output& output);
+void EmitDllExportMacros(absl::string_view dllexport_decl, Output& output);
 std::string MessageName(upb::MessageDefPtr descriptor);
 std::string FileLayoutName(upb::FileDefPtr file);
 std::string MiniTableHeaderFilename(upb::FileDefPtr file);

--- a/upb_generator/common.h
+++ b/upb_generator/common.h
@@ -61,7 +61,6 @@ std::string ToPreproc(absl::string_view str);
 void EmitFileWarning(absl::string_view name, Output& output);
 std::string MessageInit(absl::string_view full_name);
 std::string MessageInitName(upb::MessageDefPtr descriptor);
-void EmitDllExportMacros(absl::string_view dllexport_decl, Output& output);
 std::string MessageName(upb::MessageDefPtr descriptor);
 std::string FileLayoutName(upb::FileDefPtr file);
 std::string MiniTableHeaderFilename(upb::FileDefPtr file);

--- a/upb_generator/protoc-gen-upb.cc
+++ b/upb_generator/protoc-gen-upb.cc
@@ -890,16 +890,16 @@ void WriteHeader(const DefPoolPair& pools, upb::FileDefPtr file,
 
   if (options.bootstrap) {
     for (auto message : this_file_messages) {
-      output("extern const $1upb_MiniTable* $0();\n", MessageInitName(message),
-             PadSuffix(options.dllexport_decl));
+      output("extern const$1 upb_MiniTable* $0();\n", MessageInitName(message),
+             PadPrefix(options.dllexport_decl));
     }
     for (auto message : forward_messages) {
-      output("extern const $1upb_MiniTable* $0();\n", MessageInitName(message),
-             PadSuffix(options.dllexport_decl));
+      output("extern const$1 upb_MiniTable* $0();\n", MessageInitName(message),
+             PadPrefix(options.dllexport_decl));
     }
     for (auto enumdesc : this_file_enums) {
-      output("extern const $1upb_MiniTableEnum* $0();\n", EnumInit(enumdesc),
-             PadSuffix(options.dllexport_decl));
+      output("extern const$1 upb_MiniTableEnum* $0();\n", EnumInit(enumdesc),
+             PadPrefix(options.dllexport_decl));
     }
     output("\n");
   }

--- a/upb_generator/protoc-gen-upb.cc
+++ b/upb_generator/protoc-gen-upb.cc
@@ -43,7 +43,7 @@ namespace {
 
 struct Options {
   bool bootstrap = false;
-  std::string dllexport_tag;
+  std::string dllexport_decl;
 };
 
 std::string SourceFilename(upb::FileDefPtr file) {
@@ -888,20 +888,20 @@ void WriteHeader(const DefPoolPair& pools, upb::FileDefPtr file,
       "#endif\n"
       "\n");
 
-  EmitDllExportMacros(options.dllexport_tag, output);
+  EmitDllExportMacros(options.dllexport_decl, output);
 
   if (options.bootstrap) {
     for (auto message : this_file_messages) {
       output("extern const $1upb_MiniTable* $0();\n", MessageInitName(message),
-             PadSuffix(options.dllexport_tag));
+             PadSuffix(options.dllexport_decl));
     }
     for (auto message : forward_messages) {
       output("extern const $1upb_MiniTable* $0();\n", MessageInitName(message),
-             PadSuffix(options.dllexport_tag));
+             PadSuffix(options.dllexport_decl));
     }
     for (auto enumdesc : this_file_enums) {
       output("extern const $1upb_MiniTableEnum* $0();\n", EnumInit(enumdesc),
-             PadSuffix(options.dllexport_tag));
+             PadSuffix(options.dllexport_decl));
     }
     output("\n");
   }
@@ -1112,8 +1112,8 @@ bool ParseOptions(Plugin* plugin, Options* options) {
   for (const auto& pair : ParseGeneratorParameter(plugin->parameter())) {
     if (pair.first == "bootstrap_upb") {
       options->bootstrap = true;
-    } else if (pair.first == "dllexport_tag") {
-      options->dllexport_tag = pair.second;
+    } else if (pair.first == "dllexport_decl") {
+      options->dllexport_decl = pair.second;
     } else {
       plugin->SetError(absl::Substitute("Unknown parameter: $0", pair.first));
       return false;

--- a/upb_generator/protoc-gen-upb.cc
+++ b/upb_generator/protoc-gen-upb.cc
@@ -888,8 +888,6 @@ void WriteHeader(const DefPoolPair& pools, upb::FileDefPtr file,
       "#endif\n"
       "\n");
 
-  EmitDllExportMacros(options.dllexport_decl, output);
-
   if (options.bootstrap) {
     for (auto message : this_file_messages) {
       output("extern const $1upb_MiniTable* $0();\n", MessageInitName(message),

--- a/upb_generator/protoc-gen-upb.cc
+++ b/upb_generator/protoc-gen-upb.cc
@@ -43,6 +43,7 @@ namespace {
 
 struct Options {
   bool bootstrap = false;
+  std::string dllexport_tag;
 };
 
 std::string SourceFilename(upb::FileDefPtr file) {
@@ -732,7 +733,7 @@ void GenerateNonRepeatedSetters(upb::FieldDefPtr field,
 
   if (field == field.containing_type().map_value()) {
     output(R"cc(
-             UPB_INLINE void $0_set_$1($0 *msg, $2 value) {
+             UPB_INLINE void $0_set_$1($0* msg, $2 value) {
                _upb_msg_map_set_value(msg, &value, $3);
              }
            )cc",
@@ -741,7 +742,7 @@ void GenerateNonRepeatedSetters(upb::FieldDefPtr field,
                                               : "sizeof(" + CType(field) + ")");
   } else {
     output(R"cc(
-             UPB_INLINE void $0_set_$1($0 *msg, $2 value) {
+             UPB_INLINE void $0_set_$1($0* msg, $2 value) {
                const upb_MiniTableField field = $3;
                _upb_Message_SetNonExtensionField((upb_Message *)msg, &field, &value);
              }
@@ -887,15 +888,20 @@ void WriteHeader(const DefPoolPair& pools, upb::FileDefPtr file,
       "#endif\n"
       "\n");
 
+  EmitDllExportMacros(options.dllexport_tag, output);
+
   if (options.bootstrap) {
     for (auto message : this_file_messages) {
-      output("extern const upb_MiniTable* $0();\n", MessageInitName(message));
+      output("extern const $1upb_MiniTable* $0();\n", MessageInitName(message),
+             PadSuffix(options.dllexport_tag));
     }
     for (auto message : forward_messages) {
-      output("extern const upb_MiniTable* $0();\n", MessageInitName(message));
+      output("extern const $1upb_MiniTable* $0();\n", MessageInitName(message),
+             PadSuffix(options.dllexport_tag));
     }
     for (auto enumdesc : this_file_enums) {
-      output("extern const upb_MiniTableEnum* $0();\n", EnumInit(enumdesc));
+      output("extern const $1upb_MiniTableEnum* $0();\n", EnumInit(enumdesc),
+             PadSuffix(options.dllexport_tag));
     }
     output("\n");
   }
@@ -1040,9 +1046,9 @@ void WriteEnumMiniDescriptorInitializer(upb::EnumDefPtr enum_def,
           static const upb_MiniTableEnum* mini_table = NULL;
           static const char* mini_descriptor = "$1";
           if (mini_table) return mini_table;
-          mini_table =
-              upb_MiniTableEnum_Build(mini_descriptor, strlen(mini_descriptor),
-                                      upb_BootstrapArena(), NULL);
+          mini_table = upb_MiniTableEnum_Build(mini_descriptor,
+                                               strlen(mini_descriptor),
+                                               upb_BootstrapArena(), NULL);
           return mini_table;
         }
       )cc",
@@ -1106,6 +1112,8 @@ bool ParseOptions(Plugin* plugin, Options* options) {
   for (const auto& pair : ParseGeneratorParameter(plugin->parameter())) {
     if (pair.first == "bootstrap_upb") {
       options->bootstrap = true;
+    } else if (pair.first == "dllexport_tag") {
+      options->dllexport_tag = pair.second;
     } else {
       plugin->SetError(absl::Substitute("Unknown parameter: $0", pair.first));
       return false;

--- a/upb_generator/protoc-gen-upbdefs.cc
+++ b/upb_generator/protoc-gen-upbdefs.cc
@@ -43,7 +43,7 @@ void GenerateMessageDefAccessor(upb::MessageDefPtr d, Output& output) {
   output("\n");
 }
 
-void WriteDefHeader(upb::FileDefPtr file, Options const& options,
+void WriteDefHeader(upb::FileDefPtr file, const Options& options,
                     Output& output) {
   EmitFileWarning(file.name(), output);
 
@@ -80,7 +80,7 @@ void WriteDefHeader(upb::FileDefPtr file, Options const& options,
       ToPreproc(file.name()));
 }
 
-void WriteDefSource(upb::FileDefPtr file, Options const& options, Output& output) {
+void WriteDefSource(upb::FileDefPtr file, const Options& options, Output& output) {
   EmitFileWarning(file.name(), output);
 
   output("#include \"upb/reflection/def.h\"\n");
@@ -132,7 +132,7 @@ void WriteDefSource(upb::FileDefPtr file, Options const& options, Output& output
   output("};\n");
 }
 
-void GenerateFile(upb::FileDefPtr file, Options const& options,
+void GenerateFile(upb::FileDefPtr file, const Options& options,
                   Plugin* plugin) {
   Output h_def_output;
   WriteDefHeader(file, options, h_def_output);

--- a/upb_generator/protoc-gen-upbdefs.cc
+++ b/upb_generator/protoc-gen-upbdefs.cc
@@ -59,8 +59,8 @@ void WriteDefHeader(upb::FileDefPtr file, const Options& options,
       "#endif\n\n",
       ToPreproc(file.name()));
 
-  output("extern $1_upb_DefPool_Init $0;\n", DefInitSymbol(file),
-         PadSuffix(options.dllexport_decl));
+  output("extern$1 _upb_DefPool_Init $0;\n", DefInitSymbol(file),
+         PadPrefix(options.dllexport_decl));
   output("\n");
 
   for (auto msg : SortedMessages(file)) {
@@ -87,8 +87,8 @@ void WriteDefSource(upb::FileDefPtr file, const Options& options, Output& output
   output("\n");
 
   for (int i = 0; i < file.dependency_count(); i++) {
-    output("extern $1_upb_DefPool_Init $0;\n",
-           DefInitSymbol(file.dependency(i)), PadSuffix(options.dllexport_decl));
+    output("extern$1 _upb_DefPool_Init $0;\n",
+           DefInitSymbol(file.dependency(i)), PadPrefix(options.dllexport_decl));
   }
 
   upb::Arena arena;

--- a/upb_generator/protoc-gen-upbdefs.cc
+++ b/upb_generator/protoc-gen-upbdefs.cc
@@ -59,8 +59,6 @@ void WriteDefHeader(upb::FileDefPtr file, const Options& options,
       "#endif\n\n",
       ToPreproc(file.name()));
 
-  EmitDllExportMacros(options.dllexport_decl, output);
-
   output("extern $1_upb_DefPool_Init $0;\n", DefInitSymbol(file),
          PadSuffix(options.dllexport_decl));
   output("\n");

--- a/upb_generator/protoc-gen-upbdefs.cc
+++ b/upb_generator/protoc-gen-upbdefs.cc
@@ -18,6 +18,10 @@ namespace upb {
 namespace generator {
 namespace {
 
+struct Options {
+  std::string dllexport_tag;
+};
+
 std::string DefInitSymbol(upb::FileDefPtr file) {
   return ToCIdent(file.name()) + "_upbdefinit";
 }
@@ -39,7 +43,8 @@ void GenerateMessageDefAccessor(upb::MessageDefPtr d, Output& output) {
   output("\n");
 }
 
-void WriteDefHeader(upb::FileDefPtr file, Output& output) {
+void WriteDefHeader(upb::FileDefPtr file, Options const& options,
+                    Output& output) {
   EmitFileWarning(file.name(), output);
 
   output(
@@ -54,7 +59,10 @@ void WriteDefHeader(upb::FileDefPtr file, Output& output) {
       "#endif\n\n",
       ToPreproc(file.name()));
 
-  output("extern _upb_DefPool_Init $0;\n", DefInitSymbol(file));
+  EmitDllExportMacros(options.dllexport_tag, output);
+
+  output("extern $1_upb_DefPool_Init $0;\n", DefInitSymbol(file),
+         PadSuffix(options.dllexport_tag));
   output("\n");
 
   for (auto msg : SortedMessages(file)) {
@@ -72,7 +80,7 @@ void WriteDefHeader(upb::FileDefPtr file, Output& output) {
       ToPreproc(file.name()));
 }
 
-void WriteDefSource(upb::FileDefPtr file, Output& output) {
+void WriteDefSource(upb::FileDefPtr file, Options const& options, Output& output) {
   EmitFileWarning(file.name(), output);
 
   output("#include \"upb/reflection/def.h\"\n");
@@ -81,7 +89,8 @@ void WriteDefSource(upb::FileDefPtr file, Output& output) {
   output("\n");
 
   for (int i = 0; i < file.dependency_count(); i++) {
-    output("extern _upb_DefPool_Init $0;\n", DefInitSymbol(file.dependency(i)));
+    output("extern $1_upb_DefPool_Init $0;\n",
+           DefInitSymbol(file.dependency(i)), PadSuffix(options.dllexport_tag));
   }
 
   upb::Arena arena;
@@ -123,14 +132,28 @@ void WriteDefSource(upb::FileDefPtr file, Output& output) {
   output("};\n");
 }
 
-void GenerateFile(upb::FileDefPtr file, Plugin* plugin) {
+void GenerateFile(upb::FileDefPtr file, Options const& options,
+                  Plugin* plugin) {
   Output h_def_output;
-  WriteDefHeader(file, h_def_output);
+  WriteDefHeader(file, options, h_def_output);
   plugin->AddOutputFile(DefHeaderFilename(file), h_def_output.output());
 
   Output c_def_output;
-  WriteDefSource(file, c_def_output);
+  WriteDefSource(file, options, c_def_output);
   plugin->AddOutputFile(DefSourceFilename(file), c_def_output.output());
+}
+
+bool ParseOptions(Plugin* plugin, Options* options) {
+  for (const auto& pair : ParseGeneratorParameter(plugin->parameter())) {
+    if (pair.first == "dllexport_tag") {
+      options->dllexport_tag = pair.second;
+    } else {
+      plugin->SetError(absl::Substitute("Unknown parameter: $0", pair.first));
+      return false;
+    }
+  }
+
+  return true;
 }
 
 }  // namespace
@@ -139,13 +162,10 @@ void GenerateFile(upb::FileDefPtr file, Plugin* plugin) {
 
 int main(int argc, char** argv) {
   upb::generator::Plugin plugin;
-  if (!plugin.parameter().empty()) {
-    plugin.SetError(
-        absl::StrCat("Expected no parameters, got: ", plugin.parameter()));
-    return 0;
-  }
+  upb::generator::Options options;
+  if (!ParseOptions(&plugin, &options)) return 0;
   plugin.GenerateFiles([&](upb::FileDefPtr file) {
-    upb::generator::GenerateFile(file, &plugin);
+    upb::generator::GenerateFile(file, options, &plugin);
   });
   return 0;
 }

--- a/upb_generator/protoc-gen-upbdefs.cc
+++ b/upb_generator/protoc-gen-upbdefs.cc
@@ -19,7 +19,7 @@ namespace generator {
 namespace {
 
 struct Options {
-  std::string dllexport_tag;
+  std::string dllexport_decl;
 };
 
 std::string DefInitSymbol(upb::FileDefPtr file) {
@@ -59,10 +59,10 @@ void WriteDefHeader(upb::FileDefPtr file, Options const& options,
       "#endif\n\n",
       ToPreproc(file.name()));
 
-  EmitDllExportMacros(options.dllexport_tag, output);
+  EmitDllExportMacros(options.dllexport_decl, output);
 
   output("extern $1_upb_DefPool_Init $0;\n", DefInitSymbol(file),
-         PadSuffix(options.dllexport_tag));
+         PadSuffix(options.dllexport_decl));
   output("\n");
 
   for (auto msg : SortedMessages(file)) {
@@ -90,7 +90,7 @@ void WriteDefSource(upb::FileDefPtr file, Options const& options, Output& output
 
   for (int i = 0; i < file.dependency_count(); i++) {
     output("extern $1_upb_DefPool_Init $0;\n",
-           DefInitSymbol(file.dependency(i)), PadSuffix(options.dllexport_tag));
+           DefInitSymbol(file.dependency(i)), PadSuffix(options.dllexport_decl));
   }
 
   upb::Arena arena;
@@ -145,8 +145,8 @@ void GenerateFile(upb::FileDefPtr file, Options const& options,
 
 bool ParseOptions(Plugin* plugin, Options* options) {
   for (const auto& pair : ParseGeneratorParameter(plugin->parameter())) {
-    if (pair.first == "dllexport_tag") {
-      options->dllexport_tag = pair.second;
+    if (pair.first == "dllexport_decl") {
+      options->dllexport_decl = pair.second;
     } else {
       plugin->SetError(absl::Substitute("Unknown parameter: $0", pair.first));
       return false;


### PR DESCRIPTION
I have been collaborating with the grpc developers to make it possible to build that library as a Windows DLL - a couple of PRs were already merged, more like https://github.com/grpc/grpc/pull/34345 are pending.

The grpc library incorporates some upb-generated, and upbdefs-generated code into grpc.dll, which is referenced by other code that consumes the library. Since this is now a DLL, that code doesn't know how to link to these generated symbols because they are not annotated with __declspec(dllimport).

This PR aims to fix that by introducing a parameter 'dllexport_tag' to the upb and upbdefs plugins. That parameter should be a string e.g. MYAPP_DLL and when set, the extern symbols are annotated with a macro with that name. This can either be set externally to __declspec(dllimport) or, as is usual practice, when compiling code into a DLL, the macro <dllexport_tag>_EXPORT (i.e. MYAPP_DLL_EXPORT) is defined, and when consuming the DLL <dllexport_tag>_IMPORT is defined if neither are defined then the MYAPP_DLL macro becomes empty string which is what you want for building a static library.

This is a continuation of https://github.com/protocolbuffers/protobuf/pull/14230

Fixes: https://github.com/protocolbuffers/protobuf/issues/14255