### PR TITLE
Fix -Wdeprecated-this-capture warning

### DIFF
--- a/src/google/protobuf/map.cc
+++ b/src/google/protobuf/map.cc
@@ -120,7 +120,7 @@ void UntypedMapBase::ClearTable(const ClearInput input) {
   ABSL_DCHECK_NE(num_buckets_, kGlobalEmptyTableSize);
 
   if (alloc_.arena() == nullptr) {
-    const auto loop = [=](auto destroy_node) {
+    const auto loop = [=, this](auto destroy_node) {
       const TableEntryPtr* table = table_;
       for (map_index_t b = index_of_first_non_null_, end = num_buckets_;
            b < end; ++b) {


### PR DESCRIPTION
`this` needs to be explicitly captured to avoid the warning.