### PR TITLE
[bzlmod] Set repo_name to com_google_protobuf

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,18 +1,19 @@
 # TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
 # https://github.com/protocolbuffers/protobuf/issues/14313
-PROTOBUF_VERSION  = "27.0"
+PROTOBUF_VERSION = "27.0"
 
 module(
     name = "protobuf",
-    compatibility_level = 1,
     version = PROTOBUF_VERSION,
+    compatibility_level = 1,
+    repo_name = "com_google_protobuf",
 )
 
 # LOWER BOUND dependency versions.
 # Bzlmod follows MVS:
 # https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
 # Thus the highest version in their module graph is resolved.
-bazel_dep(name = "abseil-cpp", repo_name = "com_google_absl", version = "20230802.0.bcr.1")
+bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "jsoncpp", version = "1.9.5")
 bazel_dep(name = "rules_cc", version = "0.0.9")


### PR DESCRIPTION
This is currently required by https://github.com/protocolbuffers/protobuf/blob/8d025c08ff9c4e63f37f62b64f3046183ef7ab20/upb_generator/bootstrap_compiler.bzl#L30

We could try to change it but this is fine to do for now