### PR TITLE
In ruby/README.md, correct a target name

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -115,7 +115,7 @@ $ bazel test //ruby/tests/...
 To run tests against the FFI implementation:
 
 ```
-$ bazel test //ruby/tests/... //ruby:ffi=enabled --test_env=PROTOCOL_BUFFERS_RUBY_IMPLEMENTATION=FFI
+$ bazel test //ruby/tests/... //ruby:ffi_enabled --test_env=PROTOCOL_BUFFERS_RUBY_IMPLEMENTATION=FFI
 ```
 
 Version Number Scheme


### PR DESCRIPTION
When attempting to run the Ruby tests, I noticed that the README is slightly off; it points to a target that doesn't exist:

```
charles@AlterCation:~/protobuf$ bazel test //ruby/tests/... //ruby:ffi=enabled --test_env=PROTOCOL_BUFFERS_RUBY_IMPLEMENTATION=FFI
ERROR: Skipping '//ruby:ffi=enabled': no such target '//ruby:ffi=enabled': target 'ffi=enabled' not declared in package 'ruby' defined by /home/charles/protobuf/ruby/BUILD.bazel (did you mean 'ffi_enabled'? Tip: use `query "//ruby:*"` to see all the targets in that package)
ERROR: no such target '//ruby:ffi=enabled': target 'ffi=enabled' not declared in package 'ruby' defined by /home/charles/protobuf/ruby/BUILD.bazel (did you mean 'ffi_enabled'? Tip: use `query "//ruby:*"` to see all the targets in that package)
INFO: Elapsed time: 0.679s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
ERROR: Couldn't start the build. Unable to run tests
charles@AlterCation:~/protobuf$
```

Instead, it looks like `//ruby:ffi_enabled` is what you're supposed to use, which sets the flag on:
https://github.com/protocolbuffers/protobuf/blob/main/ruby/BUILD.bazel#L28-L30
