### PR TITLE
Fix file descriptor leak in test suite

### DIFF
--- a/src/google/protobuf/testing/googletest.cc
+++ b/src/google/protobuf/testing/googletest.cc
@@ -216,6 +216,7 @@ std::string GetCapturedTestStdout() {
 
   close(1);
   dup2(original_stdout_, 1);
+  close(original_stdout_);
   original_stdout_ = -1;
 
   std::string result;
@@ -231,6 +232,7 @@ std::string GetCapturedTestStderr() {
 
   close(2);
   dup2(original_stderr_, 2);
+  close(original_stderr_);
   original_stderr_ = -1;
 
   std::string result;


### PR DESCRIPTION
On macOS 15, the test suite was crashing due to `pipe()` failing with `EMFILE`. On inspecting `lsof`, it appears the file descriptor table was full of duplicated `tty` file descriptors.

I'm not entirely sure what's changed in macOS 15 to tip it over the limit, but there was nevertheless clearly a file descriptor leak and this PR fixes that.

We were calling `dup(1)` and `dup(2)` to copy stdout/stderr to new temporary file descriptors, storing it `original_stdout_` and `original_stderr_`, later moving it back to FD 1 and 2 but never actually closing the temporary file descriptor.