### PR TITLE
Fix the bug of DefaultValueObjectWriter class

### DIFF
--- a/src/google/protobuf/util/internal/default_value_objectwriter.cc
+++ b/src/google/protobuf/util/internal/default_value_objectwriter.cc
@@ -254,6 +254,8 @@ DefaultValueObjectWriter::Node* DefaultValueObjectWriter::Node::FindChild(
 
 void DefaultValueObjectWriter::Node::WriteTo(ObjectWriter* ow) {
   if (kind_ == PRIMITIVE) {
+    // Empty strings should be rendered for the JSON key.
+    ow->empty_name_ok_for_next_key();
     ObjectWriter::RenderDataPieceTo(data_, name_, ow);
     return;
   }

--- a/src/google/protobuf/util/json_util_test.cc
+++ b/src/google/protobuf/util/json_util_test.cc
@@ -266,6 +266,19 @@ TEST_F(JsonUtilTest, ParsePrimitiveMapIn) {
   EXPECT_EQ(message.DebugString(), other.DebugString());
 }
 
+TEST_F(JsonUtilTest, PrintEmptyMapKey) {
+  MapIn message;
+  (*message.mutable_map_input())[""] = "";
+  JsonPrintOptions print_options;
+  print_options.always_print_primitive_fields = true;
+  JsonParseOptions parse_options;
+  EXPECT_EQ("{\"other\":\"\",\"things\":[],\"mapInput\":{\"\":\"\"}}",
+            ToJson(message, print_options));
+  MapIn other;
+  ASSERT_TRUE(FromJson(ToJson(message, print_options), &other, parse_options));
+  EXPECT_EQ(message.DebugString(), other.DebugString());
+}
+
 TEST_F(JsonUtilTest, PrintPrimitiveOneof) {
   TestOneof message;
   JsonPrintOptions options;


### PR DESCRIPTION
Fix the bug when the DefaultValueObjectWriter class handles the element whose key is an empty string in the map.