### PR TITLE
Fix BUILD.bazel for newer rules_android_ndk

### DIFF
--- a/build_defs/BUILD.bazel
+++ b/build_defs/BUILD.bazel
@@ -38,7 +38,7 @@ config_setting(
 config_setting(
     name = "config_android",
     values = {
-        "crosstool_top": "//external:android/crosstool",
+        "crosstool_top": "@platforms//os:android",
     },
 )
 


### PR DESCRIPTION
When using transitions, and `rules_android_ndk` the constraint needs to be changed to `@platforms`.