### PR TITLE
Increased the size of the error message buffer by 4x, to 511 bytes.

### DIFF
--- a/ruby/lib/google/protobuf/ffi/ffi.rb
+++ b/ruby/lib/google/protobuf/ffi/ffi.rb
@@ -21,7 +21,7 @@ module Google
       Upb_Map_Begin = -1
 
       ## Encoding Status
-      Upb_Status_MaxMessage = 127
+      Upb_Status_MaxMessage = 511
       Upb_Encode_Deterministic = 1
       Upb_Encode_SkipUnknown = 2
 

--- a/upb/base/status.h
+++ b/upb/base/status.h
@@ -13,7 +13,7 @@
 // Must be last.
 #include "upb/port/def.inc"
 
-#define _kUpb_Status_MaxMessage 127
+#define _kUpb_Status_MaxMessage 511
 
 typedef struct {
   bool ok;


### PR DESCRIPTION
The previous limit of 127 was causing error messages to get truncated when long identifiers are in use.

This will increase the stack usage of any code that is allocating a `upb_Status` on the stack. If we want to support smaller stacks in the future, we could change `upb_Status` to store its capacity inline, so different users can allocate error buffers with different capacity.

Fixes: https://github.com/protocolbuffers/protobuf/issues/14376
PiperOrigin-RevId: 603136385