### PR TITLE
Binary compatibility shims for GeneratedMessageV3 and nested classes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -231,6 +231,7 @@ http_archive(
     name = "com_google_protobuf_v25.0",
     strip_prefix = "protobuf-25.0",
     url = "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protobuf-25.0.tar.gz",
+    sha256 = "7beed9c511d632cff7c22ac0094dd7720e550153039d5da7e059bcceb488474a",
 )
 
 # Needed as a dependency of @com_google_protobuf_v25.x, which was before

--- a/compatibility/BUILD.bazel
+++ b/compatibility/BUILD.bazel
@@ -17,3 +17,27 @@ java_runtime_conformance(
     name = "java_conformance_v3.25.0",
     gencode_version = "3.25.0",
 )
+
+java_test(
+    name = "java_conformance_unittest_v3.25.0_jar",
+    size = "small",
+    test_class = "com.google.protobuf.CompatibilityTest",
+    srcs = ["CompatibilityTest.java"],
+    deps = [
+        ":libconformance_v3.25.0_lib.jar",
+        "//java/core",
+        "@maven//:junit_junit",
+    ],
+)
+
+java_test(
+    name = "java_conformance_unittest_v3.25.0",
+    size = "small",
+    test_class = "com.google.protobuf.CompatibilityTest",
+    srcs = ["CompatibilityTest.java"],
+    deps = [
+        ":conformance_v3.25.0_lib",
+        "//java/core",
+        "@maven//:junit_junit",
+    ],
+)

--- a/compatibility/CompatibilityTest.java
+++ b/compatibility/CompatibilityTest.java
@@ -1,7 +1,7 @@
 package com.google.protobuf;
 
-import protobuf_unittest.UnittestProto.Int64ParseTester;
 import protobuf_unittest.UnittestProto.TestAllTypes;
+import protobuf_unittest.UnittestProto.TestMixedFieldsAndExtensions;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,16 +11,16 @@ import org.junit.runners.JUnit4;
 public class CompatibilityTest {
     @Test
     public void testFoo() throws Exception {
-        final TestAllTypes obj = TestAllTypes.newBuilder().setOptionalInt32(1).build();
+        final TestAllTypes obj = TestAllTypes.newBuilder().setOptionalInt32(1).addRepeatedInt32(1).build();
         final byte[] serialized = obj.toByteArray();
         final TestAllTypes parsed = TestAllTypes.parseFrom(serialized);
 
         obj.toString();
         parsed.toString();
 
-        final Int64ParseTester obj2 = Int64ParseTester.newBuilder().setOptionalInt64Hifield(0).build();
+        final TestMixedFieldsAndExtensions obj2 = TestMixedFieldsAndExtensions.newBuilder().setA(1).setExtension(TestMixedFieldsAndExtensions.c, 1).build();
         final byte[] serialized2 = obj2.toByteArray();
-        final Int64ParseTester parsed2 = Int64ParseTester.parseFrom(serialized2);
+        final TestMixedFieldsAndExtensions parsed2 = TestMixedFieldsAndExtensions.parseFrom(serialized2);
         obj2.toString();
         parsed2.toString();
     }

--- a/compatibility/CompatibilityTest.java
+++ b/compatibility/CompatibilityTest.java
@@ -1,0 +1,27 @@
+package com.google.protobuf;
+
+import protobuf_unittest.UnittestProto.Int64ParseTester;
+import protobuf_unittest.UnittestProto.TestAllTypes;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CompatibilityTest {
+    @Test
+    public void testFoo() throws Exception {
+        final TestAllTypes obj = TestAllTypes.newBuilder().setOptionalInt32(1).build();
+        final byte[] serialized = obj.toByteArray();
+        final TestAllTypes parsed = TestAllTypes.parseFrom(serialized);
+
+        obj.toString();
+        parsed.toString();
+
+        final Int64ParseTester obj2 = Int64ParseTester.newBuilder().setOptionalInt64Hifield(0).build();
+        final byte[] serialized2 = obj2.toByteArray();
+        final Int64ParseTester parsed2 = Int64ParseTester.parseFrom(serialized2);
+        obj2.toString();
+        parsed2.toString();
+    }
+}

--- a/compatibility/runtime_conformance.bzl
+++ b/compatibility/runtime_conformance.bzl
@@ -16,9 +16,11 @@ def java_runtime_conformance(name, gencode_version, tags = []):
 
     if gencode_version == "main":
         protoc = "//:protoc"
+        runtime = "//java/core"
     else:
         minor = gencode_version[gencode_version.find(".") + 1:]
         protoc = Label("@com_google_protobuf_v%s//:protoc" % minor)
+        runtime = "@com_google_protobuf_v%s//java/core" % minor
 
     gencode = [
         "v%s/protobuf_unittest/UnittestProto.java" % gencode_version,
@@ -42,7 +44,7 @@ def java_runtime_conformance(name, gencode_version, tags = []):
     native.java_library(
         name = conformance_lib_name,
         srcs = gencode,
-        deps = ["//java/core"],
+        deps = [runtime],
         tags = tags,
     )
 

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -752,7 +752,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
     }
 
     @Override
-    public final UnknownFieldSet getUnknownFields() {
+    public UnknownFieldSet getUnknownFields() {
       if (unknownFieldsOrBuilder instanceof UnknownFieldSet) {
         return (UnknownFieldSet) unknownFieldsOrBuilder;
       } else {
@@ -1036,7 +1036,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
       private Map.Entry<FieldDescriptor, Object> next;
       private final boolean messageSetWireFormat;
 
-      private ExtensionWriter(final boolean messageSetWireFormat) {
+      protected ExtensionWriter(final boolean messageSetWireFormat) {
         if (iter.hasNext()) {
           next = iter.next();
         }
@@ -1939,7 +1939,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
    * Users should ignore this class. This class provides the implementation with access to the
    * fields of a message object using Java reflection.
    */
-  public static final class FieldAccessorTable {
+  public static class FieldAccessorTable {
 
     /**
      * Construct a FieldAccessorTable for a particular message class. Only one FieldAccessorTable

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -7,25 +7,148 @@
 
 package com.google.protobuf;
 
+import com.google.protobuf.AbstractMessage.BuilderParent;
+import com.google.protobuf.Descriptors.Descriptor;
 import java.util.List;
 
 /**
  * Stub for GeneratedMessageV3 wrapping GeneratedMessage for compatibility with older gencode.
+ * 
+ * <p> Extends GeneratedMessage.ExtendableMessage instead of GeneratedMessage to allow "multiple
+ * inheritance" for GeneratedMessageV3.ExtendableMessage subclass.
  *
  * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
  *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses GeneratedMessage
  *     instead of GeneratedMessageV3.
  */
 @Deprecated
-public abstract class GeneratedMessageV3 extends GeneratedMessage {
+public abstract class GeneratedMessageV3
+    extends GeneratedMessage.ExtendableMessage<GeneratedMessageV3> {
   private static final long serialVersionUID = 1L;
 
+  @Deprecated
   protected GeneratedMessageV3() {
     super();
   }
 
+  @Deprecated
   protected GeneratedMessageV3(Builder<?> builder) {
     super(builder);
+  }
+
+  /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
+  * 
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+  * GeneratedMessage.internalGetFieldAccessorTable instead of GeneratedMessageV3.internalGetFieldAccessorTable.
+  */
+  @Deprecated
+  @Override
+  protected FieldAccessorTable internalGetFieldAccessorTable() {
+    throw new UnsupportedOperationException("Should be overridden in gencode.");
+  }
+
+  /**
+   * Stub for GeneratedMessageV3.Builder wrapping GeneratedMessage.Builder for compatibility with
+   * older gencode.
+   *
+   * <p>Extends GeneratedMessage.ExtendableBuilder instead of GeneratedMessage.Builder to allow
+   * "multiple inheritance" for GeneratedMessageV3.ExtendableBuilder subclass.
+   *
+   * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
+   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.ExtendableBuilder instead of GeneratedMessageV3.ExtendableBuilder.
+   */
+  @Deprecated
+  public abstract static class Builder<
+          BuilderT extends GeneratedMessage.ExtendableBuilder<GeneratedMessageV3, BuilderT>>
+      extends GeneratedMessage.ExtendableBuilder<GeneratedMessageV3, BuilderT> {
+
+     @Deprecated
+     protected Builder() {
+       super(null);
+     }
+
+     @Deprecated
+     protected Builder(BuilderParent builderParent) {
+       super(builderParent);
+     }
+  }
+
+  /**
+   * Stub for GeneratedMessageV3.ExtendableMessageOrBuilder wrapping GeneratedMessage.ExtendableMessageOrBuilder for
+   * compatibility with older gencode.
+   *
+   * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
+   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.ExtendableMessageOrBuilder instead of GeneratedMessageV3.ExtendableMessageOrBuilder.
+   */
+  @Deprecated
+  public interface ExtendableMessageOrBuilder<MessageT extends ExtendableMessage<MessageT>>
+    extends GeneratedMessage.ExtendableMessageOrBuilder<GeneratedMessageV3>, MessageOrBuilder {}
+
+  /**
+   * Stub for GeneratedMessageV3.ExtendableMessage wrapping GeneratedMessage.ExtendableMessage for
+   * compatibility with older gencode.
+   *
+   * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
+   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.FieldAccessorTable instead of GeneratedMessageV3.FieldAccessorTable.
+   */
+  @Deprecated
+  public abstract static class ExtendableMessage<MessageT extends ExtendableMessage<MessageT>>
+      extends GeneratedMessageV3  // Extends GeneratedMessage.ExtendableMessage via GeneratedMessageV3
+      implements ExtendableMessageOrBuilder<MessageT> {
+
+    @Deprecated
+    protected ExtendableMessage() {
+      super();
+    }
+
+    @Deprecated
+    protected ExtendableMessage(ExtendableBuilder<MessageT, ?> builder) {
+      super(builder);
+    }
+
+    /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
+    * 
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+    * GeneratedMessage.internalGetFieldAccessorTable instead of GeneratedMessageV3.internalGetFieldAccessorTable.
+    */
+    @Deprecated
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+      throw new UnsupportedOperationException("Should be overridden in gencode.");
+    }
+
+    /**
+     * Stub for GeneratedMessageV3.ExtendableMessage.ExtensionWriter wrapping
+     * GeneratedMessage.ExtendableMessage.ExtensionWriter for compatibility with older gencode.
+     *
+     * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
+     *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+     *     GeneratedMessage.ExtendableMessage.ExtensionWriter instead of
+     *     GeneratedMessageV3.ExtendableMessage.ExtensionWriter.
+     */
+    @Deprecated
+    protected class ExtensionWriter extends GeneratedMessage.ExtendableMessage.ExtensionWriter {
+      private ExtensionWriter(final boolean messageSetWireFormat) {
+        super(messageSetWireFormat);
+      }
+    }
+
+    /* Returns GeneratedMessageV3.ExtendableMessage.ExtensionWriter instead of GeneratedMessage.ExtendableMessage.ExtensionWriter.
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+     * GeneratedMessage.ExtendableMessage.ExtensionWriter instead of GeneratedMessageV3.ExtendableMessage.ExtensionWriter.
+     */
+    @Deprecated
+    @Override
+    protected ExtensionWriter newExtensionWriter() {
+      return new ExtensionWriter(false);
+    }
   }
 
   /**
@@ -38,46 +161,93 @@ public abstract class GeneratedMessageV3 extends GeneratedMessage {
    */
   @Deprecated
   public abstract static class ExtendableBuilder<
-          MessageT extends ExtendableMessage<MessageT>,
-          BuilderT extends ExtendableBuilder<MessageT, BuilderT>>
-      extends GeneratedMessage.ExtendableBuilder<MessageT, BuilderT>
-      implements GeneratedMessage.ExtendableMessageOrBuilder<MessageT> {
+          MessageT extends GeneratedMessageV3.ExtendableMessage<MessageT>,
+          BuilderT extends GeneratedMessageV3.ExtendableBuilder<MessageT, BuilderT>>
+      extends GeneratedMessageV3.Builder<BuilderT>  // Extends GeneratedMessage.ExtendableBuilder via Builder
+      implements GeneratedMessageV3.ExtendableMessageOrBuilder<MessageT> {
+    
+    @Deprecated
     protected ExtendableBuilder() {
       super();
     }
 
+    @Deprecated
     protected ExtendableBuilder(BuilderParent parent) {
       super(parent);
     }
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
     public <T> BuilderT setExtension(
-        final GeneratedMessage.GeneratedExtension<MessageT, T> extension, final T value) {
-      return setExtension((ExtensionLite<MessageT, T>) extension, value);
+        final GeneratedMessage.GeneratedExtension extension, final T value) {
+      return setExtension((ExtensionLite<GeneratedMessageV3, T>) extension, value);
     }
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
     public <T> BuilderT setExtension(
-        final GeneratedMessage.GeneratedExtension<MessageT, List<T>> extension,
+        final GeneratedMessage.GeneratedExtension extension,
         final int index,
         final T value) {
-      return setExtension((ExtensionLite<MessageT, List<T>>) extension, index, value);
+      return setExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, index, value);
     }
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
     public <T> BuilderT addExtension(
-        final GeneratedMessage.GeneratedExtension<MessageT, List<T>> extension, final T value) {
-      return addExtension((ExtensionLite<MessageT, List<T>>) extension, value);
+        final GeneratedMessage.GeneratedExtension extension, final T value) {
+      return addExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, value);
     }
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
     public <T> BuilderT clearExtension(
-        final GeneratedMessage.GeneratedExtension<MessageT, T> extension) {
-      return clearExtension((ExtensionLite<MessageT, T>) extension);
+        final GeneratedMessage.GeneratedExtension extension) {
+      return clearExtension((ExtensionLite<GeneratedMessageV3, T>) extension);
+    }
+  }
+
+    /**
+   * Stub for GeneratedMessageV3.FieldAccessorTable wrapping GeneratedMessage.FieldAccessorTable for compatibility with
+   * older gencode.
+   *
+   * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
+   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.FieldAccessorTable instead of GeneratedMessageV3.FieldAccessorTable.
+   */
+  @Deprecated
+  public static final class FieldAccessorTable extends GeneratedMessage.FieldAccessorTable {
+
+    @Deprecated
+    public FieldAccessorTable(
+        final Descriptor descriptor,
+        final String[] camelCaseNames,
+        final Class<? extends GeneratedMessageV3> messageClass,
+        final Class<? extends Builder<?>> builderClass) {
+      super(descriptor, camelCaseNames, messageClass, builderClass);
+    }
+
+    @Deprecated
+    public FieldAccessorTable(final Descriptor descriptor, final String[] camelCaseNames) {
+      super(descriptor, camelCaseNames);
+    }
+
+    /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+     * GeneratedMessage.ensureFieldAccessorsInitialized instead of GeneratedMessageV3.ensureFieldAccessorsInitialized.
+     */
+    @Deprecated()
+    @Override
+    public FieldAccessorTable ensureFieldAccessorsInitialized(
+        Class<? extends GeneratedMessage> messageClass,
+        Class<? extends GeneratedMessage.Builder<?>> builderClass) {
+        return (FieldAccessorTable) super.ensureFieldAccessorsInitialized(messageClass, builderClass);
     }
   }
 }


### PR DESCRIPTION
Update GeneratedMessageV3 shims for GeneratedMessageV3, Builder, ExtendableMesageOrBuilder, ExtendableMessage, ExtendableBuilder, and FieldAccessorTable classes and gencode-overriden methods that reference those types

Adds compatibility test for generated code jars built against 25.x runtime against newer runtime.