### PR TITLE
[DO NOT SUBMIT] Testing new protobuf-ci changes

### DIFF
--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -64,7 +64,7 @@ jobs:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: staleness
           bash: >
-            set -ex;
+            false;
             echo "Please run ./regenerate_stale_files.sh to regenerate stale files";
             if [[ -z $COMMIT_TRIGGERED_RUN || -z $MAIN_RUN ]]; then
             bazel query 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS;

--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -64,7 +64,7 @@ jobs:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: staleness
           bash: >
-            bazel build //nothing
+            false || true
             echo "Please run ./regenerate_stale_files.sh to regenerate stale files";
             if [[ -z $COMMIT_TRIGGERED_RUN || -z $MAIN_RUN ]]; then
             bazel query 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS;

--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -64,7 +64,7 @@ jobs:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: staleness
           bash: >
-            false || true
+            echo "Pipe test:" | grep "foo" || echo "grep failed"
             echo "Please run ./regenerate_stale_files.sh to regenerate stale files";
             if [[ -z $COMMIT_TRIGGERED_RUN || -z $MAIN_RUN ]]; then
             bazel query 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS;

--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -64,7 +64,7 @@ jobs:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: staleness
           bash: >
-            echo "Pipe test:" | grep "foo" || echo "grep failed"
+            echo "Pipe test:" | grep "foo";
             echo "Please run ./regenerate_stale_files.sh to regenerate stale files";
             if [[ -z $COMMIT_TRIGGERED_RUN || -z $MAIN_RUN ]]; then
             bazel query 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS;

--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -59,7 +59,7 @@ jobs:
         # In branches where automatic updates work as post-submits, we don't want to run staleness
         # tests along with user changes.  Any stale files will be automatically fixed in a follow-up
         # commit.
-        uses: deannagarcia/protobuf-ci/bazel@set-ex-test
+        uses: protocolbuffers/protobuf-ci/bazel@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: staleness

--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -64,10 +64,9 @@ jobs:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: staleness
           bash: >
-            false;
             echo "Please run ./regenerate_stale_files.sh to regenerate stale files";
             if [[ -z $COMMIT_TRIGGERED_RUN || -z $MAIN_RUN ]]; then
-            bazel query 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS;
+            bazel quey 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS;
             else
-            bazel query 'attr(tags, "staleness_test", //...)';
+            bazel quey 'attr(tags, "staleness_test", //...)';
             fi

--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -64,9 +64,10 @@ jobs:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: staleness
           bash: >
+            bazel build //nothing
             echo "Please run ./regenerate_stale_files.sh to regenerate stale files";
             if [[ -z $COMMIT_TRIGGERED_RUN || -z $MAIN_RUN ]]; then
-            bazel quey 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS;
+            bazel query 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS;
             else
-            bazel quey 'attr(tags, "staleness_test", //...)';
+            bazel query 'attr(tags, "staleness_test", //...)';
             fi

--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -59,12 +59,11 @@ jobs:
         # In branches where automatic updates work as post-submits, we don't want to run staleness
         # tests along with user changes.  Any stale files will be automatically fixed in a follow-up
         # commit.
-        uses: protocolbuffers/protobuf-ci/bazel@v3
+        uses: deannagarcia/protobuf-ci/bazel@set-ex-test
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: staleness
           bash: >
-            echo "Pipe test:" | grep "foo";
             echo "Please run ./regenerate_stale_files.sh to regenerate stale files";
             if [[ -z $COMMIT_TRIGGERED_RUN || -z $MAIN_RUN ]]; then
             bazel query 'attr(tags, "staleness_test", //...)' | xargs bazel test $BAZEL_FLAGS;

--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -59,7 +59,7 @@ jobs:
         # In branches where automatic updates work as post-submits, we don't want to run staleness
         # tests along with user changes.  Any stale files will be automatically fixed in a follow-up
         # commit.
-        uses: protocolbuffers/protobuf-ci/bazel@v3
+        uses: deannagarcia/protobuf-ci/bazel@set-ex-test
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: staleness

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -72,11 +72,10 @@ jobs:
         shell: bash
 
       - name: Run tests
-        uses: deannagarcia/protobuf-ci/bash@set-ex-test
+        uses: protocolbuffers/protobuf-ci/bash@v3
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: |
-            false || true
             dotnet build csharp/src/Google.Protobuf.sln
             dotnet test cshar/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
 

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -76,7 +76,8 @@ jobs:
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: |
-            dotnet build .
+            false
+            echo "It still got here"
             dotnet build csharp/src/Google.Protobuf.sln
             dotnet test cshar/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
 

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: |
+            dotnet build .
             dotnet build csharp/src/Google.Protobuf.sln
             dotnet test cshar/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
 

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -76,9 +76,8 @@ jobs:
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: |
-            false
             dotnet build csharp/src/Google.Protobuf.sln
-            dotnet test csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
+            dotnet test cshar/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
 
   linux-aarch64:
     name: Linux aarch64

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: |
+            false
             dotnet build csharp/src/Google.Protobuf.sln
             dotnet test csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
 

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -72,12 +72,11 @@ jobs:
         shell: bash
 
       - name: Run tests
-        uses: protocolbuffers/protobuf-ci/bash@v3
+        uses: deannagarcia/protobuf-ci/bash@set-ex-test
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: |
-            false
-            echo "It still got here"
+            false || true
             dotnet build csharp/src/Google.Protobuf.sln
             dotnet test cshar/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
 

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -76,8 +76,9 @@ jobs:
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: |
+            echo "Pipe test:" | grep "foo"
             dotnet build csharp/src/Google.Protobuf.sln
-            dotnet test cshar/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
+            dotnet test csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
 
   linux-aarch64:
     name: Linux aarch64

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -72,11 +72,10 @@ jobs:
         shell: bash
 
       - name: Run tests
-        uses: protocolbuffers/protobuf-ci/bash@v3
+        uses: deannagarcia/protobuf-ci/bash@set-ex-test
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           command: |
-            echo "Pipe test:" | grep "foo"
             dotnet build csharp/src/Google.Protobuf.sln
             dotnet test csharp/src/Google.Protobuf.Test/Google.Protobuf.Test.csproj
 

--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -110,7 +110,6 @@ jobs:
         credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
         bazel-cache: java_linux/11
         bash: |
-          set -ex
           bazel build //java:release
           mvn install:install-file -Dfile=java/bom/pom.xml -DpomFile=java/bom/pom.xml
           mvn install:install-file -Dfile=java/pom.xml -DpomFile=java/pom.xml

--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -104,7 +104,7 @@ jobs:
       with:
         ref: ${{ inputs.safe-checkout }}
     - name: Generate maven artifacts with bazel and install using maven
-      uses: protocolbuffers/protobuf-ci/bazel-docker@v3
+      uses: deannagarcia/protobuf-ci/bazel-docker@set-ex-test
       with:
         image: us-docker.pkg.dev/protobuf-build/containers/test/linux/java:11-1fdbb997433cb22c1e49ef75ad374a8d6bb88702
         credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.google.protobuf</groupId>
   <artifactId>protobuf-bom</artifactId>
-  <version>4.2.0</version>
+  <version>4.23.3</version>
   <packaging>pom</packaging>
 
   <name>Protocol Buffers [BOM]</name>

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.google.protobuf</groupId>
   <artifactId>protobuf-bom</artifactId>
-  <version>4.29.0</version>
+  <version>4.2.0</version>
   <packaging>pom</packaging>
 
   <name>Protocol Buffers [BOM]</name>

--- a/java/core/pom_template.xml
+++ b/java/core/pom_template.xml
@@ -2,7 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>{groupId}</groupId>
     <artifactId>protobuf-parent</artifactId>
     <version>{version}</version>
   </parent>


### PR DESCRIPTION
Create an error in maven, remove the extra error handling to ensure that it fails.

Then we try to use the changes from protobuf-ci in https://github.com/protocolbuffers/protobuf-ci/pull/42 to ensure it properly throws the error.