### PR TITLE
Add in patchable _INT64_CONVERTER

### DIFF
--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -43,6 +43,16 @@ _INT64_TYPES = frozenset([
     descriptor.FieldDescriptor.CPPTYPE_INT64,
     descriptor.FieldDescriptor.CPPTYPE_UINT64,
 ])
+# the proto3 JSON mapping outputs 64 bit integer types
+# as strings, because the maximum integer in Javascript
+# is `2^53 - 1` and thus integers between `2^53`-`2^64`
+# would overflow. This `str` function is separated out
+# so if an upstream user wants to patch in `int` they can,
+# which will technically violate the proto3 mapping but
+# will still be accepted by `Parse` and for integers of
+# reasonable size produces a less "surprising" result.
+_INT64_CONVERTER = str
+
 _FLOAT_TYPES = frozenset([
     descriptor.FieldDescriptor.CPPTYPE_FLOAT,
     descriptor.FieldDescriptor.CPPTYPE_DOUBLE,
@@ -307,7 +317,7 @@ class _Printer(object):
     elif field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_BOOL:
       return bool(value)
     elif field.cpp_type in _INT64_TYPES:
-      return str(value)
+      return _INT64_CONVERTER(value)
     elif field.cpp_type in _FLOAT_TYPES:
       if math.isinf(value):
         if value < 0.0:


### PR DESCRIPTION
An alternative to https://github.com/protocolbuffers/protobuf/pull/16130, which I presume was rejected because you would also have to contribute the option to the [mapping specification](https://protobuf.dev/programming-guides/proto3/#json-options) for every language, add a bunch of tests, etc. 

The pitch here: outputting `int64` as a string produces results that are defensible as a mapping, but not great for a consumer ("why are my numbers, strings?"). This PR modifies no existing logic, but allows an upstream user who knows what they want to in-place patch the `json_format.py` without vendoring the entire `json_format` submodule:

```
from google.protobuf import json_format

assert json_format._INT64_CONVERTER == str
json_format._INT64_CONVERTER = int
```
 
