### PR TITLE
remove use of mach_absolute_time (#15554)

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -51,7 +51,7 @@
 #endif  // defined(__cpp_lib_string_view)
 
 #if !defined(GOOGLE_PROTOBUF_NO_RDTSC) && defined(__APPLE__)
-#include <mach/mach_time.h>
+#include <time.h>
 #endif
 
 #include <google/protobuf/stubs/common.h>
@@ -1088,7 +1088,7 @@ class Map {
 #if defined(__APPLE__)
       // Use a commpage-based fast time function on Apple environments (MacOS,
       // iOS, tvOS, watchOS, etc).
-      s += mach_absolute_time();
+      s = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 #elif defined(__x86_64__) && defined(__GNUC__)
       uint32_t hi, lo;
       asm volatile("rdtsc" : "=a"(lo), "=d"(hi));


### PR DESCRIPTION
Cherry-pick https://github.com/protocolbuffers/protobuf/commit/76d05d4cb9200c371c8894df21f37ba4060bdc8a to 19.x. 19.x is out-of-support and should not receive further patch releases, but cherry picking to help https://github.com/protocolbuffers/protobuf/issues/16358#issuecomment-2063777905

`mach_absolute_time` is one of Apple's required reason APIs (https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time?language=objc). Replace it with the suggested `clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` so that we don't need a RRA entry in a privacy manifest.

issue #15029

Closes #15554

COPYBARA_INTEGRATE_REVIEW=https://github.com/protocolbuffers/protobuf/pull/15554 from protocolbuffers:dmaclach-mach_absolute_time 295d83178d5567743c720e7405ac974b0bcab832 PiperOrigin-RevId: 601370915