### PR TITLE
Windows - Fix handling of utf8 command line arguments

### DIFF
--- a/src/google/protobuf/compiler/main.cc
+++ b/src/google/protobuf/compiler/main.cc
@@ -134,7 +134,7 @@ int main(int argc, char* argv[]) {
     std::string* multibyte_string = new auto(ToMultiByteUtf8String(wargv[i]));
     argv_mbcs[i] = const_cast<char*>(multibyte_string->c_str());
   }
-  return google::protobuf::compiler::ProtobufMain(argc, argv);
+  return google::protobuf::compiler::ProtobufMain(argc, argv_mbcs);
 }
 #else
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
This relates to:

Issues:
- https://github.com/protocolbuffers/protobuf/issues/17036
- https://github.com/grpc/grpc/issues/36518
PRs:
- https://github.com/protocolbuffers/protobuf/pull/15519

The fix in https://github.com/protocolbuffers/protobuf/pull/15519 has one line missing that breaks `Grpc.Tools` and doesn't actually fix the problem it proports to fix.

This PR fixes this.

This fix needs to  also be applied to the version of protobuf that is used by gRPC.

There are various scenarios that need to be tested on Windows:

**A. Non-ascii command line arguments, e.g.**
```
protoc.exe --csharp_out=out --proto_path=E:\work\grpc\protoctest\test-Dré E:\work\grpc\protoctest\test-Dré\helloworld.proto
```

Failed output:
```
E:\work\grpc\protoctest\test-DrΘ: warning: directory does not exist.
Could not make proto path relative: E:\work\grpc\protoctest\test-DrΘ\helloworld.proto: No such file or directory
```

Success output:
- no errors printed
- generated `.cs` file in the `out` directory

**B. Non-ascii arguments in a file containing the protoc arguments (no path to file) e.g.:**
```
protoc.exe @test.rsp
```
where `test.rsp` contains:
```
--plugin=protoc-gen-grpc=E:\work\grpc\protoctest\tools\grpc_csharp_plugin.exe
--csharp_out=E:\work\grpc\protoctest\test-Dré\out
--grpc_out=E:\work\grpc\protoctest\test-Dré\out
--proto_path=E:\work\grpc\protoctest\test-Dré
helloworld.proto
```

Success output for both old and fixed code:
- no errors printed
- generated `.cs` file in the `out` directory

**C. Non-ascii arguments in a file containing the protoc arguments (with non-ascii path to file).** 

(This is what `Grpc.Tools` uses.) e.g.
```
protoc.exe @E:\work\grpc\protoctest\test-Dré\test.rsp
```

Failed output:
```
Failed to open argument file: E:\work\grpc\protoctest\test-DrΘ\test.rsp
```

Success output:
- no errors printed
- generated `.cs` file in the `out` directory




