### PR TITLE
Fix warnings when compiling protobuf with C++20

### DIFF
--- a/src/google/protobuf/map.cc
+++ b/src/google/protobuf/map.cc
@@ -17,7 +17,6 @@
 #include "absl/strings/string_view.h"
 #include "google/protobuf/message_lite.h"
 
-
 // Must be included last.
 #include "google/protobuf/port_def.inc"
 
@@ -120,7 +119,7 @@ void UntypedMapBase::ClearTable(const ClearInput input) {
   ABSL_DCHECK_NE(num_buckets_, kGlobalEmptyTableSize);
 
   if (alloc_.arena() == nullptr) {
-      const auto loop = [this, input](auto destroy_node) {
+    const auto loop = [this, input](auto destroy_node) {
       const TableEntryPtr* table = table_;
       for (map_index_t b = index_of_first_non_null_, end = num_buckets_;
            b < end; ++b) {

--- a/src/google/protobuf/map.cc
+++ b/src/google/protobuf/map.cc
@@ -120,7 +120,7 @@ void UntypedMapBase::ClearTable(const ClearInput input) {
   ABSL_DCHECK_NE(num_buckets_, kGlobalEmptyTableSize);
 
   if (alloc_.arena() == nullptr) {
-    const auto loop = [=](auto destroy_node) {
+      const auto loop = [this, input](auto destroy_node) {
       const TableEntryPtr* table = table_;
       for (map_index_t b = index_of_first_non_null_, end = num_buckets_;
            b < end; ++b) {


### PR DESCRIPTION
## What is the problem? 

I got these warnings when compiling gRPC libraries on Linux.
```text
/home/hungptit/working/experiments/_deps/grpc-src/third_party/protobuf/src/google/protobuf/map.cc:124:36: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
  124 |       const TableEntryPtr* table = table_;
      |                                    ^
/home/hungptit/working/experiments/_deps/grpc-src/third_party/protobuf/src/google/protobuf/map.cc:123:24: note: add an explicit capture of 'this' to capture '*this' by reference
  123 |     const auto loop = [=](auto destroy_node) {
      |                        ^
      |                         , this
1 warning generated.
/home/hungptit/working/experiments/_deps/grpc-src/third_party/protobuf/src/google/protobuf/map.cc:124:36: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
  124 |       const TableEntryPtr* table = table_;
      |                                    ^
/home/hungptit/working/experiments/_deps/grpc-src/third_party/protobuf/src/google/protobuf/map.cc:123:24: note: add an explicit capture of 'this' to capture '*this' by reference
  123 |     const auto loop = [=](auto destroy_node) {
      |                        ^
      |                         , this
1 warning generated.
```

 We can reproduce these warnings by configuring protobuf using these steps: 
```shell
cmake ./ -DCMAKE_CXX_COMPILER=clang++ -Dprotobuf_BUILD_TESTS=OFF -DABSL_PROPAGATE_CXX_STD=ON -CMAKE_CXX_STANDARD=20 -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
cmake --build ./
``` 

## Solution

* Capture `this` and `input` by values. 
