### PR TITLE
MODULE.bazel fixes for protobuf BCR release.

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,10 +1,15 @@
 matrix:
   platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  bazel: [6.x, 7.x]
 
 tasks:
   verify_targets:
     name: "Verify build targets"
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++14'
     build_targets:
     - '@protobuf//:protobuf'
     - '@protobuf//:protobuf_lite'
@@ -17,9 +22,14 @@ bcr_test_module:
   matrix:
 
     platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
   tasks:
     run_test_module:
       name: "Run test module"
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+      - '--host_cxxopt=-std=c++14'
+      - '--cxxopt=-std=c++14'
       build_targets:
       - "//..."

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,10 +1,8 @@
 # TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
 # https://github.com/protocolbuffers/protobuf/issues/14313
-PROTOBUF_VERSION = "27.0-dev"
-
 module(
     name = "protobuf",
-    version = PROTOBUF_VERSION,
+    version = "27.0-dev", # Automatically updated on release
     compatibility_level = 1,
     repo_name = "com_google_protobuf",
 )


### PR DESCRIPTION
- Specifies bazel version for presubmits
- Set C++14 version (default is c++11 otherwise, which is unsupported)
- Update MODULE.bazel version + updater since publish-to-bcr can't handle constants and adds a duplicate version number

PiperOrigin-RevId: 633729225