### PR TITLE
fix(java): fixup test codegen for maven build

### DIFF
--- a/java/core/generate-test-sources-build.xml
+++ b/java/core/generate-test-sources-build.xml
@@ -6,6 +6,7 @@
         <arg value="--proto_path=${test.proto.dir}"/>
         <arg value="${protobuf.source.dir}/google/protobuf/map_lite_unittest.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest.proto"/>
+        <arg value="${protobuf.source.dir}/google/protobuf/unittest_features.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_custom_options.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_enormous_descriptor.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_import.proto"/>
@@ -18,8 +19,10 @@
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_no_generic_services.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_optimize_for.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_proto3.proto"/>
+        <arg value="${protobuf.source.dir}/google/protobuf/unittest_proto3_extensions.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_proto3_optional.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_retention.proto"/>
+        <arg value="${protobuf.source.dir}/google/protobuf/unittest_legacy_features.proto"/>
         <arg value="${protobuf.source.dir}/google/protobuf/unittest_well_known_types.proto"/>
         <arg value="${test.proto.dir}/com/google/protobuf/any_test.proto"/>
         <arg value="${test.proto.dir}/com/google/protobuf/cached_field_size_test.proto"/>

--- a/java/lite/pom.xml
+++ b/java/lite/pom.xml
@@ -214,6 +214,7 @@
                     <exclude>GeneratedMessageTest.java</exclude>
                     <exclude>LazyFieldTest.java</exclude>
                     <exclude>LazyStringEndToEndTest.java</exclude>
+                    <exclude>LazilyParsedMessageSetTest.java</exclude>
                     <exclude>MapForProto2Test.java</exclude>
                     <exclude>MapTest.java</exclude>
                     <exclude>MessageTest.java</exclude>

--- a/java/util/pom.xml
+++ b/java/util/pom.xml
@@ -88,6 +88,7 @@
                   <arg value="--proto_path=${protobuf.source.dir}"/>
                   <arg value="--proto_path=src/test/proto"/>
                   <arg value="src/test/proto/com/google/protobuf/util/json_test.proto"/>
+                  <arg value="src/test/proto/com/google/protobuf/util/json_test_proto2.proto"/>
                 </exec>
               </target>
             </configuration>


### PR DESCRIPTION
## Summary

Fixes and closes protocolbuffers/protobuf#16170 by adding missing test-gen mappings and exclusions. Recent [changes](https://github.com/protocolbuffers/protobuf/pull/15362) to Protocol Buffers, along with the addition of the _Editions_ feature, have evolved ahead of Maven; running the build on `main` shows build errors related to the testsuite.

## Changelog

- fix: missing test-gen mappings
- fix: missing test exclusions
