### PR TITLE
[csharp] Fix indentation for MapField with nested Messages

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonFormatterTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonFormatterTest.cs
@@ -844,6 +844,56 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void WriteValueWithIndentation_MapWithNested()
+        {
+            var value = new TestMap
+            {
+                MapInt32ForeignMessage =
+                {
+                    { 1, new ForeignMessage { C = 1 } },
+                    { 2, new ForeignMessage { C = 2 } },
+                },
+            };
+
+            const string expectedJson = @"
+{
+  'mapInt32ForeignMessage': {
+    '1': {
+      'c': 1
+    },
+    '2': {
+      'c': 2
+    }
+  }
+}";
+
+            AssertWriteValue(value, expectedJson, JsonFormatter.Settings.Default.WithIndentation());
+        }
+
+        [Test]
+        public void WriteValueWithIndentation_MapWithEmptyNested()
+        {
+            var value = new TestMap
+            {
+                MapInt32ForeignMessage =
+                {
+                    { 1, new ForeignMessage() },
+                    { 2, new ForeignMessage() },
+                },
+            };
+
+            const string expectedJson = @"
+{
+  'mapInt32ForeignMessage': {
+    '1': {},
+    '2': {}
+  }
+}";
+
+            AssertWriteValue(value, expectedJson, JsonFormatter.Settings.Default.WithIndentation());
+        }
+
+        [Test]
         public void WriteValueWithIndentation_List()
         {
             var value = new RepeatedField<int> { 1, 2, 3 };

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -608,7 +608,7 @@ namespace Google.Protobuf {
         MaybeWriteValueWhitespace(writer, indentationLevel + 1);
         WriteString(writer, keyText);
         writer.Write(NameValueSeparator);
-        WriteValue(writer, pair.Value);
+        WriteValue(writer, pair.Value, indentationLevel + 1);
         first = false;
       }
 


### PR DESCRIPTION
WriteDictionary does not pass indentationLevel downwards to WriteValue. The existing test for `MapField` only tests `MapField<string, string>`, which isn't affected by the issue.
Tests are added for this issue.

Note: I also added `WriteValueWithIndentation_MapWithEmptyNested` to ensure this change would break things, but I doubt if it's necessary. Let me know whether to remove it.