### PR TITLE
Cherry-pick: Fix Android platforms constraint (#16246)

### DIFF
--- a/build_defs/BUILD.bazel
+++ b/build_defs/BUILD.bazel
@@ -38,9 +38,7 @@ config_setting(
 # When using https://bazel.build/concepts/platforms
 config_setting(
     name = "config_android",
-    values = {
-        "crosstool_top": "@platforms//os:android",
-    },
+    constraint_values = ["@platforms//os:android"],
 )
 
 # When using legacy flags like --android_crosstool_top, --android_cpu, and --fat_apk_cpu


### PR DESCRIPTION
This is necessary to unblock gRPC's upgrade to protobuf 26.x.