### PR TITLE
Update to latest absl release 20240116.0

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -43,8 +43,8 @@ def protobuf_deps():
         _github_archive(
             name = "com_google_absl",
             repo = "https://github.com/abseil/abseil-cpp",
-            commit = "ad73c6dc1a253203c1c8b529cda18f2138d49df0",  # Abseil LTS 20240116.rc1
-            sha256 = "a5db8c1877e98da6bed00d3a5e89d1dc9e03b58298304cc278aedab97cc350e1",
+            commit = "4a2c63365eff8823a5221db86ef490e828306f9d",  # Abseil LTS 20240116.rc2
+            sha256 = "f49929d22751bf70dd61922fb1fd05eb7aec5e7a7f870beece79a6e28f0a06c1",
         )
 
     if not native.existing_rule("zlib"):

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -43,7 +43,7 @@ def protobuf_deps():
         _github_archive(
             name = "com_google_absl",
             repo = "https://github.com/abseil/abseil-cpp",
-            commit = "fb3621f4f897824c0dbe0615fa94543df6192f30",  # Abseil LTS 20230802.1
+            commit = "ad73c6dc1a253203c1c8b529cda18f2138d49df0",  # Abseil LTS 20240116.rc1
             sha256 = "aa768256d0567f626334fcbe722f564c40b281518fc8423e2708a308e5f983ea",
         )
 

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -44,7 +44,7 @@ def protobuf_deps():
             name = "com_google_absl",
             repo = "https://github.com/abseil/abseil-cpp",
             commit = "ad73c6dc1a253203c1c8b529cda18f2138d49df0",  # Abseil LTS 20240116.rc1
-            sha256 = "aa768256d0567f626334fcbe722f564c40b281518fc8423e2708a308e5f983ea",
+            sha256 = "a5db8c1877e98da6bed00d3a5e89d1dc9e03b58298304cc278aedab97cc350e1",
         )
 
     if not native.existing_rule("zlib"):

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -43,7 +43,7 @@ def protobuf_deps():
         _github_archive(
             name = "com_google_absl",
             repo = "https://github.com/abseil/abseil-cpp",
-            commit = "4a2c63365eff8823a5221db86ef490e828306f9d",  # Abseil LTS 20240116.rc2
+            commit = "4a2c63365eff8823a5221db86ef490e828306f9d",  # Abseil LTS 20240116.0
             sha256 = "f49929d22751bf70dd61922fb1fd05eb7aec5e7a7f870beece79a6e28f0a06c1",
         )
 

--- a/src/google/protobuf/json/internal/zero_copy_buffered_stream_test.cc
+++ b/src/google/protobuf/json/internal/zero_copy_buffered_stream_test.cc
@@ -13,6 +13,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "google/protobuf/io/test_zero_copy_stream.h"
 #include "google/protobuf/stubs/status_macros.h"


### PR DESCRIPTION
Upgrade Protobuf to absl's latest release, now that RC2 has been promoted to the actual release.