### PR TITLE
Allow builders to return default instance in Java

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -476,6 +476,9 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
     // to dispatch dirty invalidations. See GeneratedMessage.BuilderListener.
     private boolean isClean;
 
+    // Indicates that the default instance can be used
+    private boolean isDefault = true;
+
     /**
      * This field holds either an {@link UnknownFieldSet} or {@link UnknownFieldSet.Builder}.
      *
@@ -525,6 +528,15 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
      */
     protected boolean isClean() {
       return isClean;
+    }
+
+    /**
+     * Gets whether the default instance can be used
+     *
+     * @return whether the default instance can be used
+     */
+    protected boolean isDefault() {
+      return isDefault;
     }
 
     @Override
@@ -834,6 +846,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
         // Don't keep dispatching invalidations until build is called again.
         isClean = false;
       }
+      isDefault = false;
     }
 
     /**

--- a/java/core/src/main/java/com/google/protobuf/NewInstanceSchemaFull.java
+++ b/java/core/src/main/java/com/google/protobuf/NewInstanceSchemaFull.java
@@ -10,6 +10,7 @@ package com.google.protobuf;
 final class NewInstanceSchemaFull implements NewInstanceSchema {
   @Override
   public Object newInstance(Object defaultInstance) {
-    return ((Message) defaultInstance).toBuilder().buildPartial();
+    return ((GeneratedMessage) defaultInstance)
+        .newInstance(GeneratedMessage.UnusedPrivateParameter.INSTANCE);
   }
 }

--- a/java/core/src/test/java/com/google/protobuf/NestedBuildersTest.java
+++ b/java/core/src/test/java/com/google/protobuf/NestedBuildersTest.java
@@ -157,6 +157,20 @@ public class NestedBuildersTest {
   }
 
   @Test
+  public void testUsesDefaultInstance() {
+    Vehicle vehicle1 = Vehicle.newBuilder().build();
+    // Should use the default instance -- no allocation
+    assertThat(vehicle1).isSameInstanceAs(Vehicle.getDefaultInstance());
+
+    Vehicle vehicle2 =
+        Vehicle.newBuilder()
+            .addWheel(Wheel.newBuilder().build())
+            .build();
+    // Should use the default instance -- no allocation
+    assertThat(vehicle2.getWheel(0)).isSameInstanceAs(Wheel.getDefaultInstance());
+  }
+
+  @Test
   public void testGettingBuilderMarksFieldAsHaving() {
     Vehicle.Builder vehicleBuilder = Vehicle.newBuilder();
     vehicleBuilder.getEngineBuilder();

--- a/src/google/protobuf/compiler/java/immutable/message.cc
+++ b/src/google/protobuf/compiler/java/immutable/message.cc
@@ -363,6 +363,15 @@ void ImmutableMessageGenerator::Generate(io::Printer* printer) {
       "}\n"
       "\n");
 
+  printer->Print(variables,
+                 "@java.lang.Override\n"
+                 "@SuppressWarnings({\"unused\"})\n"
+                 "protected java.lang.Object newInstance(\n"
+                 "    UnusedPrivateParameter unused) {\n"
+                 "  return new $classname$();\n"
+                 "}\n"
+                 "\n");
+
   GenerateDescriptorMethods(printer);
 
   // Nested types

--- a/src/google/protobuf/compiler/java/immutable/message_builder.cc
+++ b/src/google/protobuf/compiler/java/immutable/message_builder.cc
@@ -475,6 +475,7 @@ void MessageBuilderGenerator::GenerateBuildPartial(io::Printer* printer) {
   printer->Print(
       "@java.lang.Override\n"
       "public $classname$ buildPartial() {\n"
+      "  if (isDefault()) { onBuilt(); return $classname$.getDefaultInstance(); }\n"
       "  $classname$ result = new $classname$(this);\n",
       "classname", name_resolver_->GetImmutableClassName(descriptor_));
 


### PR DESCRIPTION
rationale: I was investigating allocations during parsing where a lot of empty messages were present and realized that each of these empty messages was a newly allocated instance, when it would be more memory efficient to reuse the default instance each time.

solution: add a default flag to the builder which is invalidated onChange. then conditionally return the default instance if that flag is true.

note: I had to bring back some logic removed in c0d08bdcade9d44698015b85c9c23343ca1319b7 in order for the schema flow to work correctly since it was using toBuilder and expecting a new instance, not the default instance.