### PR TITLE
Fix string_type bugs in edition 2023

### DIFF
--- a/src/file_lists.cmake
+++ b/src/file_lists.cmake
@@ -1081,6 +1081,7 @@ set(protobuf_test_protos_files
   ${protobuf_SOURCE_DIR}/src/google/protobuf/unittest_proto3_lite.proto
   ${protobuf_SOURCE_DIR}/src/google/protobuf/unittest_proto3_optional.proto
   ${protobuf_SOURCE_DIR}/src/google/protobuf/unittest_retention.proto
+  ${protobuf_SOURCE_DIR}/src/google/protobuf/unittest_string_type.proto
   ${protobuf_SOURCE_DIR}/src/google/protobuf/unittest_string_view.proto
   ${protobuf_SOURCE_DIR}/src/google/protobuf/unittest_well_known_types.proto
 )

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -835,6 +835,7 @@ filegroup(
         "unittest_proto3_lite.proto",
         "unittest_proto3_optional.proto",
         "unittest_retention.proto",
+        "unittest_string_type.proto",
         "unittest_well_known_types.proto",
     ],
     visibility = ["//:__subpackages__"],
@@ -925,6 +926,7 @@ proto_library(
     deps = [
         ":any_proto",
         ":api_proto",
+        ":cpp_features_proto",
         ":descriptor_proto",
         ":duration_proto",
         ":empty_proto",

--- a/src/google/protobuf/compiler/cpp/generator.cc
+++ b/src/google/protobuf/compiler/cpp/generator.cc
@@ -397,9 +397,19 @@ absl::Status CppGenerator::ValidateFeatures(const FileDescriptor* file) const {
                          " specifies string_type=CORD which is not supported "
                          "for extensions."));
       } else if (field.options().has_ctype()) {
-        status = absl::FailedPreconditionError(absl::StrCat(
-            field.full_name(),
-            " specifies both string_type and ctype which is not supported."));
+        // NOTE: this is just a sanity check. This case should never happen
+        // because descriptor builder makes string_type override ctype.
+        const FieldOptions::CType ctype = field.options().ctype();
+        const pb::CppFeatures::StringType string_type =
+            unresolved_features.string_type();
+        if ((ctype == FieldOptions::STRING &&
+             string_type != pb::CppFeatures::STRING) ||
+            (ctype == FieldOptions::CORD &&
+             string_type != pb::CppFeatures::CORD)) {
+          status = absl::FailedPreconditionError(
+              absl::StrCat(field.full_name(),
+                           " specifies inconsistent string_type and ctype."));
+        }
       }
     }
 

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -5457,11 +5457,12 @@ static void InferLegacyProtoFeatures(const FieldDescriptorProto& proto,
 // TODO: we should update proto code to not need ctype to be set
 // when string_type is set.
 static void EnforceCTypeStringTypeConsistency(
-    Edition edition, FieldDescriptor::CppType type,
+    Edition edition, uint8_t type,
     const pb::CppFeatures& cpp_features, FieldOptions& options) {
   if (&options == &FieldOptions::default_instance()) return;
   if (edition < Edition::EDITION_2024 &&
-      type == FieldDescriptor::CPPTYPE_STRING) {
+      (type == FieldDescriptor::TYPE_STRING ||
+        type == FieldDescriptor::TYPE_BYTES)) {
     switch (cpp_features.string_type()) {
       case pb::CppFeatures::CORD:
         options.set_ctype(FieldOptions::CORD);
@@ -6126,7 +6127,7 @@ FileDescriptor* DescriptorBuilder::BuildFileImpl(
 
     internal::VisitDescriptors(*result, [&](const FieldDescriptor& field) {
       EnforceCTypeStringTypeConsistency(
-          field.file()->edition(), field.cpp_type(),
+          field.file()->edition(), field.type_,
           field.merged_features_->GetExtension(pb::cpp),
           const_cast<  // NOLINT(google3-runtime-proto-const-cast)
               FieldOptions&>(*field.options_));

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -3047,6 +3047,10 @@ void FieldDescriptor::CopyTo(FieldDescriptorProto* proto) const {
 
   if (&options() != &FieldOptions::default_instance()) {
     *proto->mutable_options() = options();
+    if (proto_features_->GetExtension(pb::cpp).has_string_type()) {
+      // ctype must have been set in InferLegacyProtoFeatures so avoid copying.
+      proto->mutable_options()->clear_ctype();
+    }
   }
 
   RestoreFeaturesToOptions(proto_features_, proto);
@@ -5450,6 +5454,24 @@ static void InferLegacyProtoFeatures(const FieldDescriptorProto& proto,
   }
 }
 
+// TODO: we should update proto code to not need ctype to be set
+// when string_type is set.
+static void EnforceCTypeStringTypeConsistency(
+    Edition edition, FieldDescriptor::CppType type,
+    const pb::CppFeatures& cpp_features, FieldOptions& options) {
+  if (&options == &FieldOptions::default_instance()) return;
+  if (edition < Edition::EDITION_2024 &&
+      type == FieldDescriptor::CPPTYPE_STRING) {
+    switch (cpp_features.string_type()) {
+      case pb::CppFeatures::CORD:
+        options.set_ctype(FieldOptions::CORD);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
 template <class DescriptorT>
 void DescriptorBuilder::ResolveFeaturesImpl(
     Edition edition, const typename DescriptorT::Proto& proto,
@@ -6067,6 +6089,24 @@ FileDescriptor* DescriptorBuilder::BuildFileImpl(
          iter != options_to_interpret_.end(); ++iter) {
       option_interpreter.InterpretNonExtensionOptions(&(*iter));
     }
+
+    // TODO: move this check back to generator.cc once we no longer
+    // need to set both ctype and string_type internally.
+    internal::VisitDescriptors(
+        *result, proto,
+        [&](const FieldDescriptor& field, const FieldDescriptorProto& proto) {
+          if (field.options_->has_ctype() && field.options_->features()
+                                                 .GetExtension(pb::cpp)
+                                                 .has_string_type()) {
+            AddError(
+                field.full_name(), proto, DescriptorPool::ErrorCollector::TYPE,
+                absl::StrFormat("Field %s specifies both string_type and ctype "
+                                "which is not supported.",
+                                field.full_name())
+                    .c_str());
+          }
+        });
+
     // Handle feature resolution.  This must occur after option interpretation,
     // but before validation.
     internal::VisitDescriptors(
@@ -6083,6 +6123,14 @@ FileDescriptor* DescriptorBuilder::BuildFileImpl(
                   OptionsT*>(descriptor.options_),
               alloc);
         });
+
+    internal::VisitDescriptors(*result, [&](const FieldDescriptor& field) {
+      EnforceCTypeStringTypeConsistency(
+          field.file()->edition(), field.cpp_type(),
+          field.merged_features_->GetExtension(pb::cpp),
+          const_cast<  // NOLINT(google3-runtime-proto-const-cast)
+              FieldOptions&>(*field.options_));
+    });
 
     // Post-process cleanup for field features.
     internal::VisitDescriptors(

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -7514,6 +7514,20 @@ TEST_F(FeaturesTest, Proto2Features) {
       }
       field { name: "utf8" number: 6 label: LABEL_REPEATED type: TYPE_STRING }
       field { name: "req" number: 7 label: LABEL_REQUIRED type: TYPE_INT32 }
+      field {
+        name: "cord"
+        number: 8
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        options { ctype: CORD }
+      }
+      field {
+        name: "piece"
+        number: 9
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        options { ctype: STRING_PIECE }
+      }
     }
     enum_type {
       name: "Foo2"
@@ -7564,6 +7578,10 @@ TEST_F(FeaturesTest, Proto2Features) {
       Utf8CheckMode::kVerify);
   EXPECT_EQ(GetUtf8CheckMode(message->FindFieldByName("str"), /*is_lite=*/true),
             Utf8CheckMode::kNone);
+  EXPECT_EQ(GetCoreFeatures(message->FindFieldByName("cord"))
+                .GetExtension(pb::cpp)
+                .string_type(),
+            pb::CppFeatures::CORD);
   EXPECT_FALSE(field->is_packed());
   EXPECT_FALSE(field->legacy_enum_field_treated_as_closed());
   EXPECT_FALSE(HasPreservingUnknownEnumSemantics(field));

--- a/src/google/protobuf/unittest_string_type.proto
+++ b/src/google/protobuf/unittest_string_type.proto
@@ -1,0 +1,16 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+edition = "2023";
+
+package protobuf_unittest;
+
+import "google/protobuf/cpp_features.proto";
+
+message EntryProto {
+  bytes value = 3 [features.(pb.cpp).string_type = CORD];
+}


### PR DESCRIPTION
We change InferLegacyProtoFeatures to set ctype based on string_type when string_type is set. We need to update CppGenerator::ValidateFeatures to allow both ctype and string_type to be set because it runs after InferLegacyProtoFeatures.

PiperOrigin-RevId: 645480157