### PR TITLE
Fix missing any.h in protobuf target

### DIFF
--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -541,6 +541,7 @@ cc_library(
         "wire_format.cc",
     ],
     hdrs = [
+        "any.h",
         "cpp_edition_defaults.h",
         "cpp_features.pb.h",
         "descriptor.h",


### PR DESCRIPTION
note: spotted when trying to build google/ortools "out of the source tree" using:

```sh
bazel --output_user_root=/tmp/foo build -c opt -s //ortools/base/...
```
ref: https://bazel.build/configure/windows#long-path-issues

I highly suggest to use  `--output_user_root` in your CI to spot this kind of issue.

DevNote:

https://github.com/protocolbuffers/protobuf/blob/3d79d0374bf4aaf24d55f3143de4a1ada36a0948/src/google/protobuf/any.cc#L8

https://github.com/protocolbuffers/protobuf/blob/3d79d0374bf4aaf24d55f3143de4a1ada36a0948/src/google/protobuf/BUILD.bazel#L518-L521
https://github.com/protocolbuffers/protobuf/blob/3d79d0374bf4aaf24d55f3143de4a1ada36a0948/src/google/protobuf/BUILD.bazel#L542-L544

note: Tried to reproduce it from my protobuf fork (from v25.1) without success
```sh
bazel --output_user_root=/tmp/proto build -c opt -s //src/google/protobuf/...
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: Repository rules_java instantiated at:
  /usr/local/google/home/corentinl/work/protobuf/WORKSPACE:13:14: in <toplevel>
  /usr/local/google/home/corentinl/work/protobuf/protobuf_deps.bzl:88:21: in protobuf_deps
Repository rule http_archive defined at:
  /tmp/proto/a53e932bd844601a684c96d408c36961/external/bazel_tools/tools/build_defs/repo/http.bzl:384:31: in <toplevel>
ERROR: no such package '@@com_google_protobuf//': The repository '@@com_google_protobuf' could not be resolved: Repository '@@com_google_protobuf' is not defined
ERROR: /tmp/proto/a53e932bd844601a684c96d408c36961/external/bazel_tools/tools/proto/BUILD:10:6: no such package '@@com_google_protobuf//': The repository '@@com_google_protobuf' could not be resolved: Repository '@@com_google_protobuf' is not defined and referenced by '@@bazel_tools//tools/proto:protoc'
Use --verbose_failures to see the command lines of failed build steps.
ERROR: Analysis of target '//src/google/protobuf:timestamp_proto' failed; build aborted: Analysis failed
INFO: Elapsed time: 26.541s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
FAILED: 
    Fetching https://github.com/bazelbuild/rules_java/releases/download/6.0.0/rules_java-6.0.0.tar.gz
```