### PR TITLE
[Ruby] Fix mismatched pointer type

### DIFF
--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -1510,7 +1510,7 @@ static VALUE MethodDescriptor_initialize(VALUE _self, VALUE cookie,
   }
 
   RB_OBJ_WRITE(_self, &self->descriptor_pool, descriptor_pool);
-  self->methoddef = (const upb_ServiceDef*)NUM2ULL(ptr);
+  self->methoddef = (const upb_MethodDef*)NUM2ULL(ptr);
 
   return Qnil;
 }


### PR DESCRIPTION
This PR fixes the following error on windows ruby 3.4 (head):

```
current directory:
D:/a/sass-embedded-host-ruby/sass-embedded-host-ruby/vendor/bundle/ruby/3.4.0+0/gems/google-protobuf-4.27.1/ext/google/protobuf_c
make.exe DESTDIR\= sitearchdir\=./.gem.20240623-6612-4umz58
sitelibdir\=./.gem.20240623-6612-4umz58
generating protobuf_c-x64-mingw-ucrt.def
compiling protobuf.c
compiling convert.c
compiling defs.c
defs.c: In function 'MethodDescriptor_initialize':
defs.c:1513:19: error: assignment to 'const upb_MethodDef *' from incompatible
pointer type 'const upb_ServiceDef *' [-Wincompatible-pointer-types]
 1513 |   self->methoddef = (const upb_ServiceDef*)NUM2ULL(ptr);
      |                   ^
make: *** [Makefile:250: defs.o] Error 1

make failed, exit code 2
```

- Closes #17266