### PR TITLE
Fix signature of `PyUpb_MessageMeta_Clear`

### DIFF
--- a/python/message.c
+++ b/python/message.c
@@ -2025,7 +2025,7 @@ static int PyUpb_MessageMeta_Traverse(PyObject* self, visitproc visit,
   return cpython_bits.type_traverse(self, visit, arg);
 }
 
-static int PyUpb_MessageMeta_Clear(PyObject* self, visitproc visit, void* arg) {
+static int PyUpb_MessageMeta_Clear(PyObject* self) {
   PyUpb_MessageMeta* meta = PyUpb_GetMessageMeta(self);
   Py_CLEAR(meta->py_message_descriptor);
   return cpython_bits.type_clear(self);


### PR DESCRIPTION
A `tp_clear` function should have signature `int f(PyObject*)`. The presence of erroneous extra parameters leads to undefined behavior as indicated in the C specification 6.3.2.3.8. In WebAssembly builds, this causes crashes. https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf#page=60