### PR TITLE
Deprecation in getter is triggered only when field is actually used

### DIFF
--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -575,6 +575,9 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
                          " is deprecated.', E_USER_DEPRECATED);\n        ")
           : "";
 
+  std::string deprecation_trigger_getter =
+      "if ($this->^name^ !== null) {\n    ^deprecation_trigger^\n}";
+
   // Emit getter.
   if (oneof != nullptr) {
     printer->Print(
@@ -584,7 +587,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
         "}\n\n",
         "camel_name", UnderscoresToCamelCase(field->name(), true), "number",
         IntToString(field->number()), "deprecation_trigger",
-        deprecation_trigger);
+        deprecation_trigger_getter);
   } else if (field->has_presence() && !field->message_type()) {
     printer->Print(
         "public function get^camel_name^()\n"
@@ -594,7 +597,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
         "}\n\n",
         "camel_name", UnderscoresToCamelCase(field->name(), true), "name",
         field->name(), "default_value", DefaultForField(field),
-        "deprecation_trigger", deprecation_trigger);
+        "deprecation_trigger", deprecation_trigger_getter);
   } else {
     printer->Print(
         "public function get^camel_name^()\n"
@@ -602,7 +605,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
         "    ^deprecation_trigger^return $this->^name^;\n"
         "}\n\n",
         "camel_name", UnderscoresToCamelCase(field->name(), true), "name",
-        field->name(), "deprecation_trigger", deprecation_trigger);
+        field->name(), "deprecation_trigger", deprecation_trigger_getter);
   }
 
   // Emit hazzers/clear.


### PR DESCRIPTION
See #13428

This is my first commit here, having no experience with this project or language. I think I got it right, but I cannot compile `protoc` to actually test it. Nor do I know if there's an automated test here I need to write/improve. So any help is appreciated to get this through.

This is the build error I'm getting:

```
❯ bazel build :protoc
INFO: Analyzed target //:protoc (0 packages loaded, 0 targets configured).
ERROR: /Users/peter/projects/protobuf/src/google/protobuf/io/BUILD.bazel:98:11: Compiling src/google/protobuf/io/printer.cc failed: (Exit 1): cc_wrapper.sh failed: error executing CppCompile command (from target //src/google/protobuf/io:printer) external/local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics ... (remaining 42 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from src/google/protobuf/io/printer.cc:12:
bazel-out/darwin_arm64-fastbuild/bin/src/google/protobuf/io/_virtual_includes/printer/google/protobuf/io/printer.h:918:19: error: 'get<std::function<bool ()>, std::string, std::function<bool ()>>' is unavailable: introduced in macOS 10.13
    value = absl::get<Callback>(that.value);
                  ^
bazel-out/darwin_arm64-fastbuild/bin/src/google/protobuf/io/_virtual_includes/printer/google/protobuf/io/printer.h:863:11: note: in instantiation of function template specialization 'google::protobuf::io::Printer::ValueImpl<false>::operator=<true>' requested here
    *this = that;
          ^
bazel-out/darwin_arm64-fastbuild/bin/src/google/protobuf/io/_virtual_includes/printer/google/protobuf/io/printer.h:1150:12: note: in instantiation of function template specialization 'google::protobuf::io::Printer::ValueImpl<false>::ValueImpl<true>' requested here
    return ValueView(it->second);
           ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/variant:1581:22: note: 'get<std::function<bool ()>, std::string, std::function<bool ()>>' has been explicitly marked unavailable here
constexpr const _Tp& get(const variant<_Types...>& __v) {
```

Looks like it's the same as in #16944 but I don't know how to apply the workaround for it.

/cc @bshaffer 