### PR TITLE
Add `java` to reserved names to escape extensions to `java_`. This may break existing references to gencode for extensions named java.

### DIFF
--- a/editions/golden/editions_transform_proto2.proto
+++ b/editions/golden/editions_transform_proto2.proto
@@ -15,7 +15,7 @@ edition = "2023";
 package protobuf_editions_test;
 
 import "net/proto/proto1_features.proto";
-import "third_party/java/protobuf/java_features.proto";
+import "google/protobuf/java_features.proto";
 import "google/protobuf/cpp_features.proto";
 import "google/protobuf/editions/proto/editions_transform_proto3.proto";
 

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -334,6 +334,7 @@ proto_library(
     deps = [
         "//:any_proto",
         "//:descriptor_proto",
+        "//:java_features_proto",
         "//:lite_test_protos",
         "//:wrappers_proto",
         "//src/google/protobuf:generic_test_protos",

--- a/java/core/src/main/java/com/google/protobuf/Descriptors.java
+++ b/java/core/src/main/java/com/google/protobuf/Descriptors.java
@@ -94,7 +94,7 @@ public final class Descriptors {
         if (javaEditionDefaults == null) {
           try {
             ExtensionRegistry registry = ExtensionRegistry.newInstance();
-            registry.add(JavaFeaturesProto.java);
+            registry.add(JavaFeaturesProto.java_);
             setTestJavaEditionDefaults(
                 FeatureSetDefaults.parseFrom(
                     JavaEditionDefaults.PROTOBUF_INTERNAL_JAVA_EDITION_DEFAULTS.getBytes(
@@ -679,7 +679,7 @@ public final class Descriptors {
       if (getEdition() == Edition.EDITION_PROTO2) {
         if (proto.getOptions().getJavaStringCheckUtf8()) {
           features.setExtension(
-              JavaFeaturesProto.java,
+              JavaFeaturesProto.java_,
               JavaFeatures.newBuilder()
                   .setUtf8Validation(JavaFeatures.Utf8Validation.VERIFY)
                   .build());
@@ -1320,7 +1320,7 @@ public final class Descriptors {
         return true;
       }
       if (this.features
-          .getExtension(JavaFeaturesProto.java)
+          .getExtension(JavaFeaturesProto.java_)
           .getUtf8Validation()
           .equals(JavaFeatures.Utf8Validation.VERIFY)) {
         return true;
@@ -1577,7 +1577,7 @@ public final class Descriptors {
       }
 
       return getType() == Type.ENUM
-          && (this.features.getExtension(JavaFeaturesProto.java).getLegacyClosedEnum()
+          && (this.features.getExtension(JavaFeaturesProto.java_).getLegacyClosedEnum()
               || enumType.isClosed());
     }
 

--- a/java/core/src/test/java/com/google/protobuf/DescriptorsTest.java
+++ b/java/core/src/test/java/com/google/protobuf/DescriptorsTest.java
@@ -1158,7 +1158,7 @@ public class DescriptorsTest {
                   .setOptions(FileOptions.newBuilder().setJavaStringCheckUtf8(true))
                   .build(),
               new FileDescriptor[0]);
-      assertThat(file.features.getExtension(JavaFeaturesProto.java).getUtf8Validation())
+      assertThat(file.features.getExtension(JavaFeaturesProto.java_).getUtf8Validation())
           .isEqualTo(JavaFeaturesProto.JavaFeatures.Utf8Validation.VERIFY);
     }
 
@@ -1178,8 +1178,8 @@ public class DescriptorsTest {
       assertThat(features.getJsonFormat())
           .isEqualTo(DescriptorProtos.FeatureSet.JsonFormat.LEGACY_BEST_EFFORT);
 
-      assertThat(features.getExtension(JavaFeaturesProto.java).getLegacyClosedEnum()).isTrue();
-      assertThat(features.getExtension(JavaFeaturesProto.java).getUtf8Validation())
+      assertThat(features.getExtension(JavaFeaturesProto.java_).getLegacyClosedEnum()).isTrue();
+      assertThat(features.getExtension(JavaFeaturesProto.java_).getUtf8Validation())
           .isEqualTo(JavaFeaturesProto.JavaFeatures.Utf8Validation.DEFAULT);
     }
 
@@ -1198,8 +1198,8 @@ public class DescriptorsTest {
       assertThat(features.getMessageEncoding())
           .isEqualTo(DescriptorProtos.FeatureSet.MessageEncoding.LENGTH_PREFIXED);
 
-      assertThat(features.getExtension(JavaFeaturesProto.java).getLegacyClosedEnum()).isFalse();
-      assertThat(features.getExtension(JavaFeaturesProto.java).getUtf8Validation())
+      assertThat(features.getExtension(JavaFeaturesProto.java_).getLegacyClosedEnum()).isFalse();
+      assertThat(features.getExtension(JavaFeaturesProto.java_).getUtf8Validation())
           .isEqualTo(JavaFeaturesProto.JavaFeatures.Utf8Validation.DEFAULT);
     }
 

--- a/java/core/src/test/proto/com/google/protobuf/test_check_utf8.proto
+++ b/java/core/src/test/proto/com/google/protobuf/test_check_utf8.proto
@@ -12,7 +12,10 @@ edition = "2023";
 
 package proto2_test_check_utf8;
 
-option features.utf8_validation = VERIFY;
+import "google/protobuf/java_features.proto";
+
+option features.utf8_validation = NONE;
+option features.(pb.java).utf8_validation = VERIFY;
 option java_outer_classname = "TestCheckUtf8";
 
 message StringWrapper {

--- a/objectivec/Tests/unittest.proto
+++ b/objectivec/Tests/unittest.proto
@@ -1109,11 +1109,11 @@ message TestNestedGroupExtensionOuter {
     repeated group Layer2RepeatedGroup = 2 {
       extensions 3
         // NOTE: extension metadata is not supported due to targets such as
-        // `//third_party/protobuf_legacy_opensource/src:shell_scripts_test`,
+        // `//google/protobuf_legacy_opensource/src:shell_scripts_test`,
         // eee https://screenshot.googleplex.com/Axz2QD8nxjdpyFF
         //[metadata = {
         // NOTE: can't write type there due to some clever build gen code at
-        // http://google3/net/proto2/internal/BUILD;l=1247;rcl=411090862
+        // http://google3/google/protobuf/BUILD;l=1247;rcl=411090862
         // type: "objc.protobuf.tests.TestNestedGroupExtensionInnerExtension",
         // name: "inner",
         // }]

--- a/src/google/protobuf/compiler/java/names.cc
+++ b/src/google/protobuf/compiler/java/names.cc
@@ -39,16 +39,17 @@ const char* DefaultPackage(Options options) {
 bool IsReservedName(absl::string_view name) {
   static const auto& kReservedNames =
       *new absl::flat_hash_set<absl::string_view>({
-          "abstract",   "assert",       "boolean",   "break",      "byte",
-          "case",       "catch",        "char",      "class",      "const",
-          "continue",   "default",      "do",        "double",     "else",
-          "enum",       "extends",      "final",     "finally",    "float",
-          "for",        "goto",         "if",        "implements", "import",
-          "instanceof", "int",          "interface", "long",       "native",
-          "new",        "package",      "private",   "protected",  "public",
-          "return",     "short",        "static",    "strictfp",   "super",
-          "switch",     "synchronized", "this",      "throw",      "throws",
-          "transient",  "try",          "void",      "volatile",   "while",
+          "abstract", "assert",     "boolean",  "break",     "byte",
+          "case",     "catch",      "char",     "class",     "const",
+          "continue", "default",    "do",       "double",    "else",
+          "enum",     "extends",    "false",    "final",     "finally",
+          "float",    "for",        "goto",     "if",        "implements",
+          "import",   "instanceof", "int",      "interface", "java",
+          "long",     "native",     "new",      "package", "private",
+          "protected",  "public",   "return",    "short", "static",
+          "strictfp",   "super",    "switch",    "synchronized",
+          "this",     "throw",      "throws",   "transient", "true",
+          "try",      "void",       "volatile", "while",
       });
   return kReservedNames.contains(name);
 }

--- a/src/google/protobuf/edition_unittest.proto
+++ b/src/google/protobuf/edition_unittest.proto
@@ -1254,11 +1254,11 @@ message TestNestedGroupExtensionOuter {
     message Layer2RepeatedGroup {
       extensions 3
         // NOTE: extension metadata is not supported due to targets such as
-        // `//third_party/protobuf_legacy_opensource/src:shell_scripts_test`,
+        // `//google/protobuf_legacy_opensource/src:shell_scripts_test`,
         // eee https://screenshot.googleplex.com/Axz2QD8nxjdpyFF
         //[metadata = {
         // NOTE: can't write type there due to some clever build gen code at
-        // http://google3/net/proto2/internal/BUILD;l=1247;rcl=411090862
+        // http://google3/google/protobuf/BUILD;l=1247;rcl=411090862
         // type: "edition_unittest.TestNestedGroupExtensionInnerExtension",
         // name: "inner",
         // }]

--- a/src/google/protobuf/unittest.proto
+++ b/src/google/protobuf/unittest.proto
@@ -1225,11 +1225,11 @@ message TestNestedGroupExtensionOuter {
     repeated group Layer2RepeatedGroup = 2 {
       extensions 3
         // NOTE: extension metadata is not supported due to targets such as
-        // `//third_party/protobuf_legacy_opensource/src:shell_scripts_test`,
+        // `//google/protobuf_legacy_opensource/src:shell_scripts_test`,
         // eee https://screenshot.googleplex.com/Axz2QD8nxjdpyFF
         //[metadata = {
         // NOTE: can't write type there due to some clever build gen code at
-        // http://google3/net/proto2/internal/BUILD;l=1247;rcl=411090862
+        // http://google3/google/protobuf/BUILD;l=1247;rcl=411090862
         // type: "protobuf_unittest.TestNestedGroupExtensionInnerExtension",
         // name: "inner",
         // }]


### PR DESCRIPTION
This prevents shadowing of `java.lang` package commonly used in protobuf gencode. Existing extensions named `java` may or may not previously fail to compile depending on if the contents of their .proto result in gencode using `java.lang`. This is needed to fix `java_features.proto` lite gencode since enum gencode uses `java.lang`. Fields named `java` should already be escaped.

*Warning: This may break user code for existing protos with extensions named `java`. References to the extension should be renamed to use `java_` e.g. registry.add(GeneratedClassName.java_)*

PiperOrigin-RevId: 632508249

Cherry-pick of ffd753fb637b35b9b9c937eec31efc532546da5d