### PR TITLE
Fixed bootstrapping bug with upb when building from a different repo.

### DIFF
--- a/build_defs/upb.patch
+++ b/build_defs/upb.patch
@@ -5,7 +5,7 @@
  # begin:github_only
  _is_google3 = False
 -_extra_proto_path = "-Iexternal/com_google_protobuf/src "
-+_extra_proto_path = "-Isrc "
++_extra_proto_path = "-I$$(dirname $(location @com_google_protobuf//:descriptor_proto_srcs))/../.. "
  # end:github_only
  
  def _upbc(stage):


### PR DESCRIPTION
This is essentially backporting a fix that exists on main already: https://github.com/protocolbuffers/protobuf/blob/a3c33a87c1f24a7aa082317257a9ee297b4d883d/upb_generator/bootstrap_compiler.bzl#L23

Fixes: https://github.com/protocolbuffers/protobuf/issues/14681