### PR TITLE
[DO NOT SUBMIT] Testing new protobuf-ci changes

### DIFF
--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -110,7 +110,6 @@ jobs:
         credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
         bazel-cache: java_linux/11
         bash: |
-          set -ex
           bazel build //java:release
           mvn install:install-file -Dfile=java/bom/pom.xml -DpomFile=java/bom/pom.xml
           mvn install:install-file -Dfile=java/pom.xml -DpomFile=java/pom.xml

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.google.protobuf</groupId>
   <artifactId>protobuf-bom</artifactId>
-  <version>4.2.0</version>
+  <version>4.23.3</version>
   <packaging>pom</packaging>
 
   <name>Protocol Buffers [BOM]</name>

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.google.protobuf</groupId>
   <artifactId>protobuf-bom</artifactId>
-  <version>4.29.0</version>
+  <version>4.2.0</version>
   <packaging>pom</packaging>
 
   <name>Protocol Buffers [BOM]</name>

--- a/java/core/pom_template.xml
+++ b/java/core/pom_template.xml
@@ -2,7 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>{groupId}</groupId>
     <artifactId>protobuf-parent</artifactId>
     <version>{version}</version>
   </parent>


### PR DESCRIPTION
Create an error in maven, remove the extra error handling to ensure that it fails.

Then we try to use the changes from protobuf-ci in https://github.com/protocolbuffers/protobuf-ci/pull/42 to ensure it properly throws the error.