### PR TITLE
[C#] Eliminate string concatenation when looking for enum values descriptor

### DIFF
--- a/csharp/src/Google.Protobuf/ObjectFullNamePair.cs
+++ b/csharp/src/Google.Protobuf/ObjectFullNamePair.cs
@@ -1,0 +1,51 @@
+#region Copyright notice and license
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+namespace Google.Protobuf
+{
+    /// <summary>
+    /// Struct used to hold the keys for the enumValuesByFullName table in DescriptorPool.
+    /// </summary>
+    internal struct ObjectFullNamePair<T> : IEquatable<ObjectFullNamePair<T>> where T : class
+    {
+        private readonly string fullName;
+        private readonly string name;
+        private readonly T obj;
+
+        internal ObjectFullNamePair(T obj, string fullName, string name)
+        {
+            this.fullName = fullName;
+            this.name = name;
+            this.obj = obj;
+        }
+
+        public bool Equals(ObjectFullNamePair<T> other)
+        {
+            return obj == other.obj
+                   && fullName == other.fullName
+                   && name == other.name;
+        }
+
+        public override bool Equals(object obj) => obj is ObjectFullNamePair<T> pair && Equals(pair);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (fullName != null ? fullName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (name != null ? name.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ EqualityComparer<T>.Default.GetHashCode(obj);
+                return hashCode;
+            }
+        }
+    }
+}

--- a/csharp/src/Google.Protobuf/Reflection/EnumDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/EnumDescriptor.cs
@@ -92,7 +92,7 @@ namespace Google.Protobuf.Reflection
         /// <returns>The value's descriptor, or null if not found.</returns>
         public EnumValueDescriptor FindValueByName(string name)
         {
-            return File.DescriptorPool.FindSymbol<EnumValueDescriptor>(FullName + "." + name);
+            return File.DescriptorPool.FindEnumValueByFullName(this, FullName, name);
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/EnumValueDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/EnumValueDescriptor.cs
@@ -25,6 +25,7 @@ namespace Google.Protobuf.Reflection
             EnumDescriptor = parent;
             file.DescriptorPool.AddSymbol(this);
             file.DescriptorPool.AddEnumValueByNumber(this);
+            file.DescriptorPool.AddEnumValueByFullName(this);
         }
 
         internal EnumValueDescriptorProto Proto { get; }


### PR DESCRIPTION
While deserializing our definitions I've found following concatenation:
![image](https://github.com/protocolbuffers/protobuf/assets/12857389/e09855de-616b-4a34-b8b3-dad0ad7c6d3e)

Using same pattern already used for enum lookup by number, I've created a struct key and used it in a new Dictionary.
This helps eliminating this concatenation:
![image](https://github.com/protocolbuffers/protobuf/assets/12857389/8b1addde-8034-42e8-932a-fde4cdeda355)
