### PR TITLE
draft: ruby codegen: support generation of rbs files

### DIFF
--- a/src/google/protobuf/compiler/main.cc
+++ b/src/google/protobuf/compiler/main.cc
@@ -16,6 +16,7 @@
 #include "google/protobuf/compiler/python/generator.h"
 #include "google/protobuf/compiler/python/pyi_generator.h"
 #include "google/protobuf/compiler/ruby/ruby_generator.h"
+#include "google/protobuf/compiler/ruby/rbs_generator.h"
 #include "google/protobuf/compiler/rust/generator.h"
 
 // Must be included last.
@@ -83,6 +84,11 @@ int ProtobufMain(int argc, char* argv[]) {
   ruby::Generator rb_generator;
   cli.RegisterGenerator("--ruby_out", "--ruby_opt", &rb_generator,
                         "Generate Ruby source file.");
+
+  // Ruby
+  ruby::RbsGenerator rbs_generator;
+  cli.RegisterGenerator("--rbs_out", &rb_generator,
+                        "Generate Ruby rbs stub.");
 
   // CSharp
   csharp::Generator csharp_generator;

--- a/src/google/protobuf/compiler/ruby/rbs_generator.cc
+++ b/src/google/protobuf/compiler/ruby/rbs_generator.cc
@@ -1,0 +1,43 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include "google/protobuf/compiler/ruby/rbs_generator.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/absl_check.h"
+#include "absl/log/absl_log.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+#include "google/protobuf/compiler/code_generator.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/descriptor.pb.h"
+#include "google/protobuf/io/printer.h"
+#include "google/protobuf/io/zero_copy_stream.h"
+
+namespace google {
+namespace protobuf {
+namespace compiler {
+namespace ruby {
+
+bool RbsGenerator::Generate(const FileDescriptor* file,
+                            const std::string& parameter,
+                            GeneratorContext* context,
+                            std::string* error) const {
+
+  return true;
+}
+
+}  // namespace ruby
+}  // namespace compiler
+}  // namespace protobuf
+}  // namespace google

--- a/src/google/protobuf/compiler/ruby/rbs_generator.h
+++ b/src/google/protobuf/compiler/ruby/rbs_generator.h
@@ -1,0 +1,50 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+// Author: jieluo@google.com (Jie Luo)
+//
+// Generates Ruby type definition (.rbs) for a given .proto file.
+
+#ifndef GOOGLE_PROTOBUF_COMPILER_RUBY_RBS_GENERATOR_H__
+#define GOOGLE_PROTOBUF_COMPILER_RUBY_RBS_GENERATOR_H__
+
+#include <string>
+
+#include "google/protobuf/compiler/code_generator.h"
+
+#include "google/protobuf/port_def.inc"
+
+namespace google {
+namespace protobuf {
+namespace compiler {
+namespace ruby {
+
+class PROTOC_EXPORT RbsGenerator : public CodeGenerator {
+ public:
+  RbsGenerator();
+  RbsGenerator(const RbsGenerator&) = delete;
+  RbsGenerator& operator=(const RbsGenerator&) = delete;
+  ~RbsGenerator() override;
+
+  // CodeGenerator methods.
+  uint64_t GetSupportedFeatures() const override {
+    return FEATURE_PROTO3_OPTIONAL;
+  }
+  bool Generate(const FileDescriptor* file, const std::string& parameter,
+                GeneratorContext* generator_context,
+                std::string* error) const override;
+
+};
+
+}  // namespace ruby
+}  // namespace compiler
+}  // namespace protobuf
+}  // namespace google
+
+#include "google/protobuf/port_undef.inc"
+
+#endif  // GOOGLE_PROTOBUF_COMPILER_RUBY_RBS_GENERATOR_H__


### PR DESCRIPTION
this introduces support for a new protoc option, `--rbs_out`, which points to a directory where ruby type definition files, defined in the RBS format, are stored.

[rbs](https://github.com/ruby/rbs) is the type signature syntax blessed by the ruby core team, used by static analysis tools such as [steep](https://github.com/soutaro/steep), which integrates with VS Code, the `irb` console (for features such as autocompletion). and [typeprof](https://github.com/ruby/typeprof).

It relies on type definitions written into `.rbs` files.

The `protobuf` library already exposes type definitions in [gem_rbs_collection](https://github.com/ruby/gem_rbs_collection/tree/main/gems/google-protobuf/3.22), which is used to source type definitions for libraries which do not want, or can't maintain type definitions themselves.

(`protobuf` could arguably import these into this repository, lmk if you're interested).

This should fix gaps such as better IDE integration, such as the ones described
[here](https://github.com/protocolbuffers/protobuf/issues/9495).

The plan is to do roughly the same type of integration as was done for `.pyi` annotations, which also write to separate files: add the cli option and the rbs generator.

protobuf classes in ruby rely on dynamic attribution of the base class, which makes what I'm trying to achieve a bit difficult. Ideally the type hierarchy could be specified statically in the ruby source code.

```ruby
class Bar < AbstractMessage
class Bar <
Google::Protobuf::DescriptorPool.generated_pool.lookup("Bar").msgclass
```

```