### PR TITLE
Avoid a 'may be used uninitialized' warning when built with '-c opt'.

### DIFF
--- a/src/google/protobuf/arena.cc
+++ b/src/google/protobuf/arena.cc
@@ -193,7 +193,7 @@ SizedPtr SerialArena::Free(Deallocator deallocator) {
 PROTOBUF_NOINLINE
 void* SerialArena::AllocateAlignedFallback(size_t n) {
   AllocateNewBlock(n);
-  void* ret;
+  void* ret = nullptr;
   bool res = MaybeAllocateAligned(n, &ret);
   ABSL_DCHECK(res);
   return ret;


### PR DESCRIPTION
The motivation for this is first that under some combinations of flags it breaks builds and second it's trivial (and possibly zero runtime cost) to fix.

It looks like the possibly bad case "should never happen", but converting this to a null pointer in the error case (which should at least make the failure less problematic) is cheap. 