### PR TITLE
[python] Remove semicolon after `PyObject_HEAD`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
 BasedOnStyle: Google
 DerivePointerAlignment: false
 PointerAlignment: Left
+StatementMacros: [PyObject_HEAD]

--- a/python/descriptor.c
+++ b/python/descriptor.c
@@ -23,7 +23,7 @@
 // This representation is used by all concrete descriptors.
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   PyObject* pool;          // We own a ref.
   const void* def;         // Type depends on the class. Kept alive by "pool".
   PyObject* options;       // NULL if not present or not cached.

--- a/python/descriptor_containers.c
+++ b/python/descriptor_containers.c
@@ -29,7 +29,7 @@ err:
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   const PyUpb_ByNameMap_Funcs* funcs;
   const void* parent;    // upb_MessageDef*, upb_DefPool*, etc.
   PyObject* parent_obj;  // Python object that keeps parent alive, we own a ref.
@@ -89,7 +89,7 @@ static PyType_Spec PyUpb_ByNameIterator_Spec = {
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   const PyUpb_ByNumberMap_Funcs* funcs;
   const void* parent;    // upb_MessageDef*, upb_DefPool*, etc.
   PyObject* parent_obj;  // Python object that keeps parent alive, we own a ref.
@@ -149,7 +149,7 @@ static PyType_Spec PyUpb_ByNumberIterator_Spec = {
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   const PyUpb_GenericSequence_Funcs* funcs;
   const void* parent;    // upb_MessageDef*, upb_DefPool*, etc.
   PyObject* parent_obj;  // Python object that keeps parent alive, we own a ref.
@@ -342,7 +342,7 @@ static PyType_Spec PyUpb_GenericSequence_Spec = {
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   const PyUpb_ByNameMap_Funcs* funcs;
   const void* parent;    // upb_MessageDef*, upb_DefPool*, etc.
   PyObject* parent_obj;  // Python object that keeps parent alive, we own a ref.
@@ -556,7 +556,7 @@ static PyType_Spec PyUpb_ByNameMap_Spec = {
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   const PyUpb_ByNumberMap_Funcs* funcs;
   const void* parent;    // upb_MessageDef*, upb_DefPool*, etc.
   PyObject* parent_obj;  // Python object that keeps parent alive, we own a ref.

--- a/python/descriptor_pool.c
+++ b/python/descriptor_pool.c
@@ -21,7 +21,7 @@
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   upb_DefPool* symtab;
   PyObject* db;  // The DescriptorDatabase underlying this pool.  May be NULL.
 } PyUpb_DescriptorPool;

--- a/python/extension_dict.c
+++ b/python/extension_dict.c
@@ -16,7 +16,7 @@
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   PyObject* msg;  // Owning ref to our parent pessage.
 } PyUpb_ExtensionDict;
 
@@ -168,7 +168,7 @@ static PyType_Spec PyUpb_ExtensionDict_Spec = {
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   PyObject* msg;
   size_t iter;
 } PyUpb_ExtensionIterator;

--- a/python/google/protobuf/pyext/descriptor_pool.h
+++ b/python/google/protobuf/pyext/descriptor_pool.h
@@ -32,7 +32,7 @@ struct CMessageClass;
 // "Methods" that interacts with this DescriptorPool are in the cdescriptor_pool
 // namespace.
 typedef struct PyDescriptorPool {
-  PyObject_HEAD;
+  PyObject_HEAD
 
   // The C++ pool containing Descriptors.
   const DescriptorPool* pool;

--- a/python/google/protobuf/pyext/extension_dict.cc
+++ b/python/google/protobuf/pyext/extension_dict.cc
@@ -66,7 +66,7 @@ static Py_ssize_t len(ExtensionDict* self) {
 }
 
 struct ExtensionIterator {
-  PyObject_HEAD;
+  PyObject_HEAD
   Py_ssize_t index;
   std::vector<const FieldDescriptor*> fields;
 

--- a/python/google/protobuf/pyext/extension_dict.h
+++ b/python/google/protobuf/pyext/extension_dict.h
@@ -25,7 +25,7 @@ class FieldDescriptor;
 namespace python {
 
 typedef struct ExtensionDict {
-  PyObject_HEAD;
+  PyObject_HEAD
 
   // Strong, owned reference to the parent message. Never NULL.
   CMessage* parent;

--- a/python/google/protobuf/pyext/field.h
+++ b/python/google/protobuf/pyext/field.h
@@ -20,7 +20,7 @@ namespace python {
 
 // A data descriptor that represents a field in a Message class.
 struct PyMessageFieldProperty {
-  PyObject_HEAD;
+  PyObject_HEAD
 
   // This pointer is owned by the same pool as the Message class it belongs to.
   const FieldDescriptor* field_descriptor;

--- a/python/google/protobuf/pyext/map_container.cc
+++ b/python/google/protobuf/pyext/map_container.cc
@@ -46,7 +46,7 @@ class MapReflectionFriend {
 };
 
 struct MapIterator {
-  PyObject_HEAD;
+  PyObject_HEAD
 
   std::unique_ptr<::google::protobuf::MapIterator> iter;
 

--- a/python/google/protobuf/pyext/message.h
+++ b/python/google/protobuf/pyext/message.h
@@ -46,7 +46,7 @@ struct CMessageClass;
 // don't store any data, and always refer to their parent message.
 
 struct ContainerBase {
-  PyObject_HEAD;
+  PyObject_HEAD
 
   // Strong reference to a parent message object. For a CMessage there are three
   // cases:

--- a/python/google/protobuf/pyext/unknown_field_set.h
+++ b/python/google/protobuf/pyext/unknown_field_set.h
@@ -26,7 +26,7 @@ namespace python {
 struct CMessage;
 
 struct PyUnknownFieldSet {
-  PyObject_HEAD;
+  PyObject_HEAD
   // If parent is nullptr, it is a top UnknownFieldSet.
   PyUnknownFieldSet* parent;
 
@@ -36,7 +36,7 @@ struct PyUnknownFieldSet {
 };
 
 struct PyUnknownField {
-  PyObject_HEAD;
+  PyObject_HEAD
   // Every Python PyUnknownField holds a reference to its parent
   // PyUnknownFieldSet in order to keep it alive.
   PyUnknownFieldSet* parent;

--- a/python/map.c
+++ b/python/map.c
@@ -18,7 +18,7 @@
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   PyObject* arena;
   // The field descriptor (upb_FieldDef*).
   // The low bit indicates whether the container is reified (see ptr below).
@@ -420,7 +420,7 @@ static PyType_Spec PyUpb_MessageMapContainer_Spec = {
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   PyUpb_MapContainer* map;  // We own a reference.
   size_t iter;
   int version;

--- a/python/message.c
+++ b/python/message.c
@@ -176,7 +176,7 @@ err:
 // The parent may also be non-present, in which case a mutation will trigger a
 // chain reaction.
 typedef struct PyUpb_Message {
-  PyObject_HEAD;
+  PyObject_HEAD
   PyObject* arena;
   uintptr_t def;  // Tagged, low bit 1 == upb_FieldDef*, else upb_MessageDef*
   union {

--- a/python/protobuf.c
+++ b/python/protobuf.c
@@ -199,7 +199,7 @@ PyObject* PyUpb_ObjCache_Get(const void* key) {
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   upb_Arena* arena;
 } PyUpb_Arena;
 

--- a/python/repeated.c
+++ b/python/repeated.c
@@ -18,7 +18,7 @@ static PyObject* PyUpb_RepeatedScalarContainer_Append(PyObject* _self,
 
 // Wrapper for a repeated field.
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   PyObject* arena;
   // The field descriptor (PyObject*).
   // The low bit indicates whether the container is reified (see ptr below).

--- a/python/unknown_fields.c
+++ b/python/unknown_fields.c
@@ -18,7 +18,7 @@
 // -----------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   PyObject* fields;
 } PyUpb_UnknownFieldSet;
 


### PR DESCRIPTION
`PyObject_HEAD` already expands to a field with a semicolon; the extra semicolon is unnecessary, and makes some compilers unhappy.