### PR TITLE
Replace deprecated use of `toBytes()` with `Character` property `.code`

### DIFF
--- a/java/kotlin/src/test/kotlin/com/google/protobuf/ByteStringsTest.kt
+++ b/java/kotlin/src/test/kotlin/com/google/protobuf/ByteStringsTest.kt
@@ -35,8 +35,8 @@ class ByteStringsTest {
   @Test
   fun byteAt() {
     val str = "abc".toByteStringUtf8()
-    assertThat(str[0]).isEqualTo('a'.toByte())
-    assertThat(str[2]).isEqualTo('c'.toByte())
+    assertThat(str[0]).isEqualTo('a'.code)
+    assertThat(str[2]).isEqualTo('c'.code)
   }
 
   @Test


### PR DESCRIPTION
Addresses the warning which is otherwise output during build asking that we do this.
