### PR TITLE
feat: add visionOS deployment target for Cocoapods

### DIFF
--- a/Protobuf-C++.podspec
+++ b/Protobuf-C++.podspec
@@ -36,6 +36,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.13'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '6.0'
+  s.visionos.deployment_target = '1.0'
 
   s.pod_target_xcconfig = {
     # Do not let src/google/protobuf/stubs/time.h override system API

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -45,6 +45,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '6.0'
+  s.visionos.deployment_target = '1.0'
   s.requires_arc = false
 
   # The unittest need the generate sources from the testing related .proto

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -46,6 +46,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '6.0'
   s.visionos.deployment_target = '1.0'
+  
   s.requires_arc = false
 
   # The unittest need the generate sources from the testing related .proto


### PR DESCRIPTION
add visionOS deployment target for Cocoapods