### PR TITLE
Add [ThreadStatic] StringBuilder in JsonTextTokenizer

### DIFF
--- a/csharp/src/Google.Protobuf/JsonTokenizer.cs
+++ b/csharp/src/Google.Protobuf/JsonTokenizer.cs
@@ -772,7 +772,7 @@ namespace Google.Protobuf
                 {
                     if (sb.Capacity <= MaxCachedStringBuilderSize)
                     {
-                        cachedInstance = sb;
+                        cachedInstance = cachedInstance?.Capacity >= sb.Capacity ? cachedInstance : sb;
                     }
                 }
 

--- a/csharp/src/Google.Protobuf/JsonTokenizer.cs
+++ b/csharp/src/Google.Protobuf/JsonTokenizer.cs
@@ -732,7 +732,10 @@ namespace Google.Protobuf
                 }
             }
 
-            /// <summary>Provide a cached reusable instance of stringbuilder per thread.</summary>
+            /// <summary>
+            /// Provide a cached reusable instance of stringbuilder per thread.
+            /// Copied from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Text/StringBuilderCache.cs
+            /// </summary>
             private static class StringBuilderCache
             {
                 private const int MaxCachedStringBuilderSize = 360;

--- a/csharp/src/Google.Protobuf/JsonTokenizer.cs
+++ b/csharp/src/Google.Protobuf/JsonTokenizer.cs
@@ -739,7 +739,7 @@ namespace Google.Protobuf
                 private const int DefaultStringBuilderCapacity = 16; // == StringBuilder.DefaultCapacity
 
                 [ThreadStatic]
-                private static StringBuilder? cachedInstance;
+                private static StringBuilder cachedInstance;
 
                 /// <summary>Get a StringBuilder for the specified capacity.</summary>
                 /// <remarks>If a StringBuilder of an appropriate size is cached, it will be returned and the cache emptied.</remarks>
@@ -747,7 +747,7 @@ namespace Google.Protobuf
                 {
                     if (capacity <= MaxCachedStringBuilderSize)
                     {
-                        StringBuilder? sb = cachedInstance;
+                        StringBuilder sb = cachedInstance;
                         if (sb != null)
                         {
                             // Avoid stringbuilder block fragmentation by getting a new StringBuilder


### PR DESCRIPTION
While profiling allocations in our code, I've found a lot of StringBuilder instances.
![image](https://github.com/protocolbuffers/protobuf/assets/12857389/036079fa-c6ef-4a00-887d-061dc788c5d6)

Changes add similar functionality to the dotnet StringBuilderCache class in  JsonTextTokenizer.
They are not modifying existing logic and only will reduce relatively small text/number allocations by using cached instance.