### PR TITLE
[Ruby] Delegate difference, intersection, union from RepeatedField to Array

### DIFF
--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -47,12 +47,12 @@ module Google
       def_delegators :to_ary,
         :&, :*, :-, :'<=>',
         :assoc, :bsearch, :bsearch_index, :combination, :compact, :count,
-        :cycle, :dig, :drop, :drop_while, :eql?, :fetch, :find_index, :flatten,
-        :include?, :index, :inspect, :join,
+        :cycle, :difference, :dig, :drop, :drop_while, :eql?, :fetch, :find_index, :flatten,
+        :include?, :index, :inspect, :intersection, :join,
         :pack, :permutation, :product, :pretty_print, :pretty_print_cycle,
         :rassoc, :repeated_combination, :repeated_permutation, :reverse,
         :rindex, :rotate, :sample, :shuffle, :shelljoin,
-        :to_s, :transpose, :uniq, :|
+        :to_s, :transpose, :union, :uniq, :|
 
 
       def first(n=nil)

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -22,9 +22,9 @@ class RepeatedFieldTest < Test::Unit::TestCase
     arr_methods -= [ :indices, :iter_for_each, :iter_for_each_index,
       :iter_for_each_with_index, :dimensions, :copy_data, :copy_data_simple,
       :nitems, :iter_for_reverse_each, :indexes, :append, :prepend]
-    arr_methods -= [:union, :difference, :filter!]
+    arr_methods -= [:filter!]
     # ruby 2.7 methods we can ignore
-    arr_methods -= [:intersection, :deconstruct, :resolve_feature_path]
+    arr_methods -= [:deconstruct, :resolve_feature_path]
     # ruby 3.1 methods we can ignore
     arr_methods -= [:intersect?]
     arr_methods.each do |method_name|


### PR DESCRIPTION
Coming from [[protobuf/issues/15180] [Ruby] Support for currently ignored Array methods in `RepeatedField`](https://github.com/protocolbuffers/protobuf/issues/15180)

This adds a couple of `Array` methods to what gets delegated from `RepeatedField`.

- `intersection`, because `|` was already delegated
- `union`, because `&` was already delegated
- `difference`, because `-` was already delegated