### PR TITLE
Add rake runtime dependency for ruby

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -119,7 +119,7 @@ else
       # rake-compiler would call `spec.extensions.clear` which removes the `Rakefile` extension,
       # that `rake` doesn't need to be a runtime dependency for native gems.
       gem_spec.dependencies.delete_if { |dependency| dependency.name == 'rake' }
-      gem_spec.add_development_dependency 'rake', '>= 13.0.0'
+      gem_spec.add_development_dependency 'rake', '>= 13'
     end
   end
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -114,6 +114,13 @@ else
       'x86_64-linux', 'x86-linux',
       'x86_64-darwin', 'arm64-darwin',
     ]
+
+    ext.cross_compiling do |gem_spec|
+      # rake-compiler would call `spec.extensions.clear` which removes the `Rakefile` extension,
+      # that `rake` doesn't need to be a runtime dependency for native gems.
+      gem_spec.dependencies.delete_if { |dependency| dependency.name == 'rake' }
+      gem_spec.add_development_dependency 'rake', '>= 13.0.0'
+    end
   end
 
   task 'gem:java' do

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency "rake-compiler-dock", "= 1.2.1"
   end
   s.required_ruby_version = '>= 2.7'
-  s.add_development_dependency "rake", "~> 13"
+  s.add_dependency "rake", ">= 13"
   s.add_development_dependency "ffi", "~>1"
   s.add_development_dependency "ffi-compiler", "~>1"
   s.add_development_dependency "rake-compiler", "~> 1.1.0"


### PR DESCRIPTION
We have a rake based extension `ext/google/protobuf_c/Rakefile` (added since 3.25.0), which depends on `rake`. However, when gem is installed by `bundle` command, `rake` is not guaranteed to be activated by `bundle` (e.g. when `BUNDLE_PATH` is not default and rake is not already installed in `BUNDLE_PATH`). Therefore, we have to explicit declare a runtime dependency on `rake` for the extension, or otherwise the installation will fail with `can't find gem rake (>= 0.a) with executable rake (Gem::GemNotFoundException)`. 

Here is a reproduction:

```
root@4d9cb6ba41b1:/build# cat Gemfile
source 'https://rubygems.org'
gem 'google-protobuf'


root@4d9cb6ba41b1:/build# bundle config --local path vendor/bundle


root@4d9cb6ba41b1:/build# bundle
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Installing google-protobuf 3.25.1 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /build/vendor/bundle/ruby/3.3.0/gems/google-protobuf-3.25.1/ext/google/protobuf_c
rake RUBYARCHDIR\=/build/vendor/bundle/ruby/3.3.0/extensions/aarch64-linux/3.3.0/google-protobuf-3.25.1 RUBYLIBDIR\=/build/vendor/bundle/ruby/3.3.0/extensions/aarch64-linux/3.3.0/google-protobuf-3.25.1
/usr/local/lib/ruby/3.3.0/rubygems.rb:259:in `find_spec_for_exe': can't find gem rake (>= 0.a) with executable rake (Gem::GemNotFoundException)
	from /usr/local/lib/ruby/3.3.0/rubygems.rb:278:in `activate_bin_path'
	from /usr/local/bin/rake:25:in `<main>'

rake failed, exit code 1

Gem files will remain installed in /build/vendor/bundle/ruby/3.3.0/gems/google-protobuf-3.25.1 for inspection.
Results logged to /build/vendor/bundle/ruby/3.3.0/extensions/aarch64-linux/3.3.0/google-protobuf-3.25.1/gem_make.out

  /usr/local/lib/ruby/3.3.0/rubygems/ext/builder.rb:125:in `run'
  /usr/local/lib/ruby/3.3.0/rubygems/ext/rake_builder.rb:30:in `build'
  /usr/local/lib/ruby/3.3.0/rubygems/ext/builder.rb:193:in `build_extension'
  /usr/local/lib/ruby/3.3.0/rubygems/ext/builder.rb:227:in `block in build_extensions'
  /usr/local/lib/ruby/3.3.0/rubygems/ext/builder.rb:224:in `each'
  /usr/local/lib/ruby/3.3.0/rubygems/ext/builder.rb:224:in `build_extensions'
  /usr/local/lib/ruby/3.3.0/rubygems/installer.rb:852:in `build_extensions'
  /usr/local/lib/ruby/3.3.0/bundler/rubygems_gem_installer.rb:76:in `build_extensions'
  /usr/local/lib/ruby/3.3.0/bundler/rubygems_gem_installer.rb:28:in `install'
  /usr/local/lib/ruby/3.3.0/bundler/source/rubygems.rb:205:in `install'
  /usr/local/lib/ruby/3.3.0/bundler/installer/gem_installer.rb:54:in `install'
  /usr/local/lib/ruby/3.3.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /usr/local/lib/ruby/3.3.0/bundler/installer/parallel_installer.rb:132:in `do_install'
  /usr/local/lib/ruby/3.3.0/bundler/installer/parallel_installer.rb:123:in `block in worker_pool'
  /usr/local/lib/ruby/3.3.0/bundler/worker.rb:62:in `apply_func'
  /usr/local/lib/ruby/3.3.0/bundler/worker.rb:57:in `block in process_queue'
  <internal:kernel>:187:in `loop'
  /usr/local/lib/ruby/3.3.0/bundler/worker.rb:54:in `process_queue'
  /usr/local/lib/ruby/3.3.0/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing google-protobuf (3.25.1), and Bundler cannot continue.

In Gemfile:
  google-protobuf

```