### PR TITLE
Bump rules_apple to 3.1.1

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -122,8 +122,8 @@ def protobuf_deps():
     if not native.existing_rule("build_bazel_rules_apple"):
         http_archive(
             name = "build_bazel_rules_apple",
-            sha256 = "f94e6dddf74739ef5cb30f000e13a2a613f6ebfa5e63588305a71fce8a8a9911",
-            url = "https://github.com/bazelbuild/rules_apple/releases/download/1.1.3/rules_apple.1.1.3.tar.gz",
+            sha256 = "34c41bfb59cdaea29ac2df5a2fa79e5add609c71bb303b2ebb10985f93fa20e7",
+            url = "https://github.com/bazelbuild/rules_apple/releases/download/3.1.1/rules_apple.3.1.1.tar.gz",
         )
 
     if not native.existing_rule("io_bazel_rules_kotlin"):


### PR DESCRIPTION
On my local setup (WSL Ubuntu), I noticed that attempting to build Ruby tests fails, because of an error in `rules_apple`:

```
charles@AlterCation:~/protobuf$ bazel test //ruby/tests/...
WARNING: Build option --test_env has changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
/usr/local/bin/ruby: No such file or directory -- bundler/exe/bundler (LoadError)
ERROR: Traceback (most recent call last):
        File "/home/charles/.cache/bazel/_bazel_charles/dcd9f4fa8672aac49359d11b9a237597/external/build_bazel_rules_apple/apple/internal/rule_support.bzl", line 221, column 36, in <toplevel>
                deps_cfg = apple_common.multi_arch_split,
Error: 'apple_common' value has no field or method 'multi_arch_split'
```

This is an error previously reported in `rules_apple`, and fixed here: https://github.com/bazelbuild/rules_apple/pull/2034

Looks like that was pulled into release 3.0.0, but I figured we may as well try for 3.1.1 ([the latest release](https://github.com/bazelbuild/rules_apple/releases)).

With this bump, I no longer get the above error.