### PR TITLE
Force descriptor initialization of dependencies *before* internalUpdateFileDescriptor().

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/Descriptors.java
+++ b/java/core/src/main/java/com/google/protobuf/Descriptors.java
@@ -348,7 +348,7 @@ public final class Descriptors {
      * Construct a {@code FileDescriptor}.
      *
      * @param proto the protocol message form of the FileDescriptort
-     * @param dependencies {@code FileDescriptor}s corresponding to all of the file's dependencies
+     * @param dependencies {@code FileDescriptor}s corresponding to all of the file's dependencies.
      * @throws DescriptorValidationException {@code proto} is not a valid descriptor. This can occur
      *     for a number of reasons; for instance, because a field has an undefined type or because
      *     two messages were defined with the same name.
@@ -397,7 +397,9 @@ public final class Descriptors {
       result.crossLink();
       // Skip feature resolution until later for calls from gencode.
       if (!allowUnresolvedFeatures) {
-        result.resolveAllFeatures();
+        // We do not need to force feature resolution for proto1 dependencies
+        // since dependencies from non-gencode should already be fully feature resolved.
+        result.resolveAllFeaturesInternal();
       }
       return result;
     }
@@ -480,19 +482,19 @@ public final class Descriptors {
       return internalBuildGeneratedFileFrom(descriptorDataParts, dependencies);
     }
 
-    /**
-     * This method is to be called by generated code only. It updates the FileDescriptorProto
-     * associated with the descriptor by parsing it again with the given ExtensionRegistry. This is
-     * needed to recognize custom options.
-     */
-    public static void internalUpdateFileDescriptor(
+    public static void internalUpdateFileDescriptorImmutable(
         FileDescriptor descriptor, ExtensionRegistry registry) {
+      internalUpdateFileDescriptor(descriptor, registry, false);
+    }
+
+    private static void internalUpdateFileDescriptor(
+        FileDescriptor descriptor, ExtensionRegistry registry, boolean mutable) {
       ByteString bytes = descriptor.proto.toByteString();
       try {
         FileDescriptorProto proto = FileDescriptorProto.parseFrom(bytes, registry);
         synchronized (descriptor) {
           descriptor.setProto(proto);
-          descriptor.resolveAllFeatures();
+          descriptor.resolveAllFeaturesImmutable();
         }
       } catch (InvalidProtocolBufferException e) {
         throw new IllegalArgumentException(
@@ -618,11 +620,15 @@ public final class Descriptors {
       pool.addSymbol(message);
     }
 
+    public void resolveAllFeaturesImmutable() {
+      resolveAllFeaturesInternal();
+    }
+
     /**
      * This method is to be called by generated code only. It resolves features for the descriptor
      * and all of its children.
      */
-    public void resolveAllFeatures() {
+    private void resolveAllFeaturesInternal() {
       if (this.features != null) {
         return;
       }

--- a/src/google/protobuf/compiler/java/shared_code_generator.cc
+++ b/src/google/protobuf/compiler/java/shared_code_generator.cc
@@ -76,9 +76,6 @@ void SharedCodeGenerator::Generate(
                              options_.annotate_code ? info_relative_path : "",
                              options_);
 
-    if (!options_.opensource_runtime) {
-      printer->Print("@com.google.protobuf.Internal.ProtoNonnullApi\n");
-    }
 
     printer->Print(
 
@@ -87,17 +84,12 @@ void SharedCodeGenerator::Generate(
         "returns\n"
         "  * an incomplete descriptor for internal use only. */\n"
         "  public static com.google.protobuf.Descriptors.FileDescriptor\n"
-        "      descriptor;\n"
-        "  /* This method is to be called by generated code only. It returns\n"
-        "  * an incomplete descriptor for internal use only. */\n"
-        "  public static com.google.protobuf.Descriptors.FileDescriptor "
-        "getDescriptor() {\n"
-        "    descriptor.resolveAllFeatures();\n"
-        "    return descriptor;\n"
-        "  }\n"
-        "  static {\n",
+        "      descriptor;\n",
         "classname", classname);
     printer->Annotate("classname", file_->name());
+
+
+    printer->Print("  static {\n");
     printer->Indent();
     printer->Indent();
     GenerateDescriptors(printer.get());


### PR DESCRIPTION
This fixes an edge-case where EnumDescriptor for a custom option may be unresolved if used in the same file, since adding the field to ExtensionRegistry doesn't trigger its static init block if the Enum is imported from a dependency.

Also renames feature resolution methods exposed from gencode. Private resolveAllFeaturesInternal() method may be renamed back to resolveAllFeatures() in a followup change.

PiperOrigin-RevId: 603852391