### PR TITLE
Do no longer depend on deprecated //external:python_headers

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -191,11 +191,6 @@ load("@fuzzing_py_deps//:requirements.bzl", fuzzing_py_deps_install_deps = "inst
 
 fuzzing_py_deps_install_deps()
 
-bind(
-    name = "python_headers",
-    actual = "@system_python//:python_headers",
-)
-
 http_archive(
     name = "rules_rust",
     sha256 = "9ecd0f2144f0a24e6bc71ebcc50a1ee5128cedeceb32187004532c9710cb2334",

--- a/python/build_targets.bzl
+++ b/python/build_targets.bzl
@@ -85,7 +85,7 @@ def build_targets(name):
         ],
         deps = select({
             "//conditions:default": [],
-            ":use_fast_cpp_protos": ["//external:python_headers"],
+            ":use_fast_cpp_protos": ["@system_python//:python_headers"],
         }),
     )
 
@@ -123,7 +123,7 @@ def build_targets(name):
             "//:protobuf",
         ] + select({
             "//conditions:default": [],
-            ":use_fast_cpp_protos": ["//external:python_headers"],
+            ":use_fast_cpp_protos": ["@system_python//:python_headers"],
         }),
     )
 
@@ -387,7 +387,7 @@ def build_targets(name):
         hdrs = ["google/protobuf/proto_api.h"],
         visibility = ["//visibility:public"],
         deps = [
-            "//external:python_headers",
+            "@system_python//:python_headers",
         ],
     )
 


### PR DESCRIPTION
`bind()` targets are deprecated and unsupported with Bzlmod. Specifying the dependency directly as a mitigation.

Alternative: Define an `alias()` within `/third_party/BUILD`.