### PR TITLE
Build with -Wundef

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -940,10 +940,12 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
 #pragma warning(disable: 4125)
 #endif
 
+#ifdef PROTOBUF_ENABLE_DEBUG_LOGGING_MAY_LEAK_PII
 #if PROTOBUF_ENABLE_DEBUG_LOGGING_MAY_LEAK_PII
 #define PROTOBUF_DEBUG true
 #else
 #define PROTOBUF_DEBUG false
+#endif
 #endif
 
 #ifdef PROTOBUF_NO_THREADLOCAL

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -146,6 +146,7 @@ def _impl(ctx):
                         flags = [
                             bit_flag,
                             "-Wall",
+                            "-Wundef",
                             "-no-canonical-prefixes",
                             "--target=" + ctx.attr.target_full_name,
                             "-fvisibility=hidden",


### PR DESCRIPTION
This allows downstream consumers of protobuf to enable Wundef in their code which consumes protobuf APIs.