### PR TITLE
[draft] Test csharp behavior with unknown enum string values

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
@@ -949,6 +949,14 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void UnknownStringEnumValue_Invalid()
+        {
+            var parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+            string json = "{ \"singleNestedEnum\": \"UNKNOWN_VALUE\" }";
+            Assert.Throws<InvalidProtocolBufferException>(() => parser.Parse<TestAllTypes>(json));
+        }
+
+        [Test]
         [TestCase("5")]
         [TestCase("\"text\"")]
         [TestCase("[0, 1, 2]")]


### PR DESCRIPTION
# Motivation

Help understand the confusion from this comment: https://github.com/protocolbuffers/protobuf/issues/7392#issuecomment-1884660360

Not for merging.

# Test result

C# JSON parser fails when an unknown enum string value is encountered even if ignore unknown fields is set.
