### PR TITLE
fix raw_ptr.cc on exotic architectures

### DIFF
--- a/src/google/protobuf/raw_ptr.cc
+++ b/src/google/protobuf/raw_ptr.cc
@@ -18,7 +18,7 @@ namespace protobuf {
 namespace internal {
 
 ABSL_CONST_INIT PROTOBUF_EXPORT
-    ABSL_CACHELINE_ALIGNED const char kZeroBuffer[ABSL_CACHELINE_SIZE] = {};
+    ABSL_CACHELINE_ALIGNED const char kZeroBuffer[std::max(ABSL_CACHELINE_SIZE, 64)] = {};
 
 }  // namespace internal
 }  // namespace protobuf


### PR DESCRIPTION
I was working with an exotic architecture where ABSL_CACHELINE_SIZE of abseil was less than 64, so I got a compilation error about redefined symbols. I think the cc file should be adapted to the header file, so here is my change.