### PR TITLE
Update GHA tests to return single pass/fail signal at the end

### DIFF
--- a/.github/workflows/test_bazel.yml
+++ b/.github/workflows/test_bazel.yml
@@ -3,6 +3,10 @@ name: Bazel Tests
 on:
   workflow_call:
     inputs:
+      test-type:
+        required: true
+        description: "The type of test this is run from -- presubmit or continuous"
+        type: string
       safe-checkout:
         required: true
         description: "The SHA key for the commit we want to run over"
@@ -19,33 +23,39 @@ jobs:
         runner: [ ubuntu, windows, macos ]
         bazelversion: [ '7.1.2' ]
         bzlmod: [true, false ]
+        run-on-presubmit: [ true ]
         include:
           - runner: ubuntu
             bazelversion: '6.4.0'
             bzlmod: true
+            run-on-presubmit: false
           - runner: ubuntu
             bazelversion: '6.4.0'
             bzlmod: false
+            run-on-presubmit: false
     runs-on: ${{ matrix.runner }}-latest
-    name: Examples ${{ matrix.runner }} ${{ matrix.bazelversion }}${{ matrix.bzlmod && ' (bzlmod)' || '' }}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Examples ${{ matrix.runner }} ${{ matrix.bazelversion }}${{ matrix.bzlmod && ' (bzlmod)' || '' }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Windows startup flags
-        if: runner.os == 'Windows'
+        if: ${{ runner.os == 'Windows' && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         working-directory: examples
         shell: bash
         run: echo "startup --output_user_root=C:/ --windows_enable_symlinks" >> .bazelrc
 
       - name: Configure Bazel version
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continous' }}
         working-directory: examples
         shell: bash
         run: echo "${{ matrix.bazelversion }}" > .bazelversion
 
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bazel@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -3,6 +3,10 @@ name: C++ Tests
 on:
   workflow_call:
     inputs:
+      test-type:
+        required: true
+        description: "The type of test this is run from -- presubmit or continuous"
+        type: string
       safe-checkout:
         required: true
         description: "The SHA key for the commit we want to run over"
@@ -17,13 +21,13 @@ jobs:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
         config:
-          - { name: Optimized, flags: --config=opt }
-          - { name: Debug, flags: --config=dbg }
-          - { name: ASAN, flags: --config=asan, runner: ubuntu-20-large }
-          - { name: MSAN, flags: --config=docker-msan, runner: ubuntu-20-large }
-          - { name: TSAN, flags: --config=tsan, runner: ubuntu-20-large }
-          - { name: UBSAN, flags: --config=ubsan }
-          - { name: No-RTTI, flags: --cxxopt=-fno-rtti }
+          - { name: Optimized, flags: --config=opt, run-on-presubmit: true }
+          - { name: Debug, flags: --config=dbg, run-on-presubmit: false }
+          - { name: ASAN, flags: --config=asan, runner: ubuntu-20-large, run-on-presubmit: true }
+          - { name: MSAN, flags: --config=docker-msan, runner: ubuntu-20-large, run-on-presubmit: false }
+          - { name: TSAN, flags: --config=tsan, runner: ubuntu-20-large, run-on-presubmit: false }
+          - { name: UBSAN, flags: --config=ubsan, run-on-presubmit: false }
+          - { name: No-RTTI, flags: --cxxopt=-fno-rtti, run-on-presubmit: false }
         include:
           # Set defaults
           - image: us-docker.pkg.dev/protobuf-build/containers/test/linux/sanitize@sha256:3d959f731dc5c54af4865c31ee2bd581ec40028adcdf4c038f3122581f595191
@@ -39,14 +43,16 @@ jobs:
           - config: { name: "aarch64" }
             targets: "//src/... //src/google/protobuf/compiler:protoc_aarch64_test //third_party/utf8_range/..."
             image: "us-docker.pkg.dev/protobuf-build/containers/test/linux/emulation:6.3.0-aarch64-68e662b3a56b881804dc4e9d45f949791cbc4b94"
-    name: Linux ${{ matrix.config.name }}
+    name: ${{ (!matrix.config.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Linux ${{ matrix.config.name }} ${{ !matrix.config.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ${{ matrix.config.runner || 'ubuntu-latest' }}
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.config.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
       - name: Run tests
+        if: ${{ matrix.config.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bazel-docker@v3
         with:
           image: ${{ matrix.image }}
@@ -121,31 +127,38 @@ jobs:
       matrix:
         include:
           - flags: -Dprotobuf_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=14
+            run-on-presubmit: true
           - name: Ninja
             flags: -G Ninja -DCMAKE_CXX_STANDARD=14
+            run-on-presubmit: false
           - name: Shared
             flags: -Dprotobuf_BUILD_SHARED_LIBS=ON -Dprotobuf_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=14
+            run-on-presubmit: false
           - name: C++17
             flags: -DCMAKE_CXX_STANDARD=17
+            run-on-presubmit: true
           # TODO Re-enable this.
           #- name: C++20
           #  flags: -DCMAKE_CXX_STANDARD=20
 
-    name: Linux CMake ${{ matrix.name}}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Linux CMake ${{ matrix.name}} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Setup sccache
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/sccache@v3
         with:
           cache-prefix: linux-cmake
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/docker@v3
         with:
           image: us-docker.pkg.dev/protobuf-build/containers/test/linux/cmake:3.13.3-63dd26c0c7a808d92673a3e52e848189d4ab0f17
@@ -190,6 +203,8 @@ jobs:
 
   linux-cmake-examples:
     name: Linux CMake Examples
+    # Skip this test on presubmit
+    if: ${{ inputs.test-type == 'continuous' }} 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pending changes
@@ -224,27 +239,33 @@ jobs:
         include:
           - name: C++14
             flags: -DCMAKE_CXX_STANDARD=14
+            run-on-presubmit: true
           - name: C++17
             flags: -DCMAKE_CXX_STANDARD=17
+            run-on-presubmit: false
           - name: C++20
             flags: -DCMAKE_CXX_STANDARD=20
+            run-on-presubmit: true
 
-    name: Linux CMake GCC ${{ matrix.name }}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Linux CMake GCC ${{ matrix.name }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
           submodules: recursive
 
       - name: Setup sccache
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/sccache@v3
         with:
           cache-prefix: linux-cmake-gcc
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/docker@v3
         with:
           image: us-docker.pkg.dev/protobuf-build/containers/test/linux/gcc:12.2-6.3.0-63dd26c0c7a808d92673a3e52e848189d4ab0f17
@@ -324,34 +345,41 @@ jobs:
             os: macos-12
             cache_key: macos-12
             bazel: test //src/... //third_party/utf8_range/...
+            run-on-presubmit: true
           - name: MacOS Bazel 7
             os: macos-12
             cache_key: macos-12-bazel7
             bazel: test //src/... //third_party/utf8_range/...
             bazel_version: '7.1.2'
+            run-on-presubmit: false
           - name: MacOS Apple Silicon (build only) Bazel
             os: macos-12
             cache_key: macos-12-arm
             # Current github runners are all Intel based, so just build/compile
             # for Apple Silicon to detect issues there.
             bazel: build --cpu=darwin_arm64 //src/... //third_party/utf8_range/...
+            run-on-presubmit: true
           - name: Windows Bazel
             os: windows-2022
             cache_key: windows-2022
             bazel: test //src/...  @com_google_protobuf_examples//... --test_tag_filters=-conformance --build_tag_filters=-conformance
+            run-on-presubmit: true
           - name: Windows Bazel 7
             os: windows-2022
             cache_key: windows-2022-bazel7
             bazel: test //src/...  @com_google_protobuf_examples//... --test_tag_filters=-conformance --build_tag_filters=-conformance
             bazel_version: '7.1.2'
-    name: ${{ matrix.name }}
+            run-on-presubmit: false
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} ${{ matrix.name }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bazel@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
@@ -377,6 +405,7 @@ jobs:
               -Dprotobuf_BUILD_EXAMPLES=ON
             vsversion: '2022'
             cache-prefix: windows-2022-cmake
+            run-on-presubmit: false
           - name: Windows CMake 2019
             os: windows-2019
             flags: >-
@@ -387,6 +416,7 @@ jobs:
             cache-prefix: windows-2019-cmake
             # windows-2019 has python3.7 installed, which is incompatible with the latest gcloud
             python-version: '3.9'
+            run-on-presubmit: false
           - name: Windows CMake 32-bit
             os: windows-2022
             flags: >-
@@ -394,6 +424,7 @@ jobs:
             vsversion: '2022'
             windows-arch: 'win32'
             cache-prefix: windows-2022-win32-cmake
+            run-on-presubmit: false
           - name: Windows CMake Shared
             os: windows-2022
             flags: >-
@@ -401,6 +432,7 @@ jobs:
               -Dprotobuf_BUILD_SHARED_LIBS=ON
             vsversion: '2022'
             cache-prefix: windows-2022-cmake
+            run-on-presubmit: true
           - name: Windows CMake Install
             os: windows-2022
             install-flags: -G Ninja -Dprotobuf_WITH_ZLIB=OFF -Dprotobuf_BUILD_CONFORMANCE=OFF -Dprotobuf_BUILD_TESTS=OFF
@@ -410,17 +442,19 @@ jobs:
               -Dprotobuf_BUILD_PROTOBUF_BINARIES=OFF
             vsversion: '2022'
             cache-prefix: windows-2022-cmake
-    name: ${{ matrix.name }}
+            run-on-presubmit: false
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} ${{ matrix.name }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout pending changes
+        if: ${{ runner.os == 'Windows' && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
           submodules: recursive
 
       - name: Setup MSVC
-        if: ${{ runner.os == 'Windows' }}
+        if: ${{ runner.os == 'Windows' && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89 # v1.12.1
         with:
           arch: ${{ matrix.windows-arch || 'x64' }}
@@ -428,16 +462,17 @@ jobs:
 
       # Workaround for incompatibility between gcloud and windows-2019 runners.
       - name: Install Python
-        if: ${{ matrix.python-version }}
+        if: ${{ matrix.python-version && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Use custom python for gcloud
-        if: ${{ matrix.python-version }}
+        if: ${{ matrix.python-version  && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         run: echo "CLOUDSDK_PYTHON=${Python3_ROOT_DIR}\\python3" >> $GITHUB_ENV
         shell: bash
 
       - name: Setup sccache
+        if: ${{ runner.os == 'Windows' && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         uses: protocolbuffers/protobuf-ci/sccache@v3
         with:
           cache-prefix: ${{ matrix.cache-prefix }}
@@ -445,42 +480,46 @@ jobs:
 
       # Install phase.
       - name: Configure CMake for install
-        if: matrix.install-flags
+        if: ${{ matrix.install-flags && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         uses: protocolbuffers/protobuf-ci/bash@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: cmake . ${{ matrix.install-flags }} ${{ env.SCCACHE_CMAKE_FLAGS }} -Dprotobuf_ALLOW_CCACHE=ON
       - name: Build for install
-        if: matrix.install-flags
+        if: ${{ matrix.install-flags && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         shell: bash
         run: VERBOSE=1 cmake --build . --parallel 20
       - name: Install
-        if: matrix.install-flags
+        if: ${{ matrix.install-flags && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         shell: bash
         run: cmake --build . --target install
       - name: Report and clear sccache stats
-        if: matrix.install-flags
+        if: ${{ matrix.install-flags && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         shell: bash
         run: sccache -s && sccache -z
       - name: Clear CMake cache
-        if: matrix.install-flags
+        if: ${{ matrix.install-flags && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         shell: bash
         run: cmake --build . --target clean && rm CMakeCache.txt
 
       - name: Configure CMake
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bash@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: cmake . ${{ matrix.flags }} ${{ env.SCCACHE_CMAKE_FLAGS }} -Dprotobuf_ALLOW_CCACHE=ON 
 
       - name: Build
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         shell: bash
         run: VERBOSE=1 cmake --build . --parallel 20
 
       - name: Test
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         shell: bash
         run: ctest --verbose --parallel 20 -C Debug
 
       - name: Report sccache stats
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         shell: bash
         run: sccache -s

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -12,6 +12,8 @@ permissions:
   contents: read
 
 jobs:
+  # All C# jobs are currently run on presubmit
+  # If you wish to add continuous-only jobs you will need to import test-type above
   linux:
     name: Linux
     runs-on: ubuntu-latest

--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -3,6 +3,10 @@ name: Java Tests
 on:
   workflow_call:
     inputs:
+      test-type:
+        required: true
+        description: "The type of test this is run from -- presubmit or continuous"
+        type: string
       safe-checkout:
         required: true
         description: "The SHA key for the commit we want to run over"
@@ -23,28 +27,34 @@ jobs:
             # TODO: b/318555165 - enable the layering check. Currently it does
             # not work correctly with the toolchain in this Docker image.
             targets: //java/... //java/internal:java_version //compatibility/... --features=-layering_check
+            run-on-presubmit: false
           - name: OpenJDK 11
             version: '11'
             image: us-docker.pkg.dev/protobuf-build/containers/test/linux/java:11-1fdbb997433cb22c1e49ef75ad374a8d6bb88702
             targets: //java/... //java/internal:java_version //compatibility/...
+            run-on-presubmit: false
           - name: OpenJDK 17
             version: '17'
             image: us-docker.pkg.dev/protobuf-build/containers/test/linux/java:17-1fdbb997433cb22c1e49ef75ad374a8d6bb88702
             targets: //java/... //java/internal:java_version //compatibility/...
+            run-on-presubmit: true
           - name: aarch64
             version: 'aarch64'
             image: us-docker.pkg.dev/protobuf-build/containers/test/linux/emulation:aarch64-63dd26c0c7a808d92673a3e52e848189d4ab0f17
             targets: //java/... //compatibility/... //src/google/protobuf/compiler:protoc_aarch64_test
+            run-on-presubmit: true
 
-    name: Linux ${{ matrix.name }}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Linux ${{ matrix.name }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pending changes
         uses: protocolbuffers/protobuf-ci/checkout@v3
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         with:
           ref: ${{ inputs.safe-checkout }}
       - name: Run tests
         uses: protocolbuffers/protobuf-ci/bazel-docker@v3
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         with:
           image: ${{ matrix.image }}
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}

--- a/.github/workflows/test_objectivec.yml
+++ b/.github/workflows/test_objectivec.yml
@@ -3,6 +3,10 @@ name: Objective-C Tests
 on:
   workflow_call:
     inputs:
+      test-type:
+        required: true
+        description: "The type of test this is run from -- presubmit or continuous"
+        type: string
       safe-checkout:
         required: true
         description: "The SHA key for the commit we want to run over"
@@ -27,24 +31,32 @@ jobs:
         - platform: "iOS"
           destination: "platform=iOS Simulator,name=iPhone 13,OS=latest"
           xc_project: "ProtocolBuffers_iOS.xcodeproj"
+        # We run presubmits on all "Debug" entries, but not on "Release" entries
+        - xc_config: "Debug"
+          run-on-presubmit: true
+        - xc_config: "Release"
+          run-on-presubmit: false
 
-    name: Xcode ${{ matrix.platform}} ${{ matrix.xc_config }}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Xcode ${{ matrix.platform}} ${{ matrix.xc_config }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: macos-12
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
     steps:
       - name: Checkout pending changes
+        if: ${{ !matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Setup ccache
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/ccache@v3
         with:
           cache-prefix: objectivec_${{ matrix.platform }}_${{ matrix.xc_config }}
           support-modules: true
 
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bash@v3
         env:
           CC: ${{ github.workspace }}/ci/clang_wrapper
@@ -61,6 +73,7 @@ jobs:
               | xcpretty
 
       - name: Report ccache stats
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         shell: bash
         run: ccache -s -v
 
@@ -76,16 +89,24 @@ jobs:
           - OS: macos-14
             PLATFORM: "visionos"
             XCODE: "15.2"
-    name: CocoaPods ${{ matrix.PLATFORM }} ${{ matrix.CONFIGURATION }}
+          # We run presubmits on all "Debug" entries, but not on "Release" entries
+          - CONFIGURATION: "Debug"
+            run-on-presubmit: true
+          - CONFIGURATION: "Release"
+            run-on-presubmit: false
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} CocoaPods ${{ matrix.PLATFORM }} ${{ matrix.CONFIGURATION }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ${{ matrix.OS }}
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
       - name: Xcode version
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.XCODE }}.app
       - name: Pod lib lint
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bazel@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
@@ -105,30 +126,36 @@ jobs:
           - name: Optimized
             flags: --config=opt
             bazel_action: test
+            run-on-presubmit: false
           - name: Debug
             flags: --config=dbg
             bazel_action: test
+            run-on-presubmit: true
           # Current github runners are all Intel based, so just build/compile
           # for Apple Silicon to detect issues there.
           - name: Apple_Silicon_Optimized
             flags: --config=opt --cpu=darwin_arm64
             bazel_action: build
+            run-on-presubmit: false
           - name: Apple_Silicon_Debug
             flags: --config=dbg --cpu=darwin_arm64
             bazel_action: build
+            run-on-presubmit: true
         # TODO: Could add iOS to atleast build the objc_library targets for that.
         platform: ["macOS"]
         include:
         - platform: "macOS"
           bazel_targets: //objectivec/...
-    name: Bazel ${{ matrix.platform }} ${{ matrix.config.name }}
+    name: ${{ (!matrix.config.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Bazel ${{ matrix.platform }} ${{ matrix.config.name }} ${{ !matrix.config.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: macos-12
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.config.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
       - name: bazel ${{ matrix.config.bazel_action }}
+        if: ${{ matrix.config.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bazel@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}

--- a/.github/workflows/test_php.yml
+++ b/.github/workflows/test_php.yml
@@ -4,6 +4,10 @@ name: PHP Tests
 on:
   workflow_call:
     inputs:
+      test-type:
+        required: true
+        description: "The type of test this is run from -- presubmit or continuous"
+        type: string
       safe-checkout:
         required: true
         description: "The SHA key for the commit we want to run over"
@@ -22,37 +26,45 @@ jobs:
             version: "8.1.14"
             version-short: "8.1"
             command: composer test \&\& composer test_c
+            run-on-presubmit: true
           - name: 8.1 Debug
             version: 8.1.14-dbg
             version-short: "8.1"
             command: composer test \&\& composer test_c
+            run-on-presubmit: false
           - name: 8.1 Memory Leak
             version: 8.1.14-dbg
             version-short: "8.1"
             # Run specialized memory leak & multirequest tests.
             command: composer test_c \&\& tests/multirequest.sh \&\& tests/memory_leak_test.sh
+            run-on-presubmit: false
           - name: 8.1 Valgrind
             version: 8.1.14-dbg
             version-short: "8.1"
             command: composer test_valgrind
+            run-on-presubmit: false
           - name: 8.3 Optimized
             version: "8.3.1"
             version-short: "8.3"
             command: composer test \&\& composer test_c
+            run-on-presubmit: true
 
-    name: Linux ${{ matrix.name}}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Linux ${{ matrix.name}} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
       - name: Setup composer
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/composer-setup@v3
         with:
           cache-prefix: php-${{ matrix.version-short }}
           directory: php
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/docker@v3
         with:
           image: us-docker.pkg.dev/protobuf-build/containers/test/linux/php:${{ matrix.version }}-66964dc8b07b6d1fc73a5cc14e59e84c1c534cea
@@ -73,20 +85,27 @@ jobs:
         include:
           - suffix: '-zts'
             suffix_name: ' Thread Safe'
+            run-on-presubmit: false
           - test: 'test_c'
             test_name: ' Extension'
+            run-on-presubmit: false
+          - suffix: ''
+            test: 'test'
+            run-on-presubmit: true
 
-    name: Linux 32-bit ${{ matrix.version}}${{ matrix.suffix_name }}${{ matrix.test_name }}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Linux 32-bit ${{ matrix.version}}${{ matrix.suffix_name }}${{ matrix.test_name }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ubuntu-latest
     env:
       image: us-docker.pkg.dev/protobuf-build/containers/test/linux/32bit@sha256:836f2cedcfe351d9a30055076630408e61994fc7d783e8333a99570968990eeb
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Cross compile protoc for i386
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         id: cross-compile
         uses: protocolbuffers/protobuf-ci/cross-compile-protoc@v3
         with:
@@ -95,12 +114,14 @@ jobs:
           architecture: linux-i386
 
       - name: Setup composer
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/composer-setup@v3
         with:
           cache-prefix: php-${{ matrix.version }}
           directory: php
 
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/docker@v3
         with:
           image: ${{ env.image }}
@@ -155,37 +176,48 @@ jobs:
     strategy:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
-        version: ['8.2', '8.3']
+        include:
+          - version: '8.2'
+            run-on-presubmit: false
+          - version: '8.3'
+            run-on-presubmit: true
 
-    name: MacOS PHP ${{ matrix.version }}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} MacOS PHP ${{ matrix.version }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: macos-12
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Uninstall problematic libgd
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         run: brew uninstall --ignore-dependencies gd
 
       - name: Install dependencies
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         run: brew install coreutils gd
 
       - name: Pin PHP version
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: shivammathur/setup-php@8872c784b04a1420e81191df5d64fbd59d3d3033 # 2.30.2
         with:
           php-version: ${{ matrix.version }}
 
       - name: Check PHP version
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         run: php --version | grep ${{ matrix.version }} || (echo "Invalid PHP version - $(php --version)" && exit 1)
 
       - name: Setup composer
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/composer-setup@v3
         with:
           cache-prefix: php-${{ matrix.version }}
           directory: php
 
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bash@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
@@ -198,6 +230,7 @@ jobs:
             popd
 
       - name: Run conformance tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bazel@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}

--- a/.github/workflows/test_php_ext.yml
+++ b/.github/workflows/test_php_ext.yml
@@ -3,6 +3,10 @@ name: PHP Extension Tests
 on:
   workflow_call:
     inputs:
+      test-type:
+        required: true
+        description: "The type of test this is run from -- presubmit or continuous"
+        type: string
       safe-checkout:
         required: true
         description: "The SHA key for the commit we want to run over"
@@ -41,15 +45,23 @@ jobs:
     strategy:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
-        version: ["8.1", "8.2", "8.3"]
-    name: Build ${{ matrix.version }}
+        include:
+          - version: "8.1"
+            run-on-presubmit: false
+          - version: "8.2"
+            run-on-presubmit: false
+          - version: "8.3"
+            run-on-presubmit: true
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Build ${{ matrix.version }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         with:
           name: protobuf-php-release
 
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/docker@v3
         with:
           image: us-docker.pkg.dev/protobuf-build/containers/test/linux/php-extension:${{ matrix.version }}-a48f26c08d9a803dd0177dda63563f6ea6f7b2d4

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -3,6 +3,10 @@ name: Python Tests
 on:
   workflow_call:
     inputs:
+      test-type:
+        required: true
+        description: "The type of test this is run from -- presubmit or continuous"
+        type: string
       safe-checkout:
         required: true
         description: "The SHA key for the commit we want to run over"
@@ -32,15 +36,26 @@ jobs:
             # TODO Enable this once conformance tests are fixed.
             flags: --define=use_fast_cpp_protos=true --test_tag_filters=-conformance
             image: us-docker.pkg.dev/protobuf-build/containers/test/linux/emulation:aarch64-63dd26c0c7a808d92673a3e52e848189d4ab0f17
+            run-on-presubmit: true
+          - version: "3.8"
+            run-on-presubmit: true
+          - version: "3.9"
+            run-on-presubmit: false
+          - version: "3.10"
+            run-on-presubmit: false
+          - version: "3.11"
+            run-on-presubmit: true
 
-    name: Linux ${{ matrix.type }} ${{ matrix.version }}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Linux ${{ matrix.type }} ${{ matrix.version }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bazel-docker@v3
         with:
           image: ${{ matrix.image || format('us-docker.pkg.dev/protobuf-build/containers/test/linux/python:{0}-63dd26c0c7a808d92673a3e52e848189d4ab0f17', matrix.version) }}

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -3,6 +3,10 @@ name: Ruby Tests
 on:
   workflow_call:
     inputs:
+      test-type:
+        required: true
+        description: "The type of test this is run from -- presubmit or continuous"
+        type: string
       safe-checkout:
         required: true
         description: "The SHA key for the commit we want to run over"
@@ -19,23 +23,25 @@ jobs:
         include:
           # Test both FFI and Native implementations on the highest and lowest
           # Ruby versions for CRuby and JRuby, but only on Bazel 5.x.
-          - { name: Ruby 3.0, ruby: ruby-3.0.2, ffi: NATIVE }
-          - { name: Ruby 3.0, ruby: ruby-3.0.2, ffi: FFI }
-          - { name: Ruby 3.1, ruby: ruby-3.1.0 }
-          - { name: Ruby 3.2, ruby: ruby-3.2.0 }
-          - { name: Ruby 3.3, ruby: ruby-3.3.0, ffi: NATIVE }
-          - { name: Ruby 3.3, ruby: ruby-3.3.0, ffi: FFI }
-          - { name: JRuby 9.4, ruby: jruby-9.4.6.0, ffi: NATIVE }
-          - { name: JRuby 9.4, ruby: jruby-9.4.6.0, ffi: FFI }
+          - { name: Ruby 3.0, ruby: ruby-3.0.2, ffi: NATIVE, run-on-presubmit: true }
+          - { name: Ruby 3.0, ruby: ruby-3.0.2, ffi: FFI, run-on-presubmit: false }
+          - { name: Ruby 3.1, ruby: ruby-3.1.0, run-on-presubmit: false }
+          - { name: Ruby 3.2, ruby: ruby-3.2.0, run-on-presubmit: false }
+          - { name: Ruby 3.3, ruby: ruby-3.3.0, ffi: NATIVE, run-on-presubmit: true }
+          - { name: Ruby 3.3, ruby: ruby-3.3.0, ffi: FFI, run-on-presubmit: false }
+          - { name: JRuby 9.4, ruby: jruby-9.4.6.0, ffi: NATIVE, run-on-presubmit: true }
+          - { name: JRuby 9.4, ruby: jruby-9.4.6.0, ffi: FFI, run-on-presubmit: false }
 
-    name: Linux ${{ matrix.name }}${{ matrix.ffi == 'FFI' && ' FFI' || '' }}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Linux ${{ matrix.name }} ${{ matrix.ffi == 'FFI' && ' FFI' || '' }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bazel-docker@v3
         with:
           image: ${{ matrix.image || format('us-docker.pkg.dev/protobuf-build/containers/test/linux/ruby:{0}-6.3.0-9848710ff1370795ee7517570a20b81e140112ec', matrix.ruby) }}
@@ -120,30 +126,34 @@ jobs:
         # Test both FFI and Native implementations on the highest and lowest
         # Ruby versions for CRuby, but only on Bazel 5.x.
         # Quote versions numbers otherwise 3.0 will render as 3
-        - { version: "3.0", ffi: NATIVE }
-        - { version: "3.0", ffi: FFI }
-        - { version: "3.1" }
-        - { version: "3.2" }
-        - { version: "3.3", ffi: NATIVE }
-        - { version: "3.3", ffi: FFI }
+        - { version: "3.0", ffi: NATIVE, run-on-presubmit: true }
+        - { version: "3.0", ffi: FFI, run-on-presubmit: false }
+        - { version: "3.1", run-on-presubmit: false }
+        - { version: "3.2", run-on-presubmit: false }
+        - { version: "3.3", ffi: NATIVE, run-on-presubmit: true }
+        - { version: "3.3", ffi: FFI, run-on-presubmit: false }
 
-    name: MacOS Ruby ${{ matrix.version }}${{ matrix.ffi == 'FFI' && ' FFI' || '' }}
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} MacOS Ruby ${{ matrix.version }}${{ matrix.ffi == 'FFI' && ' FFI' || '' }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: macos-12
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Pin Ruby version
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: ruby/setup-ruby@961f85197f92e4842e3cb92a4f97bd8e010cdbaf # v1.165.0
         with:
           ruby-version: ${{ matrix.version }}
 
       - name: Validate version
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         run: ruby --version | grep ${{ matrix.version }} || (echo "Invalid Ruby version - $(ruby --version)" && exit 1)
 
       - name: Run tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bazel@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
@@ -165,7 +175,9 @@ jobs:
           - { name: Ruby 3.3, ruby: ruby-3.3.0, ffi: FFI }
           - { name: JRuby 9.4, ruby: jruby-9.4.6.0, ffi: NATIVE }
           - { name: JRuby 9.4, ruby: jruby-9.4.6.0, ffi: FFI }
-    name: Install ${{ matrix.name }}${{ matrix.ffi == 'FFI' && ' FFI' || '' }}
+    name: Install ${{ matrix.name }}${{ matrix.ffi == 'FFI' && ' FFI' || '' }} (Continuous)
+    # None of these ruby gem tests should be run on presubmit
+    if: ${{ inputs.test-type == 'continuous' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pending changes

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -77,6 +77,9 @@ jobs:
       # Store the sha for checkout so we can easily use it later.  For safe
       # events, this will be blank and use the defaults.
       checkout-sha: ${{ steps.safe-checkout.outputs.sha }}
+      # Stores a string denoting whether this is a presubmit or continuous
+      # run. This helps us determine which tests to block on.
+      test-type: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && 'presubmit' || 'continuous' }} 
     steps:
       - name: Check
         # Trivially pass for safe PRs, and explicitly error for unsafe ones
@@ -114,6 +117,7 @@ jobs:
     needs: [check-tag]
     uses: ./.github/workflows/test_bazel.yml
     with:
+      test-type: ${{ needs.check-tag.outputs.test-type }}
       safe-checkout: ${{ needs.check-tag.outputs.checkout-sha }}
     secrets: inherit
 
@@ -122,6 +126,7 @@ jobs:
     needs: [check-tag]
     uses: ./.github/workflows/test_cpp.yml
     with:
+      test-type: ${{ needs.check-tag.outputs.test-type }}
       safe-checkout: ${{ needs.check-tag.outputs.checkout-sha }}
     secrets: inherit
 
@@ -130,6 +135,7 @@ jobs:
     needs: [check-tag]
     uses: ./.github/workflows/test_java.yml
     with:
+      test-type: ${{ needs.check-tag.outputs.test-type }}
       safe-checkout: ${{ needs.check-tag.outputs.checkout-sha }}
     secrets: inherit
 
@@ -138,6 +144,7 @@ jobs:
     needs: [check-tag]
     uses: ./.github/workflows/test_python.yml
     with:
+      test-type: ${{ needs.check-tag.outputs.test-type }}
       safe-checkout: ${{ needs.check-tag.outputs.checkout-sha }}
     secrets: inherit
 
@@ -146,6 +153,7 @@ jobs:
     needs: [check-tag]
     uses: ./.github/workflows/test_ruby.yml
     with:
+      test-type: ${{ needs.check-tag.outputs.test-type }}
       safe-checkout: ${{ needs.check-tag.outputs.checkout-sha }}
     secrets: inherit
 
@@ -154,6 +162,7 @@ jobs:
     needs: [check-tag]
     uses: ./.github/workflows/test_php.yml
     with:
+      test-type: ${{ needs.check-tag.outputs.test-type }}
       safe-checkout: ${{ needs.check-tag.outputs.checkout-sha }}
     secrets: inherit
 
@@ -162,6 +171,7 @@ jobs:
     needs: [check-tag]
     uses: ./.github/workflows/test_php_ext.yml
     with:
+      test-type: ${{ needs.check-tag.outputs.test-type }}
       safe-checkout: ${{ needs.check-tag.outputs.checkout-sha }}
     secrets: inherit
 
@@ -178,6 +188,7 @@ jobs:
     needs: [check-tag]
     uses: ./.github/workflows/test_objectivec.yml
     with:
+      test-type: ${{ needs.check-tag.outputs.test-type }}
       safe-checkout: ${{ needs.check-tag.outputs.checkout-sha }}
     secrets: inherit
 
@@ -194,6 +205,7 @@ jobs:
     needs: [check-tag]
     uses: ./.github/workflows/test_upb.yml
     with:
+      test-type: ${{ needs.check-tag.outputs.test-type }}
       safe-checkout: ${{ needs.check-tag.outputs.checkout-sha }}
     secrets: inherit
 
@@ -206,3 +218,15 @@ jobs:
     with:
       safe-checkout: ${{ needs.check-tag.outputs.checkout-sha }}
     secrets: inherit
+
+  # This test depends on all blocking tests and indicates whether they all suceeded.
+  all_blocking_tests:
+    name: All Blocking Tests
+    needs: [bazel, cpp, java, python, ruby, php, php-ext, csharp, objectivec, rust, upb, staleness]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: "${{ !contains(join(needs.*.result, ' '), 'failure') && !contains(join(needs.*.result, ' '), 'cancelled') && !contains(join(needs.*.result, ' '), 'skipped') }}"
+    # This workflow must run even if one or more of the dependent workflows
+    # failed.
+    if: always()

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
 
 jobs:
+  # This job should be run on presubmit, if any continuous-only tests are added we will need to input test-type above
   linux:
     name: Linux
     runs-on: ubuntu-latest

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -3,6 +3,10 @@ name: μpb Tests
 on:
   workflow_call:
     inputs:
+      test-type:
+        required: true
+        description: "The type of test this is run from -- presubmit or continuous"
+        type: string
       safe-checkout:
         required: true
         description: "The SHA key for the commit we want to run over"
@@ -17,24 +21,26 @@ jobs:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
         config:
-          - { name: "Bazel 7", bazel_version: "7.1.1" }
-          - { name: "Fastbuild" }
-          - { name: "Optimized", flags: "-c opt" }
-          - { name: "ASAN", flags: "--config=asan -c dbg", exclude-targets: "-//benchmarks:benchmark -//python/...", runner: ubuntu-20-large }
-          - { name: "UBSAN", flags: "--config=ubsan -c dbg", exclude-targets: "-//benchmarks:benchmark -//python/... -//lua/..." }
-          - { name: "32-bit", flags: "--copt=-m32 --linkopt=-m32", exclude-targets: "-//benchmarks:benchmark -//python/..." }
+          - { name: "Bazel 7", bazel_version: "7.1.1", run-on-presubmit: false }
+          - { name: "Fastbuild", run-on-presubmit: true }
+          - { name: "Optimized", flags: "-c opt", run-on-presubmit: false }
+          - { name: "ASAN", flags: "--config=asan -c dbg", exclude-targets: "-//benchmarks:benchmark -//python/...", runner: ubuntu-20-large, run-on-presubmit: true }
+          - { name: "UBSAN", flags: "--config=ubsan -c dbg", exclude-targets: "-//benchmarks:benchmark -//python/... -//lua/...", run-on-presubmit: false }
+          - { name: "32-bit", flags: "--copt=-m32 --linkopt=-m32", exclude-targets: "-//benchmarks:benchmark -//python/...", run-on-presubmit: true }
           # TODO: Add 32-bit ASAN test
           # TODO: Restore the FastTable tests
 
-    name: ${{ matrix.config.name }}
+    name: ${{ (!matrix.config.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} ${{ matrix.config.name }} ${{ !matrix.config.run-on-presubmit && '(Continuous)' || '' }}
     runs-on: ${{ matrix.config.runner || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout pending changes
+        if: ${{ matrix.config.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/checkout@v3
         with:
           ref: ${{ inputs.safe-checkout }}
       - name: Run tests
+        if: ${{ matrix.config.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: protocolbuffers/protobuf-ci/bazel-docker@v3
         with:
           image: us-docker.pkg.dev/protobuf-build/containers/test/linux/sanitize:${{ matrix.config.bazel_version || '6.3.0' }}-75f2a85ece6526cc3d54087018c0f1097d78d42b
@@ -161,8 +167,6 @@ jobs:
           path: python/requirements.txt
 
   test_wheels:
-    name: Test Wheels
-    needs: build_wheels
     strategy:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
@@ -171,26 +175,28 @@ jobs:
           # a single wheel. As a result we can just test the oldest and newest
           # supported Python versions and assume this gives us sufficient test
           # coverage.
-          - { os: ubuntu-latest, python-version: "3.8", architecture: x64, type: 'binary' }
-          - { os: macos-11, python-version: "3.8", architecture: x64, type: 'binary' }
-          - { os: ubuntu-latest, python-version: "3.12", architecture: x64, type: 'binary' }
-          - { os: macos-12, python-version: "3.12", architecture: x64, type: 'binary' }
-          - { os: ubuntu-latest, python-version: "3.8", architecture: x64, type: 'source' }
-          - { os: macos-11, python-version: "3.8", architecture: x64, type: 'source' }
-          - { os: ubuntu-latest, python-version: "3.12", architecture: x64, type: 'source' }
-          - { os: macos-12, python-version: "3.12", architecture: x64, type: 'source' }
+          - { os: ubuntu-latest, python-version: "3.8", architecture: x64, type: 'binary', run-on-presubmit: true }
+          - { os: macos-11, python-version: "3.8", architecture: x64, type: 'binary', run-on-presubmit: true }
+          - { os: ubuntu-latest, python-version: "3.12", architecture: x64, type: 'binary', run-on-presubmit: true }
+          - { os: macos-12, python-version: "3.12", architecture: x64, type: 'binary', run-on-presubmit: true }
+          - { os: ubuntu-latest, python-version: "3.8", architecture: x64, type: 'source', run-on-presubmit: false }
+          - { os: macos-11, python-version: "3.8", architecture: x64, type: 'source', run-on-presubmit: false }
+          - { os: ubuntu-latest, python-version: "3.12", architecture: x64, type: 'source', run-on-presubmit: false }
+          - { os: macos-12, python-version: "3.12", architecture: x64, type: 'source', run-on-presubmit: false }
 
           # Windows uses the full API up until Python 3.10.
-          - { os: windows-2019, python-version: "3.8", architecture: x86, type: 'binary' }
-          - { os: windows-2019, python-version: "3.9", architecture: x86, type: 'binary' }
-          - { os: windows-2019, python-version: "3.10", architecture: x86, type: 'binary' }
-          - { os: windows-2019, python-version: "3.11", architecture: x86, type: 'binary' }
-          - { os: windows-2019, python-version: "3.12", architecture: x86, type: 'binary' }
-          - { os: windows-2019, python-version: "3.8", architecture: x64, type: 'binary' }
-          - { os: windows-2019, python-version: "3.9", architecture: x64, type: 'binary' }
-          - { os: windows-2019, python-version: "3.10", architecture: x64, type: 'binary' }
-          - { os: windows-2019, python-version: "3.11", architecture: x64, type: 'binary' }
-          - { os: windows-2019, python-version: "3.12", architecture: x64, type: 'binary' }
+          - { os: windows-2019, python-version: "3.8", architecture: x86, type: 'binary', run-on-presubmit: false }
+          - { os: windows-2019, python-version: "3.9", architecture: x86, type: 'binary', run-on-presubmit: false }
+          - { os: windows-2019, python-version: "3.10", architecture: x86, type: 'binary', run-on-presubmit: false }
+          - { os: windows-2019, python-version: "3.11", architecture: x86, type: 'binary', run-on-presubmit: false }
+          - { os: windows-2019, python-version: "3.12", architecture: x86, type: 'binary', run-on-presubmit: false }
+          - { os: windows-2019, python-version: "3.8", architecture: x64, type: 'binary', run-on-presubmit: true }
+          - { os: windows-2019, python-version: "3.9", architecture: x64, type: 'binary', run-on-presubmit: false }
+          - { os: windows-2019, python-version: "3.10", architecture: x64, type: 'binary', run-on-presubmit: false }
+          - { os: windows-2019, python-version: "3.11", architecture: x64, type: 'binary', run-on-presubmit: false }
+          - { os: windows-2019, python-version: "3.12", architecture: x64, type: 'binary', run-on-presubmit: true }
+    name: ${{ (!matrix.run-on-presubmit && inputs.test-type == 'presubmit') && '[SKIPPED]' || '' }} Test Wheels Python ${{ matrix.python-version }} ${{ matrix.os }} ${{ matrix.architecture }} ${{ matrix.type }} ${{ !matrix.run-on-presubmit && '(Continuous)' || '' }}
+    needs: build_wheels
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'pull_request_target' }}
     defaults:
@@ -198,20 +204,24 @@ jobs:
         shell: bash
     steps:
       - name: Download Wheels
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: actions/download-artifact@v3
         with:
           name: python-wheels
           path: wheels
       - name: Download Requirements
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         uses: actions/download-artifact@v3
         with:
           name: requirements
           path: requirements
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
       - name: Setup Python venv
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         run: |
           python -m pip install --upgrade pip
           python -m venv env
@@ -221,24 +231,28 @@ jobs:
       - name: Install tzdata
         run: pip install tzdata
         # Only needed on Windows, Linux ships with tzdata.
-        if: ${{ contains(matrix.os, 'windows') }}
+        if: ${{ contains(matrix.os, 'windows') && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
       - name: Install requirements
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         run: pip install -r requirements/requirements.txt
       - name: Install Protobuf Binary Wheel
+        if: ${{ matrix.type == 'binary' && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         run: pip install -vvv --no-index --find-links wheels protobuf
-        if: ${{ matrix.type == 'binary' }}
       - name: Install Protobuf Source Wheel
+        if: ${{ matrix.type == 'source' && (matrix.run-on-presubmit || inputs.test-type == 'continuous') }}
         run: |
           cd wheels
           tar -xzvf *.tar.gz
           cd protobuf-*/
           pip install .
-        if: ${{ matrix.type == 'source' }}
       - name: Test that module is importable
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         run: python -v -c 'from google._upb import _message; assert "google._upb._message.MessageMeta" in str(_message.MessageMeta)'
       - name: Install Protobuf Test Wheel
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         run: pip install -vvv --no-index --find-links wheels protobuftests
       - name: Run the unit tests
+        if: ${{ matrix.run-on-presubmit || inputs.test-type == 'continuous' }}
         run: |
           TESTS=$(pip show -f protobuftests | grep pb_unit_tests.*py$ | sed 's,/,.,g' | sed 's,\\,.,g' | sed -E 's,.py$,,g')
           for test in $TESTS; do


### PR DESCRIPTION
Before this PR, we stored a list internally of tests that must pass on presubmit and tried to keep it up to date.

This PR moves that information keeping into GitHub by adding a 'run-on-presubmit' variable to most testing matrices to allow authors to specify which of their tests should serve as submission blockers. During presubmit, tests that were specified to not run on presubmit will not be run and their names will be prefixed with "[SKIPPED]". All continuous only tests will be suffixed with "(Continuous)".

At the end of running all the tests, we have a single "All Blocking Tests" signal that will tell us whether all of the necessary tests have passed (either for presubmit or continuous based on how the test was triggered).

I've tested this from a different branch [here](https://github.com/protocolbuffers/protobuf/actions/runs/9602443750/job/26483341795?pr=17151) and from a different fork: [here](https://github.com/protocolbuffers/protobuf/actions/runs/9602554500/job/26483682665?pr=17192). These should be the same and are as far as I can tell.

I also have a continuous test run [here](https://github.com/protocolbuffers/protobuf/actions/runs/9603824200/job/26487966808) which runs the entire test suite.