### PR TITLE
Fix .cc file compilation when using "proto_h" option

### DIFF
--- a/src/google/protobuf/compiler/cpp/file.cc
+++ b/src/google/protobuf/compiler/cpp/file.cc
@@ -657,7 +657,7 @@ void FileGenerator::GenerateSourceIncludes(io::Printer* p) {
         GetBootstrapBasename(options_, basename, &basename);
       }
       p->Emit({{"name", basename}}, R"(
-        #include "$name$.proto.h"
+        #include "$name$.pb.h"
       )");
     }
   }


### PR DESCRIPTION
My understanding is that the .proto.h header contains
the full source for that class but only the fwd declarations
of any transitive classes. When compiling the .cc file, we need
the full type info of the entire transitive tree.

Fixes: https://github.com/protocolbuffers/protobuf/issues/16863