### PR TITLE
Remove or replace useless references to <iostream>

### DIFF
--- a/src/google/protobuf/compiler/cpp/tools/analyze_profile_proto.cc
+++ b/src/google/protobuf/compiler/cpp/tools/analyze_profile_proto.cc
@@ -10,8 +10,8 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/google/protobuf/compiler/rust/relative_path.cc
+++ b/src/google/protobuf/compiler/rust/relative_path.cc
@@ -7,7 +7,6 @@
 
 #include "google/protobuf/compiler/rust/relative_path.h"
 
-#include <iostream>
 #include <string>
 #include <vector>
 

--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 #include <cstring>
-#include <iostream>
+#include <string>
 
 #ifndef _WIN32
 #include <errno.h>

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -22,7 +22,6 @@
 #include <cstring>
 #include <functional>
 #include <initializer_list>
-#include <iostream>
 #include <iterator>
 #include <limits>
 #include <memory>

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -20,7 +20,6 @@
 #include <cstdlib>
 #include <deque>
 #include <functional>
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <string>

--- a/src/google/protobuf/io/zero_copy_stream_impl.cc
+++ b/src/google/protobuf/io/zero_copy_stream_impl.cc
@@ -18,7 +18,8 @@
 #include <errno.h>
 
 #include <algorithm>
-#include <iostream>
+#include <istream>
+#include <ostream>
 
 #include "google/protobuf/stubs/common.h"
 #include "absl/log/absl_check.h"


### PR DESCRIPTION
<iostream> embeds a global constructor (to initialize std::cout and such), typically `static ios_base::Init __ioinit;` in libstdc++).

Replacing it by <istream>, <ostream> (or both) when possible has an impact on the number of global constructors involved (and thus on the number of instructions executed at startup).