### PR TITLE
[C#] Use input Stream.Length if seekable

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
@@ -310,6 +310,9 @@ namespace Google.Protobuf.Collections
             float[] floats = Enumerable.Range(0, 2000).Select(x => (float)x).ToArray();
             uint packedTag = WireFormat.MakeTag(10, WireFormat.WireType.LengthDelimited);
             var stream = new MemoryStream();
+            // Offset the protobuf by 10 bytes in the stream to make sure the deserialization reads both Stream.Length
+            // and Stream.Position.
+            stream.Write(new byte[10], 0, 10);
             var output = new CodedOutputStream(stream);
             var length = floats.Sum(CodedOutputStream.ComputeFloatSize);
             output.WriteTag(packedTag);
@@ -320,7 +323,7 @@ namespace Google.Protobuf.Collections
             }
 
             output.Flush();
-            stream.Position = 0;
+            stream.Position = 10;
 
             // Deliberately "expecting" a non-packed tag, but we detect that the data is
             // actually packed.

--- a/csharp/src/Google.Protobuf/ParsingPrimitives.cs
+++ b/csharp/src/Google.Protobuf/ParsingPrimitives.cs
@@ -754,13 +754,13 @@ namespace Google.Protobuf
         /// <summary>
         /// Checks whether there is known data available of the specified size remaining to parse
         /// in the underlying data source.
-        /// When parsing from a Stream this will return false because we have no knowledge of the amount
+        /// When parsing from a non-seekable Stream this will return false because we have no knowledge of the amount
         /// of data remaining in the stream until it is read.
         /// </summary>
         private static bool IsDataAvailableInSource(ref ParserInternalState state, int size)
         {
             // Data fits in remaining source data.
-            // Note that this will never be true when reading from a stream as the total length is unknown.
+            // Note that this will never be true when reading from a non-seekable stream as the total length is unknown.
             return size <= state.segmentedBufferHelper.TotalLength - state.totalBytesRetired - state.bufferPos;
         }
 

--- a/csharp/src/Google.Protobuf/SegmentedBufferHelper.cs
+++ b/csharp/src/Google.Protobuf/SegmentedBufferHelper.cs
@@ -277,10 +277,10 @@ namespace Google.Protobuf
                 return stream.InternalBuffer.Length;
             }
 
-            // By convention, if CanSeek is true, then the Length should be available.
+            // By convention, if CanSeek is true, then the Length and Position should be available.
             if (stream.InternalInputStream.CanSeek)
             {
-                return stream.InternalInputStream.Length;
+                return stream.InternalInputStream.Length - stream.InternalInputStream.Position;
             }
 
             return null;


### PR DESCRIPTION
Closes #17111.

A large repeated packed field of floats is considered unpacked when the input is a Stream to avoiding allocating more than the input size. Though, if the Stream is a MemoryStream or a FileStream, the Length is known. I'm using Stream.CanSeek to detect that case.

The feature already existing for ROSequence. I'm just extending it for seekable streams.
