### PR TITLE
Remove rust proto libraries from the editions/BUILD file.

### DIFF
--- a/src/google/protobuf/editions/BUILD
+++ b/src/google/protobuf/editions/BUILD
@@ -1,5 +1,4 @@
 load("@rules_python//python:proto.bzl", "py_proto_library")
-load("//rust:defs.bzl", "rust_cc_proto_library", "rust_upb_proto_library")
 load("//bazel:upb_proto_library.bzl", "upb_c_proto_library", "upb_proto_reflection_library")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
@@ -127,20 +126,6 @@ py_proto_library(
     deps = [":test_messages_proto2_editions_proto"],
 )
 
-rust_cc_proto_library(
-    name = "test_messages_proto2_editions_rust_cc_proto",
-    testonly = True,
-    visibility = ["//conformance:__pkg__"],
-    deps = [":test_messages_proto2_editions_cc_proto"],
-)
-
-rust_upb_proto_library(
-    name = "test_messages_proto2_editions_rust_upb_proto",
-    testonly = True,
-    visibility = ["//conformance:__pkg__"],
-    deps = [":test_messages_proto2_editions_proto"],
-)
-
 upb_c_proto_library(
     name = "test_messages_proto2_editions_upb_proto",
     testonly = 1,
@@ -198,20 +183,6 @@ java_proto_library(
 
 py_proto_library(
     name = "test_messages_proto3_editions_py_pb2",
-    testonly = True,
-    visibility = ["//conformance:__pkg__"],
-    deps = [":test_messages_proto3_editions_proto"],
-)
-
-rust_cc_proto_library(
-    name = "test_messages_proto3_editions_rust_cc_proto",
-    testonly = True,
-    visibility = ["//conformance:__pkg__"],
-    deps = [":test_messages_proto3_editions_cc_proto"],
-)
-
-rust_upb_proto_library(
-    name = "test_messages_proto3_editions_rust_upb_proto",
     testonly = True,
     visibility = ["//conformance:__pkg__"],
     deps = [":test_messages_proto3_editions_proto"],


### PR DESCRIPTION
PiperOrigin-RevId: 605397582