### PR TITLE
GeneratedMessageV3, SingleFieldBuilderV3, RepeatedFieldBuilderV3 shims for runtime compatibility with 3.25.x.

### DIFF
--- a/compatibility/BUILD.bazel
+++ b/compatibility/BUILD.bazel
@@ -16,5 +16,4 @@ java_runtime_conformance(
 java_runtime_conformance(
     name = "java_conformance_v3.25.0",
     gencode_version = "3.25.0",
-    tags = ["manual"],
 )

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -1,0 +1,73 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package com.google.protobuf;
+
+import java.util.List;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Extension.ExtensionType;
+import com.google.protobuf.GeneratedMessage.ExtendableMessageOrBuilder;
+import com.google.protobuf.GeneratedMessage.ExtensionDescriptorRetriever;
+import com.google.protobuf.GeneratedMessage.FieldAccessorTable;
+/**
+ *  Stub for GeneratedMessageV3 wrapping GeneratedMessage for compatibility with older gencode.
+ *  This class is deprecated, and slated for removal in the next Java breaking change (5.x in 2025 Q1).
+ *  Users should update gencode to >= 4.26.x which uses GeneratedMessage instead of GeneratedMessageV3.
+ */
+@Deprecated
+public abstract class GeneratedMessageV3 extends GeneratedMessage {
+  public static boolean alwaysUseFieldBuilders = GeneratedMessage.alwaysUseFieldBuilders;
+
+  protected GeneratedMessageV3() {
+    super();
+  }
+
+  protected GeneratedMessageV3(Builder<?> builder) {
+    super(builder);
+  }
+
+  @Deprecated
+  public abstract static class ExtendableBuilder<
+          MessageT extends ExtendableMessage<MessageT>,
+          BuilderT extends ExtendableBuilder<MessageT, BuilderT>>
+      extends GeneratedMessage.ExtendableBuilder<MessageT, BuilderT> implements ExtendableMessageOrBuilder<MessageT> {
+    protected ExtendableBuilder() {
+      super();
+    }
+
+    protected ExtendableBuilder(BuilderParent parent) {
+      super(parent);
+    }
+
+    // Support old gencode override method removed in cl/597677225
+    public <T> BuilderT setExtension(
+        final GeneratedMessage.GeneratedExtension<MessageT, T> extension, final T value) {
+      return setExtension((ExtensionLite<MessageT, T>) extension, value);
+    }
+
+    // Support old gencode override method removed in cl/597677225
+    public <T> BuilderT setExtension(
+        final GeneratedMessage.GeneratedExtension<MessageT, List<T>> extension,
+        final int index, final T value) {
+      return setExtension((ExtensionLite<MessageT, List<T>>) extension, index, value);
+    }
+
+    // Support old gencode override method removed in cl/597677225
+    public <T> BuilderT addExtension(
+        final GeneratedMessage.GeneratedExtension<MessageT, List<T>> extension, final T value) {
+      return addExtension((ExtensionLite<MessageT, List<T>>) extension, value);
+    }
+
+    // Support old gencode override method removed in cl/597677225
+    public <T> BuilderT clearExtension(
+        final GeneratedMessage.GeneratedExtension<MessageT, T> extension) {
+      return clearExtension((ExtensionLite<MessageT, T>) extension);
+    }
+  }
+}

--- a/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
@@ -1,0 +1,30 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package com.google.protobuf;
+
+import java.util.List;
+
+/**
+ *  Stub for RepeatedFieldBuilderV3 wrapping RepeatedFieldBuilder for compatibility with older gencode.
+ *  This class is deprecated, and slated for removal in the next breaking change.
+ *  Users should update gencode to >= 4.26.x which replaces RepeatedFieldBuilderV3 with RepeatedFieldBuilder.
+ */
+@Deprecated
+public class RepeatedFieldBuilderV3<
+        MType extends GeneratedMessage,
+        BType extends GeneratedMessage.Builder,
+        IType extends MessageOrBuilder> extends RepeatedFieldBuilder<MType, BType, IType>{
+    
+    public RepeatedFieldBuilderV3(
+      List<MType> messages,
+      boolean isMessagesListMutable,
+      GeneratedMessage.BuilderParent parent,
+      boolean isClean) {
+    super(messages, isMessagesListMutable, parent, isClean);
+  }
+}

--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
@@ -1,0 +1,27 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package com.google.protobuf;
+
+import static com.google.protobuf.Internal.checkNotNull;
+
+/**
+ *  Stub for RepeatedFieldBuilderV3 wrapping RepeatedFieldBuilder for compatibility with older gencode.
+ *  This class is deprecated, and slated for removal in the next breaking change.
+ *  Users should update gencode to >= 4.26.x which replaces RepeatedFieldBuilderV3 with RepeatedFieldBuilder.
+ */
+@Deprecated
+public class SingleFieldBuilderV3<
+        MType extends GeneratedMessage,
+        BType extends GeneratedMessage.Builder,
+        IType extends MessageOrBuilder>
+    extends SingleFieldBuilder<MType, BType, IType> {
+  
+  public SingleFieldBuilderV3(MType message, GeneratedMessage.BuilderParent parent, boolean isClean) {
+    super(message, parent, isClean);
+  }
+}


### PR DESCRIPTION
Tested against //compatibility/java:java_conformance_v3.25.0

(ignore PR, will turn into a CL)