### PR TITLE
Fix windows 2019 staleness issue

### DIFF
--- a/upb_generator/bootstrap_compiler.bzl
+++ b/upb_generator/bootstrap_compiler.bzl
@@ -126,7 +126,14 @@ def _cmake_staleness_test(name, base_dir, src_files, proto_lib_deps, **kwargs):
             name = name + "_copy_gencode_%d" % genrule,
             outs = ["generated_sources/" + src],
             srcs = [name, name + "_minitable"],
-            cmd = "mkdir -p $(@D); for src in $(SRCS); do cp -f $$src $(@D) || echo 'copy failed!'; done",
+            cmd = """
+                mkdir -p $(@D)
+                for src in $(SRCS); do
+                    if [[ $$src == *%s ]]; then
+                        cp -f $$src $(@D) || echo 'copy failed!'
+                    fi
+                done
+            """ % src[src.rfind("/"):],
         )
 
     # Keep bazel gencode in sync with our checked-in sources needed for cmake builds.


### PR DESCRIPTION
Bazel on windows doesn't sandbox very well, and our old strategy for bootstrap staleness test was causing some non-deterministic failures.  Before, we were creating multiple genrules copying the same batch of files, but only marking a specific one as the output of each.  That works fine with proper sandboxing, but on windows can cause conflicts.  With this change, each genrule limits its scope to only copy the 1 file it's meant to generate