### PR TITLE
Add -I import flag to CLI

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2421,7 +2421,7 @@ void CommandLineInterface::PrintHelpText() {
   std::cout << "Usage: " << executable_name_ << " [OPTION] PROTO_FILES";
   std::cout << R"(
 Parse PROTO_FILES and generate output based on the options given:
-  -IPATH, --proto_path=PATH   Specify the directory in which to search for
+  -IPATH, -I, --proto_path=PATH   Specify the directory in which to search for
                               imports.  May be specified multiple times;
                               directories will be searched in order.  If not
                               given, the current working directory is used.


### PR DESCRIPTION
Given the wide usage of `protoc -I` I thought it might be useful to surface it in the CLI. 

@sbenzaquen I see the CI error of "This pull request is from an unsafe fork and hasn't been approved to run tests!" - is this a change you all would consider upstreaming?