### PR TITLE
Deprecate building from source with Maven to be removed in 4.28.x.

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -67,7 +67,35 @@ If you are contributing code to protobuf or want to use a protobuf version
 that hasn't been officially released yet, you can follow the instructions
 below to build protobuf from source code.
 
+### Build from Source
+
+You may follow these instructions to build from source. This does not require
+Maven to be installed. Note that these instructions skip running unit tests and
+only describes how to install the core protobuf library (without the util
+package).
+
+1) Build the C++ code, or obtain a binary distribution of protoc (see
+   the toplevel [README.md](../README.md)). If you install a binary
+   distribution, make sure that it is the same version as this package.
+   If in doubt, run:
+
+     $ protoc --version
+
+   If you built the C++ code without installing, the compiler binary
+   should be located in ../src.
+
+2) Invoke protoc to build DescriptorProtos.java:
+
+     $ protoc --java_out=core/src/main/java -I../src \
+         ../src/google/protobuf/descriptor.proto
+
+3) Compile the code in core/src/main/java using whatever means you prefer.
+
+4) Install the classes wherever you prefer.
+
 ### Build from Source - With Maven
+
+WARNING: Building from source with Maven is deprecated and will be removed in the 4.28.x release.
 
 1) Install Apache Maven if you don't have it:
 
@@ -108,31 +136,6 @@ The above instructions will install 2 maven artifacts:
   * protobuf-java-util: Utilities to work with protos. It contains JSON support
                         as well as utilities to work with proto3 well-known
                         types.
-
-### Build from Source - Without Maven
-
-If you would rather not install Maven to build the library, you may
-follow these instructions instead.  Note that these instructions skip
-running unit tests and only describes how to install the core protobuf
-library (without the util package).
-
-1) Build the C++ code, or obtain a binary distribution of protoc.  If
-   you install a binary distribution, make sure that it is the same
-   version as this package.  If in doubt, run:
-
-     $ protoc --version
-
-   If you built the C++ code without installing, the compiler binary
-   should be located in ../src.
-
-2) Invoke protoc to build DescriptorProtos.java:
-
-     $ protoc --java_out=core/src/main/java -I../src \
-         ../src/google/protobuf/descriptor.proto
-
-3) Compile the code in core/src/main/java using whatever means you prefer.
-
-4) Install the classes wherever you prefer.
 
 ## Compatibility Notice
 


### PR DESCRIPTION
Cherry-pick of a441721cd9faaa9798ec9e4a927c8f0f9e56d828

Most users should use the *pre-built* artifacts, or should build from source with Bazel instead.

PiperOrigin-RevId: 631070145