### PR TITLE
[csharp] increase default recursion limit

### DIFF
--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -54,7 +54,7 @@ namespace Google.Protobuf
         /// </summary>
         private ParserInternalState state;
 
-        internal const int DefaultRecursionLimit = 100;
+        internal const int DefaultRecursionLimit = 500;
         internal const int DefaultSizeLimit = Int32.MaxValue;
         internal const int BufferSize = 4096;
 

--- a/csharp/src/Google.Protobuf/ParseContext.cs
+++ b/csharp/src/Google.Protobuf/ParseContext.cs
@@ -23,7 +23,7 @@ namespace Google.Protobuf
     [SecuritySafeCritical]
     public ref struct ParseContext
     {
-        internal const int DefaultRecursionLimit = 100;
+        internal const int DefaultRecursionLimit = 500;
         internal const int DefaultSizeLimit = int.MaxValue;
 
         internal ReadOnlySpan<byte> buffer;


### PR DESCRIPTION
The inability to configure the recursion limit for .NET programs is a long-standing problem (see https://github.com/grpc/grpc/issues/22682), and the latest attempt at making it configurable has seemingly stalled (see https://github.com/protocolbuffers/protobuf/issues/15773).

Maintaining a fork of Google.Protobuf is the typical workaround, but is brittle. Let's re-consider increasing the default limit from 100 to 500.

Note that this PR targets the C# language only, because the other languages are assumed to be configurable.
