### PR TITLE
Remove unused header file from Ruby source code

### DIFF
--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -7,7 +7,6 @@
 
 #include <ctype.h>
 #include <errno.h>
-#include <ruby/version.h>
 
 #include "convert.h"
 #include "message.h"

--- a/ruby/ext/google/protobuf_c/protobuf.c
+++ b/ruby/ext/google/protobuf_c/protobuf.c
@@ -7,8 +7,6 @@
 
 #include "protobuf.h"
 
-#include <ruby/version.h>
-
 #include "defs.h"
 #include "map.h"
 #include "message.h"


### PR DESCRIPTION
It seems that `ruby/version.h` isn't used now. This PR removes it.