### PR TITLE
ruby: Fix format-security warning when compiling the Ruby Gem

### DIFF
--- a/ruby/ext/google/protobuf_c/convert.c
+++ b/ruby/ext/google/protobuf_c/convert.c
@@ -296,7 +296,7 @@ bool Msgval_IsEqual(upb_MessageValue val1, upb_MessageValue val2,
   if (upb_Status_IsOk(&status)) {
     return return_value;
   } else {
-    rb_raise(rb_eRuntimeError, upb_Status_ErrorMessage(&status));
+    rb_raise(rb_eRuntimeError, "%s", upb_Status_ErrorMessage(&status));
   }
 }
 
@@ -309,6 +309,6 @@ uint64_t Msgval_GetHash(upb_MessageValue val, TypeInfo type_info,
   if (upb_Status_IsOk(&status)) {
     return return_value;
   } else {
-    rb_raise(rb_eRuntimeError, upb_Status_ErrorMessage(&status));
+    rb_raise(rb_eRuntimeError, "%s", upb_Status_ErrorMessage(&status));
   }
 }

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -675,7 +675,7 @@ bool Message_Equal(const upb_Message* m1, const upb_Message* m2,
   if (upb_Status_IsOk(&status)) {
     return return_value;
   } else {
-    rb_raise(cParseError, upb_Status_ErrorMessage(&status));
+    rb_raise(cParseError, "%s", upb_Status_ErrorMessage(&status));
   }
 }
 
@@ -706,7 +706,7 @@ uint64_t Message_Hash(const upb_Message* msg, const upb_MessageDef* m,
   if (upb_Status_IsOk(&status)) {
     return return_value;
   } else {
-    rb_raise(cParseError, upb_Status_ErrorMessage(&status));
+    rb_raise(cParseError, "%s", upb_Status_ErrorMessage(&status));
   }
 }
 


### PR DESCRIPTION
When compiling the ruby gem with `-Werror=format-security` there are some strings that might contain formatting characters. This commit makes sure those calls are formatted with "%s" first so that any unintentional formatting characters are successfully passed through without being interpreted.