### PR TITLE
Fixed a SEGV when deep copying a non-reified sub-message.

### DIFF
--- a/python/google/protobuf/internal/reflection_test.py
+++ b/python/google/protobuf/internal/reflection_test.py
@@ -789,6 +789,11 @@ class ReflectionTest(unittest.TestCase):
     messages.remove(messages[0])
     self.assertEqual(len(messages), 0)
 
+  def testEmptyDeepCopy(self, message_module):
+    proto1 = message_module.TestAllTypes()
+    nested2 = copy.deepcopy(proto1.optional_nested_message)
+    self.assertEqual(0, nested2.bb)
+
     # TODO: Implement deepcopy for extension dict
 
   def testDisconnectingBeforeClear(self, message_module):

--- a/python/message.c
+++ b/python/message.c
@@ -1610,10 +1610,13 @@ static PyObject* PyUpb_Message_WhichOneof(PyObject* _self, PyObject* name) {
 PyObject* DeepCopy(PyObject* _self, PyObject* arg) {
   PyUpb_Message* self = (void*)_self;
   const upb_MessageDef* def = PyUpb_Message_GetMsgdef(_self);
-
+  const upb_MiniTable* mini_table = upb_MessageDef_MiniTable(def);
+  upb_Message* msg = PyUpb_Message_GetIfReified(_self);
   PyObject* arena = PyUpb_Arena_New();
-  upb_Message* clone = upb_Message_DeepClone(
-      self->ptr.msg, upb_MessageDef_MiniTable(def), PyUpb_Arena_Get(arena));
+  upb_Arena* upb_arena = PyUpb_Arena_Get(arena);
+
+  upb_Message* clone = msg ? upb_Message_DeepClone(msg, mini_table, upb_arena)
+                           : upb_Message_New(mini_table, upb_arena);
   PyObject* ret = PyUpb_Message_Get(clone, def, arena);
   Py_DECREF(arena);
 


### PR DESCRIPTION
PiperOrigin-RevId: 600951523

Cherry-pick of b9e4894462fab2e35da987a44fbe464b4c1d0140

Fixes https://github.com/protocolbuffers/protobuf/issues/17675