### PR TITLE
Fix bash ternary in `//benchmarks:size_data`

### DIFF
--- a/benchmarks/BUILD
+++ b/benchmarks/BUILD
@@ -235,7 +235,7 @@ genrule(
     ),
     outs = ["size_data.txt"],
     # We want --format=GNU which counts rodata with data, not text.
-    cmd = "size $$($$OSTYPE == 'linux-gnu' ? '--format=GNU -d' : '') $(SRCS) > $@",
+    cmd = "size $$([ $$OSTYPE == 'linux-gnu' ] && echo '--format=GNU -d' || echo '') $(SRCS) > $@",
     # "size" sometimes isn't available remotely.
     local = 1,
     tags = ["no-remote-exec"],


### PR DESCRIPTION
Replaces pseudocode bash ternary with working bash ternary.
