### PR TITLE
Fix Protobuf-C++.podspec build error problem

### DIFF
--- a/Protobuf-C++.podspec
+++ b/Protobuf-C++.podspec
@@ -16,13 +16,16 @@ Pod::Spec.new do |s|
   s.source_files = 'src/google/protobuf/*.{h,cc,inc}',
                    'src/google/protobuf/stubs/*.{h,cc}',
                    'src/google/protobuf/io/*.{h,cc}',
-                   'src/google/protobuf/util/*.{h,cc}'
+                   'src/google/protobuf/util/*.{h,cc}',
+                   'third_party/utf8_range/utf8_range.{h,c,cc}',
+                   'third_party/utf8_range/utf8_validity.{h,c,cc}'
 
   # Excluding all the tests in the directories above
   s.exclude_files = 'src/google/**/*_test.{h,cc,inc}',
                     'src/google/**/*_unittest.{h,cc}',
                     'src/google/protobuf/test_util*.{h,cc}',
                     'src/google/protobuf/map_lite_test_util.{h,cc}',
+                    'src/google/protobuf/map_probe_benchmark.cc',
                     'src/google/protobuf/map_test_util*.{h,cc,inc}',
                     'src/google/protobuf/reflection_tester.{h,cc}'
 
@@ -42,7 +45,9 @@ Pod::Spec.new do |s|
     # Do not let src/google/protobuf/stubs/time.h override system API
     'USE_HEADERMAP' => 'NO',
     'ALWAYS_SEARCH_USER_PATHS' => 'NO',
-    'HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)/src"'
+    'HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)/src" "$(PODS_TARGET_SRCROOT)/third_party/utf8_range"'
   }
+
+  s.dependency 'abseil', '1.20240116.1'
 
 end


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/protocolbuffers/protobuf/issues/13596), there is a problem with the podspec of Protobuf-C++ and an error occurs when trying to build with Xcode project modified by pod install.

This pull request resolves the build error by:
- Add `utf8_range` source files to `source_files`.
- Add files to `exclude_files` to exclude unnecessary files that cause build errors.
- Add a directory to `HEADER_SEARCH_PATHS` so that `utf8_range` headers can be searched.
- Added Abseil as a dependent library. The reason I specify version `1.20240116.1` is to include `PrivacyInfo.xcprivacy` in the Abseil framework project to be generated.