### PR TITLE
fix: [PHP] add missing reserved classnames

### DIFF
--- a/php/src/Google/Protobuf/Internal/GPBUtil.php
+++ b/php/src/Google/Protobuf/Internal/GPBUtil.php
@@ -261,7 +261,7 @@ class GPBUtil
             "function"=>0, "global"=>0, "goto"=>0, "if"=>0, "implements"=>0,
             "include"=>0, "include_once"=>0, "instanceof"=>0, "insteadof"=>0,
             "interface"=>0, "isset"=>0, "list"=>0, "match"=>0, "namespace"=>0,
-            "new"=>0, "or"=>0, "parent"=>0, "print"=>0, "private"=>0,
+            "new"=>0, "or"=>0, "object"=>0, "parent"=>0, "print"=>0, "private"=>0,
             "protected"=>0,"public"=>0, "readonly" => 0,"require"=>0,
             "require_once"=>0,"return"=>0, "self"=>0, "static"=>0, "switch"=>0,
             "throw"=>0,"trait"=>0, "try"=>0,"unset"=>0, "use"=>0, "var"=>0,

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -981,6 +981,7 @@ class GeneratedClassTest extends TestBase
         $m = new \Lower\PBnull();
         $m = new \Lower\PBvoid();
         $m = new \Lower\PBiterable();
+        $m = new \Lower\PBObject();
 
         $m = new \Upper\PBABSTRACT();
         $m = new \Upper\PBAND();
@@ -1062,6 +1063,7 @@ class GeneratedClassTest extends TestBase
         $m = new \Upper\PBNULL();
         $m = new \Upper\PBVOID();
         $m = new \Upper\PBITERABLE();
+        $m = new \Upper\PBOBJECT();
 
         $m = new \Lower_enum\PBabstract();
         $m = new \Lower_enum\PBand();

--- a/php/tests/proto/test_reserved_enum_lower.proto
+++ b/php/tests/proto/test_reserved_enum_lower.proto
@@ -82,3 +82,4 @@ enum false { ZERO74 = 0; }
 enum null { ZERO75 = 0; }
 enum void { ZERO76 = 0; }
 enum iterable { ZERO77 = 0; }
+enum object { ZERO81 = 0; }

--- a/php/tests/proto/test_reserved_enum_upper.proto
+++ b/php/tests/proto/test_reserved_enum_upper.proto
@@ -82,3 +82,4 @@ enum FALSE { ZERO74 = 0; }
 enum NULL { ZERO75 = 0; }
 enum VOID { ZERO76 = 0; }
 enum ITERABLE { ZERO77 = 0; }
+enum OBJECT { ZERO81 = 0; }

--- a/php/tests/proto/test_reserved_enum_value_lower.proto
+++ b/php/tests/proto/test_reserved_enum_value_lower.proto
@@ -83,4 +83,5 @@ enum NotAllowed {
   null = 74;
   void = 75;
   iterable = 76;
+  object = 81;
 }

--- a/php/tests/proto/test_reserved_enum_value_upper.proto
+++ b/php/tests/proto/test_reserved_enum_value_upper.proto
@@ -83,4 +83,5 @@ enum NotAllowed {
   NULL = 74;
   VOID = 75;
   ITERABLE = 76;
+  OBJECT = 81;
 }

--- a/php/tests/proto/test_reserved_message_lower.proto
+++ b/php/tests/proto/test_reserved_message_lower.proto
@@ -52,6 +52,7 @@ message match {}
 message namespace {}
 message new {}
 message or {}
+message object {}
 message parent {}
 message print {}
 message private {}

--- a/php/tests/proto/test_reserved_message_upper.proto
+++ b/php/tests/proto/test_reserved_message_upper.proto
@@ -52,6 +52,7 @@ message MATCH {}
 message NAMESPACE {}
 message NEW {}
 message OR {}
+message OBJECT {}
 message PARENT {}
 message PRINT {}
 message PRIVATE {}

--- a/src/google/protobuf/compiler/php/names.cc
+++ b/src/google/protobuf/compiler/php/names.cc
@@ -15,23 +15,24 @@
 #include "google/protobuf/descriptor.pb.h"
 
 const char* const kReservedNames[] = {
-    "abstract",     "and",        "array",        "as",         "break",
-    "callable",     "case",       "catch",        "class",      "clone",
-    "const",        "continue",   "declare",      "default",    "die",
-    "do",           "echo",       "else",         "elseif",     "empty",
-    "enddeclare",   "endfor",     "endforeach",   "endif",      "endswitch",
-    "endwhile",     "eval",       "exit",         "extends",    "final",
-    "finally",      "fn",         "for",          "foreach",    "function",
-    "global",       "goto",       "if",           "implements", "include",
-    "include_once", "instanceof", "insteadof",    "interface",  "isset",
-    "list",         "match",      "namespace",    "new",        "or",
-    "parent",       "print",      "private",      "protected",  "public",
-    "readonly",     "require",    "require_once", "return",     "self",
-    "static",       "switch",     "throw",        "trait",      "try",
-    "unset",        "use",        "var",          "while",      "xor",
-    "yield",        "int",        "float",        "bool",       "string",
-    "true",         "false",      "null",         "void",       "iterable"};
-const int kReservedNamesSize = 80;
+    "abstract",     "and",        "array",      "as",           "break",
+    "callable",     "case",       "catch",      "class",        "clone",
+    "const",        "continue",   "declare",    "default",      "die",
+    "do",           "echo",       "else",       "elseif",       "empty",
+    "enddeclare",   "endfor",     "endforeach", "endif",        "endswitch",
+    "endwhile",     "eval",       "exit",       "extends",      "final",
+    "finally",      "fn",         "for",        "foreach",      "function",
+    "global",       "goto",       "if",         "implements",   "include",
+    "include_once", "instanceof", "insteadof",  "interface",    "isset",
+    "list",         "match",      "namespace",  "new",          "or",
+    "object",       "parent",     "print",      "private",      "protected",
+    "public",       "readonly",   "require",    "require_once", "return",
+    "self",         "static",     "switch",     "throw",        "trait",
+    "try",          "unset",      "use",        "var",          "while",
+    "xor",          "yield",      "int",        "float",        "bool",
+    "string",       "true",       "false",      "null",         "void",
+    "iterable"};
+const int kReservedNamesSize = 81;
 
 namespace google {
 namespace protobuf {


### PR DESCRIPTION
Protobuf generates class with the name Object in PHP. This is an invalid class name as of PHP 7.2, and results in a fatal error. 

```
Classes named 'object' are forbidden in PHP 7.2 
```

This is not a backwards-compatibility breaking change, as any protobuf objects with the name `Object` would be throwing PHP fatal errors if generated today.