### PR TITLE
Cherrypick python deprecated warnings for reflection.py and service.py to 28.x

### DIFF
--- a/python/google/protobuf/internal/builder.py
+++ b/python/google/protobuf/internal/builder.py
@@ -105,12 +105,11 @@ def BuildServices(file_des, module_name, module):
     module: Generated _pb2 module
   """
   # pylint: disable=g-import-not-at-top
-  from google.protobuf import service as _service
   from google.protobuf import service_reflection
   # pylint: enable=g-import-not-at-top
   for (name, service) in file_des.services_by_name.items():
     module[name] = service_reflection.GeneratedServiceType(
-        name, (_service.Service,),
+        name, (),
         dict(DESCRIPTOR=service, __module__=module_name))
     stub_name = name + '_Stub'
     module[stub_name] = service_reflection.GeneratedServiceStubType(

--- a/python/google/protobuf/reflection.py
+++ b/python/google/protobuf/reflection.py
@@ -24,6 +24,7 @@ this file*.
 
 __author__ = 'robinson@google.com (Will Robinson)'
 
+import warnings
 
 from google.protobuf import message_factory
 from google.protobuf import symbol_database
@@ -40,7 +41,7 @@ def ParseMessage(descriptor, byte_str):
   """Generate a new Message instance from this Descriptor and a byte string.
 
   DEPRECATED: ParseMessage is deprecated because it is using MakeClass().
-  Please use MessageFactory.GetPrototype() instead.
+  Please use MessageFactory.GetMessageClass() instead.
 
   Args:
     descriptor: Protobuf Descriptor object
@@ -49,6 +50,12 @@ def ParseMessage(descriptor, byte_str):
   Returns:
     Newly created protobuf Message object.
   """
+  warnings.warn(
+      'reflection.ParseMessage() is deprecated. Please use '
+      'MessageFactory.GetMessageClass() and message.ParseFromString() instead. '
+      'reflection.ParseMessage() will be removed in Jan 2025.',
+      stacklevel=2,
+  )
   result_class = MakeClass(descriptor)
   new_msg = result_class()
   new_msg.ParseFromString(byte_str)
@@ -59,13 +66,19 @@ def ParseMessage(descriptor, byte_str):
 def MakeClass(descriptor):
   """Construct a class object for a protobuf described by descriptor.
 
-  DEPRECATED: use MessageFactory.GetPrototype() instead.
+  DEPRECATED: use MessageFactory.GetMessageClass() instead.
 
   Args:
     descriptor: A descriptor.Descriptor object describing the protobuf.
   Returns:
     The Message class object described by the descriptor.
   """
+  warnings.warn(
+      'reflection.MakeClass() is deprecated. Please use '
+      'MessageFactory.GetMessageClass() instead. '
+      'reflection.MakeClass() will be removed in Jan 2025.',
+      stacklevel=2,
+  )
   # Original implementation leads to duplicate message classes, which won't play
   # well with extensions. Message factory info is also missing.
   # Redirect to message_factory.

--- a/python/google/protobuf/service.py
+++ b/python/google/protobuf/service.py
@@ -19,6 +19,14 @@ and can avoid unnecessary layers of indirection.
 
 __author__ = 'petar@google.com (Petar Petrov)'
 
+import warnings
+
+warnings.warn(
+    'google.protobuf.service module is deprecated. RPC implementations '
+    'should provide code generator plugins which generate code specific to '
+    'the RPC implementation. service.py will be removed in Jan 2025',
+    stacklevel=2,
+)
 
 class RpcException(Exception):
   """Exception raised on failed blocking RPC method call."""


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/commit/2967c521a60241c35fb822c1661618493f824dda

https://github.com/protocolbuffers/protobuf/commit/55705f85db9a66da8a3dcbe18b4298594fa0dd6d