### PR TITLE
Add IceRPC to the list of third-party RPC implementations

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -150,6 +150,7 @@ GRPC (http://www.grpc.io/) is Google's RPC implementation for Protocol Buffers. 
 * https://github.com/pbkit/npm-packages/blob/main/frpc-test/src/index.spec.ts (TypeScript Node.js/Browser)
 * https://github.com/ppissias/xsrpcj (Java)
 * https://github.com/twitchtv/twirp (Multiple languages)
+* https://github.com/icerpc/icerpc-csharp (C#)
 
 Inactive:
 


### PR DESCRIPTION
This PR adds IceRPC for C# to the list of RPC implementations in third_party.doc.

IceRPC provides full support for Protobuf. See https://docs.icerpc.dev/protobuf for details.
