### PR TITLE
Cancel in-progress workflow runs for pull requests and dispatches

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -52,6 +52,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ contains(fromJSON('["pull_request", "pull_request_target", "workflow_dispatch"]'), github.event_name) }}
+
 jobs:
   check-tag:
     name: Check for Safety


### PR DESCRIPTION
This will reduce unnecessary resource consumption by cancelling running workflows when new commits are pushed to a PR or workflow dispatch. It does not cancel pushes to main or branches.