### PR TITLE
Convert JsonToken to readonly struct

### DIFF
--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -612,7 +612,7 @@ namespace Google.Protobuf
             }
         }
 
-        private static object ParseSingleNumberValue(FieldDescriptor field, JsonToken token)
+        private static object ParseSingleNumberValue(FieldDescriptor field, in JsonToken token)
         {
             double value = token.NumberValue;
             checked
@@ -805,7 +805,7 @@ namespace Google.Protobuf
             }
         }
 
-        private static void MergeTimestamp(IMessage message, JsonToken token)
+        private static void MergeTimestamp(IMessage message, in JsonToken token)
         {
             if (token.Type != JsonToken.TokenType.StringValue)
             {
@@ -881,7 +881,7 @@ namespace Google.Protobuf
             }
         }
 
-        private static void MergeDuration(IMessage message, JsonToken token)
+        private static void MergeDuration(IMessage message, in JsonToken token)
         {
             if (token.Type != JsonToken.TokenType.StringValue)
             {
@@ -925,7 +925,7 @@ namespace Google.Protobuf
             }
         }
 
-        private static void MergeFieldMask(IMessage message, JsonToken token)
+        private static void MergeFieldMask(IMessage message, in JsonToken token)
         {
             if (token.Type != JsonToken.TokenType.StringValue)
             {

--- a/csharp/src/Google.Protobuf/JsonToken.cs
+++ b/csharp/src/Google.Protobuf/JsonToken.cs
@@ -72,7 +72,7 @@ namespace Google.Protobuf
             this.numberValue = numberValue;
         }
 
-        public override bool Equals(object obj) => Equals(obj is JsonToken jt ? jt : default(JsonToken));
+        public override bool Equals(object obj) => obj is JsonToken jt && Equals(jt);
 
         public override int GetHashCode()
         {

--- a/csharp/src/Google.Protobuf/JsonToken.cs
+++ b/csharp/src/Google.Protobuf/JsonToken.cs
@@ -39,7 +39,7 @@ namespace Google.Protobuf
 
         internal enum TokenType
         {
-            Null = 1, //zero is reserved for check with default(JsonToken)
+            Null,
             False,
             True,
             StringValue,
@@ -111,13 +111,8 @@ namespace Google.Protobuf
             return other.type == type && other.stringValue == stringValue && other.numberValue.Equals(numberValue);
         }
 
-        public static bool operator ==(JsonToken x, JsonToken y)
-        {
-            return x.Equals(y);
-        }
-        public static bool operator !=(JsonToken x, JsonToken y)
-        {
-            return !x.Equals(y);
-        }
+        public static bool operator ==(JsonToken x, JsonToken y) => x.Equals(y);
+
+        public static bool operator !=(JsonToken x, JsonToken y) => !x.Equals(y);
     }
 }

--- a/csharp/src/Google.Protobuf/JsonToken.cs
+++ b/csharp/src/Google.Protobuf/JsonToken.cs
@@ -11,7 +11,7 @@ using System;
 
 namespace Google.Protobuf
 {
-    internal sealed class JsonToken : IEquatable<JsonToken>
+    internal readonly struct JsonToken : IEquatable<JsonToken>
     {
         internal static JsonToken Null { get; } = new JsonToken(TokenType.Null);
         internal static JsonToken False { get; } = new JsonToken(TokenType.False);
@@ -72,7 +72,7 @@ namespace Google.Protobuf
             this.numberValue = numberValue;
         }
 
-        public override bool Equals(object obj) => Equals(obj as JsonToken);
+        public override bool Equals(object obj) => Equals(obj is JsonToken jt ? jt : default(JsonToken));
 
         public override int GetHashCode()
         {
@@ -107,10 +107,6 @@ namespace Google.Protobuf
 
         public bool Equals(JsonToken other)
         {
-            if (other is null)
-            {
-                return false;
-            }
             // Note use of other.numberValue.Equals rather than ==, so that NaN compares appropriately.
             return other.type == type && other.stringValue == stringValue && other.numberValue.Equals(numberValue);
         }

--- a/csharp/src/Google.Protobuf/JsonToken.cs
+++ b/csharp/src/Google.Protobuf/JsonToken.cs
@@ -39,7 +39,7 @@ namespace Google.Protobuf
 
         internal enum TokenType
         {
-            Null,
+            Null = 1, //zero is reserved for check with default(JsonToken)
             False,
             True,
             StringValue,
@@ -109,6 +109,15 @@ namespace Google.Protobuf
         {
             // Note use of other.numberValue.Equals rather than ==, so that NaN compares appropriately.
             return other.type == type && other.stringValue == stringValue && other.numberValue.Equals(numberValue);
+        }
+
+        public static bool operator ==(JsonToken x, JsonToken y)
+        {
+            return x.Equals(y);
+        }
+        public static bool operator !=(JsonToken x, JsonToken y)
+        {
+            return !x.Equals(y);
         }
     }
 }

--- a/csharp/src/Google.Protobuf/JsonTokenizer.cs
+++ b/csharp/src/Google.Protobuf/JsonTokenizer.cs
@@ -59,7 +59,7 @@ namespace Google.Protobuf
 
         // TODO: Why do we allow a different token to be pushed back? It might be better to always remember the previous
         // token returned, and allow a parameterless Rewind() method (which could only be called once, just like the current PushBack).
-        internal void PushBack(JsonToken token)
+        internal void PushBack(in JsonToken token)
         {
             if (bufferedToken != null)
             {

--- a/csharp/src/Google.Protobuf/JsonTokenizer.cs
+++ b/csharp/src/Google.Protobuf/JsonTokenizer.cs
@@ -30,7 +30,7 @@ namespace Google.Protobuf
     /// </remarks>
     internal abstract class JsonTokenizer
     {
-        private JsonToken bufferedToken;
+        private JsonToken? bufferedToken;
 
         /// <summary>
         ///  Creates a tokenizer that reads from the given text reader.
@@ -61,7 +61,7 @@ namespace Google.Protobuf
         // token returned, and allow a parameterless Rewind() method (which could only be called once, just like the current PushBack).
         internal void PushBack(JsonToken token)
         {
-            if (bufferedToken != default)
+            if (bufferedToken != null)
             {
                 throw new InvalidOperationException("Can't push back twice");
             }
@@ -87,10 +87,10 @@ namespace Google.Protobuf
         internal JsonToken Next()
         {
             JsonToken tokenToReturn;
-            if (bufferedToken != default)
+            if (bufferedToken != null)
             {
-                tokenToReturn = bufferedToken;
-                bufferedToken = default;
+                tokenToReturn = bufferedToken.Value;
+                bufferedToken = null;
             }
             else
             {

--- a/csharp/src/Google.Protobuf/JsonTokenizer.cs
+++ b/csharp/src/Google.Protobuf/JsonTokenizer.cs
@@ -61,7 +61,7 @@ namespace Google.Protobuf
         // token returned, and allow a parameterless Rewind() method (which could only be called once, just like the current PushBack).
         internal void PushBack(JsonToken token)
         {
-            if (bufferedToken != null)
+            if (bufferedToken != default)
             {
                 throw new InvalidOperationException("Can't push back twice");
             }
@@ -87,10 +87,10 @@ namespace Google.Protobuf
         internal JsonToken Next()
         {
             JsonToken tokenToReturn;
-            if (bufferedToken != null)
+            if (bufferedToken != default)
             {
                 tokenToReturn = bufferedToken;
-                bufferedToken = null;
+                bufferedToken = default;
             }
             else
             {


### PR DESCRIPTION
JsonToken pops quite high in memory allocations.
![image](https://github.com/protocolbuffers/protobuf/assets/12857389/bfbb8cdf-59f5-45a8-a6e6-45070b32afa4)

This PR will convert it to readonly struct as it is already designed as immutable sealed class.