### PR TITLE
Export PrivacyInfo.xcprivacy

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,7 +12,10 @@ load(":protobuf.bzl", "internal_objc_proto_library", "internal_php_proto_library
 
 licenses(["notice"])
 
-exports_files(["LICENSE"])
+exports_files([
+    "LICENSE",
+    "PrivacyInfo.xcprivacy",
+])
 
 ################################################################################
 # Well Known Types Proto Library Rules


### PR DESCRIPTION
Export `PrivacyInfo.xcprivacy` file to allow users of protobuf to access the file from Bazel, e.g. to bundle it with an iOS application.