### PR TITLE
Change access level of ByteString.AttachBytes() method to public

### DIFF
--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -33,9 +33,9 @@ namespace Google.Protobuf
         private readonly ReadOnlyMemory<byte> bytes;
 
         /// <summary>
-        /// Internal use only. Ensure that the provided memory is not mutated and belongs to this instance.
+        /// Attach provided memory to this instance, ensuring it is not mutated externally.
         /// </summary>
-        internal static ByteString AttachBytes(ReadOnlyMemory<byte> bytes)
+        public static ByteString AttachBytes(ReadOnlyMemory<byte> bytes)
         {
             return new ByteString(bytes);
         }


### PR DESCRIPTION
In some situations, if I already have a ReadOnlyMemory containing data, and I know that this ReadOnlyMemory remains valid throughout the lifetime of ByteString, I would like to directly create a ByteString object based on this existing ReadOnlyMemory, thus avoiding data copying operations.

https://github.com/protocolbuffers/protobuf/issues/17177