### PR TITLE
Add system_python to protobuf_deps.bzl.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -164,13 +164,6 @@ http_archive(
     patch_cmds = ["find google -type f -name BUILD.bazel -delete"],
 )
 
-load("//python/dist:system_python.bzl", "system_python")
-
-system_python(
-    name = "system_python",
-    minimum_python_version = "3.7",
-)
-
 load("@system_python//:pip.bzl", "pip_parse")
 
 pip_parse(

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//python/dist:python_downloads.bzl", "python_nuget_package", "python_source_archive")
+load("//python/dist:system_python.bzl", "system_python")
 
 PROTOBUF_MAVEN_ARTIFACTS = [
     "com.google.caliper:caliper:1.0-beta-3",
@@ -100,6 +101,12 @@ def protobuf_deps():
             sha256 = "9d04041ac92a0985e344235f5d946f71ac543f1b1565f2cdbc9a2aaee8adf55b",
             strip_prefix = "rules_python-0.26.0",
             url = "https://github.com/bazelbuild/rules_python/releases/download/0.26.0/rules_python-0.26.0.tar.gz",
+        )
+
+    if not native.existing_rule("system_python"):
+        system_python(
+            name = "system_python",
+            minimum_python_version = "3.7",
         )
 
     if not native.existing_rule("rules_jvm_external"):


### PR DESCRIPTION
Cherry-pick of  8a11178606ce85d9e561729328795471fe8a6de5

These are needed to get python headers for Python C++ and Python UPB from local system python

PiperOrigin-RevId: 629786458