### PR TITLE
Set label to REQUIRED for descriptors with LEGACY_REQUIRED feature.

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/Descriptors.java
+++ b/java/core/src/main/java/com/google/protobuf/Descriptors.java
@@ -639,7 +639,7 @@ public final class Descriptors {
         if (this.features != null) {
           return;
         }
-        this.features = resolveFeatures(proto.getOptions().getFeatures());
+        resolveFeatures(proto.getOptions().getFeatures());
 
         for (Descriptor messageType : messageTypes) {
           messageType.resolveAllFeatures();
@@ -718,7 +718,7 @@ public final class Descriptors {
       this.proto = proto;
       this.options = null;
       try {
-        this.features = resolveFeatures(proto.getOptions().getFeatures());
+        resolveFeatures(proto.getOptions().getFeatures());
 
         for (int i = 0; i < messageTypes.length; i++) {
           messageTypes[i].setProto(proto.getMessageType(i));
@@ -1112,7 +1112,7 @@ public final class Descriptors {
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
     private void resolveAllFeatures() throws DescriptorValidationException {
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
 
       for (Descriptor nestedType : nestedTypes) {
         nestedType.resolveAllFeatures();
@@ -1174,7 +1174,7 @@ public final class Descriptors {
     private void setProto(final DescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
 
       for (int i = 0; i < nestedTypes.length; i++) {
         nestedTypes[i].setProto(proto.getNestedType(i));
@@ -1744,7 +1744,7 @@ public final class Descriptors {
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
     private void resolveAllFeatures() throws DescriptorValidationException {
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
     }
 
     @Override
@@ -1803,7 +1803,7 @@ public final class Descriptors {
     }
 
     @Override
-    void validateFeatures(FeatureSet features) throws DescriptorValidationException {
+    void validateFeatures() throws DescriptorValidationException {
       if (containingType != null
           && containingType.toProto().getOptions().getMessageSetWireFormat()) {
         if (isExtension()) {
@@ -1992,7 +1992,7 @@ public final class Descriptors {
     private void setProto(final FieldDescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
     }
 
     /** For internal use only. This is to satisfy the FieldDescriptorLite interface. */
@@ -2262,7 +2262,8 @@ public final class Descriptors {
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
     private void resolveAllFeatures() throws DescriptorValidationException {
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
+
       for (EnumValueDescriptor value : values) {
         value.resolveAllFeatures();
       }
@@ -2272,7 +2273,7 @@ public final class Descriptors {
     private void setProto(final EnumDescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
 
       for (int i = 0; i < values.length; i++) {
         values[i].setProto(proto.getValue(i));
@@ -2414,7 +2415,7 @@ public final class Descriptors {
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
     private void resolveAllFeatures() throws DescriptorValidationException {
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
     }
 
     /** See {@link FileDescriptor#setProto}. */
@@ -2422,7 +2423,7 @@ public final class Descriptors {
         throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
     }
   }
 
@@ -2530,7 +2531,7 @@ public final class Descriptors {
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
     private void resolveAllFeatures() throws DescriptorValidationException {
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
 
       for (MethodDescriptor method : methods) {
         method.resolveAllFeatures();
@@ -2547,7 +2548,7 @@ public final class Descriptors {
     private void setProto(final ServiceDescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
 
       for (int i = 0; i < methods.length; i++) {
         methods[i].setProto(proto.getMethod(i));
@@ -2668,7 +2669,7 @@ public final class Descriptors {
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
     private void resolveAllFeatures() throws DescriptorValidationException {
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
     }
 
     private void crossLink() throws DescriptorValidationException {
@@ -2697,7 +2698,7 @@ public final class Descriptors {
     private void setProto(final MethodDescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
     }
   }
 
@@ -2735,11 +2736,13 @@ public final class Descriptors {
 
     public abstract FileDescriptor getFile();
 
-    FeatureSet resolveFeatures(FeatureSet unresolvedFeatures) throws DescriptorValidationException {
+    void resolveFeatures(FeatureSet unresolvedFeatures) throws DescriptorValidationException {
       if (this.parent != null
           && unresolvedFeatures.equals(FeatureSet.getDefaultInstance())
           && !hasInferredLegacyProtoFeatures()) {
-        return this.parent.features;
+        this.features = this.parent.features;
+        validateFeatures();
+        return;
       }
       FeatureSet.Builder features;
       if (this.parent == null) {
@@ -2750,8 +2753,8 @@ public final class Descriptors {
       }
       features.mergeFrom(inferLegacyProtoFeatures());
       features.mergeFrom(unresolvedFeatures);
-      validateFeatures(features.build());
-      return internFeatures(features.build());
+      this.features = internFeatures(features.build());
+      validateFeatures();
     }
 
     FeatureSet inferLegacyProtoFeatures() {
@@ -2762,8 +2765,7 @@ public final class Descriptors {
       return false;
     }
 
-    void validateFeatures(FeatureSet features) throws DescriptorValidationException {
-    }
+    void validateFeatures() throws DescriptorValidationException {}
 
     GenericDescriptor parent;
     volatile FeatureSet features;
@@ -3231,13 +3233,13 @@ public final class Descriptors {
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
     private void resolveAllFeatures() throws DescriptorValidationException {
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
     }
 
     private void setProto(final OneofDescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      resolveFeatures(proto.getOptions().getFeatures());
     }
 
     private OneofDescriptor(

--- a/java/core/src/main/java/com/google/protobuf/Descriptors.java
+++ b/java/core/src/main/java/com/google/protobuf/Descriptors.java
@@ -29,6 +29,7 @@ import com.google.protobuf.DescriptorProtos.OneofDescriptorProto;
 import com.google.protobuf.DescriptorProtos.OneofOptions;
 import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto;
 import com.google.protobuf.DescriptorProtos.ServiceOptions;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
 import com.google.protobuf.JavaFeaturesProto.JavaFeatures;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -618,14 +619,18 @@ public final class Descriptors {
     }
 
     public void resolveAllFeaturesImmutable() {
-      resolveAllFeaturesInternal();
+      try {
+        resolveAllFeaturesInternal();
+      } catch (DescriptorValidationException e) {
+        throw new IllegalArgumentException("Invalid features for \"" + proto.getName() + "\".", e);
+      }
     }
 
     /**
      * This method is to be called by generated code only. It resolves features for the descriptor
      * and all of its children.
      */
-    private void resolveAllFeaturesInternal() {
+    private void resolveAllFeaturesInternal() throws DescriptorValidationException {
       if (this.features != null) {
         return;
       }
@@ -712,22 +717,26 @@ public final class Descriptors {
     private synchronized void setProto(final FileDescriptorProto proto) {
       this.proto = proto;
       this.options = null;
-      this.features = resolveFeatures(proto.getOptions().getFeatures());
+      try {
+        this.features = resolveFeatures(proto.getOptions().getFeatures());
 
-      for (int i = 0; i < messageTypes.length; i++) {
-        messageTypes[i].setProto(proto.getMessageType(i));
-      }
+        for (int i = 0; i < messageTypes.length; i++) {
+          messageTypes[i].setProto(proto.getMessageType(i));
+        }
 
-      for (int i = 0; i < enumTypes.length; i++) {
-        enumTypes[i].setProto(proto.getEnumType(i));
-      }
+        for (int i = 0; i < enumTypes.length; i++) {
+          enumTypes[i].setProto(proto.getEnumType(i));
+        }
 
-      for (int i = 0; i < services.length; i++) {
-        services[i].setProto(proto.getService(i));
-      }
+        for (int i = 0; i < services.length; i++) {
+          services[i].setProto(proto.getService(i));
+        }
 
-      for (int i = 0; i < extensions.length; i++) {
-        extensions[i].setProto(proto.getExtension(i));
+        for (int i = 0; i < extensions.length; i++) {
+          extensions[i].setProto(proto.getExtension(i));
+        }
+      } catch (DescriptorValidationException e) {
+        throw new IllegalArgumentException("Invalid features for \"" + proto.getName() + "\".", e);
       }
     }
   }
@@ -1102,7 +1111,7 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
-    private void resolveAllFeatures() {
+    private void resolveAllFeatures() throws DescriptorValidationException {
       this.features = resolveFeatures(proto.getOptions().getFeatures());
 
       for (Descriptor nestedType : nestedTypes) {
@@ -1162,7 +1171,7 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#setProto}. */
-    private void setProto(final DescriptorProto proto) {
+    private void setProto(final DescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
       this.features = resolveFeatures(proto.getOptions().getFeatures());
@@ -1327,7 +1336,9 @@ public final class Descriptors {
 
     /** Is this field declared optional? */
     public boolean isOptional() {
-      return proto.getLabel() == FieldDescriptorProto.Label.LABEL_OPTIONAL;
+      return proto.getLabel() == FieldDescriptorProto.Label.LABEL_OPTIONAL
+          && this.features.getFieldPresence()
+              != DescriptorProtos.FeatureSet.FieldPresence.LEGACY_REQUIRED;
     }
 
     /** Is this field declared repeated? */
@@ -1732,7 +1743,7 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
-    private void resolveAllFeatures() {
+    private void resolveAllFeatures() throws DescriptorValidationException {
       this.features = resolveFeatures(proto.getOptions().getFeatures());
     }
 
@@ -1789,6 +1800,19 @@ public final class Descriptors {
 
       }
       return false;
+    }
+
+    @Override
+    void validateFeatures(FeatureSet features) throws DescriptorValidationException {
+      if (containingType != null
+          && containingType.toProto().getOptions().getMessageSetWireFormat()) {
+        if (isExtension()) {
+          if (!isOptional() || getType() != Type.MESSAGE) {
+            throw new DescriptorValidationException(
+                this, "Extensions of MessageSets must be optional messages.");
+          }
+        }
+      }
     }
 
     /** Look up and cross-link all field types, etc. */
@@ -1962,23 +1986,10 @@ public final class Descriptors {
           }
         }
       }
-
-      if (containingType != null
-          && containingType.toProto().getOptions().getMessageSetWireFormat()) {
-        if (isExtension()) {
-          if (!isOptional() || getType() != Type.MESSAGE) {
-            throw new DescriptorValidationException(
-                this, "Extensions of MessageSets must be optional messages.");
-          }
-        } else {
-          throw new DescriptorValidationException(
-              this, "MessageSets cannot have fields, only extensions.");
-        }
-      }
     }
 
     /** See {@link FileDescriptor#setProto}. */
-    private void setProto(final FieldDescriptorProto proto) {
+    private void setProto(final FieldDescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
       this.features = resolveFeatures(proto.getOptions().getFeatures());
@@ -2250,7 +2261,7 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
-    private void resolveAllFeatures() {
+    private void resolveAllFeatures() throws DescriptorValidationException {
       this.features = resolveFeatures(proto.getOptions().getFeatures());
       for (EnumValueDescriptor value : values) {
         value.resolveAllFeatures();
@@ -2258,7 +2269,7 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#setProto}. */
-    private void setProto(final EnumDescriptorProto proto) {
+    private void setProto(final EnumDescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
       this.features = resolveFeatures(proto.getOptions().getFeatures());
@@ -2402,12 +2413,13 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
-    private void resolveAllFeatures() {
+    private void resolveAllFeatures() throws DescriptorValidationException {
       this.features = resolveFeatures(proto.getOptions().getFeatures());
     }
 
     /** See {@link FileDescriptor#setProto}. */
-    private void setProto(final EnumValueDescriptorProto proto) {
+    private void setProto(final EnumValueDescriptorProto proto)
+        throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
       this.features = resolveFeatures(proto.getOptions().getFeatures());
@@ -2517,7 +2529,7 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
-    private void resolveAllFeatures() {
+    private void resolveAllFeatures() throws DescriptorValidationException {
       this.features = resolveFeatures(proto.getOptions().getFeatures());
 
       for (MethodDescriptor method : methods) {
@@ -2532,7 +2544,7 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#setProto}. */
-    private void setProto(final ServiceDescriptorProto proto) {
+    private void setProto(final ServiceDescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
       this.features = resolveFeatures(proto.getOptions().getFeatures());
@@ -2655,7 +2667,7 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
-    private void resolveAllFeatures() {
+    private void resolveAllFeatures() throws DescriptorValidationException {
       this.features = resolveFeatures(proto.getOptions().getFeatures());
     }
 
@@ -2682,7 +2694,7 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#setProto}. */
-    private void setProto(final MethodDescriptorProto proto) {
+    private void setProto(final MethodDescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
       this.features = resolveFeatures(proto.getOptions().getFeatures());
@@ -2723,7 +2735,7 @@ public final class Descriptors {
 
     public abstract FileDescriptor getFile();
 
-    FeatureSet resolveFeatures(FeatureSet unresolvedFeatures) {
+    FeatureSet resolveFeatures(FeatureSet unresolvedFeatures) throws DescriptorValidationException {
       if (this.parent != null
           && unresolvedFeatures.equals(FeatureSet.getDefaultInstance())
           && !hasInferredLegacyProtoFeatures()) {
@@ -2738,6 +2750,7 @@ public final class Descriptors {
       }
       features.mergeFrom(inferLegacyProtoFeatures());
       features.mergeFrom(unresolvedFeatures);
+      validateFeatures(features.build());
       return internFeatures(features.build());
     }
 
@@ -2747,6 +2760,9 @@ public final class Descriptors {
 
     boolean hasInferredLegacyProtoFeatures() {
       return false;
+    }
+
+    void validateFeatures(FeatureSet features) throws DescriptorValidationException {
     }
 
     GenericDescriptor parent;
@@ -3214,11 +3230,11 @@ public final class Descriptors {
     }
 
     /** See {@link FileDescriptor#resolveAllFeatures}. */
-    private void resolveAllFeatures() {
+    private void resolveAllFeatures() throws DescriptorValidationException {
       this.features = resolveFeatures(proto.getOptions().getFeatures());
     }
 
-    private void setProto(final OneofDescriptorProto proto) {
+    private void setProto(final OneofDescriptorProto proto) throws DescriptorValidationException {
       this.proto = proto;
       this.options = null;
       this.features = resolveFeatures(proto.getOptions().getFeatures());

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyFieldDescriptor.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyFieldDescriptor.java
@@ -287,6 +287,8 @@ public class RubyFieldDescriptor extends RubyObject {
   private void calculateLabel(ThreadContext context) {
     if (descriptor.isRepeated()) {
       this.label = context.runtime.newSymbol("repeated");
+    } else if (descriptor.isRequired()) {
+      this.label = context.runtime.newSymbol("required");
     } else if (descriptor.isOptional()) {
       this.label = context.runtime.newSymbol("optional");
     } else {


### PR DESCRIPTION
Ensures isOptional() does not return true for LEGACY_REQUIRED fields which would otherwise get the optional label applied by default (non-optional fields still get the optional label).

Adds validation to feature resolution instead of cross link, which is too early to have FieldPresence.LEGACY_REQUIRED resolved.

PiperOrigin-RevId: 618857590