### PR TITLE
Downgrade CMake to 3.29 to workaround Abseil issue.

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -426,6 +426,12 @@ jobs:
           arch: ${{ matrix.windows-arch || 'x64' }}
           vsversion: ${{ matrix.vsversion }}
 
+      # Workaround for Abseil incompatibility with CMake 3.30 (b/352354235).
+      - name: Downgrade CMake
+        if: ${{ runner.os == 'Windows' }}
+        run: choco install cmake --version 3.29.6 --force
+        shell: bash
+
       # Workaround for incompatibility between gcloud and windows-2019 runners.
       - name: Install Python
         if: ${{ matrix.python-version }}


### PR DESCRIPTION
This was fixed in https://github.com/abseil/abseil-cpp/commit/cd7f66cab520e99531979b3fd727a25616a1ccbb, but older versions of Abseil break in CMake 3.30, which github runners now use by default.

PiperOrigin-RevId: 651854867

Cherry-pick of da7b416fc359862bfd2b1fce58cd8e83ff1d5513