### PR TITLE
Fix csharp doc commments

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
@@ -54,7 +54,13 @@ void WriteDocCommentBodyImpl(io::Printer* printer, SourceLocation location) {
           printer->Print("///\n");
         }
         last_was_empty = false;
-        printer->Print("///$line$\n", "line", *it);
+        // If the comment has an extra slash at the start then this can cause the C# compiler
+        // to complain when generating the XML documentation
+        // Issue https://github.com/grpc/grpc/issues/35905
+        if (line[0] == '/') {
+            line.replace(0,1,"&#x2F;");
+        }
+        printer->Print("///$line$\n", "line", line);
       }
     }
     printer->Print("/// </summary>\n");

--- a/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
@@ -58,7 +58,7 @@ void WriteDocCommentBodyImpl(io::Printer* printer, SourceLocation location) {
         // to complain when generating the XML documentation
         // Issue https://github.com/grpc/grpc/issues/35905
         if (line[0] == '/') {
-            line.replace(0,1,"&#x2F;");
+          line.replace(0, 1, "&#x2F;");
         }
         printer->Print("///$line$\n", "line", line);
       }


### PR DESCRIPTION
Fix C# document comments when there is an extra `/` at the start of a comment line.
See https://github.com/grpc/grpc/issues/35905

Related to https://github.com/grpc/grpc/pull/36000 which also fixes the issue in the gRPC C# plugin
