### PR TITLE
Add PrivacyInfo.xcprivacy (#15557)

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
issue##15029

As required by https://developer.apple.com/support/third-party-SDK-requirements/

Protos does not collect data.

Required reason APIs searched for using:
```
grep -ER 'NSFileCreationDate|NSFileModificationDate|fileModificationDate|NSURLContentModificationDateKey|NSURLCreationDateKey|getattrlist\(|getattrlistbulk\(|fgetattrlist\(|stat\(|fstat\(|fstatat\(|lstat\(|getattrlistat\(|systemUptime\(|mach_absolute_time\(|NSURLVolumeAvailableCapacityKey|NSURLVolumeAvailableCapacityForImportantUsageKey|NSURLVolumeAvailableCapacityForOpportunisticUsageKey|NSURLVolumeTotalCapacityKey|NSFileSystemFreeSize|NSFileSystemSize|statfs\(|statvfs\(|fstatfs\(|fstatvfs\(|getattrlist\(|fgetattrlist\(|getattrlistat\(|activeInputModes|NSUserDefaults' .
```

```
./third_party/utf8_range/utf8_to_utf16/main.c:    if (fstat(fd, &stat) == -1) {
./third_party/utf8_range/main.c:    if (fstat(fd, &stat) == -1) {
./src/google/protobuf/map.h:    s = mach_absolute_time();
./src/google/protobuf/io/io_win32.cc:int stat(const char* path, struct _stat* buffer) {
./src/google/protobuf/io/io_win32.cc:  return ::_wstat(wpath.c_str(), buffer);
./src/google/protobuf/io/io_win32.cc:  return ::_stat(path, buffer);
./src/google/protobuf/io/io_win32.h:PROTOBUF_EXPORT int stat(const char* path, struct _stat* buffer);
./src/google/protobuf/testing/file.cc:  if (lstat(name.c_str(), &stats) != 0) return;
./src/google/protobuf/compiler/importer.cc:    ret = stat(std::string(filename).c_str(), &sb);
```

`./third_party/utf8_range/...` - tool for utf that is not in user binaries `./src/google/protobuf/map.h` - resolved with pull#15554 `./src/google/protobuf/io/io_win32.cc` - windows code `./src/google/protobuf/testing/file.cc` - testing code not in user binaries `./src/google/protobuf/compiler/importer.cc` - compiler code not in user binaries

So no required reason APIs.

Apple has not yet communicated how this is to be put into podspecs so saving for future commit.

Closes #15557

COPYBARA_INTEGRATE_REVIEW=https://github.com/protocolbuffers/protobuf/pull/15557 from dmaclach:privacy 4c4e570adf4ab7c340817eb8f098ee112ed052be
PiperOrigin-RevId: 601362376