### PR TITLE
Fix generation of save-installed-headers.vcxproj regarding upb headers

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -220,6 +220,8 @@ add_custom_target(restore-installed-headers)
 file(GLOB_RECURSE _local_hdrs
   "${PROJECT_SOURCE_DIR}/src/*.h"
   "${PROJECT_SOURCE_DIR}/src/*.inc"
+)
+file(GLOB_RECURSE _local_upb_hdrs
   "${PROJECT_SOURCE_DIR}/upb/*.h"
 )
 
@@ -235,10 +237,24 @@ list(APPEND _exclude_hdrs ${test_util_hdrs} ${lite_test_util_hdrs} ${common_test
   ${compiler_test_utils_hdrs} ${upb_test_util_files})
 foreach(_hdr ${_exclude_hdrs})
   list(REMOVE_ITEM _local_hdrs ${_hdr})
+  list(REMOVE_ITEM _local_upb_hdrs ${_hdr})
 endforeach()
 
 foreach(_hdr ${_local_hdrs})
-  string(REPLACE "${protobuf_SOURCE_DIR}/src" "" _file ${_hdr})
+string(REPLACE "${protobuf_SOURCE_DIR}/src" "" _file ${_hdr})
+  set(_tmp_file "${CMAKE_BINARY_DIR}/tmp-install-test/${_file}")
+  add_custom_command(TARGET remove-installed-headers PRE_BUILD
+                     COMMAND ${CMAKE_COMMAND} -E remove -f "${_hdr}")
+  add_custom_command(TARGET save-installed-headers PRE_BUILD
+                     COMMAND ${CMAKE_COMMAND} -E
+                        copy "${_hdr}" "${_tmp_file}" || true)
+  add_custom_command(TARGET restore-installed-headers PRE_BUILD
+                     COMMAND ${CMAKE_COMMAND} -E
+                        copy "${_tmp_file}" "${_hdr}")
+endforeach()
+
+foreach(_hdr ${_local_upb_hdrs})
+string(REPLACE "${protobuf_SOURCE_DIR}/upb" "" _file ${_hdr})
   set(_tmp_file "${CMAKE_BINARY_DIR}/tmp-install-test/${_file}")
   add_custom_command(TARGET remove-installed-headers PRE_BUILD
                      COMMAND ${CMAKE_COMMAND} -E remove -f "${_hdr}")

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -254,7 +254,7 @@ foreach(_hdr ${_local_hdrs})
 endforeach()
 
 foreach(_hdr ${_local_upb_hdrs})
-string(REPLACE "${protobuf_SOURCE_DIR}/upb" "" _file ${_hdr})
+  string(REPLACE "${protobuf_SOURCE_DIR}/upb" "" _file ${_hdr})
   set(_tmp_file "${CMAKE_BINARY_DIR}/tmp-install-test/${_file}")
   add_custom_command(TARGET remove-installed-headers PRE_BUILD
                      COMMAND ${CMAKE_COMMAND} -E remove -f "${_hdr}")

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -241,7 +241,7 @@ foreach(_hdr ${_exclude_hdrs})
 endforeach()
 
 foreach(_hdr ${_local_hdrs})
-string(REPLACE "${protobuf_SOURCE_DIR}/src" "" _file ${_hdr})
+  string(REPLACE "${protobuf_SOURCE_DIR}/src" "" _file ${_hdr})
   set(_tmp_file "${CMAKE_BINARY_DIR}/tmp-install-test/${_file}")
   add_custom_command(TARGET remove-installed-headers PRE_BUILD
                      COMMAND ${CMAKE_COMMAND} -E remove -f "${_hdr}")


### PR DESCRIPTION
upb headers are not in `${protobuf_SOURCE_DIR}/src`, so the `string(REPLACE ...)` command fails and the `save-installed-headers.vcxproj` contains an invalid path regarding upb headers, causing a failure in compilation.