### PR TITLE
Add missing generated file

### DIFF
--- a/java/core/generate-test-sources-build.xml
+++ b/java/core/generate-test-sources-build.xml
@@ -19,6 +19,7 @@
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_optimize_for.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_proto3.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_proto3_optional.proto"/>
+        <arg value="${protobuf.source.dir}/google/protobuf/unittest_retention.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_well_known_types.proto"/>
         <arg value="${test.proto.dir}/com/google/protobuf/any_test.proto"/>
         <arg value="${test.proto.dir}/com/google/protobuf/cached_field_size_test.proto"/>


### PR DESCRIPTION
The proto file is required for Java test. Otherwise it fails with

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.6.1:testCompile (default-testCompile) on project protobuf-java: Compilation failure: Compilation failure: 
[ERROR] /tmp/protocolbuffers-protobuf-3.25.2/java/core/src/test/java/com/google/protobuf/DescriptorsTest.java:[46,25] cannot find symbol
[ERROR]   symbol:   class UnittestRetention
[ERROR]   location: package protobuf_unittest
[ERROR] /tmp/protocolbuffers-protobuf-3.25.2/java/core/src/test/java/com/google/protobuf/DescriptorsTest.java:[550,27] cannot find symbol
[ERROR]   symbol:   variable UnittestRetention
[ERROR]   location: class com.google.protobuf.DescriptorsTest
[ERROR] /tmp/protocolbuffers-protobuf-3.25.2/java/core/src/test/java/com/google/protobuf/DescriptorsTest.java:[551,37] cannot find symbol
[ERROR]   symbol:   variable UnittestRetention
[ERROR]   location: class com.google.protobuf.DescriptorsTest
[ERROR] /tmp/protocolbuffers-protobuf-3.25.2/java/core/src/test/java/com/google/protobuf/DescriptorsTest.java:[552,37] cannot find symbol
[ERROR]   symbol:   variable UnittestRetention
[ERROR]   location: class com.google.protobuf.DescriptorsTest
[ERROR] /tmp/protocolbuffers-protobuf-3.25.2/java/core/src/test/java/com/google/protobuf/DescriptorsTest.java:[553,37] cannot find symbol
[ERROR]   symbol:   variable UnittestRetention
[ERROR]   location: class com.google.protobuf.DescriptorsTest
[ERROR] -> [Help 1]
```