### PR TITLE
Add gRPC Federation extension

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -491,3 +491,8 @@ with info about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/ipfs/protons
     *   Extensions: 1186
+
+1.  gRPC Federation
+
+    *   Website: https://github.com/mercari/grpc-federation
+    *   Extensions: 1187

--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -249,3 +249,4 @@ There are miscellaneous other things you may find useful as a Protocol Buffers d
 *   [clojobuf-serdes - low level serialize/deserialize library for protobuf
     binary format](https://github.com/s-expresso/clojobuf-codec) `clojure`
     `clojurescript`
+*   [gRPC Federation - generates a gRPC server by writing a custom option in Protocol Buffers](https://github.com/mercari/grpc-federation)


### PR DESCRIPTION
Adds an extension id to the registry for using gRPC Federation.

gRPC Federation's Repository: https://github.com/mercari/grpc-federation
Buf Schema: https://buf.build/mercari/grpc-federation
Buf Plugin: https://buf.build/community/mercari-grpc-federation