### PR TITLE
Closes #11203 Update packagist mirror repo to include a .gitattributes file.

### DIFF
--- a/.github/workflows/update_php_repo.yml
+++ b/.github/workflows/update_php_repo.yml
@@ -39,6 +39,7 @@ jobs:
           rm -rf src
           cp -r protobuf/php/src .
           cp protobuf/php/composer.json.dist composer.json
+          echo "*.php -text diff" > .gitattributes
           rm -rf protobuf
       - name: Push Changes
         run: |


### PR DESCRIPTION
This pull request adds a .gitattributes file into the https://github.com/protocolbuffers/protobuf-php repo during the Update PHP Repo workflow update process.  

Alternatively we could add this .gitattributes into the https://github.com/protocolbuffers/protobuf/tree/main/php folder and update the action to include it when building the packagist repo.