### PR TITLE
Don't use versioned memcpy symbol on linux-x32

### DIFF
--- a/ruby/ext/google/protobuf_c/wrap_memcpy.c
+++ b/ruby/ext/google/protobuf_c/wrap_memcpy.c
@@ -16,7 +16,7 @@
 // This wrapper is enabled by passing the linker flags -Wl,-wrap,memcpy in
 // extconf.rb.
 #ifdef __linux__
-#if defined(__x86_64__) && defined(__GNU_LIBRARY__)
+#if defined(__x86_64__) && defined(__GNU_LIBRARY__) && !defined(__ILP32__)
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
 void *__wrap_memcpy(void *dest, const void *src, size_t n) {
   return memcpy(dest, src, n);


### PR DESCRIPTION
Debian bookworm's x32 libc does not provide the version required here:

```
$ objdump -T /usr/libx32/libc.so.6 | grep memcpy
000aae50  w   DF .text	00000008  GLIBC_2.16  wmemcpy
00110730 g    DF .text	00000018  GLIBC_2.16  __wmemcpy_chk
0010f470 g   iD  .text	00000107  GLIBC_2.16  __memcpy_chk
00095fc0 g   iD  .text	00000107  GLIBC_2.16  memcpy
```

Fixes https://github.com/protocolbuffers/protobuf/issues/17068

cc @acozzette 