### PR TITLE
Fix a warning from uninitialized variables

### DIFF
--- a/src/google/protobuf/thread_safe_arena.h
+++ b/src/google/protobuf/thread_safe_arena.h
@@ -76,7 +76,7 @@ class PROTOBUF_EXPORT ThreadSafeArena {
   }
 
   void ReturnArrayMemory(void* p, size_t size) {
-    SerialArena* arena;
+    SerialArena* arena = NULL;
     if (PROTOBUF_PREDICT_TRUE(GetSerialArenaFast(&arena))) {
       arena->ReturnArrayMemory(p, size);
     }
@@ -88,7 +88,7 @@ class PROTOBUF_EXPORT ThreadSafeArena {
   // have fallback function calls in tail position. This substantially improves
   // code for the happy path.
   PROTOBUF_NDEBUG_INLINE bool MaybeAllocateAligned(size_t n, void** out) {
-    SerialArena* arena;
+    SerialArena* arena = NULL;
     if (PROTOBUF_PREDICT_TRUE(GetSerialArenaFast(&arena))) {
       return arena->MaybeAllocateAligned(n, out);
     }


### PR DESCRIPTION
Currently, when a project that includes protobuf is compiled using -Werror, the build will fail due to these variables not being initialized. This fixes this warning allowing the build to complete successfully