### PR TITLE
[7392] [cpp] Fix IgnoreUnknownEnumStringValueInMap conformance tests

### DIFF
--- a/conformance/failure_list_cpp.txt
+++ b/conformance/failure_list_cpp.txt
@@ -14,8 +14,6 @@ Recommended.Editions_Proto2.JsonInput.FieldNameDuplicateDifferentCasing1        
 Recommended.Editions_Proto2.JsonInput.FieldNameDuplicateDifferentCasing2                                           # Should have failed to parse, but didn't.
 Recommended.Editions_Proto2.JsonInput.FieldNameExtension.Validator                                                 # Expected JSON payload but got type 1
 Recommended.Editions_Proto2.JsonInput.FieldNameNotQuoted                                                           # Should have failed to parse, but didn't.
-Recommended.Editions_Proto2.JsonInput.IgnoreUnknownEnumStringValueInMapPart.ProtobufOutput                         # Output was not equivalent to reference message: added: map_string_nested_enum[key2]: FOO
-Recommended.Editions_Proto2.JsonInput.IgnoreUnknownEnumStringValueInMapValue.ProtobufOutput                        # Output was not equivalent to reference message: added: map_string_nested_enum[key]: FOO
 Recommended.Editions_Proto2.JsonInput.MapFieldValueIsNull                                                          # Should have failed to parse, but didn't.
 Recommended.Editions_Proto2.JsonInput.RepeatedFieldMessageElementIsNull                                            # Should have failed to parse, but didn't.
 Recommended.Editions_Proto2.JsonInput.RepeatedFieldPrimitiveElementIsNull                                          # Should have failed to parse, but didn't.
@@ -41,8 +39,6 @@ Recommended.Editions_Proto3.JsonInput.FieldNameDuplicate                        
 Recommended.Editions_Proto3.JsonInput.FieldNameDuplicateDifferentCasing1                                           # Should have failed to parse, but didn't.
 Recommended.Editions_Proto3.JsonInput.FieldNameDuplicateDifferentCasing2                                           # Should have failed to parse, but didn't.
 Recommended.Editions_Proto3.JsonInput.FieldNameNotQuoted                                                           # Should have failed to parse, but didn't.
-Recommended.Editions_Proto3.JsonInput.IgnoreUnknownEnumStringValueInMapPart.ProtobufOutput                         # Output was not equivalent to reference message: added: map_string_nested_enum[key2]: FOO
-Recommended.Editions_Proto3.JsonInput.IgnoreUnknownEnumStringValueInMapValue.ProtobufOutput                        # Output was not equivalent to reference message: added: map_string_nested_enum[key]: FOO
 Recommended.Editions_Proto3.JsonInput.MapFieldValueIsNull                                                          # Should have failed to parse, but didn't.
 Recommended.Editions_Proto3.JsonInput.RepeatedFieldMessageElementIsNull                                            # Should have failed to parse, but didn't.
 Recommended.Editions_Proto3.JsonInput.RepeatedFieldPrimitiveElementIsNull                                          # Should have failed to parse, but didn't.
@@ -65,8 +61,6 @@ Recommended.Proto2.JsonInput.FieldNameDuplicateDifferentCasing1                 
 Recommended.Proto2.JsonInput.FieldNameDuplicateDifferentCasing2                                                    # Should have failed to parse, but didn't.
 Recommended.Proto2.JsonInput.FieldNameExtension.Validator                                                          # Expected JSON payload but got type 1
 Recommended.Proto2.JsonInput.FieldNameNotQuoted                                                                    # Should have failed to parse, but didn't.
-Recommended.Proto2.JsonInput.IgnoreUnknownEnumStringValueInMapPart.ProtobufOutput                                  # Output was not equivalent to reference message: added: map_string_nested_enum[key2]: FOO
-Recommended.Proto2.JsonInput.IgnoreUnknownEnumStringValueInMapValue.ProtobufOutput                                 # Output was not equivalent to reference message: added: map_string_nested_enum[key]: FOO
 Recommended.Proto2.JsonInput.MapFieldValueIsNull                                                                   # Should have failed to parse, but didn't.
 Recommended.Proto2.JsonInput.RepeatedFieldMessageElementIsNull                                                     # Should have failed to parse, but didn't.
 Recommended.Proto2.JsonInput.RepeatedFieldPrimitiveElementIsNull                                                   # Should have failed to parse, but didn't.
@@ -92,8 +86,6 @@ Recommended.Proto3.JsonInput.FieldNameDuplicate                                 
 Recommended.Proto3.JsonInput.FieldNameDuplicateDifferentCasing1                                                    # Should have failed to parse, but didn't.
 Recommended.Proto3.JsonInput.FieldNameDuplicateDifferentCasing2                                                    # Should have failed to parse, but didn't.
 Recommended.Proto3.JsonInput.FieldNameNotQuoted                                                                    # Should have failed to parse, but didn't.
-Recommended.Proto3.JsonInput.IgnoreUnknownEnumStringValueInMapPart.ProtobufOutput                                  # Output was not equivalent to reference message: added: map_string_nested_enum[key2]: FOO
-Recommended.Proto3.JsonInput.IgnoreUnknownEnumStringValueInMapValue.ProtobufOutput                                 # Output was not equivalent to reference message: added: map_string_nested_enum[key]: FOO
 Recommended.Proto3.JsonInput.MapFieldValueIsNull                                                                   # Should have failed to parse, but didn't.
 Recommended.Proto3.JsonInput.RepeatedFieldMessageElementIsNull                                                     # Should have failed to parse, but didn't.
 Recommended.Proto3.JsonInput.RepeatedFieldPrimitiveElementIsNull                                                   # Should have failed to parse, but didn't.

--- a/src/google/protobuf/json/internal/parser.cc
+++ b/src/google/protobuf/json/internal/parser.cc
@@ -322,11 +322,11 @@ absl::StatusOr<std::string> ParseStrOrBytes(JsonLexer& lex,
 }
 
 template <typename Traits>
-absl::StatusOr<absl::optional<int32_t>> ParseEnumFromStr(JsonLexer& lex,
-                                                         MaybeOwnedString& str,
-                                                         Field<Traits> field) {
+absl::StatusOr<absl::optional<int32_t>> ParseEnumFromStr(
+    const json_internal::ParseOptions& options, MaybeOwnedString& str,
+    Field<Traits> field) {
   absl::StatusOr<int32_t> value = Traits::EnumNumberByName(
-      field, str.AsView(), lex.options().case_insensitive_enum_parsing);
+      field, str.AsView(), options.case_insensitive_enum_parsing);
   if (value.ok()) {
     return absl::optional<int32_t>(*value);
   }
@@ -334,7 +334,7 @@ absl::StatusOr<absl::optional<int32_t>> ParseEnumFromStr(JsonLexer& lex,
   int32_t i;
   if (absl::SimpleAtoi(str.AsView(), &i)) {
     return absl::optional<int32_t>(i);
-  } else if (lex.options().ignore_unknown_fields) {
+  } else if (options.ignore_unknown_fields) {
     return {absl::nullopt};
   }
 
@@ -355,7 +355,7 @@ absl::StatusOr<absl::optional<int32_t>> ParseEnum(JsonLexer& lex,
       absl::StatusOr<LocationWith<MaybeOwnedString>> str = lex.ParseUtf8();
       RETURN_IF_ERROR(str.status());
 
-      auto e = ParseEnumFromStr<Traits>(lex, str->value, field);
+      auto e = ParseEnumFromStr<Traits>(lex.options(), str->value, field);
       RETURN_IF_ERROR(e.status());
       if (!e->has_value()) {
         return {absl::nullopt};

--- a/src/google/protobuf/json/json_test.cc
+++ b/src/google/protobuf/json/json_test.cc
@@ -507,6 +507,98 @@ TEST_P(JsonTest, ParseMap) {
   EXPECT_EQ(other->DebugString(), message.DebugString());
 }
 
+TEST_P(JsonTest, ParseMapWithEnumValuesProto2) {
+  ParseOptions options;
+  options.ignore_unknown_fields = false;
+  protobuf_unittest::TestMapOfEnums message;
+  const std::string input_json = R"json({
+    "enum_map": {
+      "key1": "PROTOCOL",
+      "key2": "UNKNOWN_ENUM_STRING_VALUE",
+      "key3": "BUFFER",
+      "key4": "UNKNOWN_ENUM_STRING_VALUE",
+      "key5": "PROTOCOL",
+    }
+  })json";
+
+  // Without ignore_unknown_fields, the unknown enum string value fails to
+  // parse.
+  EXPECT_THAT(ToProto(message, input_json, options),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST_P(JsonTest, ParseMapWithEnumValuesProto3) {
+  ParseOptions options;
+  options.ignore_unknown_fields = false;
+  proto3::MapOfEnums message;
+  const std::string input_json = R"json({
+    "map": {
+      "key1": "FOO",
+      "key2": "UNKNOWN_ENUM_STRING_VALUE",
+      "key3": "BAR",
+      "key4": "UNKNOWN_ENUM_STRING_VALUE",
+      "key5": "FOO",
+    }
+  })json";
+
+  // Without ignore_unknown_fields, the unknown enum string value fails to
+  // parse.
+  EXPECT_THAT(ToProto(message, input_json, options),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST_P(JsonTest, ParseMapWithEnumValuesProto2WithUnknownFields) {
+  ParseOptions options;
+  options.ignore_unknown_fields = true;
+  protobuf_unittest::TestMapOfEnums message;
+  const std::string input_json = R"json({
+    "enum_map": {
+      "key1": "PROTOCOL",
+      "key2": "UNKNOWN_ENUM_STRING_VALUE",
+      "key3": "BUFFER",
+      "key4": "UNKNOWN_ENUM_STRING_VALUE",
+      "key5": "PROTOCOL",
+    }
+  })json";
+
+  ASSERT_OK(ToProto(message, input_json, options));
+  // With ignore_unknown_fields set, the unknown enum string value is accepted
+  // but coerced to 0-th enum value. This behavior fails the conformance test
+  // 'IgnoreUnknownEnumStringValueInMap' and it will be fixed in
+  // https://github.com/protocolbuffers/protobuf/pull/16479.
+  EXPECT_EQ(message.enum_map().size(), 5);
+  EXPECT_EQ(message.enum_map().contains("key2"), true);
+  EXPECT_EQ(message.enum_map().contains("key4"), true);
+  EXPECT_EQ(message.enum_map().at("key2"), 0);
+  EXPECT_EQ(message.enum_map().at("key4"), 0);
+}
+
+TEST_P(JsonTest, ParseMapWithEnumValuesProto3WithUnknownFields) {
+  ParseOptions options;
+  options.ignore_unknown_fields = true;
+  proto3::MapOfEnums message;
+  const std::string input_json = R"json({
+    "map": {
+      "key1": "FOO",
+      "key2": "UNKNOWN_ENUM_STRING_VALUE",
+      "key3": "BAR",
+      "key4": "UNKNOWN_ENUM_STRING_VALUE",
+      "key5": "FOO",
+    }
+  })json";
+
+  ASSERT_OK(ToProto(message, input_json, options));
+  // With ignore_unknown_fields set, the unknown enum string value is accepted
+  // but coerced to 0-th enum value. This behavior fails the conformance test
+  // 'IgnoreUnknownEnumStringValueInMap' and it will be fixed in
+  // https://github.com/protocolbuffers/protobuf/pull/16479.
+  EXPECT_EQ(message.map().size(), 5);
+  EXPECT_EQ(message.map().contains("key2"), true);
+  EXPECT_EQ(message.map().contains("key4"), true);
+  EXPECT_EQ(message.map().at("key2"), 0);
+  EXPECT_EQ(message.map().at("key4"), 0);
+}
+
 TEST_P(JsonTest, RepeatedMapKey) {
   EXPECT_THAT(ToProto<TestMap>(R"json({
     "string_map": {

--- a/src/google/protobuf/json/json_test.cc
+++ b/src/google/protobuf/json/json_test.cc
@@ -562,15 +562,9 @@ TEST_P(JsonTest, ParseMapWithEnumValuesProto2WithUnknownFields) {
   })json";
 
   ASSERT_OK(ToProto(message, input_json, options));
-  // With ignore_unknown_fields set, the unknown enum string value is accepted
-  // but coerced to 0-th enum value. This behavior fails the conformance test
-  // 'IgnoreUnknownEnumStringValueInMap' and it will be fixed in
-  // https://github.com/protocolbuffers/protobuf/pull/16479.
-  EXPECT_EQ(message.enum_map().size(), 5);
-  EXPECT_EQ(message.enum_map().contains("key2"), true);
-  EXPECT_EQ(message.enum_map().contains("key4"), true);
-  EXPECT_EQ(message.enum_map().at("key2"), 0);
-  EXPECT_EQ(message.enum_map().at("key4"), 0);
+  EXPECT_EQ(message.enum_map().size(), 3);
+  EXPECT_EQ(message.enum_map().contains("key2"), false);
+  EXPECT_EQ(message.enum_map().contains("key4"), false);
 }
 
 TEST_P(JsonTest, ParseMapWithEnumValuesProto3WithUnknownFields) {
@@ -588,15 +582,9 @@ TEST_P(JsonTest, ParseMapWithEnumValuesProto3WithUnknownFields) {
   })json";
 
   ASSERT_OK(ToProto(message, input_json, options));
-  // With ignore_unknown_fields set, the unknown enum string value is accepted
-  // but coerced to 0-th enum value. This behavior fails the conformance test
-  // 'IgnoreUnknownEnumStringValueInMap' and it will be fixed in
-  // https://github.com/protocolbuffers/protobuf/pull/16479.
-  EXPECT_EQ(message.map().size(), 5);
-  EXPECT_EQ(message.map().contains("key2"), true);
-  EXPECT_EQ(message.map().contains("key4"), true);
-  EXPECT_EQ(message.map().at("key2"), 0);
-  EXPECT_EQ(message.map().at("key4"), 0);
+  EXPECT_EQ(message.map().size(), 3);
+  EXPECT_EQ(message.map().contains("key2"), false);
+  EXPECT_EQ(message.map().contains("key4"), false);
 }
 
 TEST_P(JsonTest, RepeatedMapKey) {


### PR DESCRIPTION
## Motivation

This PR fixes failing JSON conformance tests for cpp with name `IgnoreUnknownEnumStringValueInMap`. Specifically, for the following input of type [TestMapOfEnums](https://github.com/protocolbuffers/protobuf/blob/2f3242c576504459621fd7d78bbccf39bfaa49c5/src/google/protobuf/util/json_format.proto#L119):

```json
{
  "enum_map": {
    "key1": "PROTOCOL",
    "key2": "UNKNOWN_ENUM_STRING_VALUE",
    "key3": "BUFFER"
  }
}
```

The JSON parser with `ignore_unknown_fields=true` should produce a map with 2 entries, skipping the unknown enum value under `key2`. The implementation before this PR outputs `key2` with 0-th enum value (`PROTOCOL`) instead.

The JSON parsing spec was discussed in https://github.com/protocolbuffers/protobuf/issues/7392.

Recent similar changes in other languages:
- Python: https://github.com/protocolbuffers/protobuf/commit/86abf35ef5ee5b1004ec11bebb36d84c2ef6645e
- Swift: https://github.com/apple/swift-protobuf/pull/1345
- C#: https://github.com/protocolbuffers/protobuf/pull/15758

## Changes

The main difficulty in implementing the fix is the fact that parser will first allocate a new map entry message and then consume the value. In this special case (unknown enum string value), we need to do it the other way around: first consume the value, then allocate the map entry if needed.

The PR initially contains 5 commits, with first 4 being noop unit tests and refactors:

1. unit test that documents the mainline behavior (this test will be changed in the 5th commit)
2. noop refactoring that simplifies the signature of ParseEnumFromStr
3. noop refactoring that extract map key parsing into a separate function (we'll call it twice in 5th commit)
4. noop refactoring that extracts parse map entry into a separate function (since it will get more logic)
5. the commit that actually implements the fix and adjusts tests

