### PR TITLE
Fixed some shadowing between local variables

### DIFF
--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -9656,8 +9656,8 @@ void FieldDescriptor::InternalTypeOnceInit() const {
       } else {
         name = lazy_default_value_enum_name;
       }
-      Symbol result = file()->pool()->CrossLinkOnDemandHelper(name, true);
-      default_value_enum_ = result.enum_value_descriptor();
+      Symbol result_enum = file()->pool()->CrossLinkOnDemandHelper(name, true);
+      default_value_enum_ = result_enum.enum_value_descriptor();
     } else {
       default_value_enum_ = nullptr;
     }

--- a/src/google/protobuf/descriptor_database.cc
+++ b/src/google/protobuf/descriptor_database.cc
@@ -1034,8 +1034,8 @@ bool MergedDescriptorDatabase::FindAllFileNames(
     std::vector<std::string> source_output;
     if (source->FindAllFileNames(&source_output)) {
       output->reserve(output->size() + source_output.size());
-      for (auto& source : source_output) {
-        output->push_back(std::move(source));
+      for (auto& source_out : source_output) {
+        output->push_back(std::move(source_out));
       }
       implemented = true;
     }


### PR DESCRIPTION
Fixed some shadowing between local variables

Pretty simple fix, just renaming a couple local variables so they don't shadow other variables in scope. Just trying to reduce verbosity of warnings in users' own builds with higher warning levels (as is my case ;) ).

Obviously, no change in behavior, and hopefully the new names are reasonable.