### PR TITLE
fix pkg-config protobuf library not dependes from utf8_range

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -7,7 +7,6 @@ foreach(_target IN LISTS protobuf_ABSL_USED_TARGETS)
   string(REPLACE :: _ _modified_target ${_modified_target})
   list(APPEND _pc_targets ${_modified_target})
 endforeach()
-list(APPEND _pc_targets "utf8_range")
 
 set(_protobuf_PC_REQUIRES "")
 set(_sep "")

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -49,3 +49,4 @@ set_target_properties(libprotobuf PROPERTIES
 add_library(protobuf::libprotobuf ALIAS libprotobuf)
 
 target_link_libraries(libprotobuf PRIVATE utf8_validity)
+target_link_libraries(libprotobuf PRIVATE utf8_range)


### PR DESCRIPTION
the .pc file generated insert a dependency to a utf8_range.pc file that is not required