### PR TITLE
Fix compilation as shared libs in Windows MSYS2 clang variants

### DIFF
--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -766,7 +766,7 @@ inline void RepeatedPtrFieldBase::MergeFrom<Message>(
 
 // Appends all `std::string` values from `from` to this instance.
 template <>
-void RepeatedPtrFieldBase::MergeFrom<std::string>(
+PROTOBUF_EXPORT void RepeatedPtrFieldBase::MergeFrom<std::string>(
     const RepeatedPtrFieldBase& from);
 
 


### PR DESCRIPTION
- Originally from https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-protobuf/0001-fix-building-shared-libs-with-clang.patch, would be nice to have it upstream