### PR TITLE
fix: extern cause clang link failure

### DIFF
--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -2041,7 +2041,7 @@ UnsafeArenaAllocatedRepeatedPtrFieldBackInserter(
 namespace internal {
 // Size optimization for `memswap<N>` - supplied below N is used by every
 // `RepeatedPtrField<T>`.
-template PROTOBUF_EXPORT_TEMPLATE_DECLARE void
+extern "C" template PROTOBUF_EXPORT_TEMPLATE_DECLARE void
 memswap<ArenaOffsetHelper<RepeatedPtrFieldBase>::value>(
     char* PROTOBUF_RESTRICT, char* PROTOBUF_RESTRICT);
 }  // namespace internal

--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -2041,7 +2041,7 @@ UnsafeArenaAllocatedRepeatedPtrFieldBackInserter(
 namespace internal {
 // Size optimization for `memswap<N>` - supplied below N is used by every
 // `RepeatedPtrField<T>`.
-extern template PROTOBUF_EXPORT_TEMPLATE_DECLARE void
+template PROTOBUF_EXPORT_TEMPLATE_DECLARE void
 memswap<ArenaOffsetHelper<RepeatedPtrFieldBase>::value>(
     char* PROTOBUF_RESTRICT, char* PROTOBUF_RESTRICT);
 }  // namespace internal


### PR DESCRIPTION
Use clang-cl 17.0.6 / 18.1.8 failed to compile the code using CMake, with link error:

```
lld-link: error: undefined symbol: void __cdecl google::protobuf::internal::memswap<12>(char *__restrict, char *__restrict)
>>> referenced by xxxxx\cmake-build-debug-win-x86-md-17\stackwalker.pb.cc:1179
>>>               xxx.lib(stackwalker.pb.cc.obj):(private: void __thiscall xxx::protobuf::OnDbgHelpErrRequest::InternalSwap(class xxx::protobuf::OnDbgHelpErrRequest *))
>>> referenced by xxxxx\cmake-build-debug-win-x86-md-17\vcpkg_installed\x86-windows-static-md\include\google\protobuf\repeated_ptr_field.h:330
>>>               xxx.lib(stackwalker.pb.cc.obj):(public: void __thiscall google::protobuf::internal::RepeatedPtrFieldBase::InternalSwap(class google::protobuf::internal::RepeatedPtrFieldBase *__restrict))
ninja: build stopped: subcommand failed.
```

It seems LLVM failed to keep the symbol as extern, or it simply a bug to let the code compile using MSVC.
Either use `extern "C"` or remove `extern` solves the problem. I use `extern "C"` to keep the original behavior.