### PR TITLE
Add bigdecimal to dependencies

### DIFF
--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |s|
     s.add_development_dependency "rake-compiler-dock", "= 1.2.1"
   end
   s.required_ruby_version = '>= 3.0'
+  # bigdecimal must be used as a non-built in gem as of ruby-3.4
+  s.add_dependency "bigdecimal"
   # TODO: evaluate removing Rakefile and moving logic to extconf.rb, so that we
   # can remove this runtime dependency on rake. See the discussion here for
   # more details:

--- a/ruby/lib/google/BUILD.bazel
+++ b/ruby/lib/google/BUILD.bazel
@@ -81,7 +81,10 @@ ruby_library(
         "ruby/lib",
     ],
     visibility = ["//ruby:__pkg__"],
-    deps = ["//ruby:well_known_ruby_protos"] + select({
+    deps = [
+        "//ruby:well_known_ruby_protos",
+        "@protobuf_bundle//:bigdecimal",
+    ] + select({
         "//ruby:ffi_enabled": [
             "@protobuf_bundle//:ffi",
             "@protobuf_bundle//:ffi-compiler",


### PR DESCRIPTION
In Ruby 3.4, `bigdecimal` is no longer built in. See announcement in [Ruby 3.3 release notes](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/#:~:text=base64-,bigdecimal,-csv).