### PR TITLE
Make the underlying type of the enum by 8-bits instead of using bitfi…

### DIFF
--- a/src/google/protobuf/descriptor.h
+++ b/src/google/protobuf/descriptor.h
@@ -2896,7 +2896,7 @@ typename FieldOpts::CType EffectiveStringCType(const FieldDesc* field) {
 }
 
 #ifndef SWIG
-enum class Utf8CheckMode {
+enum class Utf8CheckMode : uint8_t {
   kStrict = 0,  // Parsing will fail if non UTF-8 data is in string fields.
   kVerify = 1,  // Only log an error but parsing will succeed.
   kNone = 2,    // No UTF-8 check.

--- a/src/google/protobuf/generated_message_tctable_gen.h
+++ b/src/google/protobuf/generated_message_tctable_gen.h
@@ -96,7 +96,7 @@ struct PROTOBUF_EXPORT TailCallTableInfo {
     uint16_t type_card;
 
     // For internal caching.
-    cpp::Utf8CheckMode utf8_check_mode : 8;
+    cpp::Utf8CheckMode utf8_check_mode;
   };
   std::vector<FieldEntryInfo> field_entries;
 


### PR DESCRIPTION
…elds for

it.
It silences a warning in gcc 8/9.

PiperOrigin-RevId: 633719795