### PR TITLE
make hasOptionalKeyword function public

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/Descriptors.java
+++ b/java/core/src/main/java/com/google/protobuf/Descriptors.java
@@ -1443,7 +1443,7 @@ public final class Descriptors {
      * Returns true if this field was syntactically written with "optional" in the .proto file.
      * Excludes singular proto3 fields that do not have a label.
      */
-    boolean hasOptionalKeyword() {
+    public boolean hasOptionalKeyword() {
       return isProto3Optional
           || (file.getEdition() == Edition.EDITION_PROTO2
               && isOptional()


### PR DESCRIPTION
Hi, I am currently migrating my third party Kotlin protobuf code generation libaray, krotoDC from protobuf v3 to v4.
However, I noticed that `FieldDescriptor::hasOptionalKeyword()` has become package-private. My library relies on this api to check if the field is private or not. can we please make this function public again?