### PR TITLE
Fix and re-enable Java Maven BOM test 

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -112,8 +112,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.6.1</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
per our minimum Java version in [https://github.com/google/oss-policies-info/blob/main/foundational-java-support-matrix.md](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2Fgoogle%2Foss-policies-info%2Fblob%2Fmain%2Ffoundational-java-support-matrix.md) and https://cloud.google.com/java/docs/supported-java-versions

PiperOrigin-RevId: 603802046