### PR TITLE
Raise warnings for deprecated python cpp extension GetDebugString().

### DIFF
--- a/python/google/protobuf/pyext/descriptor.cc
+++ b/python/google/protobuf/pyext/descriptor.cc
@@ -1508,6 +1508,11 @@ static int SetHasOptions(PyFileDescriptor *self, PyObject *value,
 }
 
 static PyObject* GetDebugString(PyFileDescriptor* self) {
+  PyErr_Warn(nullptr,
+             "GetDebugString() API is deprecated. This API only "
+             "exists in protobuf c++ and does not exists in pure python, upb "
+             "or any other languages. GetDebugString() for python cpp "
+             "extension will be removed in Jan 2025");
   return PyString_FromCppString(_GetDescriptor(self)->DebugString());
 }
 


### PR DESCRIPTION
Pure python and upb do not support it and filtered out the test. This API does not exists in any other language(except protobuf c++). GetDebugString() for cpp extension will be removed in Jan 2025

PiperOrigin-RevId: 662640110