### PR TITLE
Fixes error: array subscription is outside array bounds

### DIFF
--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -412,7 +412,7 @@ class PROTOBUF_EXPORT RepeatedPtrFieldBase {
     // our arena pointer, and we can add to array without resizing it (at
     // least one slot that is not allocated).
     void** elems = elements();
-    if (current_size_ < allocated_size()) {
+    if ((current_size_ > 0) && (current_size_ < allocated_size())) {
       // Make space at [current] by moving first allocated element to end of
       // allocated list.
       elems[allocated_size()] = elems[current_size_];
@@ -436,7 +436,7 @@ class PROTOBUF_EXPORT RepeatedPtrFieldBase {
       // Clear() would leak memory.
       using H = CommonHandler<TypeHandler>;
       Delete<H>(element_at(current_size_), arena_);
-    } else if (current_size_ < allocated_size()) {
+    } else if ((current_size_ > 0) && (current_size_ < allocated_size())) {
       // We have some cleared objects.  We don't care about their order, so we
       // can just move the first one to the end to make space.
       element_at(allocated_size()) = element_at(current_size_);


### PR DESCRIPTION
gcc-13 w. C++17 enabled fails to compile the following code:

google::protobuf::RepeatedPtrField<std::string> r;

with the following error:

In member function 'void google::protobuf::internal::RepeatedPtrFieldBase::AddAllocated(Value<Handler>*) [with TypeHandler = google::protobuf::internal::GenericTypeHandler<std::__cxx11::basic_string<char> >]',
    inlined from 'void google::protobuf::RepeatedPtrField<T>::AddAllocated(Element*) [with Element = std::__cxx11::basic_string<char>]' at /libsystem/build/usr/include/google/protobuf/repeated_ptr_field.h:1522:50,
    inlined from 'pulsar::MessageBuilder& pulsar::MessageBuilder::disableReplication(bool)' at /libsystem/build/sources/apache-pulsar-client-cpp-3.3.0/lib/MessageBuilder.cc:154:23:
/libsystem/build/usr/include/google/protobuf/repeated_ptr_field.h:418:52: error: array subscript [-2147483648, -1] is outside array bounds of 'google::protobuf::RepeatedPtrField<std::__cxx11::basic_string<char> > [1]' [-Werror=array-bounds=]
  418 |       elems[allocated_size()] = elems[current_size_];
      |                                 ~~~~~~~~~~~~~~~~~~~^
/libsystem/build/sources/apache-pulsar-client-cpp-3.3.0/lib/MessageBuilder.cc: In member function 'pulsar::MessageBuilder& pulsar::MessageBuilder::disableReplication(bool)':
/libsystem/build/sources/apache-pulsar-client-cpp-3.3.0/lib/MessageBuilder.cc:152:53: note: at offset [-17179869184, -8] into object 'r' of size 24
  152 |     google::protobuf::RepeatedPtrField<std::string> r;