### PR TITLE
Show full path in errors with --error_format gcc

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -393,12 +393,7 @@ class CommandLineInterface::ErrorPrinter
                          absl::string_view message, absl::string_view type,
                          std::ostream& out) {
     std::string dfile;
-    if (
-#ifndef PROTOBUF_OPENSOURCE
-        // Print full path when running under MSVS
-        format_ == CommandLineInterface::ERROR_FORMAT_MSVS &&
-#endif  // !PROTOBUF_OPENSOURCE
-        tree_ != nullptr && tree_->VirtualFileToDiskFile(filename, &dfile)) {
+    if (tree_ != nullptr && tree_->VirtualFileToDiskFile(filename, &dfile)) {
       out << dfile;
     } else {
       out << filename;

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -2687,7 +2687,7 @@ TEST_F(CommandLineInterfaceTest, ParseErrors) {
       "--proto_path=$tmpdir foo.proto");
 
   ExpectErrorText(
-      "foo.proto:2:1: Expected top-level statement (e.g. \"message\").\n");
+      "$tmpdir/foo.proto:2:1: Expected top-level statement (e.g. \"message\").\n");
 }
 
 TEST_F(CommandLineInterfaceTest, ParseErrors_DescriptorSetIn) {
@@ -2721,10 +2721,10 @@ TEST_F(CommandLineInterfaceTest, ParseErrorsMultipleFiles) {
       "--proto_path=$tmpdir foo.proto");
 
   ExpectErrorText(
-      "bar.proto:2:1: Expected top-level statement (e.g. \"message\").\n"
-      "baz.proto:2:1: Import \"bar.proto\" was not found or had errors.\n"
-      "foo.proto:2:1: Import \"bar.proto\" was not found or had errors.\n"
-      "foo.proto:3:1: Import \"baz.proto\" was not found or had errors.\n");
+      "$tmpdir/bar.proto:2:1: Expected top-level statement (e.g. \"message\").\n"
+      "$tmpdir/baz.proto:2:1: Import \"bar.proto\" was not found or had errors.\n"
+      "$tmpdir/foo.proto:2:1: Import \"bar.proto\" was not found or had errors.\n"
+      "$tmpdir/foo.proto:3:1: Import \"baz.proto\" was not found or had errors.\n");
 }
 
 TEST_F(CommandLineInterfaceTest, RecursiveImportFails) {
@@ -3188,7 +3188,7 @@ TEST_F(CommandLineInterfaceTest, GccFormatErrors) {
       "--proto_path=$tmpdir --error_format=gcc foo.proto");
 
   ExpectErrorText(
-      "foo.proto:2:1: Expected top-level statement (e.g. \"message\").\n");
+      "$tmpdir/foo.proto:2:1: Expected top-level statement (e.g. \"message\").\n");
 }
 
 TEST_F(CommandLineInterfaceTest, MsvsFormatErrors) {


### PR DESCRIPTION
Currently full path for errors only shown with --error_format msvs.
But gcc will also display the full path that user provided to it.
Thus display full path for both error formats.

Fixes #17507