### PR TITLE
Pin bundler version to 2.4.22 for Ruby 2.7 support.

### DIFF
--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -67,9 +67,10 @@ jobs:
         with:
           image: i386/ruby:2.7.3-buster
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          # Pin to Ruby 2.7 compatible bundler version.
           command: >-
             /bin/bash -cex '
-            gem install bundler;
+            gem install bundler -v 2.4.22;
             cd /workspace/ruby;
             bundle;
             PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }} rake;
@@ -98,9 +99,10 @@ jobs:
         with:
           image: arm64v8/ruby:2.7.3-buster
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          # Pin to Ruby 2.7 compatible bundler version.
           command: >-
             /bin/bash -cex '
-            gem install bundler;
+            gem install bundler -v 2.4.22;
             cd /workspace/ruby;
             bundle;
             PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }} rake;


### PR DESCRIPTION
Latest bundler 2.5.0 release results in the following error: `The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with gem install bundler -v 2.4.22 bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.3.183.`

PiperOrigin-RevId: 591288515