### PR TITLE
Update absl to 20240722.rc2

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -286,7 +286,7 @@ jobs:
       - name: Run tests
         uses: protocolbuffers/protobuf-ci/docker@v3
         with:
-          image: us-docker.pkg.dev/protobuf-build/containers/test/linux/cmake:3.13.3-63dd26c0c7a808d92673a3e52e848189d4ab0f17
+          image: us-docker.pkg.dev/protobuf-build/containers/test/linux/cmake:3.16.9-f62a3d3bf0f46ee0f2a642927df56328a84bd3b2
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: >-
             /test.sh ${{ env.SCCACHE_CMAKE_FLAGS }}

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -311,7 +311,7 @@ jobs:
       - name: Run tests
         uses: protocolbuffers/protobuf-ci/docker@v3
         with:
-          image: us-docker.pkg.dev/protobuf-build/containers/test/linux/32bit@sha256:8275360dc5d676f3470872d79087901c0e4153453976bea908a92c82e8d209ea
+          image: us-docker.pkg.dev/protobuf-build/containers/test/linux/32bit@sha256:c81788b5b9b40146c84de7c5ab5fd2527dc325ed05f75e23e3140df2249a10b4
           platform: linux/386
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: >-

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -64,8 +64,8 @@ def protobuf_deps():
             repo = "https://github.com/abseil/abseil-cpp",
             # TODO: use Layout::WithStaticSizes in SerialArenaChunk when we update
             # abseil to new release.
-            commit = "ebdba5af75fab91ebe9bc4daa0077f9c57c36692",  # Abseil LTS 20240722.rc1
-            sha256 = "47b0d4cd52bf817cd7ef71f819ece5f24bc2b1d65a59eae75dcad0123456d6f6",
+            commit = "7e5c339b1aa790ae03cc614a8d7626d5b4831891",  # Abseil LTS 20240722.rc2
+            sha256 = "2ad33d08a720fa3a67ec12bd8cf9846da7ed53045163d69047856cc671a0cbe5",
         )
 
     if not native.existing_rule("zlib"):

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -64,8 +64,8 @@ def protobuf_deps():
             repo = "https://github.com/abseil/abseil-cpp",
             # TODO: use Layout::WithStaticSizes in SerialArenaChunk when we update
             # abseil to new release.
-            commit = "4a2c63365eff8823a5221db86ef490e828306f9d",  # Abseil LTS 20240116.0
-            sha256 = "f49929d22751bf70dd61922fb1fd05eb7aec5e7a7f870beece79a6e28f0a06c1",
+            commit = "ebdba5af75fab91ebe9bc4daa0077f9c57c36692",  # Abseil LTS 20240722.rc1
+            sha256 = "47b0d4cd52bf817cd7ef71f819ece5f24bc2b1d65a59eae75dcad0123456d6f6",
         )
 
     if not native.existing_rule("zlib"):


### PR DESCRIPTION
DO_NOT_SUBMIT: This PR tests out the absl pre-release and should be updated to pick up 20240722.0 once actually released.