### PR TITLE
add support for module import prefix on Python compiler

### DIFF
--- a/src/google/protobuf/compiler/python/generator.cc
+++ b/src/google/protobuf/compiler/python/generator.cc
@@ -227,6 +227,9 @@ bool Generator::Generate(const FileDescriptor* file,
     if (options.strip_nonfunctional_codegen) {
       pyi_options.push_back("experimental_strip_nonfunctional_codegen");
     }
+    if (!options.module_import_prefix.empty()) {
+      pyi_options.push_back(absl::StrCat("module_import_prefix", "=", options.module_import_prefix));
+    }
     if (!pyi_generator.Generate(file, absl::StrJoin(pyi_options, ","), context,
                                 error)) {
       return false;

--- a/src/google/protobuf/compiler/python/generator.cc
+++ b/src/google/protobuf/compiler/python/generator.cc
@@ -200,9 +200,9 @@ GeneratorOptions Generator::ParseParameter(absl::string_view parameter,
       options.annotate_pyi = true;
     } else if (option.first == "experimental_strip_nonfunctional_codegen") {
       options.strip_nonfunctional_codegen = true;
-    } else if (options.first == "module_prefix") {
+    } else if (option.first == "module_import_prefix") {
       options.module_import_prefix =
-          std::string(absl::StripSuffix(options[i].second, "."));
+          std::string(absl::StripSuffix(option.second, "."));
     } else {
       *error = absl::StrCat("Unknown generator option: ", option.first);
     }

--- a/src/google/protobuf/compiler/python/generator.cc
+++ b/src/google/protobuf/compiler/python/generator.cc
@@ -461,6 +461,9 @@ void Generator::PrintImports(absl::string_view module_import_prefix) const {
       module_name =
           std::string(absl::StripPrefix(module_name, kThirdPartyPrefix));
     }
+    if (!module_import_prefix.empty()) {
+      module_name = absl::StrCat(module_import_prefix, ".", module_name);
+    }
     printer_->Print("from $module$ import *\n", "module", module_name);
   }
   printer_->Print("\n");

--- a/src/google/protobuf/compiler/python/generator.h
+++ b/src/google/protobuf/compiler/python/generator.h
@@ -47,6 +47,8 @@ namespace python {
 // CodeGenerator with the CommandLineInterface in your main() function.
 
 struct GeneratorOptions {
+  std::string module_import_prefix;
+
   bool generate_pyi = false;
   bool annotate_pyi = false;
   bool bootstrap = false;
@@ -82,7 +84,7 @@ class PROTOC_EXPORT Generator : public CodeGenerator {
  private:
   GeneratorOptions ParseParameter(absl::string_view parameter,
                                   std::string* error) const;
-  void PrintImports() const;
+  void PrintImports(absl::string_view module_import_prefix) const;
   template <typename DescriptorT>
   std::string GetResolvedFeatures(const DescriptorT& descriptor) const;
   void PrintResolvedFeatures() const;

--- a/src/google/protobuf/compiler/python/pyi_generator.cc
+++ b/src/google/protobuf/compiler/python/pyi_generator.cc
@@ -131,9 +131,12 @@ void CheckImportModules(const Descriptor* descriptor,
 
 void PyiGenerator::PrintImportForDescriptor(
     const FileDescriptor& desc, absl::flat_hash_set<std::string>* seen_aliases,
-    bool* has_importlib) const {
+    bool* has_importlib, absl::string_view module_import_prefix) const {
   const std::string& filename = desc.name();
   std::string module_name_owned = StrippedModuleName(filename);
+  if (!module_import_prefix.empty()) {
+    module_name_owned = absl::StrCat(module_import_prefix, ".", StrippedModuleName(filename));
+  }
   absl::string_view module_name(module_name_owned);
   size_t last_dot_pos = module_name.rfind('.');
   std::string alias = absl::StrCat("_", module_name.substr(last_dot_pos + 1));
@@ -173,10 +176,11 @@ void PyiGenerator::PrintImports(absl::string_view module_import_prefix) const {
     if (strip_nonfunctional_codegen_ && IsKnownFeatureProto(dep->name())) {
       continue;
     }
-    PrintImportForDescriptor(*dep, &seen_aliases, &has_importlib);
+    PrintImportForDescriptor(*dep, &seen_aliases, &has_importlib,
+                             module_import_prefix);
     for (int j = 0; j < dep->public_dependency_count(); ++j) {
       PrintImportForDescriptor(*dep->public_dependency(j), &seen_aliases,
-                               &has_importlib);
+                               &has_importlib, module_import_prefix);
     }
   }
 

--- a/src/google/protobuf/compiler/python/pyi_generator.cc
+++ b/src/google/protobuf/compiler/python/pyi_generator.cc
@@ -135,7 +135,8 @@ void PyiGenerator::PrintImportForDescriptor(
   const std::string& filename = desc.name();
   std::string module_name_owned = StrippedModuleName(filename);
   if (!module_import_prefix.empty()) {
-    module_name_owned = absl::StrCat(module_import_prefix, ".", StrippedModuleName(filename));
+    module_name_owned =
+        absl::StrCat(module_import_prefix, ".", module_name_owned);
   }
   absl::string_view module_name(module_name_owned);
   size_t last_dot_pos = module_name.rfind('.');
@@ -266,8 +267,10 @@ void PyiGenerator::PrintImports(absl::string_view module_import_prefix) const {
   // Public imports
   for (int i = 0; i < file_->public_dependency_count(); ++i) {
     const FileDescriptor* public_dep = file_->public_dependency(i);
-    std::string module_name = absl::StrCat(
-        module_import_prefix, StrippedModuleName(public_dep->name()));
+    std::string module_name = StrippedModuleName(public_dep->name());
+    if (!module_import_prefix.empty()) {
+      module_name = absl::StrCat(module_import_prefix, ".", module_name);
+    }
     // Top level messages in public imports
     for (int i = 0; i < public_dep->message_type_count(); ++i) {
       printer_->Print(

--- a/src/google/protobuf/compiler/python/pyi_generator.h
+++ b/src/google/protobuf/compiler/python/pyi_generator.h
@@ -64,7 +64,8 @@ class PROTOC_EXPORT PyiGenerator : public google::protobuf::compiler::CodeGenera
  private:
   void PrintImportForDescriptor(const FileDescriptor& desc,
                                 absl::flat_hash_set<std::string>* seen_aliases,
-                                bool* has_importlib) const;
+                                bool* has_importlib,
+                                absl::string_view module_import_prefix) const;
   template <typename DescriptorT>
   void Annotate(const std::string& label, const DescriptorT* descriptor) const;
   void PrintImports(absl::string_view module_import_prefix) const;

--- a/src/google/protobuf/compiler/python/pyi_generator.h
+++ b/src/google/protobuf/compiler/python/pyi_generator.h
@@ -67,7 +67,7 @@ class PROTOC_EXPORT PyiGenerator : public google::protobuf::compiler::CodeGenera
                                 bool* has_importlib) const;
   template <typename DescriptorT>
   void Annotate(const std::string& label, const DescriptorT* descriptor) const;
-  void PrintImports() const;
+  void PrintImports(absl::string_view module_import_prefix) const;
   void PrintTopLevelEnums() const;
   void PrintEnum(const EnumDescriptor& enum_descriptor) const;
   void PrintEnumValues(const EnumDescriptor& enum_descriptor,
@@ -92,6 +92,7 @@ class PROTOC_EXPORT PyiGenerator : public google::protobuf::compiler::CodeGenera
   mutable const FileDescriptor* file_;  // Set in Generate().  Under mutex_.
   mutable io::Printer* printer_;        // Set in Generate().  Under mutex_.
   mutable bool strip_nonfunctional_codegen_ = false;  // Set in Generate().
+  mutable std::string module_import_prefix;  // Set in Generate().
   // import_map will be a mapping from filename to module alias, e.g.
   // "google3/foo/bar.py" -> "_bar"
   mutable absl::flat_hash_map<std::string, std::string> import_map_;


### PR DESCRIPTION
## Problem
When generating code in monorepos, some generated code is used with a prefix path, see https://rules-proto-grpc.com/en/latest/lang/python.html . 
However, when a prefix_path is used, the generated proto import paths are no longer valid unless the module imports are also prefixed similarly.
This adds an option to support adding an import prefix to the printed imports.

## Approach
This follows a [similar approach already in use in the objectivec compiler](https://github.com/protocolbuffers/protobuf/blob/cbb3abfc4bf342e3f7cff1b657b46db0e1ef1537/src/google/protobuf/compiler/objectivec/generator.cc#L94).

## How did I validate the approach?

I ran some basic manual tests like the following and validated that the module prefix was added to imports:
```
bazel run //src/google/protobuf/compiler:protoc -- --python_out=module_
import_prefix=test.prefix,pyi_out:$(PWD) <path to local repo clone>/csharp/compatibility_tests/v3.0.0/protos/src/google/protobuf/unittest_import_p
roto3.proto --proto_path=<path to local repo clone>/csharp/compatibility_tests/v3.0.0/protos/src
```

The diff when comparing with and without the `module_import_prefix=test.prefix` parameter:
```diff
diff --color=auto -r a/google/protobuf/unittest_import_proto3_pb2.py b/google/protobuf/unittest_import_proto3_pb2.py
25c25
< from google.protobuf import unittest_import_public_proto3_pb2 as google_dot_protobuf_dot_unittest__import__public__proto3__pb2
---
> from test.prefix.google.protobuf import unittest_import_public_proto3_pb2 as google_dot_protobuf_dot_unittest__import__public__proto3__pb2
27c27
< from google.protobuf.unittest_import_public_proto3_pb2 import *
---
> from test.prefix.google.protobuf.unittest_import_public_proto3_pb2 import *
Only in b/google/protobuf: unittest_import_proto3_pb2.pyi
```

## Remaining TODOs
- [ ] Add a test for this feature
- [x] Make sure this feature works with pyi generation

I couldn't find tests for parameter behavior. plugin_unittest, https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/compiler/python/plugin_unittest.cc doesn't test much of the plugin logic.
I would appreciate some guidance in how to add a test for this feature (or if a test is needed).

## Related Issues
* https://github.com/protocolbuffers/protobuf/issues/7061