### PR TITLE
Binary compatibility shims for GeneratedMessageV3 and nested classes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -231,6 +231,7 @@ http_archive(
     name = "com_google_protobuf_v25.0",
     strip_prefix = "protobuf-25.0",
     url = "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protobuf-25.0.tar.gz",
+    sha256 = "7beed9c511d632cff7c22ac0094dd7720e550153039d5da7e059bcceb488474a",
 )
 
 # Needed as a dependency of @com_google_protobuf_v25.x, which was before

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -229,8 +229,8 @@ crate_repositories()
 # For testing runtime against old gencode from a previous major version.
 http_archive(
     name = "com_google_protobuf_v25",
-    strip_prefix = "protobuf-3d93344ca26afa0092b4e4933835057b263fc007", # 25.x commit with public visibility for //java/core test java_proto_library 
-    url = "https://github.com/protocolbuffers/protobuf/archive/3d93344ca26afa0092b4e4933835057b263fc007.zip",
+    strip_prefix = "protobuf-25.0", # 25.x commit with public visibility for //java/core test java_proto_library 
+    url = "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protobuf-25.0.tar.gz",
 )
 
 load("@com_google_protobuf_v25//:protobuf_deps.bzl", protobuf_v25_deps="protobuf_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -234,10 +234,7 @@ http_archive(
     sha256 = "7beed9c511d632cff7c22ac0094dd7720e550153039d5da7e059bcceb488474a",
 )
 
-# Needed as a dependency of @com_google_protobuf_v25.x, which was before
-# utf8_range was merged in.
-http_archive(
-    name = "utf8_range",
-    strip_prefix = "utf8_range-d863bc33e15cba6d873c878dcca9e6fe52b2f8cb",
-    url = "https://github.com/protocolbuffers/utf8_range/archive/d863bc33e15cba6d873c878dcca9e6fe52b2f8cb.zip",
-)
+load("@com_google_protobuf_v25.0//:protobuf_deps.bzl", protobuf_v25_deps="protobuf_deps")
+
+# Needed as a dependency of @com_google_protobuf_v25.x
+protobuf_v25_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -228,12 +228,12 @@ crate_repositories()
 
 # For testing runtime against old gencode from a previous major version.
 http_archive(
-    name = "com_google_protobuf_v25.0",
-    strip_prefix = "protobuf-b43602626257300eadd9adabc1db5d8ae4dce89a", # 25.x commit with public visibility for //java/core test java_proto_library 
-    url = "https://github.com/protocolbuffers/protobuf/archive/b43602626257300eadd9adabc1db5d8ae4dce89a.zip",
+    name = "com_google_protobuf_v25",
+    strip_prefix = "protobuf-0706804dea7b769c52a48ac29c5ec7495d474449", # 25.x commit with public visibility for //java/core test java_proto_library 
+    url = "https://github.com/protocolbuffers/protobuf/archive/0706804dea7b769c52a48ac29c5ec7495d474449.zip",
 )
 
-load("@com_google_protobuf_v25.0//:protobuf_deps.bzl", protobuf_v25_deps="protobuf_deps")
+load("@com_google_protobuf_v25//:protobuf_deps.bzl", protobuf_v25_deps="protobuf_deps")
 
-# Needed as a dependency of @com_google_protobuf_v25.x
+# Needed as a dependency of @com_google_protobuf_v25
 protobuf_v25_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -229,9 +229,8 @@ crate_repositories()
 # For testing runtime against old gencode from a previous major version.
 http_archive(
     name = "com_google_protobuf_v25.0",
-    strip_prefix = "protobuf-25.0",
-    url = "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protobuf-25.0.tar.gz",
-    sha256 = "7beed9c511d632cff7c22ac0094dd7720e550153039d5da7e059bcceb488474a",
+    strip_prefix = "protobuf-b43602626257300eadd9adabc1db5d8ae4dce89a", # 25.x commit with public visibility for //java/core test java_proto_library 
+    url = "https://github.com/protocolbuffers/protobuf/archive/b43602626257300eadd9adabc1db5d8ae4dce89a.zip",
 )
 
 load("@com_google_protobuf_v25.0//:protobuf_deps.bzl", protobuf_v25_deps="protobuf_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -229,8 +229,8 @@ crate_repositories()
 # For testing runtime against old gencode from a previous major version.
 http_archive(
     name = "com_google_protobuf_v25",
-    strip_prefix = "protobuf-0706804dea7b769c52a48ac29c5ec7495d474449", # 25.x commit with public visibility for //java/core test java_proto_library 
-    url = "https://github.com/protocolbuffers/protobuf/archive/0706804dea7b769c52a48ac29c5ec7495d474449.zip",
+    strip_prefix = "protobuf-3d93344ca26afa0092b4e4933835057b263fc007", # 25.x commit with public visibility for //java/core test java_proto_library 
+    url = "https://github.com/protocolbuffers/protobuf/archive/3d93344ca26afa0092b4e4933835057b263fc007.zip",
 )
 
 load("@com_google_protobuf_v25//:protobuf_deps.bzl", protobuf_v25_deps="protobuf_deps")

--- a/compatibility/BUILD.bazel
+++ b/compatibility/BUILD.bazel
@@ -6,6 +6,9 @@
 
 load("//compatibility:runtime_conformance.bzl", "java_runtime_conformance")
 
+package(
+    default_visibility = ["//visibility:public"],
+)
 # main gencode builds with main runtime as a proof of concept.
 java_runtime_conformance(
     name = "java_conformance_main",
@@ -26,10 +29,12 @@ java_test(
     deps = [
         ":libconformance_v3.25.0_lib.jar",
         "//java/core",
+        "//java/core:test_util",
         "@maven//:junit_junit",
         "@maven//:com_google_truth_truth",
     ],
 )
+
 
 java_test(
     name = "java_conformance_unittest_v3.25.0",
@@ -39,6 +44,7 @@ java_test(
     deps = [
         ":conformance_v3.25.0_lib",
         "//java/core",
+        "//java/core:test_util",
         "@maven//:junit_junit",
         "@maven//:com_google_truth_truth",
     ],

--- a/compatibility/BUILD.bazel
+++ b/compatibility/BUILD.bazel
@@ -27,6 +27,7 @@ java_test(
         ":libconformance_v3.25.0_lib.jar",
         "//java/core",
         "@maven//:junit_junit",
+        "@maven//:com_google_truth_truth",
     ],
 )
 
@@ -39,5 +40,6 @@ java_test(
         ":conformance_v3.25.0_lib",
         "//java/core",
         "@maven//:junit_junit",
+        "@maven//:com_google_truth_truth",
     ],
 )

--- a/compatibility/BUILD.bazel
+++ b/compatibility/BUILD.bazel
@@ -17,3 +17,27 @@ java_runtime_conformance(
     name = "java_conformance_v3.25.0",
     gencode_version = "3.25.0",
 )
+
+java_test(
+    name = "java_conformance_unittest_v3.25.0_jar",
+    size = "small",
+    test_class = "com.google.protobuf.CompatibilityTest",
+    srcs = ["CompatibilityTest.java"],
+    deps = [
+        ":libconformance_v3.25.0_lib.jar",
+        "//java/core",
+        "@maven//:junit_junit",
+    ],
+)
+
+java_test(
+    name = "java_conformance_unittest_v3.25.0",
+    size = "small",
+    test_class = "com.google.protobuf.CompatibilityTest",
+    srcs = ["CompatibilityTest.java"],
+    deps = [
+        ":conformance_v3.25.0_lib",
+        "//java/core",
+        "@maven//:junit_junit",
+    ],
+)

--- a/compatibility/BUILD.bazel
+++ b/compatibility/BUILD.bazel
@@ -9,6 +9,26 @@ load("//compatibility:runtime_conformance.bzl", "java_runtime_conformance")
 package(
     default_visibility = ["//visibility:public"],
 )
+
+# exports_files(
+#     glob(["v3.25.0/*.srcjar"]) + 
+#     glob(["v3.25.0/*.jar"])
+# )
+
+filegroup(
+    name = "v3.25.0_srcjar",
+    srcs = glob(["v3.25.0/*.srcjar"]),
+    testonly = True,
+    visibility= ["//java/core:__pkg__"],
+)
+
+filegroup(
+    name = "v3.25.0_jar",
+    srcs = glob(["v3.25.0/*.jar"]),
+    testonly = True,
+    visibility= ["//java/core:__pkg__"],
+)
+
 # main gencode builds with main runtime as a proof of concept.
 java_runtime_conformance(
     name = "java_conformance_main",

--- a/compatibility/CompatibilityTest.java
+++ b/compatibility/CompatibilityTest.java
@@ -2,12 +2,15 @@ package com.google.protobuf;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import protobuf_unittest.UnittestProto.TestAllTypes;
-import protobuf_unittest.UnittestProto.TestMixedFieldsAndExtensions;
-
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import protobuf_unittest.UnittestProto.TestAllExtensions;
+import protobuf_unittest.UnittestProto.TestAllTypes;
+import protobuf_unittest.UnittestProto.TestAllTypes.NestedMessage;
+import protobuf_unittest.UnittestProto.TestMixedFieldsAndExtensions;
 
 @RunWith(JUnit4.class)
 public class CompatibilityTest {
@@ -22,6 +25,29 @@ public class CompatibilityTest {
     }
 
     @Test
+    public void testGetFieldBuilderWithInitializedValue() {
+      Descriptor descriptor = TestAllTypes.getDescriptor();
+      FieldDescriptor fieldDescriptor = descriptor.findFieldByName("optional_nested_message");
+  
+      // Before setting field, builder is initialized by default value.
+      TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+      NestedMessage.Builder fieldBuilder =
+          (NestedMessage.Builder) builder.getFieldBuilder(fieldDescriptor);
+      assertThat(fieldBuilder.getBb()).isEqualTo(0);
+  
+      // Setting field value with new field builder instance.
+      builder = TestAllTypes.newBuilder();
+      NestedMessage.Builder newFieldBuilder = builder.getOptionalNestedMessageBuilder();
+      newFieldBuilder.setBb(2);
+      // Then get the field builder instance by getFieldBuilder().
+      fieldBuilder = (NestedMessage.Builder) builder.getFieldBuilder(fieldDescriptor);
+      // It should contain new value.
+      assertThat(fieldBuilder.getBb()).isEqualTo(2);
+      // These two builder should be equal.
+      assertThat(fieldBuilder).isSameInstanceAs(newFieldBuilder);
+    }
+
+    @Test
     public void testExtendableMessage() throws Exception {
         final TestMixedFieldsAndExtensions obj = TestMixedFieldsAndExtensions.newBuilder().setA(1).setExtension(TestMixedFieldsAndExtensions.c, 1).build();
         assertThat((int) obj.getExtension(TestMixedFieldsAndExtensions.c)).isEqualTo(1);
@@ -32,5 +58,62 @@ public class CompatibilityTest {
         assertThat(parsed).isEqualTo(obj);
         obj.toString();
         parsed.toString();
+    }
+
+    @Test
+    public void getBuilderForType() throws Exception {
+        TestUtil.MockBuilderParent mockParent = new TestUtil.MockBuilderParent();
+        TestMixedFieldsAndExtensions.Builder builder =
+            (TestMixedFieldsAndExtensions.Builder)
+                TestMixedFieldsAndExtensions.getDefaultInstance().newBuilderForType(mockParent);
+    }
+
+    @Test
+    public void testExtensionDefaults() throws Exception {
+        TestUtil.assertExtensionsClear(TestAllExtensions.getDefaultInstance());
+        TestUtil.assertExtensionsClear(TestAllExtensions.newBuilder().build());
+    }
+
+    @Test
+    public void testExtensionReflectionSettersRejectNull() throws Exception {
+        TestUtil.ReflectionTester extensionsReflectionTester =
+        new TestUtil.ReflectionTester(
+            TestAllExtensions.getDescriptor(), TestUtil.getFullExtensionRegistry());
+        TestAllExtensions.Builder builder = TestAllExtensions.newBuilder();
+        extensionsReflectionTester.assertReflectionSettersRejectNull(builder);
+    }
+
+    @Test
+    public void testExtensionCopy() throws Exception {
+        TestAllExtensions original = TestUtil.getAllExtensionsSet();
+        TestAllExtensions copy = TestAllExtensions.newBuilder(original).build();
+        TestUtil.assertAllExtensionsSet(copy);
+    }
+
+    @Test
+    public void testGetParserForType() throws Exception{ 
+        TestAllTypes.getDefaultInstance().getParserForType();
+    }
+
+
+    @Test
+    public void testGetDefaultInstanceForType() throws Exception{ 
+        TestAllTypes.getDefaultInstance().getDefaultInstanceForType();
+    }
+
+    @Test
+    public void testMergeFrom() throws Exception{ 
+        TestAllTypes.Builder obj = TestAllTypes.newBuilder().setOptionalInt32(1);
+        TestAllTypes obj2 = TestAllTypes.newBuilder().setOptionalString("foo").build();
+        obj.mergeFrom(obj2);
+        TestAllTypes expected = TestAllTypes.newBuilder().setOptionalInt32(1).setOptionalString("foo").build();
+        assertThat(obj.build()).isEqualTo(expected);
+        obj.isInitialized();
+    }
+
+    @Test
+    public void testFoo() throws Exception{ 
+        TestAllExtensions.Builder builder = TestAllExtensions.newBuilder();
+        builder.foo();
     }
 }

--- a/compatibility/CompatibilityTest.java
+++ b/compatibility/CompatibilityTest.java
@@ -1,7 +1,7 @@
 package com.google.protobuf;
 
-import protobuf_unittest.UnittestProto.Int64ParseTester;
 import protobuf_unittest.UnittestProto.TestAllTypes;
+import protobuf_unittest.UnittestProto.TestMixedFieldsAndExtensions;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,16 +11,16 @@ import org.junit.runners.JUnit4;
 public class CompatibilityTest {
     @Test
     public void testFoo() throws Exception {
-        final TestAllTypes obj = TestAllTypes.newBuilder().setOptionalInt32(1).build();
+        final TestAllTypes obj = TestAllTypes.newBuilder().setOptionalInt32(1).addRepeatedInt32(1).build();
         final byte[] serialized = obj.toByteArray();
         final TestAllTypes parsed = TestAllTypes.parseFrom(serialized);
 
         obj.toString();
         parsed.toString();
 
-        final Int64ParseTester obj2 = Int64ParseTester.newBuilder().setOptionalInt64Hifield(0).build();
+        final TestMixedFieldsAndExtensions obj2 = TestMixedFieldsAndExtensions.newBuilder().setA(1).setExtension(TestMixedFieldsAndExtensions.c, 1).build();
         final byte[] serialized2 = obj2.toByteArray();
-        final Int64ParseTester parsed2 = Int64ParseTester.parseFrom(serialized2);
+        final TestMixedFieldsAndExtensions parsed2 = TestMixedFieldsAndExtensions.parseFrom(serialized2);
         obj2.toString();
         parsed2.toString();
     }

--- a/compatibility/CompatibilityTest.java
+++ b/compatibility/CompatibilityTest.java
@@ -1,0 +1,27 @@
+package com.google.protobuf;
+
+import protobuf_unittest.UnittestProto.Int64ParseTester;
+import protobuf_unittest.UnittestProto.TestAllTypes;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CompatibilityTest {
+    @Test
+    public void testFoo() throws Exception {
+        final TestAllTypes obj = TestAllTypes.newBuilder().setOptionalInt32(1).build();
+        final byte[] serialized = obj.toByteArray();
+        final TestAllTypes parsed = TestAllTypes.parseFrom(serialized);
+
+        obj.toString();
+        parsed.toString();
+
+        final Int64ParseTester obj2 = Int64ParseTester.newBuilder().setOptionalInt64Hifield(0).build();
+        final byte[] serialized2 = obj2.toByteArray();
+        final Int64ParseTester parsed2 = Int64ParseTester.parseFrom(serialized2);
+        obj2.toString();
+        parsed2.toString();
+    }
+}

--- a/compatibility/CompatibilityTest.java
+++ b/compatibility/CompatibilityTest.java
@@ -1,5 +1,7 @@
 package com.google.protobuf;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import protobuf_unittest.UnittestProto.TestAllTypes;
 import protobuf_unittest.UnittestProto.TestMixedFieldsAndExtensions;
 
@@ -10,18 +12,25 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CompatibilityTest {
     @Test
-    public void testFoo() throws Exception {
+    public void testGeneratedMessage() throws Exception {
         final TestAllTypes obj = TestAllTypes.newBuilder().setOptionalInt32(1).addRepeatedInt32(1).build();
         final byte[] serialized = obj.toByteArray();
         final TestAllTypes parsed = TestAllTypes.parseFrom(serialized);
-
+        assertThat(parsed).isEqualTo(obj);
         obj.toString();
         parsed.toString();
+    }
 
-        final TestMixedFieldsAndExtensions obj2 = TestMixedFieldsAndExtensions.newBuilder().setA(1).setExtension(TestMixedFieldsAndExtensions.c, 1).build();
-        final byte[] serialized2 = obj2.toByteArray();
-        final TestMixedFieldsAndExtensions parsed2 = TestMixedFieldsAndExtensions.parseFrom(serialized2);
-        obj2.toString();
-        parsed2.toString();
+    @Test
+    public void testExtendableMessage() throws Exception {
+        final TestMixedFieldsAndExtensions obj = TestMixedFieldsAndExtensions.newBuilder().setA(1).setExtension(TestMixedFieldsAndExtensions.c, 1).build();
+        assertThat((int) obj.getExtension(TestMixedFieldsAndExtensions.c)).isEqualTo(1);
+        final byte[] serialized = obj.toByteArray();
+        ExtensionRegistry registry = ExtensionRegistry.newInstance();
+        registry.add(TestMixedFieldsAndExtensions.c);
+        final TestMixedFieldsAndExtensions parsed = TestMixedFieldsAndExtensions.parseFrom(serialized, registry);
+        assertThat(parsed).isEqualTo(obj);
+        obj.toString();
+        parsed.toString();
     }
 }

--- a/compatibility/runtime_conformance.bzl
+++ b/compatibility/runtime_conformance.bzl
@@ -16,9 +16,11 @@ def java_runtime_conformance(name, gencode_version, tags = []):
 
     if gencode_version == "main":
         protoc = "//:protoc"
+        runtime = "//java/core"
     else:
         minor = gencode_version[gencode_version.find(".") + 1:]
         protoc = Label("@com_google_protobuf_v%s//:protoc" % minor)
+        runtime = "@com_google_protobuf_v%s//java/core" % minor
 
     gencode = [
         "v%s/protobuf_unittest/UnittestProto.java" % gencode_version,
@@ -42,7 +44,7 @@ def java_runtime_conformance(name, gencode_version, tags = []):
     native.java_library(
         name = conformance_lib_name,
         srcs = gencode,
-        deps = ["//java/core"],
+        deps = [runtime],
         tags = tags,
     )
 

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -443,6 +443,16 @@ junit_tests(
     ],
 )
 
+java_library(
+    name = "v25_test_protos_srcjar",
+    srcs = [
+        "//compatibility:v3.25.0_srcjar",
+    ],
+    testonly = True,
+    deps = ["//java/core:core"],
+)
+
+# Tests source compatibility against v25 gencode compiled against current runtime 
 java_test(
     name = "v25_generated_message_test_srcjar",
     size = "small",
@@ -450,48 +460,67 @@ java_test(
     test_class = "com.google.protobuf.GeneratedMessageTest",
     deps = [
         ":core",
-        "//compatibility:testdata/java_test_protos-speed.srcjar",
-        "//compatibility:testdata/generic_test_protos-speed.srcjar",
-        "//compatibility:testdata/lite_test_protos-speed.srcjar",
+        ":v25_test_protos_srcjar",
         ":test_util",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
     ],
 )
 
+java_library(
+    name = "v25_test_protos_jar",
+    srcs = [
+        "//compatibility:v3.25.0_srcjar",
+    ],
+    testonly = True,
+    deps = ["@com_google_protobuf_v25//java/core:core"],
+)
+
+# Tests binary compatibility against v25 gencode jar compiled against v25 runtime 
 java_test(
     name = "v25_generated_message_test_jar",
     size = "small",
     srcs = ["src/test/java/com/google/protobuf/GeneratedMessageTest.java"],
-    test_class = "com.google.protobuf.GeneratedMessageTest",
     deps = [
         ":core",
-        "@com_google_protobuf_v25//java/core:testdata/libjava_test_protos-speed.jar",
-        "@com_google_protobuf_v25//java/core:testdata/libgeneric_test_protos-speed.jar",
-        "@com_google_protobuf_v25//java/core:testdata/liblite_test_protos-speed.jar",
+        ":v25_test_protos_jar",
+        # "//compatibility:v3.25.0/libjava_test_protos-speed.jar",
+        # "//compatibility:v3.25.0/libgeneric_test_protos-speed.jar",
+        # "//compatibility:v3.25.0/liblite_test_protos-speed.jar",
         ":test_util",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
     ],
 )
 
+# Tests binary compatibility against v25 gencode compiled against v25 runtime 
 junit_tests(
     name = "v25_core_tests_jar",
     size = "small",
     srcs = glob(
         ["src/test/java/**/*.java"],
         exclude = [
-            # Exclusions from :core_tests
+            # Depends on unittest_delimited.proto added in v4.27.x
+            "src/test/java/com/google/protobuf/TextFormatTest.java",
+            # Depends on editions APIs added in v4.26.x.
+            "src/test/java/com/google/protobuf/DescriptorsTest.java",
+            # TODO: Version skew?
+            # "src/test/java/com/google/protobuf/CodedOutputStreamTest.java",
+            # Excluded in core_tests
             "src/test/java/com/google/protobuf/DecodeUtf8Test.java",
             "src/test/java/com/google/protobuf/IsValidUtf8Test.java",
             "src/test/java/com/google/protobuf/TestUtil.java",
             "src/test/java/com/google/protobuf/TestUtilLite.java",
+            "src/test/java/com/google/protobuf/RuntimeVersionTest.java",
         ],
     ),
-    data = ["//src/google/protobuf:testdata"],
+    test_prefix = "v25",
     deps = [
         ":core",
-        ":lib25.0_gencode.jar",
+        ":v25_test_protos_jar",
+        # "//compatibility:v3.25.0/libjava_test_protos-speed.jar",
+        # "//compatibility:v3.25.0/libgeneric_test_protos-speed.jar",
+        # "//compatibility:v3.25.0/liblite_test_protos-speed.jar",
         ":test_util",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_truth_truth",
@@ -500,14 +529,39 @@ junit_tests(
     ],
 )
 
-java_library(
-    name = "binjars"
-    srcs= [
-        "//compatibility:testdata/java_test_protos-speed.srcjar",
-        "//compatibility:testdata/generic_test_protos-speed.srcjar",
-        "//compatibility:testdata/lite_test_protos-speed.srcjar",
-    ]
-    deps = ["@com_google_protobuf_v25//java/core:core"]
+junit_tests(
+    name = "v25_core_tests_srcjar",
+    size = "small",
+    srcs = glob(
+        ["src/test/java/**/*.java"],
+        exclude = [
+            # Depends on unittest_delimited.proto added in v4.27.x
+            "src/test/java/com/google/protobuf/TextFormatTest.java",
+            # Depends on editions APIs added in v4.26.x.
+            "src/test/java/com/google/protobuf/DescriptorsTest.java",
+            # TODO: Version skew?
+            # "src/test/java/com/google/protobuf/CodedOutputStreamTest.java",
+            # Excluded in core_tests
+            "src/test/java/com/google/protobuf/DecodeUtf8Test.java",
+            "src/test/java/com/google/protobuf/IsValidUtf8Test.java",
+            "src/test/java/com/google/protobuf/TestUtil.java",
+            "src/test/java/com/google/protobuf/TestUtilLite.java",
+            "src/test/java/com/google/protobuf/RuntimeVersionTest.java",
+        ],
+    ),
+    test_prefix = "v25SrcJar",
+    deps = [
+        ":core",
+        ":v25_test_protos_srcjar",
+        # "//compatibility:v3.25.0/libjava_test_protos-speed.jar",
+        # "//compatibility:v3.25.0/libgeneric_test_protos-speed.jar",
+        # "//compatibility:v3.25.0/liblite_test_protos-speed.jar",
+        ":test_util",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "@maven//:org_mockito_mockito_core",
+    ],
 )
 
 

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -376,7 +376,10 @@ protobuf_java_library(
         "src/test/java/com/google/protobuf/TestUtil.java",
         "src/test/java/com/google/protobuf/TestUtilLite.java",
     ],
-    visibility = ["//java:__subpackages__", "//compatibility:__subpackages__"],
+    visibility = [
+        "//compatibility:__subpackages__",
+        "//java:__subpackages__",
+    ],
     deps = [
         ":core",
         ":generic_test_protos_java_proto",
@@ -441,20 +444,78 @@ junit_tests(
 )
 
 java_test(
-    name = "v25.x_generated_message_test",
+    name = "v25_generated_message_test",
     size = "small",
-    test_class = "com.google.protobuf.GeneratedMessageTest",
     srcs = ["src/test/java/com/google/protobuf/GeneratedMessageTest.java"],
+    test_class = "com.google.protobuf.GeneratedMessageTest",
     deps = [
-        # Use v25.x gencode jars to test binary compatibility
-        "@com_google_protobuf_v25.0//java/core:generic_test_protos_java_proto", # libgeneric_test_protos-speed.jar
-        "@com_google_protobuf_v25.0//java/core:java_test_protos_java_proto", # libjava_test_protos-speed.jar
         ":core",
         ":test_util",
-        "@maven//:junit_junit",
+        "@com_google_protobuf_v25//java/core:generic_test_protos_java_proto",
+        "@com_google_protobuf_v25//java/core:java_test_protos_java_proto",
         "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
     ],
 )
+
+java_test(
+    name = "v25_generated_message_test_srcjar",
+    size = "small",
+    srcs = ["src/test/java/com/google/protobuf/GeneratedMessageTest.java"],
+    test_class = "com.google.protobuf.GeneratedMessageTest",
+    deps = [
+        ":core",
+        ":v25_gencode-src.jar",
+        ":test_util",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+    ],
+)
+
+# TODO: Try removing getRepeatedField getRepeatedFieldCount shims
+# TODO: Sanity check dropping a ncessary shim.
+java_test(
+    name = "v25_generated_message_test_jar",
+    size = "small",
+    srcs = ["src/test/java/com/google/protobuf/GeneratedMessageTest.java"],
+    test_class = "com.google.protobuf.GeneratedMessageTest",
+    deps = [
+        ":core",
+        "@com_google_protobuf_v25//java/core:libjava_test_protos-speed.jar",
+        "@com_google_protobuf_v25//java/core:libgeneric_test_protos-speed.jar",
+        "@com_google_protobuf_v25//java/core:liblite_test_protos-speed.jar",
+        ":test_util",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+    ],
+)
+
+# # TODO: Add all core_tests
+# junit_tests(
+#     name = "v25_core_tests_jar",
+#     size = "small",
+#     srcs = glob(
+#         ["src/test/java/**/*.java"],
+#         exclude = [
+#             # Exclusions from :core_tests
+#             "src/test/java/com/google/protobuf/DecodeUtf8Test.java",
+#             "src/test/java/com/google/protobuf/IsValidUtf8Test.java",
+#             "src/test/java/com/google/protobuf/TestUtil.java",
+#             "src/test/java/com/google/protobuf/TestUtilLite.java",
+#         ],
+#     ),
+#     data = ["//src/google/protobuf:testdata"],
+#     deps = [
+#         ":core",
+#         ":lib25.0_gencode.jar",
+#         ":test_util",
+#         "@maven//:com_google_guava_guava",
+#         "@maven//:com_google_truth_truth",
+#         "@maven//:junit_junit",
+#         "@maven//:org_mockito_mockito_core",
+#     ],
+# )
+
 
 # The UTF-8 validation tests are much slower than the other tests, so they get
 # their own test target with a longer timeout.

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -376,7 +376,7 @@ protobuf_java_library(
         "src/test/java/com/google/protobuf/TestUtil.java",
         "src/test/java/com/google/protobuf/TestUtilLite.java",
     ],
-    visibility = ["//java:__subpackages__"],
+    visibility = ["//java:__subpackages__", "//compatibility:__subpackages__"],
     deps = [
         ":core",
         ":generic_test_protos_java_proto",
@@ -437,6 +437,22 @@ junit_tests(
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "@maven//:org_mockito_mockito_core",
+    ],
+)
+
+java_test(
+    name = "v25.x_generated_message_test",
+    size = "small",
+    test_class = "com.google.protobuf.GeneratedMessageTest",
+    srcs = ["src/test/java/com/google/protobuf/GeneratedMessageTest.java"],
+    deps = [
+        # Use v25.x gencode jars to test binary compatibility
+        "@com_google_protobuf_v25.0//java/core:generic_test_protos_java_proto", # libgeneric_test_protos-speed.jar
+        "@com_google_protobuf_v25.0//java/core:java_test_protos_java_proto", # libjava_test_protos-speed.jar
+        ":core",
+        ":test_util",
+        "@maven//:junit_junit",
+        "@maven//:com_google_truth_truth",
     ],
 )
 

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -444,36 +444,21 @@ junit_tests(
 )
 
 java_test(
-    name = "v25_generated_message_test",
-    size = "small",
-    srcs = ["src/test/java/com/google/protobuf/GeneratedMessageTest.java"],
-    test_class = "com.google.protobuf.GeneratedMessageTest",
-    deps = [
-        ":core",
-        ":test_util",
-        "@com_google_protobuf_v25//java/core:generic_test_protos_java_proto",
-        "@com_google_protobuf_v25//java/core:java_test_protos_java_proto",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-    ],
-)
-
-java_test(
     name = "v25_generated_message_test_srcjar",
     size = "small",
     srcs = ["src/test/java/com/google/protobuf/GeneratedMessageTest.java"],
     test_class = "com.google.protobuf.GeneratedMessageTest",
     deps = [
         ":core",
-        ":v25_gencode-src.jar",
+        "@com_google_protobuf_v25//java/core:testdata/java_test_protos-speed.srcjar",
+        "@com_google_protobuf_v25//java/core:testdata/generic_test_protos-speed.srcjar",
+        "@com_google_protobuf_v25//java/core:testdata/lite_test_protos-speed.srcjar",
         ":test_util",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
     ],
 )
 
-# TODO: Try removing getRepeatedField getRepeatedFieldCount shims
-# TODO: Sanity check dropping a ncessary shim.
 java_test(
     name = "v25_generated_message_test_jar",
     size = "small",
@@ -481,40 +466,39 @@ java_test(
     test_class = "com.google.protobuf.GeneratedMessageTest",
     deps = [
         ":core",
-        "@com_google_protobuf_v25//java/core:libjava_test_protos-speed.jar",
-        "@com_google_protobuf_v25//java/core:libgeneric_test_protos-speed.jar",
-        "@com_google_protobuf_v25//java/core:liblite_test_protos-speed.jar",
+        "@com_google_protobuf_v25//java/core:testdata/libjava_test_protos-speed.jar",
+        "@com_google_protobuf_v25//java/core:testdata/libgeneric_test_protos-speed.jar",
+        "@com_google_protobuf_v25//java/core:testdata/liblite_test_protos-speed.jar",
         ":test_util",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
     ],
 )
 
-# # TODO: Add all core_tests
-# junit_tests(
-#     name = "v25_core_tests_jar",
-#     size = "small",
-#     srcs = glob(
-#         ["src/test/java/**/*.java"],
-#         exclude = [
-#             # Exclusions from :core_tests
-#             "src/test/java/com/google/protobuf/DecodeUtf8Test.java",
-#             "src/test/java/com/google/protobuf/IsValidUtf8Test.java",
-#             "src/test/java/com/google/protobuf/TestUtil.java",
-#             "src/test/java/com/google/protobuf/TestUtilLite.java",
-#         ],
-#     ),
-#     data = ["//src/google/protobuf:testdata"],
-#     deps = [
-#         ":core",
-#         ":lib25.0_gencode.jar",
-#         ":test_util",
-#         "@maven//:com_google_guava_guava",
-#         "@maven//:com_google_truth_truth",
-#         "@maven//:junit_junit",
-#         "@maven//:org_mockito_mockito_core",
-#     ],
-# )
+junit_tests(
+    name = "v25_core_tests_jar",
+    size = "small",
+    srcs = glob(
+        ["src/test/java/**/*.java"],
+        exclude = [
+            # Exclusions from :core_tests
+            "src/test/java/com/google/protobuf/DecodeUtf8Test.java",
+            "src/test/java/com/google/protobuf/IsValidUtf8Test.java",
+            "src/test/java/com/google/protobuf/TestUtil.java",
+            "src/test/java/com/google/protobuf/TestUtilLite.java",
+        ],
+    ),
+    data = ["//src/google/protobuf:testdata"],
+    deps = [
+        ":core",
+        ":lib25.0_gencode.jar",
+        ":test_util",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "@maven//:org_mockito_mockito_core",
+    ],
+)
 
 
 # The UTF-8 validation tests are much slower than the other tests, so they get

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -450,9 +450,9 @@ java_test(
     test_class = "com.google.protobuf.GeneratedMessageTest",
     deps = [
         ":core",
-        "@com_google_protobuf_v25//java/core:testdata/java_test_protos-speed.srcjar",
-        "@com_google_protobuf_v25//java/core:testdata/generic_test_protos-speed.srcjar",
-        "@com_google_protobuf_v25//java/core:testdata/lite_test_protos-speed.srcjar",
+        "//compatibility:testdata/java_test_protos-speed.srcjar",
+        "//compatibility:testdata/generic_test_protos-speed.srcjar",
+        "//compatibility:testdata/lite_test_protos-speed.srcjar",
         ":test_util",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
@@ -498,6 +498,16 @@ junit_tests(
         "@maven//:junit_junit",
         "@maven//:org_mockito_mockito_core",
     ],
+)
+
+java_library(
+    name = "binjars"
+    srcs= [
+        "//compatibility:testdata/java_test_protos-speed.srcjar",
+        "//compatibility:testdata/generic_test_protos-speed.srcjar",
+        "//compatibility:testdata/lite_test_protos-speed.srcjar",
+    ]
+    deps = ["@com_google_protobuf_v25//java/core:core"]
 )
 
 

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -752,7 +752,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
     }
 
     @Override
-    public final UnknownFieldSet getUnknownFields() {
+    public UnknownFieldSet getUnknownFields() {
       if (unknownFieldsOrBuilder instanceof UnknownFieldSet) {
         return (UnknownFieldSet) unknownFieldsOrBuilder;
       } else {
@@ -1036,7 +1036,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
       private Map.Entry<FieldDescriptor, Object> next;
       private final boolean messageSetWireFormat;
 
-      private ExtensionWriter(final boolean messageSetWireFormat) {
+      protected ExtensionWriter(final boolean messageSetWireFormat) {
         if (iter.hasNext()) {
           next = iter.next();
         }
@@ -1939,7 +1939,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
    * Users should ignore this class. This class provides the implementation with access to the
    * fields of a message object using Java reflection.
    */
-  public static final class FieldAccessorTable {
+  public static class FieldAccessorTable {
 
     /**
      * Construct a FieldAccessorTable for a particular message class. Only one FieldAccessorTable

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -1563,7 +1563,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
       }
     }
 
-    protected final void mergeExtensionFields(final ExtendableMessage<?> other) {
+    protected void mergeExtensionFields(final ExtendableMessage<?> other) {
       if (other.extensions != null) {
         ensureExtensionsIsMutable();
         extensions.mergeFrom(other.extensions);

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -752,7 +752,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
     }
 
     @Override
-    public UnknownFieldSet getUnknownFields() {
+    public final UnknownFieldSet getUnknownFields() {
       if (unknownFieldsOrBuilder instanceof UnknownFieldSet) {
         return (UnknownFieldSet) unknownFieldsOrBuilder;
       } else {
@@ -803,7 +803,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
      * Implementation of {@link BuilderParent} for giving to our children. This small inner class
      * makes it so we don't publicly expose the BuilderParent methods.
      */
-    protected class BuilderParentImpl implements BuilderParent {
+    private class BuilderParentImpl implements BuilderParent {
 
       @Override
       public void markDirty() {

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -803,7 +803,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
      * Implementation of {@link BuilderParent} for giving to our children. This small inner class
      * makes it so we don't publicly expose the BuilderParent methods.
      */
-    private class BuilderParentImpl implements BuilderParent {
+    protected class BuilderParentImpl implements BuilderParent {
 
       @Override
       public void markDirty() {

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -1309,7 +1309,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
 
     /** Set the value of an extension. */
     public final <T> BuilderT setExtension(
-        final ExtensionLite<MessageT, T> extensionLite, final T value) {
+        final ExtensionLite<? extends MessageT, T> extensionLite, final T value) {
       Extension<MessageT, T> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -1561,6 +1561,10 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
       } else {
         return super.newBuilderForField(field);
       }
+    }
+
+    protected void foo() {
+      return;
     }
 
     protected void mergeExtensionFields(final ExtendableMessage<?> other) {

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -886,16 +886,16 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
     Message getDefaultInstanceForType();
 
     /** Check if a singular extension is present. */
-    <T> boolean hasExtension(ExtensionLite<MessageT, T> extension);
+    <T> boolean hasExtension(ExtensionLite<? extends MessageT, T> extension);
 
     /** Get the number of elements in a repeated extension. */
-    <T> int getExtensionCount(ExtensionLite<MessageT, List<T>> extension);
+    <T> int getExtensionCount(ExtensionLite<? extends MessageT, List<T>> extension);
 
     /** Get the value of an extension. */
-    <T> T getExtension(ExtensionLite<MessageT, T> extension);
+    <T> T getExtension(ExtensionLite<? extends MessageT, T> extension);
 
     /** Get one element of a repeated extension. */
-    <T> T getExtension(ExtensionLite<MessageT, List<T>> extension, int index);
+    <T> T getExtension(ExtensionLite<? extends MessageT, List<T>> extension, int index);
   }
 
   /**
@@ -946,7 +946,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
       this.extensions = builder.buildExtensions();
     }
 
-    private void verifyExtensionContainingType(final Extension<MessageT, ?> extension) {
+    private void verifyExtensionContainingType(final Extension<? extends MessageT, ?> extension) {
       if (extension.getDescriptor().getContainingType() != getDescriptorForType()) {
         // This can only happen if someone uses unchecked operations.
         throw new IllegalArgumentException(
@@ -960,7 +960,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
 
     /** Check if a singular extension is present. */
     @Override
-    public final <T> boolean hasExtension(final ExtensionLite<MessageT, T> extensionLite) {
+    public final <T> boolean hasExtension(final ExtensionLite<? extends MessageT, T> extensionLite) {
       Extension<MessageT, T> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -969,7 +969,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
 
     /** Get the number of elements in a repeated extension. */
     @Override
-    public final <T> int getExtensionCount(final ExtensionLite<MessageT, List<T>> extensionLite) {
+    public final <T> int getExtensionCount(final ExtensionLite<? extends MessageT, List<T>> extensionLite) {
       Extension<MessageT, List<T>> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -980,7 +980,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
     /** Get the value of an extension. */
     @Override
     @SuppressWarnings("unchecked")
-    public final <T> T getExtension(final ExtensionLite<MessageT, T> extensionLite) {
+    public final <T> T getExtension(final ExtensionLite<? extends MessageT, T> extensionLite) {
       Extension<MessageT, T> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -1003,7 +1003,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
     @Override
     @SuppressWarnings("unchecked")
     public final <T> T getExtension(
-        final ExtensionLite<MessageT, List<T>> extensionLite, final int index) {
+        final ExtensionLite<? extends MessageT, List<T>> extensionLite, final int index) {
       Extension<MessageT, List<T>> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -1254,7 +1254,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
 
     /** Check if a singular extension is present. */
     @Override
-    public final <T> boolean hasExtension(final ExtensionLite<MessageT, T> extensionLite) {
+    public final <T> boolean hasExtension(final ExtensionLite<? extends MessageT, T> extensionLite) {
       Extension<MessageT, T> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -1263,7 +1263,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
 
     /** Get the number of elements in a repeated extension. */
     @Override
-    public final <T> int getExtensionCount(final ExtensionLite<MessageT, List<T>> extensionLite) {
+    public final <T> int getExtensionCount(final ExtensionLite<? extends MessageT, List<T>> extensionLite) {
       Extension<MessageT, List<T>> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -1273,7 +1273,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
 
     /** Get the value of an extension. */
     @Override
-    public final <T> T getExtension(final ExtensionLite<MessageT, T> extensionLite) {
+    public final <T> T getExtension(final ExtensionLite<? extends MessageT, T> extensionLite) {
       Extension<MessageT, T> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -1295,7 +1295,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
     /** Get one element of a repeated extension. */
     @Override
     public final <T> T getExtension(
-        final ExtensionLite<MessageT, List<T>> extensionLite, final int index) {
+        final ExtensionLite<? extends MessageT, List<T>> extensionLite, final int index) {
       Extension<MessageT, List<T>> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -1322,7 +1322,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
 
     /** Set the value of one element of a repeated extension. */
     public final <T> BuilderT setExtension(
-        final ExtensionLite<MessageT, List<T>> extensionLite, final int index, final T value) {
+        final ExtensionLite<? extends MessageT, List<T>> extensionLite, final int index, final T value) {
       Extension<MessageT, List<T>> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -1335,7 +1335,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
 
     /** Append a value to a repeated extension. */
     public final <T> BuilderT addExtension(
-        final ExtensionLite<MessageT, List<T>> extensionLite, final T value) {
+        final ExtensionLite<? extends MessageT, List<T>> extensionLite, final T value) {
       Extension<MessageT, List<T>> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -1347,7 +1347,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
     }
 
     /** Clear an extension. */
-    public final <T> BuilderT clearExtension(final ExtensionLite<MessageT, T> extensionLite) {
+    public final <T> BuilderT clearExtension(final ExtensionLite<? extends MessageT, T> extensionLite) {
       Extension<MessageT, T> extension = checkNotLite(extensionLite);
 
       verifyExtensionContainingType(extension);
@@ -3136,7 +3136,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
    * Checks that the {@link Extension} is non-Lite and returns it as a {@link GeneratedExtension}.
    */
   private static <MessageT extends ExtendableMessage<MessageT>, T>
-      Extension<MessageT, T> checkNotLite(ExtensionLite<MessageT, T> extension) {
+      Extension<MessageT, T> checkNotLite(ExtensionLite<? extends MessageT, T> extension) {
     if (extension.isLite()) {
       throw new IllegalArgumentException("Expected non-lite extension.");
     }

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -7,25 +7,148 @@
 
 package com.google.protobuf;
 
+import com.google.protobuf.AbstractMessage.BuilderParent;
+import com.google.protobuf.Descriptors.Descriptor;
 import java.util.List;
 
 /**
  * Stub for GeneratedMessageV3 wrapping GeneratedMessage for compatibility with older gencode.
+ * 
+ * <p> Extends GeneratedMessage.ExtendableMessage instead of GeneratedMessage to allow "multiple
+ * inheritance" for GeneratedMessageV3.ExtendableMessage subclass.
  *
  * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
  *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses GeneratedMessage
  *     instead of GeneratedMessageV3.
  */
 @Deprecated
-public abstract class GeneratedMessageV3 extends GeneratedMessage {
+public abstract class GeneratedMessageV3
+    extends GeneratedMessage.ExtendableMessage<GeneratedMessageV3> {
   private static final long serialVersionUID = 1L;
 
+  @Deprecated
   protected GeneratedMessageV3() {
     super();
   }
 
+  @Deprecated
   protected GeneratedMessageV3(Builder<?> builder) {
     super(builder);
+  }
+
+  /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
+  * 
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+  * GeneratedMessage.internalGetFieldAccessorTable instead of GeneratedMessageV3.internalGetFieldAccessorTable.
+  */
+  @Deprecated
+  @Override
+  protected FieldAccessorTable internalGetFieldAccessorTable() {
+    throw new UnsupportedOperationException("Should be overridden in gencode.");
+  }
+
+  /**
+   * Stub for GeneratedMessageV3.Builder wrapping GeneratedMessage.Builder for compatibility with
+   * older gencode.
+   *
+   * <p>Extends GeneratedMessage.ExtendableBuilder instead of GeneratedMessage.Builder to allow
+   * "multiple inheritance" for GeneratedMessageV3.ExtendableBuilder subclass.
+   *
+   * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
+   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.ExtendableBuilder instead of GeneratedMessageV3.ExtendableBuilder.
+   */
+  @Deprecated
+  public abstract static class Builder<
+          BuilderT extends GeneratedMessage.ExtendableBuilder<GeneratedMessageV3, BuilderT>>
+      extends GeneratedMessage.ExtendableBuilder<GeneratedMessageV3, BuilderT> {
+
+     @Deprecated
+     protected Builder() {
+       super(null);
+     }
+
+     @Deprecated
+     protected Builder(BuilderParent builderParent) {
+       super(builderParent);
+     }
+  }
+
+  /**
+   * Stub for GeneratedMessageV3.ExtendableMessageOrBuilder wrapping GeneratedMessage.ExtendableMessageOrBuilder for
+   * compatibility with older gencode.
+   *
+   * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
+   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.ExtendableMessageOrBuilder instead of GeneratedMessageV3.ExtendableMessageOrBuilder.
+   */
+  @Deprecated
+  public interface ExtendableMessageOrBuilder<MessageT extends ExtendableMessage<MessageT>>
+    extends GeneratedMessage.ExtendableMessageOrBuilder<GeneratedMessageV3>, MessageOrBuilder {}
+
+  /**
+   * Stub for GeneratedMessageV3.ExtendableMessage wrapping GeneratedMessage.ExtendableMessage for
+   * compatibility with older gencode.
+   *
+   * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
+   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.FieldAccessorTable instead of GeneratedMessageV3.FieldAccessorTable.
+   */
+  @Deprecated
+  public abstract static class ExtendableMessage<MessageT extends ExtendableMessage<MessageT>>
+      extends GeneratedMessageV3  // Extends GeneratedMessage.ExtendableMessage via GeneratedMessageV3
+      implements ExtendableMessageOrBuilder<MessageT> {
+
+    @Deprecated
+    protected ExtendableMessage() {
+      super();
+    }
+
+    @Deprecated
+    protected ExtendableMessage(ExtendableBuilder<MessageT, ?> builder) {
+      super(builder);
+    }
+
+    /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
+    * 
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+    * GeneratedMessage.internalGetFieldAccessorTable instead of GeneratedMessageV3.internalGetFieldAccessorTable.
+    */
+    @Deprecated
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+      throw new UnsupportedOperationException("Should be overridden in gencode.");
+    }
+
+    /**
+     * Stub for GeneratedMessageV3.ExtendableMessage.ExtensionWriter wrapping
+     * GeneratedMessage.ExtendableMessage.ExtensionWriter for compatibility with older gencode.
+     *
+     * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
+     *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+     *     GeneratedMessage.ExtendableMessage.ExtensionWriter instead of
+     *     GeneratedMessageV3.ExtendableMessage.ExtensionWriter.
+     */
+    @Deprecated
+    protected class ExtensionWriter extends GeneratedMessage.ExtendableMessage.ExtensionWriter {
+      private ExtensionWriter(final boolean messageSetWireFormat) {
+        super(messageSetWireFormat);
+      }
+    }
+
+    /* Returns GeneratedMessageV3.ExtendableMessage.ExtensionWriter instead of GeneratedMessage.ExtendableMessage.ExtensionWriter.
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+     * GeneratedMessage.ExtendableMessage.ExtensionWriter instead of GeneratedMessageV3.ExtendableMessage.ExtensionWriter.
+     */
+    @Deprecated
+    @Override
+    protected ExtensionWriter newExtensionWriter() {
+      return new ExtensionWriter(false);
+    }
   }
 
   /**
@@ -38,46 +161,93 @@ public abstract class GeneratedMessageV3 extends GeneratedMessage {
    */
   @Deprecated
   public abstract static class ExtendableBuilder<
-          MessageT extends ExtendableMessage<MessageT>,
-          BuilderT extends ExtendableBuilder<MessageT, BuilderT>>
-      extends GeneratedMessage.ExtendableBuilder<MessageT, BuilderT>
-      implements GeneratedMessage.ExtendableMessageOrBuilder<MessageT> {
+          MessageT extends GeneratedMessageV3.ExtendableMessage<MessageT>,
+          BuilderT extends GeneratedMessageV3.ExtendableBuilder<MessageT, BuilderT>>
+      extends GeneratedMessageV3.Builder<BuilderT>  // Extends GeneratedMessage.ExtendableBuilder via Builder
+      implements GeneratedMessageV3.ExtendableMessageOrBuilder<MessageT> {
+    
+    @Deprecated
     protected ExtendableBuilder() {
       super();
     }
 
+    @Deprecated
     protected ExtendableBuilder(BuilderParent parent) {
       super(parent);
     }
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
     public <T> BuilderT setExtension(
-        final GeneratedMessage.GeneratedExtension<MessageT, T> extension, final T value) {
-      return setExtension((ExtensionLite<MessageT, T>) extension, value);
+        final GeneratedMessage.GeneratedExtension extension, final T value) {
+      return setExtension((ExtensionLite<GeneratedMessageV3, T>) extension, value);
     }
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
     public <T> BuilderT setExtension(
-        final GeneratedMessage.GeneratedExtension<MessageT, List<T>> extension,
+        final GeneratedMessage.GeneratedExtension extension,
         final int index,
         final T value) {
-      return setExtension((ExtensionLite<MessageT, List<T>>) extension, index, value);
+      return setExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, index, value);
     }
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
     public <T> BuilderT addExtension(
-        final GeneratedMessage.GeneratedExtension<MessageT, List<T>> extension, final T value) {
-      return addExtension((ExtensionLite<MessageT, List<T>>) extension, value);
+        final GeneratedMessage.GeneratedExtension extension, final T value) {
+      return addExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, value);
     }
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
     public <T> BuilderT clearExtension(
-        final GeneratedMessage.GeneratedExtension<MessageT, T> extension) {
-      return clearExtension((ExtensionLite<MessageT, T>) extension);
+        final GeneratedMessage.GeneratedExtension extension) {
+      return clearExtension((ExtensionLite<GeneratedMessageV3, T>) extension);
+    }
+  }
+
+    /**
+   * Stub for GeneratedMessageV3.FieldAccessorTable wrapping GeneratedMessage.FieldAccessorTable for compatibility with
+   * older gencode.
+   *
+   * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
+   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.FieldAccessorTable instead of GeneratedMessageV3.FieldAccessorTable.
+   */
+  @Deprecated
+  public static final class FieldAccessorTable extends GeneratedMessage.FieldAccessorTable {
+
+    @Deprecated
+    public FieldAccessorTable(
+        final Descriptor descriptor,
+        final String[] camelCaseNames,
+        final Class<? extends GeneratedMessageV3> messageClass,
+        final Class<? extends Builder<?>> builderClass) {
+      super(descriptor, camelCaseNames, messageClass, builderClass);
+    }
+
+    @Deprecated
+    public FieldAccessorTable(final Descriptor descriptor, final String[] camelCaseNames) {
+      super(descriptor, camelCaseNames);
+    }
+
+    /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+     * GeneratedMessage.ensureFieldAccessorsInitialized instead of GeneratedMessageV3.ensureFieldAccessorsInitialized.
+     */
+    @Deprecated()
+    @Override
+    public FieldAccessorTable ensureFieldAccessorsInitialized(
+        Class<? extends GeneratedMessage> messageClass,
+        Class<? extends GeneratedMessage.Builder<?>> builderClass) {
+        return (FieldAccessorTable) super.ensureFieldAccessorsInitialized(messageClass, builderClass);
     }
   }
 }

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -61,7 +61,7 @@ public abstract class GeneratedMessageV3
   @Deprecated
   protected abstract Message.Builder newBuilderForType(BuilderParent parent);
 
-  // Support old gencode method removed in
+  // Gencode method removed in
   // https://github.com/protocolbuffers/protobuf/commit/787447430fc9a69c071393e85a380b664d261ab4
   @Override
   protected Message.Builder newBuilderForType(final AbstractMessage.BuilderParent parent) {
@@ -132,7 +132,7 @@ public abstract class GeneratedMessageV3
       return meAsParent;
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -140,7 +140,7 @@ public abstract class GeneratedMessageV3
       return super.setUnknownFields(unknownFields);
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -148,7 +148,7 @@ public abstract class GeneratedMessageV3
       return super.mergeUnknownFields(unknownFields);
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -163,7 +163,7 @@ public abstract class GeneratedMessageV3
       return super.clear();
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -171,7 +171,7 @@ public abstract class GeneratedMessageV3
       return super.setField(field, value);
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -179,7 +179,7 @@ public abstract class GeneratedMessageV3
       return super.clearField(field);
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -187,15 +187,15 @@ public abstract class GeneratedMessageV3
       return super.clearOneof(oneof);
     }
 
-    // Support old gencode method override removed in
-    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24    @Deprecated
+    // Gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
     public int getRepeatedFieldCount(final FieldDescriptor field) {
       return super.getRepeatedFieldCount(field);
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -203,7 +203,7 @@ public abstract class GeneratedMessageV3
       return super.getRepeatedField(field, index);
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -212,7 +212,7 @@ public abstract class GeneratedMessageV3
       return super.setRepeatedField(field, index, value);
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -233,25 +233,25 @@ public abstract class GeneratedMessageV3
   public interface ExtendableMessageOrBuilder<MessageT extends ExtendableMessage<MessageT>>
     extends GeneratedMessage.ExtendableMessageOrBuilder<GeneratedMessageV3> {
     
-    // Support method removed from GeneratedMessage.ExtendableMessageOrBuilder in
+    // Method removed from GeneratedMessage.ExtendableMessageOrBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     <T> boolean hasExtension(
       GeneratedExtension<MessageT, T> extension);
 
-    // Support method removed from GeneratedMessage.ExtendableMessageOrBuilder in
+    // Method removed from GeneratedMessage.ExtendableMessageOrBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     <T> int getExtensionCount(
       GeneratedExtension<MessageT, List<T>> extension);
 
-    // Support method removed from GeneratedMessage.ExtendableMessageOrBuilder in
+    // Method removed from GeneratedMessage.ExtendableMessageOrBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     <T> T getExtension(
       GeneratedExtension<MessageT, T> extension);
    
-    // Support method removed from GeneratedMessage.ExtendableMessageOrBuilder in
+    // Method removed from GeneratedMessage.ExtendableMessageOrBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     <T> T getExtension(
@@ -281,7 +281,7 @@ public abstract class GeneratedMessageV3
       super(builder);
     }
 
-    // Support method removed from GeneratedMessage.ExtendableMessage in
+    // Method removed from GeneratedMessage.ExtendableMessage in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     @Override
@@ -290,7 +290,7 @@ public abstract class GeneratedMessageV3
       return hasExtension((ExtensionLite<MessageT, T>) extension);
     }
     
-    // Support method removed from GeneratedMessage.ExtendableMessage in
+    // Method removed from GeneratedMessage.ExtendableMessage in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     @Override
@@ -299,7 +299,7 @@ public abstract class GeneratedMessageV3
       return getExtensionCount((ExtensionLite<MessageT, List<T>>) extension);
     }
 
-    // Support method removed from GeneratedMessage.ExtendableMessage in
+    // Method removed from GeneratedMessage.ExtendableMessage in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     @Override
@@ -308,7 +308,7 @@ public abstract class GeneratedMessageV3
       return getExtension((ExtensionLite<MessageT, T>) extension);
     }
 
-    // Support method removed from GeneratedMessage.ExtendableMessage in
+    // Method removed from GeneratedMessage.ExtendableMessage in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     @Override
@@ -383,7 +383,7 @@ public abstract class GeneratedMessageV3
       super(parent);
     }
     
-    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // Method removed from GeneratedMessage.ExtendableBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     @Override
@@ -392,7 +392,7 @@ public abstract class GeneratedMessageV3
       return hasExtension((ExtensionLite<MessageT, T>) extension);
     }
     
-    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // Method removed from GeneratedMessage.ExtendableBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     @Override
@@ -401,7 +401,7 @@ public abstract class GeneratedMessageV3
       return getExtensionCount((ExtensionLite<MessageT, List<T>>) extension);
     }
 
-    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // Method removed from GeneratedMessage.ExtendableBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     @Override
@@ -410,7 +410,7 @@ public abstract class GeneratedMessageV3
       return getExtension((ExtensionLite<MessageT, T>) extension);
     }
 
-    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // Method removed from GeneratedMessage.ExtendableBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     @Override
@@ -419,7 +419,7 @@ public abstract class GeneratedMessageV3
       return getExtension((ExtensionLite<MessageT, List<T>>) extension, index);
     }
 
-    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // Method removed from GeneratedMessage.ExtendableBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT setExtension(
@@ -427,7 +427,7 @@ public abstract class GeneratedMessageV3
       return setExtension((ExtensionLite<GeneratedMessageV3, T>) extension, value);
     }
 
-    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // Method removed from GeneratedMessage.ExtendableBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT setExtension(
@@ -437,7 +437,7 @@ public abstract class GeneratedMessageV3
       return setExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, index, value);
     }
 
-    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // Method removed from GeneratedMessage.ExtendableBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT addExtension(
@@ -445,7 +445,7 @@ public abstract class GeneratedMessageV3
       return addExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, value);
     }
 
-    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // Method removed from GeneratedMessage.ExtendableBuilder in
     // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT clearExtension(
@@ -453,7 +453,7 @@ public abstract class GeneratedMessageV3
       return clearExtension((ExtensionLite<GeneratedMessageV3, T>) extension);
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -461,7 +461,7 @@ public abstract class GeneratedMessageV3
       return super.setField(field, value);
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -469,7 +469,7 @@ public abstract class GeneratedMessageV3
       return super.clearField(field);
     }
 
-    // // Support old gencode method override removed in
+    // // Gencode method override removed in
     // // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     // @Deprecated
     // @Override
@@ -477,7 +477,7 @@ public abstract class GeneratedMessageV3
     //   return super.clearOneof(oneof);
     // }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -486,7 +486,7 @@ public abstract class GeneratedMessageV3
       return super.setRepeatedField(field, index, value);
     }
 
-    // Support old gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -184,7 +184,7 @@ public abstract class GeneratedMessageV3
       return super.addRepeatedField(field, value);
     }
 
-        // Gencode method override removed in
+    // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
     @Override
@@ -598,7 +598,7 @@ public abstract class GeneratedMessageV3
      * 
      * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
      * (5.x). Users should update gencode to >= 4.26.x which uses
-     * GeneratedMessage.FieldAccessorTable instead.
+     * GeneratedMessage.ensureFieldAccessorsInitialized() instead.
      */
     @Deprecated
     @Override

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -11,6 +11,8 @@ import com.google.protobuf.AbstractMessage.BuilderParent;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
+import com.google.protobuf.GeneratedMessage.UnusedPrivateParameter;
+
 import java.util.List;
 
 /**
@@ -37,18 +39,43 @@ public abstract class GeneratedMessageV3
     super(builder);
   }
 
-  // TODO: Restore this shim
-  // /* Overrides abstract GeneratedMessage.internalGetFieldAccessorTable().
-  // * 
-  // * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-  // * (5.x). Users should update gencode to >= 4.26.x which uses 
-  // * GeneratedMessage.internalGetFieldAccessorTable() instead.
-  // */
-  // @Deprecated
-  // @Override
-  // protected FieldAccessorTable internalGetFieldAccessorTable() {
-  //   throw new UnsupportedOperationException("Should be overridden in gencode.");
-  // }
+  /* Overrides abstract GeneratedMessage.internalGetFieldAccessorTable().
+  * 
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses 
+  * GeneratedMessage.internalGetFieldAccessorTable() instead.
+  */
+  @Deprecated
+  @Override
+  protected FieldAccessorTable internalGetFieldAccessorTable() {
+    throw new UnsupportedOperationException("Should be overridden in gencode.");
+  }
+
+  /**
+   * 
+   * 
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses 
+  * GeneratedMessage.UnusedPrivateParameter instead.*/
+  @Deprecated 
+  protected static final class UnusedPrivateParameter {
+    static final UnusedPrivateParameter INSTANCE = new UnusedPrivateParameter();
+
+    private UnusedPrivateParameter() {}
+  }
+
+
+  /**
+   *
+   * 
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which overrides 
+  * GeneratedMessage.newInstance() instead.*/
+  @Deprecated
+  @SuppressWarnings({"unused"})
+  protected Object newInstance(UnusedPrivateParameter unused) {
+    throw new UnsupportedOperationException("This method must be overridden by the subclass.");
+  }
 
   @Deprecated
   protected interface BuilderParent extends AbstractMessage.BuilderParent {}
@@ -151,22 +178,6 @@ public abstract class GeneratedMessageV3
     public BuilderT clearOneof(final OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
-
-    // // Gencode method override removed in
-    // // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    // @Deprecated
-    // @Override
-    // public int getRepeatedFieldCount(final FieldDescriptor field) {
-    //   return super.getRepeatedFieldCount(field);
-    // }
-
-    // // Gencode method override removed in
-    // // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    // @Deprecated
-    // @Override
-    // public Object getRepeatedField(final FieldDescriptor field, final int index) {
-    //   return super.getRepeatedField(field, index);
-    // }
 
     // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
@@ -492,8 +503,8 @@ public abstract class GeneratedMessageV3
      */
     @Deprecated
     public <T> BuilderT setExtension(
-        final GeneratedMessage.GeneratedExtension extension, final T value) {
-      return setExtension((ExtensionLite<GeneratedMessageV3, T>) extension, value);
+        final GeneratedMessage.GeneratedExtension<MessageT, T> extension, final T value) {
+      return setExtension((ExtensionLite<MessageT, T>) extension, value);
     }
 
     /* Removed from GeneratedMessage.ExtendableBuilder in
@@ -504,10 +515,10 @@ public abstract class GeneratedMessageV3
      */
     @Deprecated
     public <T> BuilderT setExtension(
-        final GeneratedMessage.GeneratedExtension extension,
+        final GeneratedMessage.GeneratedExtension<MessageT, List<T>> extension,
         final int index,
         final T value) {
-      return setExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, index, value);
+      return setExtension((ExtensionLite<MessageT, List<T>>) extension, index, value);
     }
 
     /* Removed from GeneratedMessage.ExtendableBuilder in
@@ -518,8 +529,8 @@ public abstract class GeneratedMessageV3
      */
     @Deprecated
     public <T> BuilderT addExtension(
-        final GeneratedMessage.GeneratedExtension extension, final T value) {
-      return addExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, value);
+        final GeneratedMessage.GeneratedExtension<MessageT, List<T>> extension, final T value) {
+      return addExtension((ExtensionLite<MessageT, List<T>>) extension, value);
     }
 
     /* Removed from GeneratedMessage.ExtendableBuilder in
@@ -530,8 +541,8 @@ public abstract class GeneratedMessageV3
      */
     @Deprecated
     public <T> BuilderT clearExtension(
-        final GeneratedMessage.GeneratedExtension extension) {
-      return clearExtension((ExtensionLite<GeneratedMessageV3, T>) extension);
+        final GeneratedMessage.GeneratedExtension<MessageT, T> extension) {
+      return clearExtension((ExtensionLite<MessageT, T>) extension);
     }
 
     // Gencode method override removed in

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -9,6 +9,9 @@ package com.google.protobuf;
 
 import com.google.protobuf.AbstractMessage.BuilderParent;
 import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.OneofDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.GeneratedMessage.Builder.BuilderParentImpl;
 
 import com.google.protobuf.GeneratedMessage.Builder.BuilderParentImpl;
@@ -128,6 +131,83 @@ public abstract class GeneratedMessageV3
       }
       return meAsParent;
     }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Override
+    public BuilderT setUnknownFields(final UnknownFieldSet unknownFields) {
+      return super.setUnknownFields(unknownFields);
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Override
+    public BuilderT mergeUnknownFields(final UnknownFieldSet unknownFields) {
+      return super.mergeUnknownFields(unknownFields);
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT clone() {
+      return super.clone();
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT setField(final FieldDescriptor field, final Object value) {
+      return super.setField(field, value);
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT clearField(final FieldDescriptor field) {
+      return super.clearField(field);
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT clearOneof(final OneofDescriptor oneof) {
+      return super.clearOneof(oneof);
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24    @Deprecated
+    @Override
+    public int getRepeatedFieldCount(final FieldDescriptor field) {
+      return super.getRepeatedFieldCount(field);
+    }
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public Object getRepeatedField(final FieldDescriptor field, final int index) {
+      return super.getRepeatedField(field, index);
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT setRepeatedField(
+        final FieldDescriptor field, final int index, final Object value) {
+      return super.setRepeatedField(field, index, value);
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT addRepeatedField(final FieldDescriptor field, final Object value) {
+      return super.addRepeatedField(field, value);
+    }
   }
 
   /**
@@ -229,7 +309,7 @@ public abstract class GeneratedMessageV3
     protected ExtendableBuilder(BuilderParent parent) {
       super(parent);
     }
-
+    
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -391,6 +391,18 @@ public abstract class GeneratedMessageV3
     protected ExtensionWriter newExtensionWriter() {
       return new ExtensionWriter(false);
     }
+
+    /* Returns GeneratedMessageV3.ExtendableMessage.ExtensionWriter instead of GeneratedMessage.ExtendableMessage.ExtensionWriter.
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which uses
+     * GeneratedMessage.ExtendableMessage.ExtensionWriter instead.
+     */
+    @Deprecated
+    @Override
+    protected ExtensionWriter newMessageSetExtensionWriter() {
+      return new ExtensionWriter(true);
+    }
   }
 
   /**

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -494,9 +494,10 @@ public abstract class GeneratedMessageV3
       return super.addRepeatedField(field, value);
     }
 
-    @Override
+    /* Stub for reference from generated code */
     @Deprecated
-    protected final void mergeExtensionFields(final ExtendableMessage other) {
+    // @Override // TODO: Why does Override annotation not work?
+    protected final void mergeExtensionFields(final ExtendableMessage<?> other) {
       super.mergeExtensionFields(other);
     }
   }

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -295,10 +295,10 @@ public abstract class GeneratedMessageV3
    */
   @Deprecated
   public abstract static class ExtendableBuilder<
-          MessageT extends GeneratedMessageV3.ExtendableMessage<MessageT>,
-          BuilderT extends GeneratedMessageV3.ExtendableBuilder<MessageT, BuilderT>>
-      extends GeneratedMessageV3.Builder<BuilderT>  // Extends GeneratedMessage.ExtendableBuilder via Builder
-      implements GeneratedMessageV3.ExtendableMessageOrBuilder<MessageT> {
+          MessageT extends ExtendableMessage<MessageT>,
+          BuilderT extends ExtendableBuilder<MessageT, BuilderT>>
+      extends Builder<BuilderT>  // Extends GeneratedMessage.ExtendableBuilder via Builder
+      implements ExtendableMessageOrBuilder<MessageT> {
     
     @Deprecated
     protected ExtendableBuilder() {
@@ -312,6 +312,7 @@ public abstract class GeneratedMessageV3
     
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    // and removed from GeneratedMessage in https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT setExtension(
         final GeneratedMessage.GeneratedExtension extension, final T value) {
@@ -320,6 +321,7 @@ public abstract class GeneratedMessageV3
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    // and removed from GeneratedMessage.ExtendableBuilder in https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT setExtension(
         final GeneratedMessage.GeneratedExtension extension,
@@ -330,6 +332,7 @@ public abstract class GeneratedMessageV3
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    // and removed from GeneratedMessage.ExtendableBuilder in https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT addExtension(
         final GeneratedMessage.GeneratedExtension extension, final T value) {
@@ -338,6 +341,7 @@ public abstract class GeneratedMessageV3
 
     // Support old gencode override method removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    // and removed from GeneratedMessage.ExtendableBuilder in https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT clearExtension(
         final GeneratedMessage.GeneratedExtension extension) {

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -184,6 +184,7 @@ public abstract class GeneratedMessageV3
     public int getRepeatedFieldCount(final FieldDescriptor field) {
       return super.getRepeatedFieldCount(field);
     }
+
     // Support old gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
@@ -220,7 +221,33 @@ public abstract class GeneratedMessageV3
    */
   @Deprecated
   public interface ExtendableMessageOrBuilder<MessageT extends ExtendableMessage<MessageT>>
-    extends GeneratedMessage.ExtendableMessageOrBuilder<GeneratedMessageV3> {}
+    extends GeneratedMessage.ExtendableMessageOrBuilder<GeneratedMessageV3> {
+    
+    // Support method removed from GeneratedMessage.ExtendableMessageOrBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    <T> boolean hasExtension(
+      GeneratedExtension<MessageT, T> extension);
+
+    // Support method removed from GeneratedMessage.ExtendableMessageOrBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    <T> int getExtensionCount(
+      GeneratedExtension<MessageT, List<T>> extension);
+
+    // Support method removed from GeneratedMessage.ExtendableMessageOrBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    <T> T getExtension(
+      GeneratedExtension<MessageT, T> extension);
+   
+    // Support method removed from GeneratedMessage.ExtendableMessageOrBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    <T> T getExtension(
+      GeneratedExtension<MessageT, List<T>> extension,
+      int index);
+  }
   /**
    * Stub for GeneratedMessageV3.ExtendableMessage wrapping GeneratedMessage.ExtendableMessage for
    * compatibility with older gencode.
@@ -242,6 +269,42 @@ public abstract class GeneratedMessageV3
     @Deprecated
     protected ExtendableMessage(ExtendableBuilder<MessageT, ?> builder) {
       super(builder);
+    }
+
+    // Support method removed from GeneratedMessage.ExtendableMessage in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    @Override
+    public final <T> boolean hasExtension(
+        final GeneratedExtension<MessageT, T> extension) {
+      return hasExtension((ExtensionLite<MessageT, T>) extension);
+    }
+    
+    // Support method removed from GeneratedMessage.ExtendableMessage in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    @Override
+    public final <T> int getExtensionCount(
+        final GeneratedExtension<MessageT, List<T>> extension) {
+      return getExtensionCount((ExtensionLite<MessageT, List<T>>) extension);
+    }
+
+    // Support method removed from GeneratedMessage.ExtendableMessage in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    @Override
+    public final <T> T getExtension(
+        final GeneratedExtension<MessageT, T> extension) {
+      return getExtension((ExtensionLite<MessageT, T>) extension);
+    }
+
+    // Support method removed from GeneratedMessage.ExtendableMessage in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    @Override
+    public final <T> T getExtension(
+        final GeneratedExtension<MessageT, List<T>> extension, final int index) {
+      return getExtension((ExtensionLite<MessageT, List<T>>) extension, index);
     }
 
     /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
@@ -310,18 +373,52 @@ public abstract class GeneratedMessageV3
       super(parent);
     }
     
-    // Support old gencode override method removed in
-    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    // and removed from GeneratedMessage in https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    @Override
+    public final <T> boolean hasExtension(
+        final GeneratedExtension<MessageT, T> extension) {
+      return hasExtension((ExtensionLite<MessageT, T>) extension);
+    }
+    
+    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    @Override
+    public final <T> int getExtensionCount(
+        final GeneratedExtension<MessageT, List<T>> extension) {
+      return getExtensionCount((ExtensionLite<MessageT, List<T>>) extension);
+    }
+
+    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    @Override
+    public final <T> T getExtension(
+        final GeneratedExtension<MessageT, T> extension) {
+      return getExtension((ExtensionLite<MessageT, T>) extension);
+    }
+
+    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    @Deprecated
+    @Override
+    public final <T> T getExtension(
+        final GeneratedExtension<MessageT, List<T>> extension, final int index) {
+      return getExtension((ExtensionLite<MessageT, List<T>>) extension, index);
+    }
+
+    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT setExtension(
         final GeneratedMessage.GeneratedExtension extension, final T value) {
       return setExtension((ExtensionLite<GeneratedMessageV3, T>) extension, value);
     }
 
-    // Support old gencode override method removed in
-    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    // and removed from GeneratedMessage.ExtendableBuilder in https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT setExtension(
         final GeneratedMessage.GeneratedExtension extension,
@@ -330,18 +427,16 @@ public abstract class GeneratedMessageV3
       return setExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, index, value);
     }
 
-    // Support old gencode override method removed in
-    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    // and removed from GeneratedMessage.ExtendableBuilder in https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT addExtension(
         final GeneratedMessage.GeneratedExtension extension, final T value) {
       return addExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, value);
     }
 
-    // Support old gencode override method removed in
-    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    // and removed from GeneratedMessage.ExtendableBuilder in https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    // Support method removed from GeneratedMessage.ExtendableBuilder in
+    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
     @Deprecated
     public <T> BuilderT clearExtension(
         final GeneratedMessage.GeneratedExtension extension) {

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -134,6 +134,7 @@ public abstract class GeneratedMessageV3
 
     // Support old gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
     @Override
     public BuilderT setUnknownFields(final UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
@@ -141,6 +142,7 @@ public abstract class GeneratedMessageV3
 
     // Support old gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
     @Override
     public BuilderT mergeUnknownFields(final UnknownFieldSet unknownFields) {
       return super.mergeUnknownFields(unknownFields);
@@ -154,6 +156,8 @@ public abstract class GeneratedMessageV3
       return super.clone();
     }
 
+    /* Returns GeneratedMessageV3.Builder instead of GeneratedMessage.Builder.*/
+    @Deprecated
     @Override
     public BuilderT clear() {
       return super.clear();
@@ -185,6 +189,7 @@ public abstract class GeneratedMessageV3
 
     // Support old gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24    @Deprecated
+    @Deprecated
     @Override
     public int getRepeatedFieldCount(final FieldDescriptor field) {
       return super.getRepeatedFieldCount(field);
@@ -490,7 +495,8 @@ public abstract class GeneratedMessageV3
     }
 
     @Override
-    protected void mergeExtensionFields(final ExtendableMessage<?> other) {
+    @Deprecated
+    protected final void mergeExtensionFields(final ExtendableMessage other) {
       super.mergeExtensionFields(other);
     }
   }

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -384,7 +384,7 @@ public abstract class GeneratedMessageV3
      * 
      * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
      * (5.x). Users should update gencode to >= 4.26.x which uses
-     * GeneratedMessage.ExtendableMessage.ExtensionWriter instead.
+     * GeneratedMessage.ExtendableMessage.newExtensionWriter() instead.
      */
     @Deprecated
     @Override
@@ -396,7 +396,7 @@ public abstract class GeneratedMessageV3
      * 
      * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
      * (5.x). Users should update gencode to >= 4.26.x which uses
-     * GeneratedMessage.ExtendableMessage.ExtensionWriter instead.
+     * GeneratedMessage.ExtendableMessage.newMessageSetExtensionWriter() instead.
      */
     @Deprecated
     @Override
@@ -574,10 +574,16 @@ public abstract class GeneratedMessageV3
       return super.addRepeatedField(field, value);
     }
 
+
+    @Override
+    protected void foo() {
+      super.foo();
+    }
+
     /* Stub for reference from generated code */
     @Deprecated
     // @Override // TODO: Why does Override annotation not work?
-    protected final void mergeExtensionFields(final ExtendableMessage<?> other) {
+    protected void mergeExtensionFields(final ExtendableMessage<?> other) {
       super.mergeExtensionFields(other);
     }
   }

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -87,7 +87,7 @@ public abstract class GeneratedMessageV3
    */
   @Deprecated
   public abstract static class Builder<
-          BuilderT extends GeneratedMessage.ExtendableBuilder<GeneratedMessageV3, BuilderT>>
+          BuilderT extends Builder<BuilderT>>
       extends GeneratedMessage.ExtendableBuilder<GeneratedMessageV3, BuilderT> {
 
     private BuilderParentImpl meAsParent;
@@ -342,6 +342,47 @@ public abstract class GeneratedMessageV3
     public <T> BuilderT clearExtension(
         final GeneratedMessage.GeneratedExtension extension) {
       return clearExtension((ExtensionLite<GeneratedMessageV3, T>) extension);
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT setField(final FieldDescriptor field, final Object value) {
+      return super.setField(field, value);
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT clearField(final FieldDescriptor field) {
+      return super.clearField(field);
+    }
+
+    // // Support old gencode method override removed in
+    // // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    // @Deprecated
+    // @Override
+    // public BuilderT clearOneof(final OneofDescriptor oneof) {
+    //   return super.clearOneof(oneof);
+    // }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT setRepeatedField(
+        final FieldDescriptor field, final int index, final Object value) {
+      return super.setRepeatedField(field, index, value);
+    }
+
+    // Support old gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT addRepeatedField(final FieldDescriptor field, final Object value) {
+      return super.addRepeatedField(field, value);
     }
   }
 

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -37,17 +37,18 @@ public abstract class GeneratedMessageV3
     super(builder);
   }
 
-  /* Overrides abstract GeneratedMessage.internalGetFieldAccessorTable().
-  * 
-  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-  * (5.x). Users should update gencode to >= 4.26.x which uses 
-  * GeneratedMessage.internalGetFieldAccessorTable() instead.
-  */
-  @Deprecated
-  @Override
-  protected FieldAccessorTable internalGetFieldAccessorTable() {
-    throw new UnsupportedOperationException("Should be overridden in gencode.");
-  }
+  // TODO: Restore this shim
+  // /* Overrides abstract GeneratedMessage.internalGetFieldAccessorTable().
+  // * 
+  // * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  // * (5.x). Users should update gencode to >= 4.26.x which uses 
+  // * GeneratedMessage.internalGetFieldAccessorTable() instead.
+  // */
+  // @Deprecated
+  // @Override
+  // protected FieldAccessorTable internalGetFieldAccessorTable() {
+  //   throw new UnsupportedOperationException("Should be overridden in gencode.");
+  // }
 
   @Deprecated
   protected interface BuilderParent extends AbstractMessage.BuilderParent {}
@@ -151,21 +152,21 @@ public abstract class GeneratedMessageV3
       return super.clearOneof(oneof);
     }
 
-    // Gencode method override removed in
-    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    @Deprecated
-    @Override
-    public int getRepeatedFieldCount(final FieldDescriptor field) {
-      return super.getRepeatedFieldCount(field);
-    }
+    // // Gencode method override removed in
+    // // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    // @Deprecated
+    // @Override
+    // public int getRepeatedFieldCount(final FieldDescriptor field) {
+    //   return super.getRepeatedFieldCount(field);
+    // }
 
-    // Gencode method override removed in
-    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    @Deprecated
-    @Override
-    public Object getRepeatedField(final FieldDescriptor field, final int index) {
-      return super.getRepeatedField(field, index);
-    }
+    // // Gencode method override removed in
+    // // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    // @Deprecated
+    // @Override
+    // public Object getRepeatedField(final FieldDescriptor field, final int index) {
+    //   return super.getRepeatedField(field, index);
+    // }
 
     // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -11,11 +11,6 @@ import com.google.protobuf.AbstractMessage.BuilderParent;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
-import com.google.protobuf.Descriptors.FieldDescriptor;
-import com.google.protobuf.GeneratedMessage.Builder.BuilderParentImpl;
-
-import com.google.protobuf.GeneratedMessage.Builder.BuilderParentImpl;
-
 import java.util.List;
 
 /**
@@ -25,8 +20,7 @@ import java.util.List;
  * inheritance" for GeneratedMessageV3.ExtendableMessage subclass.
  *
  * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
- *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses GeneratedMessage
- *     instead of GeneratedMessageV3.
+ *     (5.x). Users should update gencode to >= 4.26.x which uses GeneratedMessage instead.
  */
 @Deprecated
 public abstract class GeneratedMessageV3
@@ -43,11 +37,11 @@ public abstract class GeneratedMessageV3
     super(builder);
   }
 
-  /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
+  /* Overrides abstract GeneratedMessage.internalGetFieldAccessorTable().
   * 
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-  * GeneratedMessage.internalGetFieldAccessorTable instead of GeneratedMessageV3.internalGetFieldAccessorTable.
+  * (5.x). Users should update gencode to >= 4.26.x which uses 
+  * GeneratedMessage.internalGetFieldAccessorTable() instead.
   */
   @Deprecated
   @Override
@@ -61,8 +55,13 @@ public abstract class GeneratedMessageV3
   @Deprecated
   protected abstract Message.Builder newBuilderForType(BuilderParent parent);
 
-  // Gencode method removed in
-  // https://github.com/protocolbuffers/protobuf/commit/787447430fc9a69c071393e85a380b664d261ab4
+  /* Removed from GeneratedMessage in
+   * https://github.com/protocolbuffers/protobuf/commit/787447430fc9a69c071393e85a380b664d261ab4
+   * 
+   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+   * (5.x). Users should update gencode to >= 4.26.x which no longer uses this method.
+   */
+  @Deprecated
   @Override
   protected Message.Builder newBuilderForType(final AbstractMessage.BuilderParent parent) {
     return newBuilderForType(
@@ -82,8 +81,7 @@ public abstract class GeneratedMessageV3
    * "multiple inheritance" for GeneratedMessageV3.ExtendableBuilder subclass.
    *
    * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
-   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-   *     GeneratedMessage.ExtendableBuilder instead of GeneratedMessageV3.ExtendableBuilder.
+   *     (5.x). Users should update gencode to >= 4.26.x which uses GeneratedMessage.Builder instead.
    */
   @Deprecated
   public abstract static class Builder<
@@ -102,52 +100,6 @@ public abstract class GeneratedMessageV3
       super(builderParent);
     }
 
-    /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-     * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-     * GeneratedMessage.FieldAccessorTable instead of GeneratedMessageV3.FieldAccessorTable.
-     */
-    @Deprecated
-    @Override
-    protected FieldAccessorTable internalGetFieldAccessorTable() {
-      throw new UnsupportedOperationException("Should be overridden in gencode.");
-    }
-
-    private class BuilderParentImpl extends GeneratedMessage.Builder.BuilderParentImpl
-        implements BuilderParent {}
-
-    /* Returns GeneratedMessageV3.Builder.BuilderParent instead of GeneratedMessage.ExtendableMessage.Builder.BuilderParent.
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-     * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-     * GeneratedMessage.Builder.BuilderParent instead of GeneratedMessageV3.Builder.BuilderParent.
-     */
-    @Deprecated
-    @Override
-    protected BuilderParent getParentForChildren() {
-      if (meAsParent == null) {
-        meAsParent = new BuilderParentImpl();
-      }
-      return meAsParent;
-    }
-
-    // Gencode method override removed in
-    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    @Deprecated
-    @Override
-    public BuilderT setUnknownFields(final UnknownFieldSet unknownFields) {
-      return super.setUnknownFields(unknownFields);
-    }
-
-    // Gencode method override removed in
-    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    @Deprecated
-    @Override
-    public BuilderT mergeUnknownFields(final UnknownFieldSet unknownFields) {
-      return super.mergeUnknownFields(unknownFields);
-    }
-
     // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
@@ -161,6 +113,18 @@ public abstract class GeneratedMessageV3
     @Override
     public BuilderT clear() {
       return super.clear();
+    }
+
+    /* Overrides abstract GeneratedMessage.Builder.internalGetFieldAccessorTable().
+     *
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which overrides
+     * GeneratedMessage.Builder.internalGetFieldAccessorTable() instead.
+     */
+    @Deprecated
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+      throw new UnsupportedOperationException("Should be overridden in gencode.");
     }
 
     // Gencode method override removed in
@@ -219,6 +183,45 @@ public abstract class GeneratedMessageV3
     public BuilderT addRepeatedField(final FieldDescriptor field, final Object value) {
       return super.addRepeatedField(field, value);
     }
+
+        // Gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT setUnknownFields(final UnknownFieldSet unknownFields) {
+      return super.setUnknownFields(unknownFields);
+    }
+
+    // Gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT mergeUnknownFields(final UnknownFieldSet unknownFields) {
+      return super.mergeUnknownFields(unknownFields);
+    }
+
+    @Deprecated
+    private class BuilderParentImpl implements BuilderParent {
+      @Override
+      public void markDirty() {
+        onChanged();
+      }
+    }
+
+    /* Returns GeneratedMessageV3.Builder.BuilderParent instead of GeneratedMessage.Builder.BuilderParent.
+     *
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which uses
+     * GeneratedMessage.Builder.getParentForChildren() instead.
+     */
+    @Deprecated
+    @Override
+    protected BuilderParent getParentForChildren() {
+      if (meAsParent == null) {
+        meAsParent = new BuilderParentImpl();
+      }
+      return meAsParent;
+    }
   }
 
   /**
@@ -226,33 +229,50 @@ public abstract class GeneratedMessageV3
    * compatibility with older gencode.
    *
    * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
-   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-   *     GeneratedMessage.ExtendableMessageOrBuilder instead of GeneratedMessageV3.ExtendableMessageOrBuilder.
+   *     (5.x). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.ExtendableMessageOrBuilder.
    */
   @Deprecated
   public interface ExtendableMessageOrBuilder<MessageT extends ExtendableMessage<MessageT>>
     extends GeneratedMessage.ExtendableMessageOrBuilder<GeneratedMessageV3> {
     
-    // Method removed from GeneratedMessage.ExtendableMessageOrBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+
+    /* Removed from GeneratedMessage.ExtendableMessageOrBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     <T> boolean hasExtension(
       GeneratedExtension<MessageT, T> extension);
 
-    // Method removed from GeneratedMessage.ExtendableMessageOrBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableMessageOrBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     <T> int getExtensionCount(
       GeneratedExtension<MessageT, List<T>> extension);
 
-    // Method removed from GeneratedMessage.ExtendableMessageOrBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableMessageOrBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     <T> T getExtension(
       GeneratedExtension<MessageT, T> extension);
    
-    // Method removed from GeneratedMessage.ExtendableMessageOrBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableMessageOrBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     <T> T getExtension(
       GeneratedExtension<MessageT, List<T>> extension,
@@ -263,8 +283,8 @@ public abstract class GeneratedMessageV3
    * compatibility with older gencode.
    *
    * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
-   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-   *     GeneratedMessage.FieldAccessorTable instead of GeneratedMessageV3.FieldAccessorTable.
+   *     (5.x). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.ExtendableMessage.
    */
   @Deprecated
   public abstract static class ExtendableMessage<MessageT extends ExtendableMessage<MessageT>>
@@ -281,8 +301,12 @@ public abstract class GeneratedMessageV3
       super(builder);
     }
 
-    // Method removed from GeneratedMessage.ExtendableMessage in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableMessage in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     @Override
     public final <T> boolean hasExtension(
@@ -290,8 +314,12 @@ public abstract class GeneratedMessageV3
       return hasExtension((ExtensionLite<MessageT, T>) extension);
     }
     
-    // Method removed from GeneratedMessage.ExtendableMessage in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableMessage in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     @Override
     public final <T> int getExtensionCount(
@@ -299,8 +327,12 @@ public abstract class GeneratedMessageV3
       return getExtensionCount((ExtensionLite<MessageT, List<T>>) extension);
     }
 
-    // Method removed from GeneratedMessage.ExtendableMessage in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableMessage in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     @Override
     public final <T> T getExtension(
@@ -308,8 +340,12 @@ public abstract class GeneratedMessageV3
       return getExtension((ExtensionLite<MessageT, T>) extension);
     }
 
-    // Method removed from GeneratedMessage.ExtendableMessage in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableMessage in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     @Override
     public final <T> T getExtension(
@@ -317,12 +353,12 @@ public abstract class GeneratedMessageV3
       return getExtension((ExtensionLite<MessageT, List<T>>) extension, index);
     }
 
-    /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
-    * 
-    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-    * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-    * GeneratedMessage.internalGetFieldAccessorTable instead of GeneratedMessageV3.internalGetFieldAccessorTable.
-    */
+    /* Overrides abstract GeneratedMessage.ExtendableMessage.internalGetFieldAccessorTable().
+     *
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which overrides
+     * GeneratedMessage.ExtendableMessage.internalGetFieldAccessorTable() instead.
+     */
     @Deprecated
     @Override
     protected FieldAccessorTable internalGetFieldAccessorTable() {
@@ -334,9 +370,8 @@ public abstract class GeneratedMessageV3
      * GeneratedMessage.ExtendableMessage.ExtensionWriter for compatibility with older gencode.
      *
      * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
-     *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-     *     GeneratedMessage.ExtendableMessage.ExtensionWriter instead of
-     *     GeneratedMessageV3.ExtendableMessage.ExtensionWriter.
+     *     (5.x). Users should update gencode to >= 4.26.x which uses
+     *     GeneratedMessage.ExtendableMessage.ExtensionWriter instead.
      */
     @Deprecated
     protected class ExtensionWriter extends GeneratedMessage.ExtendableMessage.ExtensionWriter {
@@ -348,8 +383,8 @@ public abstract class GeneratedMessageV3
     /* Returns GeneratedMessageV3.ExtendableMessage.ExtensionWriter instead of GeneratedMessage.ExtendableMessage.ExtensionWriter.
      * 
      * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-     * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-     * GeneratedMessage.ExtendableMessage.ExtensionWriter instead of GeneratedMessageV3.ExtendableMessage.ExtensionWriter.
+     * (5.x). Users should update gencode to >= 4.26.x which uses
+     * GeneratedMessage.ExtendableMessage.ExtensionWriter instead.
      */
     @Deprecated
     @Override
@@ -363,8 +398,8 @@ public abstract class GeneratedMessageV3
    * compatibility with older gencode.
    *
    * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
-   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-   *     GeneratedMessage.ExtendableBuilder instead of GeneratedMessageV3.ExtendableBuilder.
+   *     (5.x). Users should update gencode to >= 4.26.x which uses
+   *     GeneratedMessage.ExtendableBuilder instead.
    */
   @Deprecated
   public abstract static class ExtendableBuilder<
@@ -383,8 +418,13 @@ public abstract class GeneratedMessageV3
       super(parent);
     }
     
-    // Method removed from GeneratedMessage.ExtendableBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+
+    /* Removed from GeneratedMessage.ExtendableBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     @Override
     public final <T> boolean hasExtension(
@@ -392,8 +432,12 @@ public abstract class GeneratedMessageV3
       return hasExtension((ExtensionLite<MessageT, T>) extension);
     }
     
-    // Method removed from GeneratedMessage.ExtendableBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     @Override
     public final <T> int getExtensionCount(
@@ -401,8 +445,12 @@ public abstract class GeneratedMessageV3
       return getExtensionCount((ExtensionLite<MessageT, List<T>>) extension);
     }
 
-    // Method removed from GeneratedMessage.ExtendableBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     @Override
     public final <T> T getExtension(
@@ -410,8 +458,12 @@ public abstract class GeneratedMessageV3
       return getExtension((ExtensionLite<MessageT, T>) extension);
     }
 
-    // Method removed from GeneratedMessage.ExtendableBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     @Override
     public final <T> T getExtension(
@@ -419,16 +471,24 @@ public abstract class GeneratedMessageV3
       return getExtension((ExtensionLite<MessageT, List<T>>) extension, index);
     }
 
-    // Method removed from GeneratedMessage.ExtendableBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     public <T> BuilderT setExtension(
         final GeneratedMessage.GeneratedExtension extension, final T value) {
       return setExtension((ExtensionLite<GeneratedMessageV3, T>) extension, value);
     }
 
-    // Method removed from GeneratedMessage.ExtendableBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     public <T> BuilderT setExtension(
         final GeneratedMessage.GeneratedExtension extension,
@@ -437,16 +497,24 @@ public abstract class GeneratedMessageV3
       return setExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, index, value);
     }
 
-    // Method removed from GeneratedMessage.ExtendableBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     public <T> BuilderT addExtension(
         final GeneratedMessage.GeneratedExtension extension, final T value) {
       return addExtension((ExtensionLite<GeneratedMessageV3, List<T>>) extension, value);
     }
 
-    // Method removed from GeneratedMessage.ExtendableBuilder in
-    // https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+    /* Removed from GeneratedMessage.ExtendableBuilder in
+     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
+     * 
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
+     */
     @Deprecated
     public <T> BuilderT clearExtension(
         final GeneratedMessage.GeneratedExtension extension) {
@@ -469,13 +537,13 @@ public abstract class GeneratedMessageV3
       return super.clearField(field);
     }
 
-    // // Gencode method override removed in
-    // // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
-    // @Deprecated
-    // @Override
-    // public BuilderT clearOneof(final OneofDescriptor oneof) {
-    //   return super.clearOneof(oneof);
-    // }
+    // Gencode method override removed in
+    // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
+    @Deprecated
+    @Override
+    public BuilderT clearOneof(final OneofDescriptor oneof) {
+      return super.clearOneof(oneof);
+    }
 
     // Gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
@@ -502,13 +570,12 @@ public abstract class GeneratedMessageV3
     }
   }
 
-    /**
+  /*
    * Stub for GeneratedMessageV3.FieldAccessorTable wrapping GeneratedMessage.FieldAccessorTable for compatibility with
    * older gencode.
    *
    * @deprecated This class is deprecated, and slated for removal in the next Java breaking change
-   *     (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-   *     GeneratedMessage.FieldAccessorTable instead of GeneratedMessageV3.FieldAccessorTable.
+   *     (5.x). Users should update gencode to >= 4.26.x which uses GeneratedMessage.FieldAccessorTable instead.
    */
   @Deprecated
   public static final class FieldAccessorTable extends GeneratedMessage.FieldAccessorTable {
@@ -530,8 +597,8 @@ public abstract class GeneratedMessageV3
     /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
      * 
      * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-     * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-     * GeneratedMessage.ensureFieldAccessorsInitialized instead of GeneratedMessageV3.ensureFieldAccessorsInitialized.
+     * (5.x). Users should update gencode to >= 4.26.x which uses
+     * GeneratedMessage.FieldAccessorTable instead.
      */
     @Deprecated
     @Override

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -9,6 +9,10 @@ package com.google.protobuf;
 
 import com.google.protobuf.AbstractMessage.BuilderParent;
 import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.GeneratedMessage.Builder.BuilderParentImpl;
+
+import com.google.protobuf.GeneratedMessage.Builder.BuilderParentImpl;
+
 import java.util.List;
 
 /**
@@ -48,6 +52,25 @@ public abstract class GeneratedMessageV3
     throw new UnsupportedOperationException("Should be overridden in gencode.");
   }
 
+  @Deprecated
+  protected interface BuilderParent extends AbstractMessage.BuilderParent {}
+
+  @Deprecated
+  protected abstract Message.Builder newBuilderForType(BuilderParent parent);
+
+  // Support old gencode method removed in
+  // https://github.com/protocolbuffers/protobuf/commit/787447430fc9a69c071393e85a380b664d261ab4
+  @Override
+  protected Message.Builder newBuilderForType(final AbstractMessage.BuilderParent parent) {
+    return newBuilderForType(
+        new BuilderParent() {
+          @Override
+          public void markDirty() {
+            parent.markDirty();
+          }
+        });
+  }
+
   /**
    * Stub for GeneratedMessageV3.Builder wrapping GeneratedMessage.Builder for compatibility with
    * older gencode.
@@ -64,15 +87,47 @@ public abstract class GeneratedMessageV3
           BuilderT extends GeneratedMessage.ExtendableBuilder<GeneratedMessageV3, BuilderT>>
       extends GeneratedMessage.ExtendableBuilder<GeneratedMessageV3, BuilderT> {
 
-     @Deprecated
-     protected Builder() {
-       super(null);
-     }
+    private BuilderParentImpl meAsParent;
 
-     @Deprecated
-     protected Builder(BuilderParent builderParent) {
-       super(builderParent);
-     }
+    @Deprecated
+    protected Builder() {
+      super(null);
+    }
+
+    @Deprecated
+    protected Builder(BuilderParent builderParent) {
+      super(builderParent);
+    }
+
+    /* Returns GeneratedMessageV3.FieldAccessorTable instead of GeneratedMessage.FieldAccessorTable.
+     *
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+     * GeneratedMessage.FieldAccessorTable instead of GeneratedMessageV3.FieldAccessorTable.
+     */
+    @Deprecated
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+      throw new UnsupportedOperationException("Should be overridden in gencode.");
+    }
+
+    private class BuilderParentImpl extends GeneratedMessage.Builder.BuilderParentImpl
+        implements BuilderParent {}
+
+    /* Returns GeneratedMessageV3.Builder.BuilderParent instead of GeneratedMessage.ExtendableMessage.Builder.BuilderParent.
+     *
+     * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+     * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+     * GeneratedMessage.Builder.BuilderParent instead of GeneratedMessageV3.Builder.BuilderParent.
+     */
+    @Deprecated
+    @Override
+    protected BuilderParent getParentForChildren() {
+      if (meAsParent == null) {
+        meAsParent = new BuilderParentImpl();
+      }
+      return meAsParent;
+    }
   }
 
   /**
@@ -241,7 +296,7 @@ public abstract class GeneratedMessageV3
      * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
      * GeneratedMessage.ensureFieldAccessorsInitialized instead of GeneratedMessageV3.ensureFieldAccessorsInitialized.
      */
-    @Deprecated()
+    @Deprecated
     @Override
     public FieldAccessorTable ensureFieldAccessorsInitialized(
         Class<? extends GeneratedMessage> messageClass,

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -154,6 +154,11 @@ public abstract class GeneratedMessageV3
       return super.clone();
     }
 
+    @Override
+    public BuilderT clear() {
+      return super.clear();
+    }
+
     // Support old gencode method override removed in
     // https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24
     @Deprecated
@@ -482,6 +487,11 @@ public abstract class GeneratedMessageV3
     @Override
     public BuilderT addRepeatedField(final FieldDescriptor field, final Object value) {
       return super.addRepeatedField(field, value);
+    }
+
+    @Override
+    protected void mergeExtensionFields(final ExtendableMessage<?> other) {
+      super.mergeExtensionFields(other);
     }
   }
 

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -85,8 +85,7 @@ public abstract class GeneratedMessageV3
    */
   @Deprecated
   public interface ExtendableMessageOrBuilder<MessageT extends ExtendableMessage<MessageT>>
-    extends GeneratedMessage.ExtendableMessageOrBuilder<GeneratedMessageV3>, MessageOrBuilder {}
-
+    extends GeneratedMessage.ExtendableMessageOrBuilder<GeneratedMessageV3> {}
   /**
    * Stub for GeneratedMessageV3.ExtendableMessage wrapping GeneratedMessage.ExtendableMessage for
    * compatibility with older gencode.

--- a/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilder.java
+++ b/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilder.java
@@ -37,8 +37,8 @@ import java.util.RandomAccess;
  * @author jonp@google.com (Jon Perlow)
  */
 public class RepeatedFieldBuilder<
-        MType extends GeneratedMessage,
-        BType extends GeneratedMessage.Builder,
+        MType extends AbstractMessage,
+        BType extends AbstractMessage.Builder,
         IType extends MessageOrBuilder>
     implements GeneratedMessage.BuilderParent {
 
@@ -551,8 +551,8 @@ public class RepeatedFieldBuilder<
    * @param <IType> the common interface for the message and the builder
    */
   private static class MessageExternalList<
-          MType extends GeneratedMessage,
-          BType extends GeneratedMessage.Builder,
+          MType extends AbstractMessage,
+          BType extends AbstractMessage.Builder,
           IType extends MessageOrBuilder>
       extends AbstractList<MType> implements List<MType>, RandomAccess {
 
@@ -585,8 +585,8 @@ public class RepeatedFieldBuilder<
    * @param <IType> the common interface for the message and the builder
    */
   private static class BuilderExternalList<
-          MType extends GeneratedMessage,
-          BType extends GeneratedMessage.Builder,
+          MType extends AbstractMessage,
+          BType extends AbstractMessage.Builder,
           IType extends MessageOrBuilder>
       extends AbstractList<BType> implements List<BType>, RandomAccess {
 
@@ -619,8 +619,8 @@ public class RepeatedFieldBuilder<
    * @param <IType> the common interface for the message and the builder
    */
   private static class MessageOrBuilderExternalList<
-          MType extends GeneratedMessage,
-          BType extends GeneratedMessage.Builder,
+          MType extends AbstractMessage,
+          BType extends AbstractMessage.Builder,
           IType extends MessageOrBuilder>
       extends AbstractList<IType> implements List<IType>, RandomAccess {
 

--- a/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
@@ -35,8 +35,8 @@ public class RepeatedFieldBuilderV3<
   /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
   *
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.setMessage() instead.
   */
   @Deprecated
   @Override
@@ -47,8 +47,8 @@ public class RepeatedFieldBuilderV3<
   /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
   *
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.addMessage() instead.
   */
   public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(MType message) {
     return (RepeatedFieldBuilderV3<MType, BType, IType>) super.addMessage(message);
@@ -57,8 +57,8 @@ public class RepeatedFieldBuilderV3<
   /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
   *
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.addMessage() instead.
   */
   public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(int index, MType message) {
     return (RepeatedFieldBuilderV3<MType, BType, IType>) super.addMessage(index, message);
@@ -67,8 +67,8 @@ public class RepeatedFieldBuilderV3<
   /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
   *
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.addAllMessages() instead.
   */
   public RepeatedFieldBuilderV3<MType, BType, IType> addAllMessages(
       Iterable<? extends MType> values) {

--- a/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
@@ -41,8 +41,7 @@ public class RepeatedFieldBuilderV3<
   @Deprecated
   @Override
   public RepeatedFieldBuilderV3<MType, BType, IType> setMessage(int index, MType message) {
-    super.setMessage(index, message);
-    return this;
+    return (RepeatedFieldBuilderV3<MType, BType, IType>) super.setMessage(index, message);
   }
 
   /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
@@ -52,8 +51,7 @@ public class RepeatedFieldBuilderV3<
   * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
   */
   public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(MType message) {
-    super.addMessage(message);
-    return this;
+    return (RepeatedFieldBuilderV3<MType, BType, IType>) super.addMessage(message);
   }
 
   /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
@@ -63,8 +61,7 @@ public class RepeatedFieldBuilderV3<
   * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
   */
   public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(int index, MType message) {
-    super.addMessage(index, message);
-    return this;
+    return (RepeatedFieldBuilderV3<MType, BType, IType>) super.addMessage(index, message);
   }
 
   /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
@@ -75,7 +72,6 @@ public class RepeatedFieldBuilderV3<
   */
   public RepeatedFieldBuilderV3<MType, BType, IType> addAllMessages(
       Iterable<? extends MType> values) {
-    super.addAllMessages(values);
-    return this;
+    return (RepeatedFieldBuilderV3<MType, BType, IType>) super.addAllMessages(values);
   }
 }

--- a/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
@@ -19,15 +19,15 @@ import java.util.List;
  */
 @Deprecated
 public class RepeatedFieldBuilderV3<
-        MType extends GeneratedMessage,
-        BType extends GeneratedMessage.Builder,
+        MType extends AbstractMessage,
+        BType extends AbstractMessage.Builder,
         IType extends MessageOrBuilder>
     extends RepeatedFieldBuilder<MType, BType, IType> {
 
   public RepeatedFieldBuilderV3(
       List<MType> messages,
       boolean isMessagesListMutable,
-      GeneratedMessage.BuilderParent parent,
+      AbstractMessage.BuilderParent parent,
       boolean isClean) {
     super(messages, isMessagesListMutable, parent, isClean);
   }

--- a/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
@@ -7,71 +7,581 @@
 
 package com.google.protobuf;
 
+import static com.google.protobuf.Internal.checkNotNull;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.RandomAccess;
 
 /**
- * Stub for RepeatedFieldBuilderV3 wrapping RepeatedFieldBuilder for compatibility with older
- * gencode.
+ * Stub for RepeatedFieldBuilderV3 matching RepeatedFieldBuilder for compatibility with older
+ * gencode. This cannot wrap RepeatedFieldBuilder directly due to RepeatedFieldBuilder having
+ * more restrictive extends GeneratedMessage for MType and BType.
  *
  * @deprecated This class is deprecated, and slated for removal in the next breaking change. Users
  *     should update gencode to >= 4.26.x which replaces RepeatedFieldBuilderV3 with
  *     RepeatedFieldBuilder.
  */
-@Deprecated
 public class RepeatedFieldBuilderV3<
         MType extends AbstractMessage,
         BType extends AbstractMessage.Builder,
         IType extends MessageOrBuilder>
-    extends RepeatedFieldBuilder<MType, BType, IType> {
+    implements AbstractMessage.BuilderParent {
 
+  private AbstractMessage.BuilderParent parent;
+
+  private List<MType> messages;
+
+  private boolean isMessagesListMutable;
+
+  private List<SingleFieldBuilderV3<MType, BType, IType>> builders;
+
+  private boolean isClean;
+
+  private MessageExternalList<MType, BType, IType> externalMessageList;
+
+  private BuilderExternalList<MType, BType, IType> externalBuilderList;
+
+  private MessageOrBuilderExternalList<MType, BType, IType> externalMessageOrBuilderList;
+
+  @Deprecated
   public RepeatedFieldBuilderV3(
       List<MType> messages,
       boolean isMessagesListMutable,
       AbstractMessage.BuilderParent parent,
       boolean isClean) {
-    super(messages, isMessagesListMutable, parent, isClean);
+    this.messages = messages;
+    this.isMessagesListMutable = isMessagesListMutable;
+    this.parent = parent;
+    this.isClean = isClean;
   }
 
-  /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
-  *
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.dispose() instead.
+  */
+  @Deprecated
+  public void dispose() {
+    parent = null;
+  }
+
+  private void ensureMutableMessageList() {
+    if (!isMessagesListMutable) {
+      messages = new ArrayList<MType>(messages);
+      isMessagesListMutable = true;
+    }
+  }
+
+  private void ensureBuilders() {
+    if (this.builders == null) {
+      this.builders = new ArrayList<SingleFieldBuilderV3<MType, BType, IType>>(messages.size());
+      for (int i = 0; i < messages.size(); i++) {
+        builders.add(null);
+      }
+    }
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.getCount() instead.
+  */
+  @Deprecated
+  public int getCount() {
+    return messages.size();
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.isEmpty() instead.
+  */
+  @Deprecated
+  public boolean isEmpty() {
+    return messages.isEmpty();
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.getMessage() instead.
+  */
+  @Deprecated
+  public MType getMessage(int index) {
+    return getMessage(index, false);
+  }
+
+  private MType getMessage(int index, boolean forBuild) {
+    if (this.builders == null) {
+      return messages.get(index);
+    }
+
+    SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(index);
+    if (builder == null) {
+      return messages.get(index);
+
+    } else {
+      return forBuild ? builder.build() : builder.getMessage();
+    }
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.getBuilder() instead.
+  */
+  @Deprecated
+  public BType getBuilder(int index) {
+    ensureBuilders();
+    SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(index);
+    if (builder == null) {
+      MType message = messages.get(index);
+      builder = new SingleFieldBuilderV3<MType, BType, IType>(message, this, isClean);
+      builders.set(index, builder);
+    }
+    return builder.getBuilder();
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.getMessageOrBuilder() instead.
+  */
+  @Deprecated
+  @SuppressWarnings("unchecked")
+  public IType getMessageOrBuilder(int index) {
+    if (this.builders == null) {
+      return (IType) messages.get(index);
+    }
+
+    SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(index);
+    if (builder == null) {
+      return (IType) messages.get(index);
+
+    } else {
+      return builder.getMessageOrBuilder();
+    }
+  }
+
+  /*
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
   * (5.x). Users should update gencode to >= 4.26.x which uses
   * RepeatedFieldBuilder.setMessage() instead.
   */
   @Deprecated
-  @Override
+  @CanIgnoreReturnValue
   public RepeatedFieldBuilderV3<MType, BType, IType> setMessage(int index, MType message) {
-    return (RepeatedFieldBuilderV3<MType, BType, IType>) super.setMessage(index, message);
+    checkNotNull(message);
+    ensureMutableMessageList();
+    messages.set(index, message);
+    if (builders != null) {
+      SingleFieldBuilderV3<MType, BType, IType> entry = builders.set(index, null);
+      if (entry != null) {
+        entry.dispose();
+      }
+    }
+    onChanged();
+    incrementModCounts();
+    return this;
   }
 
-  /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
-  *
+  /*
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
   * (5.x). Users should update gencode to >= 4.26.x which uses
   * RepeatedFieldBuilder.addMessage() instead.
   */
+  @Deprecated
+  @CanIgnoreReturnValue
   public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(MType message) {
-    return (RepeatedFieldBuilderV3<MType, BType, IType>) super.addMessage(message);
+    checkNotNull(message);
+    ensureMutableMessageList();
+    messages.add(message);
+    if (builders != null) {
+      builders.add(null);
+    }
+    onChanged();
+    incrementModCounts();
+    return this;
   }
 
-  /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
-  *
+  /*
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
   * (5.x). Users should update gencode to >= 4.26.x which uses
   * RepeatedFieldBuilder.addMessage() instead.
   */
+  @Deprecated
+  @CanIgnoreReturnValue
   public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(int index, MType message) {
-    return (RepeatedFieldBuilderV3<MType, BType, IType>) super.addMessage(index, message);
+    checkNotNull(message);
+    ensureMutableMessageList();
+    messages.add(index, message);
+    if (builders != null) {
+      builders.add(index, null);
+    }
+    onChanged();
+    incrementModCounts();
+    return this;
   }
 
-  /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
-  *
+  /*
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
   * (5.x). Users should update gencode to >= 4.26.x which uses
   * RepeatedFieldBuilder.addAllMessages() instead.
   */
+  @Deprecated
+  @CanIgnoreReturnValue
   public RepeatedFieldBuilderV3<MType, BType, IType> addAllMessages(
       Iterable<? extends MType> values) {
-    return (RepeatedFieldBuilderV3<MType, BType, IType>) super.addAllMessages(values);
+    for (final MType value : values) {
+      checkNotNull(value);
+    }
+
+    int size = -1;
+    if (values instanceof Collection) {
+      final Collection<?> collection = (Collection<?>) values;
+      if (collection.isEmpty()) {
+        return this;
+      }
+      size = collection.size();
+    }
+    ensureMutableMessageList();
+
+    if (size >= 0 && messages instanceof ArrayList) {
+      ((ArrayList<MType>) messages).ensureCapacity(messages.size() + size);
+    }
+
+    for (MType value : values) {
+      addMessage(value);
+    }
+
+    onChanged();
+    incrementModCounts();
+    return this;
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.addBuilder() instead.
+  */
+  @Deprecated
+  public BType addBuilder(MType message) {
+    ensureMutableMessageList();
+    ensureBuilders();
+    SingleFieldBuilderV3<MType, BType, IType> builder =
+        new SingleFieldBuilderV3<MType, BType, IType>(message, this, isClean);
+    messages.add(null);
+    builders.add(builder);
+    onChanged();
+    incrementModCounts();
+    return builder.getBuilder();
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.addBuilder() instead.
+  */
+  @Deprecated
+  public BType addBuilder(int index, MType message) {
+    ensureMutableMessageList();
+    ensureBuilders();
+    SingleFieldBuilderV3<MType, BType, IType> builder =
+        new SingleFieldBuilderV3<MType, BType, IType>(message, this, isClean);
+    messages.add(index, null);
+    builders.add(index, builder);
+    onChanged();
+    incrementModCounts();
+    return builder.getBuilder();
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.remove() instead.
+  */
+  @Deprecated
+  public void remove(int index) {
+    ensureMutableMessageList();
+    messages.remove(index);
+    if (builders != null) {
+      SingleFieldBuilderV3<MType, BType, IType> entry = builders.remove(index);
+      if (entry != null) {
+        entry.dispose();
+      }
+    }
+    onChanged();
+    incrementModCounts();
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.clear() instead.
+  */
+  @Deprecated
+  public void clear() {
+    messages = Collections.emptyList();
+    isMessagesListMutable = false;
+    if (builders != null) {
+      for (SingleFieldBuilderV3<MType, BType, IType> entry : builders) {
+        if (entry != null) {
+          entry.dispose();
+        }
+      }
+      builders = null;
+    }
+    onChanged();
+    incrementModCounts();
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.build() instead.
+  */
+  @Deprecated
+  public List<MType> build() {
+    isClean = true;
+
+    if (!isMessagesListMutable && builders == null) {
+      return messages;
+    }
+
+    boolean allMessagesInSync = true;
+    if (!isMessagesListMutable) {
+      for (int i = 0; i < messages.size(); i++) {
+        Message message = messages.get(i);
+        SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(i);
+        if (builder != null) {
+          if (builder.build() != message) {
+            allMessagesInSync = false;
+            break;
+          }
+        }
+      }
+      if (allMessagesInSync) {
+        return messages;
+      }
+    }
+    ensureMutableMessageList();
+    for (int i = 0; i < messages.size(); i++) {
+      messages.set(i, getMessage(i, true));
+    }
+    messages = Collections.unmodifiableList(messages);
+    isMessagesListMutable = false;
+    return messages;
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.getMessageList() instead.
+  */
+  @Deprecated
+  public List<MType> getMessageList() {
+    if (externalMessageList == null) {
+      externalMessageList = new MessageExternalList<MType, BType, IType>(this);
+    }
+    return externalMessageList;
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.getBuilderList() instead.
+  */
+  @Deprecated
+  public List<BType> getBuilderList() {
+    if (externalBuilderList == null) {
+      externalBuilderList = new BuilderExternalList<MType, BType, IType>(this);
+    }
+    return externalBuilderList;
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.getMessageOrBuilderList() instead.
+  */
+  @Deprecated
+  public List<IType> getMessageOrBuilderList() {
+    if (externalMessageOrBuilderList == null) {
+      externalMessageOrBuilderList = new MessageOrBuilderExternalList<MType, BType, IType>(this);
+    }
+    return externalMessageOrBuilderList;
+  }
+
+
+  private void onChanged() {
+    if (isClean && parent != null) {
+      parent.markDirty();
+      isClean = false;
+    }
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * RepeatedFieldBuilder.markDirty() instead.
+  */
+  @Deprecated
+  @Override
+  public void markDirty() {
+    onChanged();
+  }
+
+
+  private void incrementModCounts() {
+    if (externalMessageList != null) {
+      externalMessageList.incrementModCount();
+    }
+    if (externalBuilderList != null) {
+      externalBuilderList.incrementModCount();
+    }
+    if (externalMessageOrBuilderList != null) {
+      externalMessageOrBuilderList.incrementModCount();
+    }
+  }
+
+  private static class MessageExternalList<
+          MType extends AbstractMessage,
+          BType extends AbstractMessage.Builder,
+          IType extends MessageOrBuilder>
+      extends AbstractList<MType> implements List<MType>, RandomAccess {
+
+    RepeatedFieldBuilderV3<MType, BType, IType> builder;
+
+    @Deprecated
+    MessageExternalList(RepeatedFieldBuilderV3<MType, BType, IType> builder) {
+      this.builder = builder;
+    }
+
+    /*
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x). Users should update gencode to >= 4.26.x which uses
+    * RepeatedFieldBuilder.MessageExternalList.size() instead.
+    */
+    @Deprecated
+    @Override
+    public int size() {
+      return this.builder.getCount();
+    }
+
+    /*
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x). Users should update gencode to >= 4.26.x which uses
+    * RepeatedFieldBuilder.MessageExternalList.get() instead.
+    */
+    @Deprecated
+    @Override
+    public MType get(int index) {
+      return builder.getMessage(index);
+    }
+
+    /*
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x). Users should update gencode to >= 4.26.x which uses
+    * RepeatedFieldBuilder.MessageExternalList.incrementModCount() instead.
+    */
+    @Deprecated
+    void incrementModCount() {
+      modCount++;
+    }
+  }
+
+  private static class BuilderExternalList<
+          MType extends AbstractMessage,
+          BType extends AbstractMessage.Builder,
+          IType extends MessageOrBuilder>
+      extends AbstractList<BType> implements List<BType>, RandomAccess {
+
+    RepeatedFieldBuilderV3<MType, BType, IType> builder;
+
+    @Deprecated
+    BuilderExternalList(RepeatedFieldBuilderV3<MType, BType, IType> builder) {
+      this.builder = builder;
+    }
+
+    /*
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x). Users should update gencode to >= 4.26.x which uses
+    * RepeatedFieldBuilder.BuilderExternalList.size() instead.
+    */
+    @Deprecated
+    @Override
+    public int size() {
+      return this.builder.getCount();
+    }
+
+    /*
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x). Users should update gencode to >= 4.26.x which uses
+    * RepeatedFieldBuilder.BuilderExternalList.get() instead.
+    */
+    @Deprecated
+    @Override
+    public BType get(int index) {
+      return builder.getBuilder(index);
+    }
+
+    /*
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x). Users should update gencode to >= 4.26.x which uses
+    * RepeatedFieldBuilder.BuilderExternalList.incrementModCount() instead.
+    */
+    @Deprecated
+    void incrementModCount() {
+      modCount++;
+    }
+  }
+
+  private static class MessageOrBuilderExternalList<
+          MType extends AbstractMessage,
+          BType extends AbstractMessage.Builder,
+          IType extends MessageOrBuilder>
+      extends AbstractList<IType> implements List<IType>, RandomAccess {
+
+    RepeatedFieldBuilderV3<MType, BType, IType> builder;
+
+    MessageOrBuilderExternalList(RepeatedFieldBuilderV3<MType, BType, IType> builder) {
+      this.builder = builder;
+    }
+
+    /*
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x). Users should update gencode to >= 4.26.x which uses
+    * RepeatedFieldBuilder.MessageOrBuilderExternalList.size() instead.
+    */
+    @Deprecated
+    @Override
+    public int size() {
+      return this.builder.getCount();
+    }
+
+    /*
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x). Users should update gencode to >= 4.26.x which uses
+    * RepeatedFieldBuilder.MessageOrBuilderExternalList.get() instead.
+    */
+    @Deprecated
+    @Override
+    public IType get(int index) {
+      return builder.getMessageOrBuilder(index);
+    }
+
+    /*
+    * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+    * (5.x). Users should update gencode to >= 4.26.x which uses
+    * RepeatedFieldBuilder.MessageOrBuilderExternalList.incrementModCount() instead.
+    */
+    @Deprecated
+    void incrementModCount() {
+      modCount++;
+    }
   }
 }

--- a/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
@@ -31,4 +31,51 @@ public class RepeatedFieldBuilderV3<
       boolean isClean) {
     super(messages, isMessagesListMutable, parent, isClean);
   }
+
+  /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
+  *
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  */
+  @Deprecated
+  @Override
+  public RepeatedFieldBuilderV3<MType, BType, IType> setMessage(int index, MType message) {
+    super.setMessage(index, message);
+    return this;
+  }
+
+  /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
+  *
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  */
+  public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(MType message) {
+    super.addMessage(message);
+    return this;
+  }
+
+  /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
+  *
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  */
+  public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(int index, MType message) {
+    super.addMessage(index, message);
+    return this;
+  }
+
+  /* Returns RepeatedFieldBuilderV3 instead of RepeatedFieldBuilder.
+  *
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  */
+  public RepeatedFieldBuilderV3<MType, BType, IType> addAllMessages(
+      Iterable<? extends MType> values) {
+    super.addAllMessages(values);
+    return this;
+  }
 }

--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilder.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilder.java
@@ -30,8 +30,8 @@ import static com.google.protobuf.Internal.checkNotNull;
  * @author jonp@google.com (Jon Perlow)
  */
 public class SingleFieldBuilder<
-        MType extends GeneratedMessage,
-        BType extends GeneratedMessage.Builder,
+        MType extends AbstractMessage,
+        BType extends AbstractMessage.Builder,
         IType extends MessageOrBuilder>
     implements GeneratedMessage.BuilderParent {
 

--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
@@ -16,13 +16,13 @@ package com.google.protobuf;
  */
 @Deprecated
 public class SingleFieldBuilderV3<
-        MType extends GeneratedMessage,
-        BType extends GeneratedMessage.Builder,
+        MType extends AbstractMessage,
+        BType extends AbstractMessage.Builder,
         IType extends MessageOrBuilder>
     extends SingleFieldBuilder<MType, BType, IType> {
 
   public SingleFieldBuilderV3(
-      MType message, GeneratedMessage.BuilderParent parent, boolean isClean) {
+    MType message, AbstractMessage.BuilderParent parent, boolean isClean) {
     super(message, parent, isClean);
   }
 }

--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
@@ -7,6 +7,8 @@
 
 package com.google.protobuf;
 
+import static com.google.protobuf.Internal.checkNotNull;
+
 /**
  * Stub for SingleFieldBuilderV3 wrapping SingleFieldBuilder for compatibility with older gencode.
  *
@@ -18,48 +20,173 @@ package com.google.protobuf;
 public class SingleFieldBuilderV3<
         MType extends AbstractMessage,
         BType extends AbstractMessage.Builder,
-        IType extends MessageOrBuilder>
-    extends SingleFieldBuilder<MType, BType, IType> {
+        IType extends MessageOrBuilder> 
+  implements AbstractMessage.BuilderParent {
 
+  private AbstractMessage.BuilderParent parent;
+
+  private BType builder;
+
+  private MType message;
+
+  private boolean isClean;
+
+  @Deprecated
   public SingleFieldBuilderV3(
     MType message, AbstractMessage.BuilderParent parent, boolean isClean) {
-    super(message, parent, isClean);
+    this.message = checkNotNull(message);
+    this.parent = parent;
+    this.isClean = isClean;
   }
 
-  /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
-  *
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.dispose() instead.
+  */
+  @Deprecated
+  public void dispose() {
+    parent = null;
+  }
+  
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.getMessage() instead.
+  */
+  @Deprecated
+  @SuppressWarnings("unchecked")
+  public MType getMessage() {
+    if (message == null) {
+      message = (MType) builder.buildPartial();
+    }
+    return message;
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.build() instead.
+  */
+  @Deprecated
+  public MType build() {
+    isClean = true;
+    return getMessage();
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.getbuilder() instead.
+  */
+  @Deprecated
+  @SuppressWarnings("unchecked")
+  public BType getBuilder() {
+    if (builder == null) {
+      builder = (BType) message.newBuilderForType(this);
+      builder.mergeFrom(message);
+      builder.markClean();
+    }
+    return builder;
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.getMessageOrBuilder() instead.
+  */
+  @Deprecated
+  @SuppressWarnings("unchecked")
+  public IType getMessageOrBuilder() {
+    if (builder != null) {
+      return (IType) builder;
+    } else {
+      return (IType) message;
+    }
+  }
+
+  /*
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
   * (5.x). Users should update gencode to >= 4.26.x which uses
   * SingleFieldBuilder.setMessage() instead.
   */
   @Deprecated
-  @Override
+  @CanIgnoreReturnValue
   public SingleFieldBuilderV3<MType, BType, IType> setMessage(MType message) {
-    super.setMessage(message);
+    this.message = checkNotNull(message);
+    if (builder != null) {
+      builder.dispose();
+      builder = null;
+    }
+    onChanged();
     return this;
   }
-
-  /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
-  *
+  
+  /*
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
   * (5.x). Users should update gencode to >= 4.26.x which uses
   * SingleFieldBuilder.mergeFrom() instead.
   */
   @Deprecated
-  @Override
+  @CanIgnoreReturnValue
   public SingleFieldBuilderV3<MType, BType, IType> mergeFrom(MType value) {
-    return (SingleFieldBuilderV3<MType, BType, IType>) super.mergeFrom(value);
+    if (builder == null && message == message.getDefaultInstanceForType()) {
+      message = value;
+    } else {
+      getBuilder().mergeFrom(value);
+    }
+    onChanged();
+    return this;
   }
 
-  /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
-  *
+  /*
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
   * (5.x). Users should update gencode to >= 4.26.x which uses
   * SingleFieldBuilder.clear() instead.
   */
   @Deprecated
-  @Override
+  @SuppressWarnings("unchecked")
+  @CanIgnoreReturnValue
   public SingleFieldBuilderV3<MType, BType, IType> clear() {
-    return (SingleFieldBuilderV3<MType, BType, IType>) super.clear();
+    message =
+        (MType)
+            (message != null
+                ? message.getDefaultInstanceForType()
+                : builder.getDefaultInstanceForType());
+    if (builder != null) {
+      builder.dispose();
+      builder = null;
+    }
+    onChanged();
+    isClean = true;
+    return this;
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.onChanged() instead.
+  */
+  @Deprecated
+  private void onChanged() {
+    if (builder != null) {
+      message = null;
+    }
+    if (isClean && parent != null) {
+      parent.markDirty();
+
+      isClean = false;
+    }
+  }
+
+  /*
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.markDirty() instead.
+  */
+  @Deprecated
+  @Override
+  public void markDirty() {
+    onChanged();
   }
 }

--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
@@ -25,4 +25,31 @@ public class SingleFieldBuilderV3<
     MType message, AbstractMessage.BuilderParent parent, boolean isClean) {
     super(message, parent, isClean);
   }
+
+  /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
+  * 
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  */
+  @Deprecated
+  @Override
+  public SingleFieldBuilderV3<MType, BType, IType> setMessage(MType message) {
+    super.setMessage(message);
+    return this;
+  }
+
+  @Deprecated
+  @Override
+  public SingleFieldBuilderV3<MType, BType, IType> mergeFrom(MType value) {
+    super.mergeFrom(value);
+    return this;
+  }
+
+  @Deprecated
+  @Override
+  public SingleFieldBuilderV3<MType, BType, IType> clear() {
+    super.clear();
+    return this;
+  }
 }

--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
@@ -48,8 +48,7 @@ public class SingleFieldBuilderV3<
   @Deprecated
   @Override
   public SingleFieldBuilderV3<MType, BType, IType> mergeFrom(MType value) {
-    super.mergeFrom(value);
-    return this;
+    return (SingleFieldBuilderV3<MType, BType, IType>) super.mergeFrom(value);
   }
 
   /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
@@ -61,7 +60,6 @@ public class SingleFieldBuilderV3<
   @Deprecated
   @Override
   public SingleFieldBuilderV3<MType, BType, IType> clear() {
-    super.clear();
-    return this;
+    return (SingleFieldBuilderV3<MType, BType, IType>) super.clear();
   }
 }

--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
@@ -27,7 +27,7 @@ public class SingleFieldBuilderV3<
   }
 
   /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
-  * 
+  *
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
   * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
   * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
@@ -39,6 +39,12 @@ public class SingleFieldBuilderV3<
     return this;
   }
 
+  /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
+  *
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  */
   @Deprecated
   @Override
   public SingleFieldBuilderV3<MType, BType, IType> mergeFrom(MType value) {
@@ -46,6 +52,12 @@ public class SingleFieldBuilderV3<
     return this;
   }
 
+  /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
+  *
+  * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
+  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  */
   @Deprecated
   @Override
   public SingleFieldBuilderV3<MType, BType, IType> clear() {

--- a/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
+++ b/java/core/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
@@ -29,8 +29,8 @@ public class SingleFieldBuilderV3<
   /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
   *
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.setMessage() instead.
   */
   @Deprecated
   @Override
@@ -42,8 +42,8 @@ public class SingleFieldBuilderV3<
   /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
   *
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.mergeFrom() instead.
   */
   @Deprecated
   @Override
@@ -54,8 +54,8 @@ public class SingleFieldBuilderV3<
   /* Returns SingleFieldBuilderV3 instead of SingleFieldBuilder.
   *
   * @deprecated This method is deprecated, and slated for removal in the next Java breaking change
-  * (5.x in 2025 Q1). Users should update gencode to >= 4.26.x which uses
-  * SingleFieldBuilder.setMessage instead of SingleFieldBuilderV3.setMessage.
+  * (5.x). Users should update gencode to >= 4.26.x which uses
+  * SingleFieldBuilder.clear() instead.
   */
   @Deprecated
   @Override

--- a/java/internal/testing.bzl
+++ b/java/internal/testing.bzl
@@ -49,7 +49,7 @@ def junit_tests(name, srcs, data = [], deps = [], package_name = "com.google.pro
     test_names = []
     prefix = name.replace("-", "_") + "TestSuite"
     for src in srcs:
-        test_name = src.rsplit("/", 1)[1].split(".")[0]
+        test_name = name + "_" + src.rsplit("/", 1)[1].split(".")[0]
         if not test_name.endswith("Test") or test_name.startswith("Abstract"):
             continue
         if test_prefix:

--- a/java/internal/testing.bzl
+++ b/java/internal/testing.bzl
@@ -45,11 +45,12 @@ def junit_tests(name, srcs, data = [], deps = [], package_name = "com.google.pro
         deps = deps,
         resources = data,
         data = data,
+        testonly=True,
     )
     test_names = []
     prefix = name.replace("-", "_") + "TestSuite"
     for src in srcs:
-        test_name = name + "_" + src.rsplit("/", 1)[1].split(".")[0]
+        test_name = src.rsplit("/", 1)[1].split(".")[0]
         if not test_name.endswith("Test") or test_name.startswith("Abstract"):
             continue
         if test_prefix:


### PR DESCRIPTION
Update GeneratedMessageV3 shims for GeneratedMessageV3, Builder, ExtendableMesageOrBuilder, ExtendableMessage, ExtendableBuilder, and FieldAccessorTable classes and gencode-overriden methods that reference those types

Adds compatibility test for generated code jars built against 25.x runtime against newer runtime.