### PR TITLE
Include gRPC API Gateway in the options documentation

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -501,3 +501,8 @@ with info about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/solo-io/protoc-gen-openapi
     *   Extensions: 1188-1189
+
+1.  gRPC API Gateway
+
+    *   Website: https://github.com/meshapi/grpc-api-gateway
+    *   Extensions: 1190-1192


### PR DESCRIPTION
Adding [gRPC API Gateway](https://github.com/meshapi/grpc-api-gateway) to the options documentation.