### PR TITLE
Cherry-pick "Revert workaround for std::mutex issues on github windows runners" and "Downgrade CMake to 3.29 to workaround Abseil issue."

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -426,6 +426,12 @@ jobs:
           arch: ${{ matrix.windows-arch || 'x64' }}
           vsversion: ${{ matrix.vsversion }}
 
+      # Workaround for Abseil incompatibility with CMake 3.30 (b/352354235).
+      - name: Downgrade CMake
+        if: ${{ runner.os == 'Windows' }}
+        run: choco install cmake --version 3.29.6 --force
+        shell: bash
+
       # Workaround for incompatibility between gcloud and windows-2019 runners.
       - name: Install Python
         if: ${{ matrix.python-version }}

--- a/protos/protos_extension_lock_test.cc
+++ b/protos/protos_extension_lock_test.cc
@@ -102,8 +102,6 @@ void TestConcurrentExtensionAccess(::protos::ExtensionRegistry registry) {
   test_theme();
   test_theme_extension();
 }
-#ifndef _MSC_VER
-// TODO Re-enable this once github runner issue is resolved.
 
 TEST(CppGeneratedCode, ConcurrentAccessDoesNotRaceBothLazy) {
   ::upb::Arena arena;
@@ -121,8 +119,6 @@ TEST(CppGeneratedCode, ConcurrentAccessDoesNotRaceBothEager) {
   TestConcurrentExtensionAccess(
       {{&theme, &ThemeExtension::theme_extension}, arena});
 }
-
-#endif  // _MSC_VER
 
 }  // namespace
 }  // namespace protos_generator::test::protos

--- a/src/google/protobuf/compiler/main.cc
+++ b/src/google/protobuf/compiler/main.cc
@@ -35,10 +35,7 @@ namespace protobuf {
 namespace compiler {
 
 int ProtobufMain(int argc, char* argv[]) {
-#ifndef _MSC_VER
-  // TODO Re-enable this once github runner issue is resolved.
   absl::InitializeLog();
-#endif  // !_MSC_VER
 
   CommandLineInterface cli;
   cli.AllowPlugins("protoc-");

--- a/src/google/protobuf/compiler/main_no_generators.cc
+++ b/src/google/protobuf/compiler/main_no_generators.cc
@@ -19,10 +19,7 @@ namespace compiler {
 // This is a version of protoc that has no built-in code generators.
 // See go/protobuf-toolchain-protoc
 int ProtocMain(int argc, char* argv[]) {
-#ifndef _MSC_VER
-  // TODO Re-enable this once github runner issue is resolved.
   absl::InitializeLog();
-#endif  // !_MSC_VER
 
   CommandLineInterface cli;
   cli.AllowPlugins("protoc-");


### PR DESCRIPTION
Cherry-pick of 8d1efddeb6b9948bd23985bd8c7de6cfc6072ef2 and da7b416fc359862bfd2b1fce58cd8e83ff1d5513