### PR TITLE
Add config option to print 64-bit numbers in JSON as unquoted in python library

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -1588,6 +1588,26 @@ class JsonFormatTest(JsonFormatBase):
     json_format.Parse(json_string, new_parsed_message)
     self.assertEqual(new_message, new_parsed_message)
 
+  def testUnquoted64(self):
+    message = json_format_proto3_pb2.TestMessage()
+    message.repeated_int64_value.append(0)
+    message.repeated_int64_value.append(42)
+    message.repeated_int64_value.append(-((1 << 60) + 1))
+    message.repeated_int64_value.append((1 << 63) - 1)
+    message.repeated_int64_value.append(-(1 << 63))
+    message.repeated_uint64_value.append(0)
+    message.repeated_uint64_value.append(42)
+    message.repeated_uint64_value.append((1 << 60) + 1)
+    message.repeated_uint64_value.append((1 << 64) - 1)
+    text = (
+      '{"repeatedInt64Value":[0,42,"-1152921504606846977","9223372036854775807",-9223372036854775808],'
+      '"repeatedUint64Value":[0,42,"1152921504606846977","18446744073709551615"]}'
+    )
+    self.assertEqual(
+        json.loads(json_format.MessageToJson(message, unquote_int64_if_possible=True)),
+        json.loads(text),
+    )
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/python/google/protobuf/internal/type_checkers.py
+++ b/python/google/protobuf/internal/type_checkers.py
@@ -23,6 +23,7 @@ TYPE_TO_DESERIALIZE_METHOD: A dictionary with field types and deserialization
 __author__ = 'robinson@google.com (Will Robinson)'
 
 import ctypes
+import math
 import numbers
 
 from google.protobuf.internal import decoder
@@ -50,6 +51,13 @@ def ToShortestFloat(original):
     precision += 1
     rounded = float('{0:.{1}g}'.format(original, precision))
   return rounded
+
+def RoundTripsThroughDouble(x):
+  """ Returns true if x round-trips through being cast to a double, i.e., if
+  x is representable exactly as a double. This is a slightly weaker condition
+  than x < 2^52.
+  """
+  return int(float(x)) == x
 
 
 def GetTypeChecker(field):


### PR DESCRIPTION
Add config option to print 64-bit numbers in JSON as unquoted ints if they can be losslessly converted into a 64-bit float, similar to how it's done in c++