### PR TITLE
Update TimestampBase to allow for DateTimeInterface rather than specific implementation and allow fluent setter for factory usage.

### DIFF
--- a/php/src/Google/Protobuf/Internal/TimestampBase.php
+++ b/php/src/Google/Protobuf/Internal/TimestampBase.php
@@ -12,7 +12,7 @@ class TimestampBase extends \Google\Protobuf\Internal\Message
      * Converts PHP DateTime to Timestamp.
      *
      * @param \DateTimeInterface $datetime
-     * @return  \Google\Protobuf\Internal\TimestampBase
+     * @return \Google\Protobuf\Internal\TimestampBase
      */
     public function fromDateTime(\DateTimeInterface $datetime): static
     {

--- a/php/src/Google/Protobuf/Internal/TimestampBase.php
+++ b/php/src/Google/Protobuf/Internal/TimestampBase.php
@@ -13,10 +13,12 @@ class TimestampBase extends \Google\Protobuf\Internal\Message
      *
      * @param \DateTime $datetime
      */
-    public function fromDateTime(\DateTime $datetime)
+    public function fromDateTime(\DateTimeInterface $datetime): static
     {
         $this->seconds = $datetime->getTimestamp();
         $this->nanos = 1000 * $datetime->format('u');
+
+        return $this;
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/TimestampBase.php
+++ b/php/src/Google/Protobuf/Internal/TimestampBase.php
@@ -11,7 +11,8 @@ class TimestampBase extends \Google\Protobuf\Internal\Message
     /*
      * Converts PHP DateTime to Timestamp.
      *
-     * @param \DateTime $datetime
+     * @param \DateTimeInterface $datetime
+     * @return  \Google\Protobuf\Internal\TimestampBase
      */
     public function fromDateTime(\DateTimeInterface $datetime): static
     {


### PR DESCRIPTION
- Allow Timestamp to be populated by any class that matches the built-in DateTimeInterface interface (ie DateTimeImmutable).

- Change to fluent setter to more easily use as a factory.