### PR TITLE
Use UPB_LONGJMP macro instead of longjmp

### DIFF
--- a/upb/json/encode.c
+++ b/upb/json/encode.c
@@ -47,7 +47,7 @@ static void jsonenc_value(jsonenc* e, const upb_Message* msg,
 
 UPB_NORETURN static void jsonenc_err(jsonenc* e, const char* msg) {
   upb_Status_SetErrorMessage(e->status, msg);
-  longjmp(e->err, 1);
+  UPB_LONGJMP(e->err, 1);
 }
 
 UPB_PRINTF(2, 3)
@@ -56,7 +56,7 @@ UPB_NORETURN static void jsonenc_errf(jsonenc* e, const char* fmt, ...) {
   va_start(argp, fmt);
   upb_Status_VSetErrorFormat(e->status, fmt, argp);
   va_end(argp);
-  longjmp(e->err, 1);
+  UPB_LONGJMP(e->err, 1);
 }
 
 static upb_Arena* jsonenc_arena(jsonenc* e) {


### PR DESCRIPTION
When compiling the upb codebase, I randomly noticed there was one usage of directly calling `longjmp` though it seems the convention is to use the `UPB_LONGJMP` macro. AFAICT, the macro is mostly a wrapper to improve behavior on MacOS, so this may improve behavior there, otherwise it should be just making the code more consistent.