### PR TITLE
Check ctype() in DescriptorBuilder for edition 2023 and beyond.

### DIFF
--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -7723,7 +7723,8 @@ void DescriptorBuilder::ValidateOptions(const FieldDescriptor* field,
 
   // The following check is temporarily OSS only till we fix all affected
   // google3 TAP tests.
-  if (field->options().has_ctype()) {
+  if (field->file()->edition() >= Edition::EDITION_2023 &&
+      field->options().has_ctype()) {
     if (field->cpp_type() != FieldDescriptor::CPPTYPE_STRING) {
       AddError(
           field->full_name(), proto, DescriptorPool::ErrorCollector::TYPE,

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -2947,6 +2947,9 @@ TEST_F(MiscTest, InvalidFieldOptions) {
   FileDescriptorProto file_proto;
   file_proto.set_name("foo.proto");
 
+  file_proto.set_syntax("editions");
+  file_proto.set_edition(Edition::EDITION_2023);
+
   DescriptorProto* message_proto = AddMessage(&file_proto, "TestMessage");
   AddField(message_proto, "foo", 1, FieldDescriptorProto::LABEL_OPTIONAL,
            FieldDescriptorProto::TYPE_INT32);


### PR DESCRIPTION
It seems possible that old data is stored with serialized descriptors. If we reject old descriptors due to invalid ctype, the change effectively becomes breaking changes. We should apply this stricter check for edition 2023 or beyond.

PiperOrigin-RevId: 602516135