### PR TITLE
protoc: support inf, -inf, nan, and -nan in option values

### DIFF
--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -1623,12 +1623,19 @@ bool Parser::ParseOption(Message* options,
       case io::Tokenizer::TYPE_IDENTIFIER: {
         value_location.AddPath(
             UninterpretedOption::kIdentifierValueFieldNumber);
-        if (is_negative) {
-          RecordError("Invalid '-' symbol before identifier.");
-          return false;
-        }
         std::string value;
         DO(ConsumeIdentifier(&value, "Expected identifier."));
+        if (is_negative) {
+          if (value == "inf") {
+            uninterpreted_option->set_double_value(-std::numeric_limits<double>::infinity());
+          } else if (value == "nan") {
+            uninterpreted_option->set_double_value(std::numeric_limits<double>::quiet_NaN());
+          } else {
+            RecordError("Identifier after '-' symbol must be inf or nan.");
+            return false;
+          }
+          break;
+        }
         uninterpreted_option->set_identifier_value(value);
         break;
       }

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -20,7 +20,6 @@
 
 #include "google/protobuf/any.pb.h"
 #include "google/protobuf/descriptor.pb.h"
-#include "google/protobuf/dynamic_message.h"
 #include <gmock/gmock.h>
 #include "google/protobuf/testing/googletest.h"
 #include <gtest/gtest.h>
@@ -1460,108 +1459,46 @@ TEST_F(ParseMiscTest, ParseFileOptions) {
       "}");
 }
 
-TEST_F(ParseMiscTest, InterpretFileOptions) {
-  SetupParser(
-      "import \"google/protobuf/descriptor.proto\";\n"
-      "extend google.protobuf.FileOptions {\n"
-      "  optional float float_a = 10101;\n"
-      "  optional float float_b = 10102;\n"
-      "  optional float float_c = 10103;\n"
-      "  optional float float_d = 10104;\n"
-      "  optional double double_a = 10105;\n"
-      "  optional double double_b = 10106;\n"
-      "  optional double double_c = 10107;\n"
-      "  optional double double_d = 10108;\n"
-      "}\n"
-      "option (float_a) = inf;\n"
-      "option (double_a) = inf;\n"
-      "option (float_b) = -inf;\n"
-      "option (double_b) = -inf;\n"
-      "option (float_c) = nan;\n"
-      "option (double_c) = nan;\n"
-      "option (float_d) = -nan;\n"
-      "option (double_d) = -nan;\n");
-  FileDescriptorProto parsed;
-  parser_->Parse(input_.get(), &parsed);
-  EXPECT_EQ(io::Tokenizer::TYPE_END, input_->current().type);
-  ASSERT_EQ("", error_collector_.text_);
-  parsed.set_name("test.proto");
-
-  // We now have a FileDescriptorProto, but we need to link it to
-  // examine interpreted options. This file imports descriptor.proto,
-  // so we need to setup that dependency.
-  const FileDescriptor* import = FileDescriptorProto::descriptor()->file();
-  FileDescriptorProto import_proto;
-  import->CopyTo(&import_proto);
-  ASSERT_TRUE(pool_.BuildFile(import_proto) != nullptr);
-
-  const FileDescriptor* actual = pool_.BuildFile(parsed);
-  ASSERT_TRUE(actual != nullptr) << error_collector_.text_;
-
-  // In order to inspect interpreted options as known values (instead of
-  // poking around unrecognized fields set), we have to copy the options
-  // into a dynamic message via serializing and then de-serializing.
-  const FileOptions& orig_opts = actual->options();
-  const Descriptor* option_descriptor =
-      pool_.FindMessageTypeByName(orig_opts.GetDescriptor()->full_name());
-  ASSERT_TRUE(option_descriptor != nullptr);
-
-  DynamicMessageFactory factory;
-  std::unique_ptr<Message> dynamic_options(
-    factory.GetPrototype(option_descriptor)->New());
-  std::string serialized = orig_opts.SerializeAsString();
-  io::CodedInputStream input(
-      reinterpret_cast<const uint8_t*>(serialized.c_str()),
-      serialized.size());
-  input.SetExtensionRegistry(&pool_, &factory);
-  ASSERT_TRUE(dynamic_options->ParseFromCodedStream(&input));
-  const Reflection* reflect = dynamic_options->GetReflection();
-
-  // Now we can make assertions about some of the interpreted values.
-
-  const FieldDescriptor* float_opt = actual->FindExtensionByName("float_a");
-  ASSERT_TRUE(float_opt != nullptr);
-  const FieldDescriptor* double_opt = actual->FindExtensionByName("double_a");
-  ASSERT_TRUE(double_opt != nullptr);
-
-  float float_val = reflect->GetFloat(*dynamic_options, float_opt);
-  ASSERT_TRUE(std::isinf(float_val));
-  ASSERT_GT(float_val, 0);
-  double double_val = reflect->GetDouble(*dynamic_options, double_opt);
-  ASSERT_TRUE(std::isinf(double_val));
-  ASSERT_GT(double_val, 0);
-
-  float_opt = actual->FindExtensionByName("float_b");
-  ASSERT_TRUE(float_opt != nullptr);
-  double_opt = actual->FindExtensionByName("double_b");
-  ASSERT_TRUE(double_opt != nullptr);
-
-  float_val = reflect->GetFloat(*dynamic_options, float_opt);
-  ASSERT_TRUE(std::isinf(float_val));
-  ASSERT_LT(float_val, 0);
-  double_val = reflect->GetDouble(*dynamic_options, double_opt);
-  ASSERT_TRUE(std::isinf(double_val));
-  ASSERT_LT(double_val, 0);
-
-  float_opt = actual->FindExtensionByName("float_c");
-  ASSERT_TRUE(float_opt != nullptr);
-  double_opt = actual->FindExtensionByName("double_c");
-  ASSERT_TRUE(double_opt != nullptr);
-
-  float_val = reflect->GetFloat(*dynamic_options, float_opt);
-  ASSERT_TRUE(std::isnan(float_val));
-  double_val = reflect->GetDouble(*dynamic_options, double_opt);
-  ASSERT_TRUE(std::isnan(double_val));
-
-  float_opt = actual->FindExtensionByName("float_d");
-  ASSERT_TRUE(float_opt != nullptr);
-  double_opt = actual->FindExtensionByName("double_d");
-  ASSERT_TRUE(double_opt != nullptr);
-
-  float_val = reflect->GetFloat(*dynamic_options, float_opt);
-  ASSERT_TRUE(std::isnan(float_val));
-  double_val = reflect->GetDouble(*dynamic_options, double_opt);
-  ASSERT_TRUE(std::isnan(double_val));
+TEST_F(ParseMiscTest, InterpretedOptions) {
+  // Since we're importing the generated code from parsing/compiling
+  // unittest_custom_options.proto, we can just look at the option
+  // values from that file's descriptor in the generated code.
+  {
+    const MessageOptions& options = protobuf_unittest::SettingRealsFromInf
+                                    ::descriptor()->options();
+    float float_val = options.GetExtension(protobuf_unittest::float_opt);
+    ASSERT_TRUE(std::isinf(float_val));
+    ASSERT_GT(float_val, 0);
+    double double_val = options.GetExtension(protobuf_unittest::double_opt);
+    ASSERT_TRUE(std::isinf(double_val));
+    ASSERT_GT(double_val, 0);
+  }
+  {
+    const MessageOptions& options = protobuf_unittest::SettingRealsFromNegativeInf
+                                    ::descriptor()->options();
+    float float_val = options.GetExtension(protobuf_unittest::float_opt);
+    ASSERT_TRUE(std::isinf(float_val));
+    ASSERT_LT(float_val, 0);
+    double double_val = options.GetExtension(protobuf_unittest::double_opt);
+    ASSERT_TRUE(std::isinf(double_val));
+    ASSERT_LT(double_val, 0);
+  }
+  {
+    const MessageOptions& options = protobuf_unittest::SettingRealsFromNan
+                                    ::descriptor()->options();
+    float float_val = options.GetExtension(protobuf_unittest::float_opt);
+    ASSERT_TRUE(std::isnan(float_val));
+    double double_val = options.GetExtension(protobuf_unittest::double_opt);
+    ASSERT_TRUE(std::isnan(double_val));
+  }
+  {
+    const MessageOptions& options = protobuf_unittest::SettingRealsFromNegativeNan
+                                    ::descriptor()->options();
+    float float_val = options.GetExtension(protobuf_unittest::float_opt);
+    ASSERT_TRUE(std::isnan(float_val));
+    double double_val = options.GetExtension(protobuf_unittest::double_opt);
+    ASSERT_TRUE(std::isnan(double_val));
+  }
 }
 
 // ===================================================================

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -658,6 +658,66 @@ TEST_F(ParseMessageTest, FieldOptionsSupportLargeDecimalLiteral) {
       "}");
 }
 
+TEST_F(ParseMessageTest, FieldOptionsSupportInfAndNan) {
+  // decimal integer literal > uint64 max
+  ExpectParsesTo(
+      "import \"google/protobuf/descriptor.proto\";\n"
+      "extend google.protobuf.FieldOptions {\n"
+      "  optional double f = 10101;\n"
+      "}\n"
+      "message TestMessage {\n"
+      "  optional double a = 1 [(f) = inf];\n"
+      "  optional double b = 2 [(f) = -inf];\n"
+      "  optional double c = 3 [(f) = nan];\n"
+      "  optional double d = 4 [(f) = -nan];\n"
+      "}\n",
+
+      "dependency: \"google/protobuf/descriptor.proto\""
+      "extension {"
+      "  name: \"f\" label: LABEL_OPTIONAL type: TYPE_DOUBLE number: 10101"
+      "  extendee: \"google.protobuf.FieldOptions\""
+      "}"
+      "message_type {"
+      "  name: \"TestMessage\""
+      "  field {"
+      "    name: \"a\" label: LABEL_OPTIONAL type: TYPE_DOUBLE number: 1"
+      "    options{"
+      "      uninterpreted_option{"
+      "        name{ name_part: \"f\" is_extension: true }"
+      "        identifier_value: \"inf\""
+      "      }"
+      "    }"
+      "  }"
+      "  field {"
+      "    name: \"b\" label: LABEL_OPTIONAL type: TYPE_DOUBLE number: 2"
+      "    options{"
+      "      uninterpreted_option{"
+      "        name{ name_part: \"f\" is_extension: true }"
+      "        double_value: -infinity"
+      "      }"
+      "    }"
+      "  }"
+      "  field {"
+      "    name: \"c\" label: LABEL_OPTIONAL type: TYPE_DOUBLE number: 3"
+      "    options{"
+      "      uninterpreted_option{"
+      "        name{ name_part: \"f\" is_extension: true }"
+      "        identifier_value: \"nan\""
+      "      }"
+      "    }"
+      "  }"
+      "  field {"
+      "    name: \"d\" label: LABEL_OPTIONAL type: TYPE_DOUBLE number: 4"
+      "    options{"
+      "      uninterpreted_option{"
+      "        name{ name_part: \"f\" is_extension: true }"
+      "        double_value: nan"
+      "      }"
+      "    }"
+      "  }"
+      "}");
+}
+
 TEST_F(ParseMessageTest, Oneof) {
   ExpectParsesTo(
       "message TestMessage {\n"

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -9140,6 +9140,10 @@ bool DescriptorBuilder::OptionInterpreter::SetOptionValue(
         value = uninterpreted_option_->positive_int_value();
       } else if (uninterpreted_option_->has_negative_int_value()) {
         value = uninterpreted_option_->negative_int_value();
+      } else if (uninterpreted_option_->identifier_value() == "inf") {
+        value = std::numeric_limits<float>::infinity();
+      } else if (uninterpreted_option_->identifier_value() == "nan") {
+        value = std::numeric_limits<float>::quiet_NaN();
       } else {
         return AddValueError([&] {
           return absl::StrCat("Value must be number for float option \"",
@@ -9159,6 +9163,10 @@ bool DescriptorBuilder::OptionInterpreter::SetOptionValue(
         value = uninterpreted_option_->positive_int_value();
       } else if (uninterpreted_option_->has_negative_int_value()) {
         value = uninterpreted_option_->negative_int_value();
+      } else if (uninterpreted_option_->identifier_value() == "inf") {
+        value = std::numeric_limits<double>::infinity();
+      } else if (uninterpreted_option_->identifier_value() == "nan") {
+        value = std::numeric_limits<double>::quiet_NaN();
       } else {
         return AddValueError([&] {
           return absl::StrCat("Value must be number for double option \"",

--- a/src/google/protobuf/unittest_custom_options.proto
+++ b/src/google/protobuf/unittest_custom_options.proto
@@ -191,6 +191,26 @@ message SettingRealsFromNegativeInts {
   option (double_opt) = -154;
 }
 
+message SettingRealsFromInf {
+  option (float_opt) = inf;
+  option (double_opt) = inf;
+}
+
+message SettingRealsFromNegativeInf {
+  option (float_opt) = -inf;
+  option (double_opt) = -inf;
+}
+
+message SettingRealsFromNan {
+  option (float_opt) = nan;
+  option (double_opt) = nan;
+}
+
+message SettingRealsFromNegativeNan {
+  option (float_opt) = -nan;
+  option (double_opt) = -nan;
+}
+
 // Options of complex message types, themselves combined and extended in
 // various ways.
 


### PR DESCRIPTION
The parser already supports these values for the special "default" field option. But, inconsistently, does not support them for other options whose type is float or double. This addresses that inconsistency.

Fixes #15010.