### PR TITLE
Add <shellapi.h> include for CommandLineToArgvW

### DIFF
--- a/src/google/protobuf/compiler/main.cc
+++ b/src/google/protobuf/compiler/main.cc
@@ -23,6 +23,7 @@
 
 #ifdef _MSC_VER
 #include <windows.h>
+#include <shellapi.h>
 #endif
 
 namespace google {


### PR DESCRIPTION
This should fix the following error:
```
third_party\protobuf\src\google\protobuf\compiler\main.cc(127): error C3861: 'CommandLineToArgvW': identifier not found
```

PiperOrigin-RevId: 613319460