### PR TITLE
Floats in ruby/protobuf are not in fact equal

### DIFF
--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -56,6 +56,16 @@ module CommonTests
     assert_equal :C, m.optional_enum
   end
 
+  def test_float_precision
+    # See https://github.com/protocolbuffers/protobuf/issues/6966
+    # A float field in protobuf is a single-precision floating point value.
+    # The Ruby Float type uses double-precision floating point.
+    # When you convert a double-precision floating point value to single precision, there is going to be some loss of precision.
+    m = proto_module::TestMessage.new
+    m.optional_float = 0.1
+    refute_equal 0.1, m.optional_float
+  end
+
   def test_ctor_args
     m = proto_module::TestMessage.new(:optional_int32 => -42,
                                       :optional_msg => proto_module::TestMessage2.new,


### PR DESCRIPTION
The existing test is misleading:
https://github.com/protocolbuffers/protobuf/blob/82e83ddc95330bbd988ba874ea5aa37d343d4490/ruby/tests/common_tests.rb#L39-L40

This change adds a new test making the difference between ruby and protobuf floats explicit.

Something else to consider is currently the assignment of a ruby float returns the float with ruby precision. Perhaps the setter should return the float with protobuf precision?