### PR TITLE
Remove `/utf-8` flag added in #14197

### DIFF
--- a/build_defs/cpp_opts.bzl
+++ b/build_defs/cpp_opts.bzl
@@ -15,7 +15,6 @@ COPTS = select({
         "/wd4506",  # no definition for inline function 'function'
         "/wd4800",  # 'type' : forcing value to bool 'true' or 'false' (performance warning)
         "/wd4996",  # The compiler encountered a deprecated declaration.
-        "/utf-8",  # Set source and execution character sets to UTF-8
     ],
     "//conditions:default": [
         "-DHAVE_ZLIB",


### PR DESCRIPTION
We have received several reports in #17036 that the addition of this flag actually broke the use of command argument files with non-ASCII characters in their names. It looks like #14253 ended up fixing the original issue with a different solution anyway. Hopefully this change fixes the issue with non-ASCII characters.

PiperOrigin-RevId: 655660885

Cherry-pick of https://github.com/protocolbuffers/protobuf/commit/35cfde6d74160c3aeb5442e8fabc1fd55358220a