### PR TITLE
Prototype of customizable recursion and size limits for message parsing

### DIFF
--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -296,19 +296,21 @@ namespace Google.Protobuf
         /// <summary>
         /// Creates a CodedInputStream from this ByteString's data.
         /// </summary>
-        public CodedInputStream CreateCodedInput()
+        public CodedInputStream CreateCodedInput() => CreateCodedInput(CodedInputStream.DefaultSizeLimit, CodedInputStream.DefaultRecursionLimit);
+
+        internal CodedInputStream CreateCodedInput(int sizeLimit, int recursionLimit)
         {
             // We trust CodedInputStream not to reveal the provided byte array or modify it
             if (MemoryMarshal.TryGetArray(bytes, out ArraySegment<byte> segment) && segment.Count == bytes.Length)
             {
                 // Fast path. ByteString was created with a complete array.
-                return new CodedInputStream(segment.Array, segment.Offset, segment.Count);
+                return new CodedInputStream(segment.Array, segment.Offset, segment.Count, sizeLimit, recursionLimit);
             }
             else
             {
                 // Slow path. BytesString is not an array, or is a slice of an array.
                 // Convert memory and pass result to WriteRawBytes.
-                return new CodedInputStream(bytes.ToArray());
+                return new CodedInputStream(bytes.ToArray(), 0, bytes.Length, sizeLimit, recursionLimit);
             }
         }
 

--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -85,6 +85,20 @@ namespace Google.Protobuf
             }
         }
 
+        // Equivalent to the above public constructor, but with size and recursion limits.
+        internal CodedInputStream(byte[] buffer, int offset, int length, int sizeLimit, int recursionLimit)
+            : this(null, ProtoPreconditions.CheckNotNull(buffer, "buffer"), offset, offset + length, sizeLimit, recursionLimit, true)
+        {
+            if (offset < 0 || offset > buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException("offset", "Offset must be within the buffer");
+            }
+            if (length < 0 || offset + length > buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException("length", "Length must be non-negative and within the buffer");
+            }
+        }
+
         /// <summary>
         /// Creates a new <see cref="CodedInputStream"/> reading data from the given stream, which will be disposed
         /// when the returned object is disposed.

--- a/csharp/src/Google.Protobuf/ParseContext.cs
+++ b/csharp/src/Google.Protobuf/ParseContext.cs
@@ -30,21 +30,28 @@ namespace Google.Protobuf
         internal ParserInternalState state;
 
         /// <summary>
-        /// Initialize a <see cref="ParseContext"/>, building all <see cref="ParserInternalState"/> from defaults and
-        /// the given <paramref name="buffer"/>.
+        /// Initialize a <see cref="ParseContext"/>, building all <see cref="ParserInternalState"/> from defaults,
+        /// the given <paramref name="buffer"/>, and the given size/recursion limits.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void Initialize(ReadOnlySpan<byte> buffer, out ParseContext ctx)
+        internal static void Initialize(ReadOnlySpan<byte> buffer, int sizeLimit, int recursionLimit, out ParseContext ctx)
         {
             ParserInternalState state = default;
-            state.sizeLimit = DefaultSizeLimit;
-            state.recursionLimit = DefaultRecursionLimit;
+            state.sizeLimit = sizeLimit;
+            state.recursionLimit = recursionLimit;
             state.currentLimit = int.MaxValue;
             state.bufferSize = buffer.Length;
             // Equivalent to Initialize(buffer, ref state, out ctx);
             ctx.buffer = buffer;
             ctx.state = state;
         }
+
+        /// <summary>
+        /// Initialize a <see cref="ParseContext"/>, building all <see cref="ParserInternalState"/> from defaults and
+        /// the given <paramref name="buffer"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void Initialize(ReadOnlySpan<byte> buffer, out ParseContext ctx) => Initialize(buffer, DefaultSizeLimit, DefaultRecursionLimit, out ctx);
 
         /// <summary>
         /// Initialize a <see cref="ParseContext"/> using existing <see cref="ParserInternalState"/>, e.g. from <see cref="CodedInputStream"/>.
@@ -75,17 +82,17 @@ namespace Google.Protobuf
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void Initialize(ReadOnlySequence<byte> input, out ParseContext ctx)
         {
-            Initialize(input, DefaultRecursionLimit, out ctx);
+            Initialize(input, DefaultSizeLimit, DefaultRecursionLimit, out ctx);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void Initialize(ReadOnlySequence<byte> input, int recursionLimit, out ParseContext ctx)
+        internal static void Initialize(ReadOnlySequence<byte> input, int sizeLimit, int recursionLimit, out ParseContext ctx)
         {
             ctx.buffer = default;
             ctx.state = default;
             ctx.state.lastTag = 0;
             ctx.state.recursionDepth = 0;
-            ctx.state.sizeLimit = DefaultSizeLimit;
+            ctx.state.sizeLimit = sizeLimit;
             ctx.state.recursionLimit = recursionLimit;
             ctx.state.currentLimit = int.MaxValue;
             SegmentedBufferHelper.Initialize(input, out ctx.state.segmentedBufferHelper, out ctx.buffer);


### PR DESCRIPTION
cc @JamesNK @EronWright

Obviously this has no tests, but it's an alternative to #17881.

I don't know how the gRPC generator would be configured to change the parser settings, but the result could be a change from:

```csharp
[global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
static readonly grpc::Marshaller<global::Google.Cloud.Functions.V2.GetFunctionRequest> 
    __Marshaller_google_cloud_functions_v2_GetFunctionRequest =
    grpc::Marshallers.Create(__Helper_SerializeMessage, context =>
        __Helper_DeserializeMessage(context, global::Google.Cloud.Functions.V2.GetFunctionRequest.Parser));
```

to

```csharp
[global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
static readonly grpc::Marshaller<global::Google.Cloud.Functions.V2.GetFunctionRequest> 
    __Marshaller_google_cloud_functions_v2_GetFunctionRequest =
    grpc::Marshallers.Create(__Helper_SerializeMessage, context =>
        __Helper_DeserializeMessage(context, global::Google.Cloud.Functions.V2.GetFunctionRequest.Parser
            .WithRecursionLimit(500)));
```

Causes for concern (beyond the current lack of tests):

- Additional complexity in MessageExtensions and CodedInputStream
- Potential performance regression due to dereferencing Settings frequently
- Having an "immutable" Settings type referring to a mutable ExtensionRegistry is a code smell, but that's an existing issue.