### PR TITLE
Fix various unsigned to signed comparison warnings.

### DIFF
--- a/src/google/protobuf/compiler/java/full/enum.cc
+++ b/src/google/protobuf/compiler/java/full/enum.cc
@@ -82,14 +82,13 @@ void EnumNonLiteGenerator::Generate(io::Printer* printer) {
     }
   }
 
-  for (int i = 0; i < canonical_values_.size(); i++) {
+  for (const auto& value : canonical_values_) {
     absl::flat_hash_map<absl::string_view, std::string> vars;
-    vars["name"] = canonical_values_[i]->name();
-    vars["index"] = absl::StrCat(canonical_values_[i]->index());
-    vars["number"] = absl::StrCat(canonical_values_[i]->number());
-    WriteEnumValueDocComment(printer, canonical_values_[i],
-                             context_->options());
-    if (canonical_values_[i]->options().deprecated()) {
+    vars["name"] = value->name();
+    vars["index"] = absl::StrCat(value->index());
+    vars["number"] = absl::StrCat(value->number());
+    WriteEnumValueDocComment(printer, value, context_->options());
+    if (value->options().deprecated()) {
       printer->Print("@java.lang.Deprecated\n");
     }
     if (ordinal_is_index) {
@@ -97,7 +96,7 @@ void EnumNonLiteGenerator::Generate(io::Printer* printer) {
     } else {
       printer->Print(vars, "$name$($index$, $number$),\n");
     }
-    printer->Annotate("name", canonical_values_[i]);
+    printer->Annotate("name", value);
   }
 
   if (!descriptor_->is_closed()) {
@@ -122,15 +121,15 @@ void EnumNonLiteGenerator::Generate(io::Printer* printer) {
   printer->Outdent();
   printer->Print("}\n");
 
-  for (int i = 0; i < aliases_.size(); i++) {
+  for (const auto& alias : aliases_) {
     absl::flat_hash_map<absl::string_view, std::string> vars;
     vars["classname"] = descriptor_->name();
-    vars["name"] = aliases_[i].value->name();
-    vars["canonical_name"] = aliases_[i].canonical_value->name();
-    WriteEnumValueDocComment(printer, aliases_[i].value, context_->options());
+    vars["name"] = alias.value->name();
+    vars["canonical_name"] = alias.canonical_value->name();
+    WriteEnumValueDocComment(printer, alias.value, context_->options());
     printer->Print(
         vars, "public static final $classname$ $name$ = $canonical_name$;\n");
-    printer->Annotate("name", aliases_[i].value);
+    printer->Annotate("name", alias.value);
   }
 
   for (int i = 0; i < descriptor_->value_count(); i++) {
@@ -206,10 +205,9 @@ void EnumNonLiteGenerator::Generate(io::Printer* printer) {
   printer->Indent();
   printer->Indent();
 
-  for (int i = 0; i < canonical_values_.size(); i++) {
-    printer->Print("case $number$: return $name$;\n", "name",
-                   canonical_values_[i]->name(), "number",
-                   absl::StrCat(canonical_values_[i]->number()));
+  for (const auto& value : canonical_values_) {
+    printer->Print("case $number$: return $name$;\n", "name", value->name(),
+                   "number", absl::StrCat(value->number()));
   }
 
   printer->Outdent();

--- a/src/google/protobuf/compiler/java/full/message.cc
+++ b/src/google/protobuf/compiler/java/full/message.cc
@@ -804,8 +804,7 @@ void ImmutableMessageGenerator::GenerateDescriptorMethods(
         "  switch (number) {\n");
     printer->Indent();
     printer->Indent();
-    for (int i = 0; i < map_fields.size(); ++i) {
-      const FieldDescriptor* field = map_fields[i];
+    for (const auto& field : map_fields) {
       const FieldGeneratorInfo* info = context_->GetFieldGeneratorInfo(field);
       printer->Print(
           "case $number$:\n"

--- a/src/google/protobuf/compiler/java/full/message_builder.cc
+++ b/src/google/protobuf/compiler/java/full/message_builder.cc
@@ -211,8 +211,7 @@ void MessageBuilderGenerator::GenerateDescriptorMethods(io::Printer* printer) {
         "  switch (number) {\n");
     printer->Indent();
     printer->Indent();
-    for (int i = 0; i < map_fields.size(); ++i) {
-      const FieldDescriptor* field = map_fields[i];
+    for (const auto& field : map_fields) {
       const FieldGeneratorInfo* info = context_->GetFieldGeneratorInfo(field);
       printer->Print(
           "case $number$:\n"
@@ -237,8 +236,7 @@ void MessageBuilderGenerator::GenerateDescriptorMethods(io::Printer* printer) {
         "  switch (number) {\n");
     printer->Indent();
     printer->Indent();
-    for (int i = 0; i < map_fields.size(); ++i) {
-      const FieldDescriptor* field = map_fields[i];
+    for (const auto& field : map_fields) {
       const FieldGeneratorInfo* info = context_->GetFieldGeneratorInfo(field);
       printer->Print(
           "case $number$:\n"

--- a/src/google/protobuf/compiler/java/lite/enum.cc
+++ b/src/google/protobuf/compiler/java/lite/enum.cc
@@ -67,17 +67,16 @@ void EnumLiteGenerator::Generate(io::Printer* printer) {
   printer->Annotate("classname", descriptor_);
   printer->Indent();
 
-  for (int i = 0; i < canonical_values_.size(); i++) {
+  for (const auto& value : canonical_values_) {
     absl::flat_hash_map<absl::string_view, std::string> vars;
-    vars["name"] = canonical_values_[i]->name();
-    vars["number"] = absl::StrCat(canonical_values_[i]->number());
-    WriteEnumValueDocComment(printer, canonical_values_[i],
-                             context_->options());
-    if (canonical_values_[i]->options().deprecated()) {
+    vars["name"] = value->name();
+    vars["number"] = absl::StrCat(value->number());
+    WriteEnumValueDocComment(printer, value, context_->options());
+    if (value->options().deprecated()) {
       printer->Print("@java.lang.Deprecated\n");
     }
     printer->Print(vars, "$name$($number$),\n");
-    printer->Annotate("name", canonical_values_[i]);
+    printer->Annotate("name", value);
   }
 
   if (!descriptor_->is_closed()) {
@@ -91,15 +90,15 @@ void EnumLiteGenerator::Generate(io::Printer* printer) {
 
   // -----------------------------------------------------------------
 
-  for (int i = 0; i < aliases_.size(); i++) {
+  for (const auto& alias : aliases_) {
     absl::flat_hash_map<absl::string_view, std::string> vars;
     vars["classname"] = descriptor_->name();
-    vars["name"] = aliases_[i].value->name();
-    vars["canonical_name"] = aliases_[i].canonical_value->name();
-    WriteEnumValueDocComment(printer, aliases_[i].value, context_->options());
+    vars["name"] = alias.value->name();
+    vars["canonical_name"] = alias.canonical_value->name();
+    WriteEnumValueDocComment(printer, alias.value, context_->options());
     printer->Print(
         vars, "public static final $classname$ $name$ = $canonical_name$;\n");
-    printer->Annotate("name", aliases_[i].value);
+    printer->Annotate("name", alias.value);
   }
 
   for (int i = 0; i < descriptor_->value_count(); i++) {
@@ -162,10 +161,9 @@ void EnumLiteGenerator::Generate(io::Printer* printer) {
   printer->Indent();
   printer->Indent();
 
-  for (int i = 0; i < canonical_values_.size(); i++) {
-    printer->Print("case $number$: return $name$;\n", "name",
-                   canonical_values_[i]->name(), "number",
-                   absl::StrCat(canonical_values_[i]->number()));
+  for (const auto& value : canonical_values_) {
+    printer->Print("case $number$: return $name$;\n", "name", value->name(),
+                   "number", absl::StrCat(value->number()));
   }
 
   printer->Outdent();

--- a/src/google/protobuf/compiler/rust/relative_path.cc
+++ b/src/google/protobuf/compiler/rust/relative_path.cc
@@ -62,7 +62,7 @@ std::string RelativePath::Relative(const RelativePath& dest) const {
     result.push_back(segment);
   }
   // Push `..` from the common ancestor to the current path.
-  for (int i = 0; i < current_segments.size(); ++i) {
+  for (size_t i = 0; i < current_segments.size(); ++i) {
     result.push_back("..");
   }
   absl::c_reverse(result);

--- a/src/google/protobuf/io/printer.h
+++ b/src/google/protobuf/io/printer.h
@@ -124,8 +124,8 @@ class AnnotationProtoCollector : public AnnotationCollector {
                      const std::string& file_path, const std::vector<int>& path,
                      absl::optional<Semantic> semantic) override {
     auto* annotation = annotation_proto_->add_annotation();
-    for (int i = 0; i < path.size(); ++i) {
-      annotation->add_path(path[i]);
+    for (const auto segment : path) {
+      annotation->add_path(segment);
     }
     annotation->set_source_file(file_path);
     annotation->set_begin(begin_offset);


### PR DESCRIPTION
GCC aggressively emit warnings when comparing unsigned and signed integer types, which causes failures under protobuf's -Werror default. We can fix these often by switching to iterators, but sometimes it's easiest to add a cast or switch a variable type.
