### PR TITLE
Handle conflicting macros for Android

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -826,6 +826,14 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
 #undef TYPE_BOOL
 #endif  // __APPLE__
 
+#if defined(ANDROID) || defined(__ANDROID__)
+// Inconvenient macro names from usr/include/limits.h in some Android NDKs.
+#pragma push_macro("UID_MAX")
+#undef UID_MAX
+#pragma push_macro("GID_MAX")
+#undef GID_MAX
+#endif  // defined(ANDROID) || defined(__ANDROID__)
+
 #ifdef __FreeBSD__
 // Inconvenient macro names from /usr/include/sys/param.h.
 #pragma push_macro("TRUE")

--- a/src/google/protobuf/port_undef.inc
+++ b/src/google/protobuf/port_undef.inc
@@ -151,6 +151,11 @@
 #pragma pop_macro("TYPE_BOOL")
 #endif  // __APPLE__
 
+#if defined(ANDROID) || defined(__ANDROID__)
+#pragma pop_macro("UID_MAX")
+#pragma pop_macro("GID_MAX")
+#endif  // defined(ANDROID) || defined(__ANDROID__)
+
 #ifdef __FreeBSD__
 #pragma pop_macro("TRUE")
 #pragma pop_macro("FALSE")


### PR DESCRIPTION
Trying to build `protobuf/3.21.12` my tests is failing on Android due to the GID_MAX/UID_MAX macros. This is because port_def.inc is missing these entries for Android. This PR adds those missing macros. I am not sure if I should apply the same port for the `TRUE`/`FALSE` macros as well, any opinion here would be appreciated.

See compile errors below:

```
C:\Users\edukaj\.conan2\p\b\andro6a387be0e6a99\p\bin\toolchains\llvm\prebuilt\windows-x86_64\bin\clang++.exe --target=aarch64-none-linux-android29 --gcc-toolchain=C:/Users/edukaj/.conan2/p/b/andro6a387be0e6a99/p/bin/toolchai
ns/llvm/prebuilt/windows-x86_64 --sysroot=C:/Users/edukaj/.conan2/p/b/andro6a387be0e6a99/p/bin/toolchains/llvm/prebuilt/windows-x86_64/sysroot  -IC:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9
-armv8-17-debug -isystem C:/Users/edukaj/.conan2/p/b/proto97c417c206dce/p/include -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat 
-Werror=format-security   -O0 -fno-limit-debug-info  -std=c++17 -fPIE -MD -MT CMakeFiles/test_package.dir/addressbook.pb.cc.o -MF CMakeFiles\test_package.dir\addressbook.pb.cc.o.d -o CMakeFiles/test_package.dir/addressbook.p
b.cc.o -c C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.cc
In file included from C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.cc:4:
C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.h:834:24: error: expected member name or ';' after declaration specifiers
  static constexpr GID GID_MAX =
  ~~~~~~~~~~~~~~~~~~~~ ^
C:/Users/edukaj/.conan2/p/b/andro6a387be0e6a99/p/bin/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/include\limits.h:118:18: note: expanded from macro 'GID_MAX'
# define GID_MAX        UINT_MAX        /* max value for a gid_t */
                        ^
C:\Users\edukaj\.conan2\p\b\andro6a387be0e6a99\p\bin\toolchains\llvm\prebuilt\windows-x86_64\lib64\clang\9.0.9\include\limits.h:56:20: note: expanded from macro 'UINT_MAX'
#define UINT_MAX  (__INT_MAX__  *2U +1U)
                   ^
<built-in>:92:21: note: expanded from here
#define __INT_MAX__ 2147483647
                    ^
In file included from C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.cc:4:
C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.h:834:24: error: expected ')'
C:/Users/edukaj/.conan2/p/b/andro6a387be0e6a99/p/bin/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/include\limits.h:118:18: note: expanded from macro 'GID_MAX'
# define GID_MAX        UINT_MAX        /* max value for a gid_t */
                        ^
C:\Users\edukaj\.conan2\p\b\andro6a387be0e6a99\p\bin\toolchains\llvm\prebuilt\windows-x86_64\lib64\clang\9.0.9\include\limits.h:56:20: note: expanded from macro 'UINT_MAX'
#define UINT_MAX  (__INT_MAX__  *2U +1U)
                   ^
<built-in>:92:21: note: expanded from here
#define __INT_MAX__ 2147483647
                    ^
C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.h:834:24: note: to match this '('
C:/Users/edukaj/.conan2/p/b/andro6a387be0e6a99/p/bin/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/include\limits.h:118:18: note: expanded from macro 'GID_MAX'
# define GID_MAX        UINT_MAX        /* max value for a gid_t */
                        ^
C:\Users\edukaj\.conan2\p\b\andro6a387be0e6a99\p\bin\toolchains\llvm\prebuilt\windows-x86_64\lib64\clang\9.0.9\include\limits.h:56:19: note: expanded from macro 'UINT_MAX'
#define UINT_MAX  (__INT_MAX__  *2U +1U)
                  ^
In file included from C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.cc:4:
C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.h:862:24: error: expected member name or ';' after declaration specifiers
  static constexpr UID UID_MAX =
  ~~~~~~~~~~~~~~~~~~~~ ^
C:/Users/edukaj/.conan2/p/b/andro6a387be0e6a99/p/bin/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/include\limits.h:117:18: note: expanded from macro 'UID_MAX'
# define UID_MAX        UINT_MAX        /* max value for a uid_t */
                        ^
C:\Users\edukaj\.conan2\p\b\andro6a387be0e6a99\p\bin\toolchains\llvm\prebuilt\windows-x86_64\lib64\clang\9.0.9\include\limits.h:56:20: note: expanded from macro 'UINT_MAX'
#define UINT_MAX  (__INT_MAX__  *2U +1U)
                   ^
<built-in>:92:21: note: expanded from here
#define __INT_MAX__ 2147483647
                    ^
In file included from C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.cc:4:
C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.h:862:24: error: expected ')'
C:/Users/edukaj/.conan2/p/b/andro6a387be0e6a99/p/bin/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/include\limits.h:117:18: note: expanded from macro 'UID_MAX'
# define UID_MAX        UINT_MAX        /* max value for a uid_t */
                        ^
C:\Users\edukaj\.conan2\p\b\andro6a387be0e6a99\p\bin\toolchains\llvm\prebuilt\windows-x86_64\lib64\clang\9.0.9\include\limits.h:56:20: note: expanded from macro 'UINT_MAX'
#define UINT_MAX  (__INT_MAX__  *2U +1U)
                   ^
<built-in>:92:21: note: expanded from here
#define __INT_MAX__ 2147483647
                    ^
C:/qxr/repo/conan-center-index/recipes/protobuf/all/test_package/build/clang-9-armv8-17-debug/addressbook.pb.h:862:24: note: to match this '('
C:/Users/edukaj/.conan2/p/b/andro6a387be0e6a99/p/bin/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/include\limits.h:117:18: note: expanded from macro 'UID_MAX'
# define UID_MAX        UINT_MAX        /* max value for a uid_t */
                        ^
C:\Users\edukaj\.conan2\p\b\andro6a387be0e6a99\p\bin\toolchains\llvm\prebuilt\windows-x86_64\lib64\clang\9.0.9\include\limits.h:56:19: note: expanded from macro 'UINT_MAX'
#define UINT_MAX  (__INT_MAX__  *2U +1U)
                  ^
4 errors generated.
ninja: build stopped: subcommand failed.
```
