### PR TITLE
Remove codes for unsupported Ruby

### DIFF
--- a/ruby/tests/gc_test.rb
+++ b/ruby/tests/gc_test.rb
@@ -4,9 +4,7 @@
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__)))
 
 old_gc = GC.stress
-# Ruby 2.7.0 - 2.7.1 has a GC bug in its parser, so turn off stress for now
-# See https://bugs.ruby-lang.org/issues/16807
-GC.stress = 0x01 | 0x04 unless RUBY_VERSION.match?(/^2\.7\./)
+GC.stress = 0x01 | 0x04
 require 'generated_code_pb'
 require 'generated_code_proto2_pb'
 GC.stress = old_gc

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -215,28 +215,16 @@ class RepeatedFieldTest < Test::Unit::TestCase
       arr[-5..-1]
     end
     check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
-      # Infinite range; introduce in Ruby 2.7.
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
-        eval "arr[0..]"
-      end
+      eval "arr[0..]"
     end
     check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
-      # Beginless range; introduced in Ruby 2.7.
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
-        eval "arr[..-1]"
-      end
+      eval "arr[..-1]"
     end
     check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
-      # Infinite range; introduce in Ruby 2.7.
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
-        eval "arr[0...]" # Exclusive range
-      end
+      eval "arr[0...]" # Exclusive range
     end
     check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
-      # Beginless range; introduced in Ruby 2.7.
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
-        eval "arr[...-1]" # Exclusive range
-      end
+      eval "arr[...-1]" # Exclusive range
     end
     check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
       arr[-1, 1]


### PR DESCRIPTION
Protocol Buffers  only supports Ruby >= 3.0 since 360531cd0875759dd99ea9f14e75990d73af0910