### PR TITLE
Set exit status to 1 when finding warnings with fatal_warnings being on

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.h
+++ b/src/google/protobuf/compiler/command_line_interface.h
@@ -288,7 +288,7 @@ class PROTOC_EXPORT CommandLineInterface {
       GeneratorContext* generator_context, std::string* error);
 
   // Implements --encode and --decode.
-  bool EncodeOrDecode(const DescriptorPool* pool);
+  bool EncodeOrDecode(const DescriptorPool* pool, ErrorPrinter* default_error_collector);
 
   // Implements the --descriptor_set_out option.
   bool WriteDescriptorSet(

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -4099,7 +4099,7 @@ TEST_P(EncodeDecodeTest, Partial) {
           " --encode=protobuf_unittest.TestRequired"));
   ExpectStdoutMatchesText("");
   ExpectStderrMatchesText(
-      "warning:  Input message is missing required fields:  a, b, c\n");
+      "input: warning: Input message is missing required fields:  a, b, c\n");
 }
 
 TEST_P(EncodeDecodeTest, DecodeRaw) {


### PR DESCRIPTION
This is a resubmission of [PR#15738](https://github.com/protocolbuffers/protobuf/pull/15738) and fixes #10486.
