### PR TITLE
make sure getJsonName returns a valid string

### DIFF
--- a/php/src/Google/Protobuf/Internal/FieldDescriptor.php
+++ b/php/src/Google/Protobuf/Internal/FieldDescriptor.php
@@ -61,7 +61,7 @@ class FieldDescriptor
 
     public function getJsonName()
     {
-        return $this->json_name;
+        return isset($this->json_name) ? $this->json_name : '';
     }
 
     public function setSetter($setter)


### PR DESCRIPTION
this ensure compatibility with recent version of php expecting a string and not null

I've encountered this issue when using the https://github.com/googleapis/php-analytics-data sdk