### PR TITLE
support bzlmod for//:protobuf_java and //:protobuf_javalite targets

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -12,6 +12,9 @@ tasks:
     - '--cxxopt=-std=c++14'
     build_targets:
     - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_java'
+    - '@protobuf//:protobuf_java_util'
+    - '@protobuf//:protobuf_javalite'
     - '@protobuf//:protobuf_lite'
     - '@protobuf//:protoc'
     - '@protobuf//:test_messages_proto2_cc_proto'

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@
 
 module(
     name = "protobuf",
-    version = "28.0-dev", # Automatically updated on release
+    version = "28.0-dev",  # Automatically updated on release
     compatibility_level = 1,
     repo_name = "com_google_protobuf",
 )
@@ -15,13 +15,36 @@ module(
 bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "jsoncpp", version = "1.9.5")
+bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_java", version = "5.3.5")
-bazel_dep(name = "rules_jvm_external", version = "5.1")
+bazel_dep(name = "rules_java", version = "6.0.0")
+bazel_dep(name = "rules_jvm_external", version = "6.0")
 bazel_dep(name = "rules_pkg", version = "0.7.0")
 bazel_dep(name = "rules_python", version = "0.10.2")
-bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "zlib", version = "1.2.11")
 
 # TODO: remove after toolchain types are moved to protobuf
 bazel_dep(name = "rules_proto", version = "4.0.0")
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.install(
+    artifacts = [
+        "biz.aQute.bnd:biz.aQute.bndlib:6.4.0",
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.code.gson:gson:2.8.9",
+        "com.google.errorprone:error_prone_annotations:2.18.0",
+        "com.google.guava:guava:32.0.1-jre",
+        "com.google.j2objc:j2objc-annotations:2.8",
+        "info.picocli:picocli:4.6.3",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://repo.maven.apache.org/maven2",
+    ],
+)
+use_repo(
+    maven,
+    "maven",
+)
+
+# -- bazel_dep definitions -- #


### PR DESCRIPTION
* support /:protobuf_java and //:protobuf_javalite with bzlmod 
* upgrade rules_java to 6.0.0 (in MODULE.bazel) 
* upgrade rules_jvm_external to 6.0.0 (in MODULE.bazel) 
* upgrade com.google.errorprone:error_prone_annotations to 2.18.0 (in MODULE.bazel) 


Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
