### PR TITLE
Cherry-pick rust visibility fix and removal of rust from BCR presubmit to 28.x

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -14,7 +14,6 @@ tasks:
     - '@protobuf//:protobuf'
     - '@protobuf//:protobuf_lite'
     - '@protobuf//:protobuf_python'
-    - '@protobuf//:protobuf_rust'
     - '@protobuf//:protoc'
     - '@protobuf//:test_messages_proto2_cc_proto'
     - '@protobuf//:test_messages_proto3_cc_proto'

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -6,6 +6,7 @@ load("//bazel/toolchains:proto_lang_toolchain.bzl", "proto_lang_toolchain")
 
 package(
     default_visibility = [
+        "//:__pkg__",  # "public" targets are alias rules in //.
         "//src/google/protobuf:__subpackages__",
     ],
 )


### PR DESCRIPTION
PiperOrigin-RevId: 652511009

Cherry-pick of 956ce0f3fdbcd15e2eb15929512617750d0162a9 and 3a79dc7a0960b5d199a7885345fc987db378c26b