### PR TITLE
Omit the `_raw_default_instance_` declaration when using DLL linkage.

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         arch: [x86_64, aarch64]
     name: Linux Release ${{ matrix.arch}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20-large
     steps:
       - name: Checkout pending changes
         uses: protocolbuffers/protobuf-ci/checkout@v3

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -19,9 +19,9 @@ jobs:
         config:
           - { name: Optimized, flags: --config=opt }
           - { name: Debug, flags: --config=dbg }
-          - { name: ASAN, flags: --config=asan, runner: ubuntu-20-large }
-          - { name: MSAN, flags: --config=docker-msan, runner: ubuntu-20-large }
-          - { name: TSAN, flags: --config=tsan, runner: ubuntu-20-large }
+          - { name: ASAN, flags: --config=asan, runner: ubuntu-20-4core }
+          - { name: MSAN, flags: --config=docker-msan, runner: ubuntu-20-4core }
+          - { name: TSAN, flags: --config=tsan, runner: ubuntu-20-4core }
           - { name: UBSAN, flags: --config=ubsan }
           - { name: No-RTTI, flags: --cxxopt=-fno-rtti }
         include:
@@ -80,7 +80,7 @@ jobs:
       matrix:
         arch: [x86_64, aarch64]
     name: Linux Release ${{ matrix.arch}}
-    runs-on: ubuntu-20-large
+    runs-on: ubuntu-20-4core
     steps:
       - name: Checkout pending changes
         uses: protocolbuffers/protobuf-ci/checkout@v3

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -172,13 +172,13 @@ jobs:
           # supported Python versions and assume this gives us sufficient test
           # coverage.
           - { os: ubuntu-latest, python-version: "3.8", architecture: x64, type: 'binary' }
-          - { os: macos-11, python-version: "3.8", architecture: x64, type: 'binary' }
+          - { os: macos-12, python-version: "3.8", architecture: x64, type: 'binary' }
           - { os: ubuntu-latest, python-version: "3.12", architecture: x64, type: 'binary' }
-          - { os: macos-12, python-version: "3.12", architecture: x64, type: 'binary' }
+          - { os: macos-13, python-version: "3.12", architecture: x64, type: 'binary' }
           - { os: ubuntu-latest, python-version: "3.8", architecture: x64, type: 'source' }
-          - { os: macos-11, python-version: "3.8", architecture: x64, type: 'source' }
+          - { os: macos-12, python-version: "3.8", architecture: x64, type: 'source' }
           - { os: ubuntu-latest, python-version: "3.12", architecture: x64, type: 'source' }
-          - { os: macos-12, python-version: "3.12", architecture: x64, type: 'source' }
+          - { os: macos-13, python-version: "3.12", architecture: x64, type: 'source' }
 
           # Windows uses the full API up until Python 3.10.
           - { os: windows-2019, python-version: "3.8", architecture: x86, type: 'binary' }

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -20,7 +20,7 @@ jobs:
           - { name: "Bazel 7", bazel_version: "7.1.1" }
           - { name: "Fastbuild" }
           - { name: "Optimized", flags: "-c opt" }
-          - { name: "ASAN", flags: "--config=asan -c dbg", exclude-targets: "-//benchmarks:benchmark -//python/...", runner: ubuntu-20-large }
+          - { name: "ASAN", flags: "--config=asan -c dbg", exclude-targets: "-//benchmarks:benchmark -//python/...", runner: ubuntu-20-4core }
           - { name: "UBSAN", flags: "--config=ubsan -c dbg", exclude-targets: "-//benchmarks:benchmark -//python/... -//lua/..." }
           - { name: "32-bit", flags: "--copt=-m32 --linkopt=-m32", exclude-targets: "-//benchmarks:benchmark -//python/..." }
           # TODO: Add 32-bit ASAN test

--- a/src/google/protobuf/any.pb.h
+++ b/src/google/protobuf/any.pb.h
@@ -281,8 +281,6 @@ class PROTOBUF_EXPORT Any final : public ::google::protobuf::Message
       36, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Any_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/api.pb.h
+++ b/src/google/protobuf/api.pb.h
@@ -241,8 +241,6 @@ class PROTOBUF_EXPORT Mixin final : public ::google::protobuf::Message
       38, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Mixin_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -504,8 +502,6 @@ class PROTOBUF_EXPORT Method final : public ::google::protobuf::Message
       68, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Method_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -785,8 +781,6 @@ class PROTOBUF_EXPORT Api final : public ::google::protobuf::Message
       39, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Api_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/compiler/java/java_features.pb.h
+++ b/src/google/protobuf/compiler/java/java_features.pb.h
@@ -276,8 +276,6 @@ class PROTOC_EXPORT JavaFeatures final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_JavaFeatures_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/compiler/plugin.pb.h
+++ b/src/google/protobuf/compiler/plugin.pb.h
@@ -303,8 +303,6 @@ class PROTOC_EXPORT Version final : public ::google::protobuf::Message
       47, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Version_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -537,8 +535,6 @@ class PROTOC_EXPORT CodeGeneratorResponse_File final : public ::google::protobuf
       86, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_CodeGeneratorResponse_File_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -794,8 +790,6 @@ class PROTOC_EXPORT CodeGeneratorResponse final : public ::google::protobuf::Mes
       60, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_CodeGeneratorResponse_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1063,8 +1057,6 @@ class PROTOC_EXPORT CodeGeneratorRequest final : public ::google::protobuf::Mess
       79, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_CodeGeneratorRequest_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/cpp_features.pb.h
+++ b/src/google/protobuf/cpp_features.pb.h
@@ -278,8 +278,6 @@ class PROTOBUF_EXPORT CppFeatures final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_CppFeatures_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/descriptor.pb.h
+++ b/src/google/protobuf/descriptor.pb.h
@@ -870,8 +870,6 @@ class PROTOBUF_EXPORT UninterpretedOption_NamePart final : public ::google::prot
       62, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_UninterpretedOption_NamePart_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1135,8 +1133,6 @@ class PROTOBUF_EXPORT SourceCodeInfo_Location final : public ::google::protobuf:
       106, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_SourceCodeInfo_Location_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1395,8 +1391,6 @@ class PROTOBUF_EXPORT GeneratedCodeInfo_Annotation final : public ::google::prot
       64, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_GeneratedCodeInfo_Annotation_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1615,8 +1609,6 @@ class PROTOBUF_EXPORT FieldOptions_FeatureSupport final : public ::google::proto
       71, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FieldOptions_FeatureSupport_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1809,8 +1801,6 @@ class PROTOBUF_EXPORT FieldOptions_EditionDefault final : public ::google::proto
       57, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FieldOptions_EditionDefault_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -2348,8 +2338,6 @@ class PROTOBUF_EXPORT FeatureSet final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FeatureSet_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -2587,8 +2575,6 @@ class PROTOBUF_EXPORT ExtensionRangeOptions_Declaration final : public ::google:
       71, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_ExtensionRangeOptions_Declaration_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -2776,8 +2762,6 @@ class PROTOBUF_EXPORT EnumDescriptorProto_EnumReservedRange final : public ::goo
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_EnumDescriptorProto_EnumReservedRange_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -2962,8 +2946,6 @@ class PROTOBUF_EXPORT DescriptorProto_ReservedRange final : public ::google::pro
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_DescriptorProto_ReservedRange_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -3238,8 +3220,6 @@ class PROTOBUF_EXPORT UninterpretedOption final : public ::google::protobuf::Mes
       75, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_UninterpretedOption_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -3424,8 +3404,6 @@ class PROTOBUF_EXPORT SourceCodeInfo final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_SourceCodeInfo_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -3603,8 +3581,6 @@ class PROTOBUF_EXPORT GeneratedCodeInfo final : public ::google::protobuf::Messa
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_GeneratedCodeInfo_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -3812,8 +3788,6 @@ class PROTOBUF_EXPORT FeatureSetDefaults_FeatureSetEditionDefault final : public
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FeatureSetDefaults_FeatureSetEditionDefault_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -4205,8 +4179,6 @@ class PROTOBUF_EXPORT ServiceOptions final : public ::google::protobuf::Message
       0, 12>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_ServiceOptions_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -4587,8 +4559,6 @@ class PROTOBUF_EXPORT OneofOptions final : public ::google::protobuf::Message
       0, 7>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_OneofOptions_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -5012,8 +4982,6 @@ class PROTOBUF_EXPORT MethodOptions final : public ::google::protobuf::Message
       0, 12>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_MethodOptions_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -5455,8 +5423,6 @@ class PROTOBUF_EXPORT MessageOptions final : public ::google::protobuf::Message
       0, 7>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_MessageOptions_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -6149,8 +6115,6 @@ class PROTOBUF_EXPORT FileOptions final : public ::google::protobuf::Message
       202, 12>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FileOptions_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -6800,8 +6764,6 @@ class PROTOBUF_EXPORT FieldOptions final : public ::google::protobuf::Message
       0, 7>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FieldOptions_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -7023,8 +6985,6 @@ class PROTOBUF_EXPORT FeatureSetDefaults final : public ::google::protobuf::Mess
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FeatureSetDefaults_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -7454,8 +7414,6 @@ class PROTOBUF_EXPORT ExtensionRangeOptions final : public ::google::protobuf::M
       0, 12>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_ExtensionRangeOptions_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -7877,8 +7835,6 @@ class PROTOBUF_EXPORT EnumValueOptions final : public ::google::protobuf::Messag
       0, 7>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_EnumValueOptions_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -8297,8 +8253,6 @@ class PROTOBUF_EXPORT EnumOptions final : public ::google::protobuf::Message
       0, 7>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_EnumOptions_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -8502,8 +8456,6 @@ class PROTOBUF_EXPORT OneofDescriptorProto final : public ::google::protobuf::Me
       49, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_OneofDescriptorProto_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -8763,8 +8715,6 @@ class PROTOBUF_EXPORT MethodDescriptorProto final : public ::google::protobuf::M
       71, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_MethodDescriptorProto_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -9155,8 +9105,6 @@ class PROTOBUF_EXPORT FieldDescriptorProto final : public ::google::protobuf::Me
       96, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FieldDescriptorProto_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -9377,8 +9325,6 @@ class PROTOBUF_EXPORT EnumValueDescriptorProto final : public ::google::protobuf
       53, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_EnumValueDescriptorProto_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -9585,8 +9531,6 @@ class PROTOBUF_EXPORT DescriptorProto_ExtensionRange final : public ::google::pr
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_DescriptorProto_ExtensionRange_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -9805,8 +9749,6 @@ class PROTOBUF_EXPORT ServiceDescriptorProto final : public ::google::protobuf::
       51, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_ServiceDescriptorProto_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -10073,8 +10015,6 @@ class PROTOBUF_EXPORT EnumDescriptorProto final : public ::google::protobuf::Mes
       61, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_EnumDescriptorProto_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -10434,8 +10374,6 @@ class PROTOBUF_EXPORT DescriptorProto final : public ::google::protobuf::Message
       65, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_DescriptorProto_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -10846,8 +10784,6 @@ class PROTOBUF_EXPORT FileDescriptorProto final : public ::google::protobuf::Mes
       79, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FileDescriptorProto_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -11042,8 +10978,6 @@ class PROTOBUF_EXPORT FileDescriptorSet final : public ::google::protobuf::Messa
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FileDescriptorSet_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/duration.pb.h
+++ b/src/google/protobuf/duration.pb.h
@@ -221,8 +221,6 @@ class PROTOBUF_EXPORT Duration final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Duration_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/empty.pb.h
+++ b/src/google/protobuf/empty.pb.h
@@ -185,8 +185,6 @@ class PROTOBUF_EXPORT Empty final : public ::google::protobuf::internal::ZeroFie
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Empty_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/field_mask.pb.h
+++ b/src/google/protobuf/field_mask.pb.h
@@ -228,8 +228,6 @@ class PROTOBUF_EXPORT FieldMask final : public ::google::protobuf::Message
       39, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FieldMask_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/source_context.pb.h
+++ b/src/google/protobuf/source_context.pb.h
@@ -216,8 +216,6 @@ class PROTOBUF_EXPORT SourceContext final : public ::google::protobuf::Message
       47, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_SourceContext_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/struct.pb.h
+++ b/src/google/protobuf/struct.pb.h
@@ -262,8 +262,6 @@ class PROTOBUF_EXPORT ListValue final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_ListValue_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -438,8 +436,6 @@ class PROTOBUF_EXPORT Struct final : public ::google::protobuf::Message
       37, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Struct_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -738,8 +734,6 @@ class PROTOBUF_EXPORT Value final : public ::google::protobuf::Message
       42, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Value_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/timestamp.pb.h
+++ b/src/google/protobuf/timestamp.pb.h
@@ -221,8 +221,6 @@ class PROTOBUF_EXPORT Timestamp final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Timestamp_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/type.pb.h
+++ b/src/google/protobuf/type.pb.h
@@ -366,8 +366,6 @@ class PROTOBUF_EXPORT Option final : public ::google::protobuf::Message
       35, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Option_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -726,8 +724,6 @@ class PROTOBUF_EXPORT Field final : public ::google::protobuf::Message
       72, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Field_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -941,8 +937,6 @@ class PROTOBUF_EXPORT EnumValue final : public ::google::protobuf::Message
       38, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_EnumValue_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1229,8 +1223,6 @@ class PROTOBUF_EXPORT Type final : public ::google::protobuf::Message
       46, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Type_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1493,8 +1485,6 @@ class PROTOBUF_EXPORT Enum final : public ::google::protobuf::Message
       40, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Enum_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;

--- a/src/google/protobuf/wrappers.pb.h
+++ b/src/google/protobuf/wrappers.pb.h
@@ -234,8 +234,6 @@ class PROTOBUF_EXPORT UInt64Value final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_UInt64Value_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -405,8 +403,6 @@ class PROTOBUF_EXPORT UInt32Value final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_UInt32Value_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -582,8 +578,6 @@ class PROTOBUF_EXPORT StringValue final : public ::google::protobuf::Message
       41, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_StringValue_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -753,8 +747,6 @@ class PROTOBUF_EXPORT Int64Value final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Int64Value_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -924,8 +916,6 @@ class PROTOBUF_EXPORT Int32Value final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_Int32Value_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1095,8 +1085,6 @@ class PROTOBUF_EXPORT FloatValue final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_FloatValue_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1266,8 +1254,6 @@ class PROTOBUF_EXPORT DoubleValue final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_DoubleValue_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1443,8 +1429,6 @@ class PROTOBUF_EXPORT BytesValue final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_BytesValue_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;
@@ -1614,8 +1598,6 @@ class PROTOBUF_EXPORT BoolValue final : public ::google::protobuf::Message
       0, 2>
       _table_;
 
-  static constexpr const void* _raw_default_instance_ =
-      &_BoolValue_default_instance_;
 
   friend class ::google::protobuf::MessageLite;
   friend class ::google::protobuf::Arena;


### PR DESCRIPTION
Cherry-pick of 79c55cb30f79b227029fbe4cc62a14354c18096d

In that mode we might not be able to make a `constexpr` pointer to the default instance. Omitting the declaration will only turn off an optimization, but the code will still be correct.

Fixes https://github.com/protocolbuffers/protobuf/issues/17303

PiperOrigin-RevId: 649160060