### PR TITLE
bazel: Update debian version on bcr CI

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["debian11", "macos", "ubuntu2004", "windows"]
   bazel: [6.x, 7.x]
 
 tasks:
@@ -22,7 +22,7 @@ tasks:
 bcr_test_module:
   module_path: "examples"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["debian11", "macos", "ubuntu2004", "windows"]
     bazel: [6.x, 7.x]
   tasks:
     run_test_module:


### PR DESCRIPTION
Debian buster is EOL next month, it also defaults to gcc 8.x, which no longer builds cleanly because of this issue fixed in 9.x https://stackoverflow.com/a/73511549/902968