### PR TITLE
Removes msvc warning in map

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -559,7 +559,7 @@ class PROTOBUF_EXPORT UntypedMapBase {
 
  protected:
   // 16 bytes is the minimum useful size for the array cache in the arena.
-  constexpr static map_index_t kMinTableSize = 16 / sizeof(void*);
+  enum : map_index_t { kMinTableSize = 16 / sizeof(void*) };
 
  public:
   Arena* arena() const { return this->alloc_.arena(); }

--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -29,7 +29,6 @@
 #include <time.h>
 #endif
 
-#include "google/protobuf/stubs/common.h"
 #include "absl/base/attributes.h"
 #include "absl/container/btree_map.h"
 #include "absl/hash/hash.h"
@@ -41,8 +40,8 @@
 #include "google/protobuf/internal_visibility.h"
 #include "google/protobuf/map_type_handler.h"
 #include "google/protobuf/port.h"
+#include "google/protobuf/stubs/common.h"
 #include "google/protobuf/wire_format_lite.h"
-
 
 #ifdef SWIG
 #error "You cannot SWIG proto headers"
@@ -560,7 +559,7 @@ class PROTOBUF_EXPORT UntypedMapBase {
 
  protected:
   // 16 bytes is the minimum useful size for the array cache in the arena.
-  enum { kMinTableSize = 16 / sizeof(void*) };
+  constexpr static map_index_t kMinTableSize = 16 / sizeof(void*);
 
  public:
   Arena* arena() const { return this->alloc_.arena(); }
@@ -645,9 +644,7 @@ class PROTOBUF_EXPORT UntypedMapBase {
   // Return a power of two no less than max(kMinTableSize, n).
   // Assumes either n < kMinTableSize or n is a power of two.
   map_index_t TableSize(map_index_t n) {
-    return n < static_cast<map_index_t>(kMinTableSize)
-               ? static_cast<map_index_t>(kMinTableSize)
-               : n;
+    return n < kMinTableSize ? kMinTableSize : n;
   }
 
   template <typename T>
@@ -697,7 +694,7 @@ class PROTOBUF_EXPORT UntypedMapBase {
   }
 
   TableEntryPtr* CreateEmptyTable(map_index_t n) {
-    ABSL_DCHECK_GE(n, map_index_t{kMinTableSize});
+    ABSL_DCHECK_GE(n, kMinTableSize);
     ABSL_DCHECK_EQ(n & (n - 1), 0u);
     TableEntryPtr* result = AllocFor<TableEntryPtr>(alloc_).allocate(n);
     memset(result, 0, n * sizeof(result[0]));
@@ -1139,7 +1136,6 @@ template <typename T, typename K>
 bool InitializeMapKey(T*, K&&, Arena*) {
   return false;
 }
-
 
 }  // namespace internal
 


### PR DESCRIPTION
Hi,
We get a compiler warning in MSVC that a signed/unsigned comparison is executed.

The warning is at around line 1073 in src/google/protobuf/map.h
```cpp
ABSL_DCHECK_GE(new_num_buckets, kMinTableSize); // <-- signed/unsigned comparison
const auto old_table = table_;
const map_index_t old_table_size = num_buckets_;
num_buckets_ = new_num_buckets;
```

This is due to `kMinTableSize` is a enum value. Probably a C++98 way to enforce constexpr.

This PR changes `kMinTableSize` to be a constexpr unsigned `map_index_t` and removes the casts instead of fixing the warning with a cast at ne 1073. 
It seems like `kMinTableSize` is correlated with the `TableSize` of this class, which is map_index_t. Therefore the min value can at maximum the max value of map_index_t. And the min value of `kMinTableSize` can also not be negative, as this makes no sense.

It is also nicer to have fewer casts.

