### PR TITLE
Cherry-pick: Add back android config_setting that looks for //external:android/crosstool

### DIFF
--- a/build_defs/BUILD.bazel
+++ b/build_defs/BUILD.bazel
@@ -35,10 +35,20 @@ config_setting(
 # For more info on the various crosstool_tops used by NDK Bazel builds, see:
 # https://docs.bazel.build/versions/master/android-ndk.html#configuring-the-stl
 
+# When using https://bazel.build/concepts/platforms
 config_setting(
     name = "config_android",
     values = {
         "crosstool_top": "@platforms//os:android",
+    },
+)
+
+# When using legacy flags like --android_crosstool_top, --android_cpu, and --fat_apk_cpu
+config_setting(
+    name = "config_android-legacy-default-crosstool",
+    values = {
+        # Default of `--android_crosstool_top`
+        "crosstool_top": "//external:android/crosstool",
     },
 )
 

--- a/build_defs/cpp_opts.bzl
+++ b/build_defs/cpp_opts.bzl
@@ -29,6 +29,7 @@ COPTS = select({
 # Android and MSVC builds do not need to link in a separate pthread library.
 LINK_OPTS = select({
     "//build_defs:config_android": [],
+    "//build_defs:config_android-legacy-default-crosstool": [],
     "//build_defs:config_android-stlport": [],
     "//build_defs:config_android-libcpp": [],
     "//build_defs:config_android-gnu-libstdcpp": [],


### PR DESCRIPTION
This fix is necessary for gRPC to be able to upgrade to 26.x.