### PR TITLE
Fix indention formatter for google.protobuf.Any

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonFormatterTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonFormatterTest.cs
@@ -901,6 +901,42 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void WriteValueWithIndentation_Any()
+        {
+            var registry = TypeRegistry.FromMessages(ForeignMessage.Descriptor);
+            var formatter = JsonFormatter.Settings.Default.WithIndentation().WithTypeRegistry(registry);
+
+            var nestedMessage = new ForeignMessage { C = 1 };
+            var value = Any.Pack(nestedMessage);
+            const string expectedJson = @"
+{
+  '@type': 'type.googleapis.com/protobuf_unittest3.ForeignMessage',
+  'c': 1
+}";
+
+            AssertWriteValue(value, expectedJson, formatter);
+        }
+
+        [Test]
+        public void WriteValueWithIndentation_NestedAny()
+        {
+            var registry = TypeRegistry.FromMessages(ForeignMessage.Descriptor);
+            var formatter = JsonFormatter.Settings.Default.WithIndentation().WithTypeRegistry(registry);
+
+            var nestedMessage = new ForeignMessage { C = 1 };
+            var value = new TestWellKnownTypes { AnyField = Any.Pack(nestedMessage) };
+            const string expectedJson = @"
+{
+  'anyField': {
+    '@type': 'type.googleapis.com/protobuf_unittest3.ForeignMessage',
+    'c': 1
+  }
+}";
+
+            AssertWriteValue(value, expectedJson, formatter);
+        }
+
+        [Test]
         public void WriteValueWithIndentation_CustomIndentation()
         {
             var value = new RepeatedField<int> { 1, 2, 3 };

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -481,6 +481,7 @@ namespace Google.Protobuf {
       }
       IMessage message = descriptor.Parser.ParseFrom(data);
       WriteBracketOpen(writer, ObjectOpenBracket);
+      MaybeWriteValueWhitespace(writer, indentationLevel + 1);
       WriteString(writer, AnyTypeUrlField);
       writer.Write(NameValueSeparator);
       WriteString(writer, typeUrl);
@@ -489,9 +490,9 @@ namespace Google.Protobuf {
         writer.Write(ValueSeparator);
         WriteString(writer, AnyWellKnownTypeValueField);
         writer.Write(NameValueSeparator);
-        WriteWellKnownTypeValue(writer, descriptor, message, indentationLevel);
+        WriteWellKnownTypeValue(writer, descriptor, message, indentationLevel + 1);
       } else {
-        WriteMessageFields(writer, message, true, indentationLevel);
+        WriteMessageFields(writer, message, true, indentationLevel + 1);
       }
       WriteBracketClose(writer, ObjectCloseBracket, true, indentationLevel);
     }


### PR DESCRIPTION
`google.protobuf.Any` formatting with indentation was somewhat off.

Formatting an `Any` as root object:
```json
{"@type": "type.googleapis.com/protobuf_unittest3.ForeignMessage",
"c": 1
}
```
changes to
```json
{
  "@type": "type.googleapis.com/protobuf_unittest3.ForeignMessage",
  "c": 1
}
```

For messages were `Any` is in a nested field the change makes more of a visual impact.
The `c` field seems to be at the same level as the `anyField`, but it's nested so it should be indented:
```json
{
  "anyField": {"@type": "type.googleapis.com/protobuf_unittest3.ForeignMessage",
  "c": 1
  }
}
```
changes to:
```json
{
  "anyField": {
    "@type": "type.googleapis.com/protobuf_unittest3.ForeignMessage",
    "c": 1
  }
}
```