### PR TITLE
java: Use `!=` to compare oneof enums in `equals`

### DIFF
--- a/src/google/protobuf/compiler/java/full/message.cc
+++ b/src/google/protobuf/compiler/java/full/message.cc
@@ -993,8 +993,8 @@ void ImmutableMessageGenerator::GenerateEqualsAndHashCode(
   for (auto& kv : oneofs_) {
     const OneofDescriptor* oneof = kv.second;
     printer->Print(
-        "if (!get$oneof_capitalized_name$Case().equals("
-        "other.get$oneof_capitalized_name$Case())) return false;\n",
+        "if (get$oneof_capitalized_name$Case() != "
+        "other.get$oneof_capitalized_name$Case()) return false;\n",
         "oneof_capitalized_name",
         context_->GetOneofGeneratorInfo(oneof)->capitalized_name);
     printer->Print("switch ($oneof_name$Case_) {\n", "oneof_name",


### PR DESCRIPTION
This PR updates the `GenerateEqualsAndHashCode` function to use `!=` for comparing oneof enums instead of the `!equals()` method. This follows the recommendation by static analysis tools like SonarSource [^1] and IntelliJ IDEA [^2].

In addition, Java's enum `equals()` implementation itself uses `==` internally to compare enum values, see https://github.com/openjdk/jdk/blob/jdk-17%2B35/src/java.base/share/classes/java/lang/Enum.java#L154-L164.

Before:

```java
if (!getChoiceCase().equals(other.getChoiceCase())) return false;
```

After:

```java
if (getChoiceCase() != other.getChoiceCase()) return false;
```

[^1]: https://rules.sonarsource.com/java/RSPEC-4551/
[^2]: https://www.jetbrains.com/help/inspectopedia/EqualsCalledOnEnumConstant.html