### PR TITLE
Fixed broken link in upb README.md

### DIFF
--- a/upb/README.md
+++ b/upb/README.md
@@ -8,7 +8,7 @@ in C.
 upb is the core runtime for protobuf languages extensions in
 [Ruby](https://github.com/protocolbuffers/protobuf/tree/main/ruby),
 [PHP](https://github.com/protocolbuffers/protobuf/tree/main/php), and
-[Python](https://github.com/protocolbuffers/protobuf/tree/main/upb/python).
+[Python](https://github.com/protocolbuffers/protobuf/tree/main/python).
 
 While upb offers a C API, the C API & ABI **are not stable**. For this reason,
 upb is not generally offered as a C library for direct consumption, and there


### PR DESCRIPTION
I noticed this link was broken.  I'm not familiar with the project, but the code in https://github.com/protocolbuffers/protobuf/tree/main/upb/python does appear to import upb headers, so I think it's the right URL.