### PR TITLE
Fix the doc for `DescriptorPool.lookup`

### DIFF
--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -147,7 +147,7 @@ VALUE DescriptorPool_add_serialized_file(VALUE _self,
  * call-seq:
  *     DescriptorPool.lookup(name) => descriptor
  *
- * Finds a Descriptor, EnumDescriptor or FieldDescriptor by name and returns it,
+ * Finds a Descriptor, EnumDescriptor, FieldDescriptor or ServiceDescriptor by name and returns it,
  * or nil if none exists with the given name.
  */
 static VALUE DescriptorPool_lookup(VALUE _self, VALUE name) {

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyDescriptorPool.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyDescriptorPool.java
@@ -100,8 +100,8 @@ public class RubyDescriptorPool extends RubyObject {
    * call-seq:
    *     DescriptorPool.lookup(name) => descriptor
    *
-   * Finds a Descriptor, EnumDescriptor or FieldDescriptor by name and returns it, or nil if none
-   * exists with the given name.
+   * Finds a Descriptor, EnumDescriptor, FieldDescriptor or ServiceDescriptor by name and returns it,
+   * or nil if none exists with the given name.
    *
    * This currently lazy loads the ruby descriptor objects as they are requested.
    * This allows us to leave the heavy lifting to the java library


### PR DESCRIPTION
`DescriptorPool#lookup` returns `ServiceDescriptor` too since #15817.
