### PR TITLE
Fix broken namespaces in `hpb_generator/`

### DIFF
--- a/hpb_generator/context.h
+++ b/hpb_generator/context.h
@@ -107,7 +107,6 @@ inline void EmitFileWarning(const google::protobuf::FileDescriptor* file, Contex
       file->name());
   ctx.Emit("\n");
 }
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator {
 
 #endif  // GOOGLE_PROTOBUF_COMPILER_HPB_CONTEXT_H__

--- a/hpb_generator/gen_accessors.cc
+++ b/hpb_generator/gen_accessors.cc
@@ -25,7 +25,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 using NameToFieldDescriptorMap =
     absl::flat_hash_map<absl::string_view, const protobuf::FieldDescriptor*>;
@@ -656,5 +656,4 @@ std::string ResolveFieldName(const protobuf::FieldDescriptor* field,
   return ResolveKeywordConflict(field_name);
 }
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator

--- a/hpb_generator/gen_accessors.h
+++ b/hpb_generator/gen_accessors.h
@@ -14,7 +14,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 void WriteFieldAccessorsInHeader(const protobuf::Descriptor* desc,
                                  Context& ctx);
@@ -24,7 +24,6 @@ void WriteUsingAccessorsInHeader(const protobuf::Descriptor* desc,
                                  MessageClassType handle_type, Context& ctx);
 void WriteOneofAccessorsInHeader(const protobuf::Descriptor* desc,
                                  Context& ctx);
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator
 
 #endif  // PROTOBUF_COMPILER_HBP_GEN_ACCESSORS_H_

--- a/hpb_generator/gen_enums.cc
+++ b/hpb_generator/gen_enums.cc
@@ -20,7 +20,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 // Convert enum value to C++ literal.
 //
@@ -112,5 +112,4 @@ void WriteEnumDeclarations(
   }
 }
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator

--- a/hpb_generator/gen_enums.h
+++ b/hpb_generator/gen_enums.h
@@ -13,7 +13,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 std::string EnumTypeName(const protobuf::EnumDescriptor* enum_descriptor);
 std::string EnumValueSymbolInNameSpace(
@@ -22,7 +22,6 @@ std::string EnumValueSymbolInNameSpace(
 void WriteEnumDeclarations(
     const std::vector<const protobuf::EnumDescriptor*>& enums, Context& ctx);
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator
 
 #endif  // PROTOBUF_COMPILER_HBP_GEN_ENUMS_H_

--- a/hpb_generator/gen_extensions.cc
+++ b/hpb_generator/gen_extensions.cc
@@ -15,7 +15,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 std::string ExtensionIdentifierBase(const protobuf::FieldDescriptor* ext) {
   assert(ext->is_extension());
@@ -93,5 +93,4 @@ void WriteExtensionIdentifiers(
   }
 }
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator

--- a/hpb_generator/gen_extensions.h
+++ b/hpb_generator/gen_extensions.h
@@ -13,7 +13,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 void WriteExtensionIdentifiersHeader(
     const std::vector<const protobuf::FieldDescriptor*>& extensions,
@@ -26,7 +26,6 @@ void WriteExtensionIdentifiers(
 void WriteExtensionIdentifier(const protobuf::FieldDescriptor* ext,
                               Context& ctx);
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator
 
 #endif  // PROTOBUF_COMPILER_HBP_GEN_EXTENSIONS_H_

--- a/hpb_generator/gen_messages.cc
+++ b/hpb_generator/gen_messages.cc
@@ -26,7 +26,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 void WriteModelAccessDeclaration(const protobuf::Descriptor* descriptor,
                                  Context& ctx);
@@ -528,5 +528,4 @@ void WriteUsingEnumsInHeader(
   }
 }
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator

--- a/hpb_generator/gen_messages.h
+++ b/hpb_generator/gen_messages.h
@@ -12,7 +12,7 @@
 #include "google/protobuf/descriptor.h"
 
 namespace google::protobuf::hpb_generator {
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 void WriteMessageClassDeclarations(
     const protobuf::Descriptor* descriptor,
@@ -23,7 +23,7 @@ void WriteMessageImplementation(
     const protobuf::Descriptor* descriptor,
     const std::vector<const protobuf::FieldDescriptor*>& file_exts,
     Context& ctx);
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+    Output& output);
+}  // namespace google::protobuf::hpb_generator
 
 #endif  // PROTOBUF_COMPILER_HBP_GEN_MESSAGES_H_

--- a/hpb_generator/gen_repeated_fields.cc
+++ b/hpb_generator/gen_repeated_fields.cc
@@ -25,7 +25,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 // Adds using accessors to reuse base Access class members from a Proxy/CProxy.
 void WriteRepeatedFieldUsingAccessors(const protobuf::FieldDescriptor* field,
@@ -344,5 +344,4 @@ void WriteRepeatedScalarAccessor(const protobuf::Descriptor* message,
   );
 }
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator

--- a/hpb_generator/gen_repeated_fields.h
+++ b/hpb_generator/gen_repeated_fields.h
@@ -14,7 +14,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 void WriteRepeatedFieldUsingAccessors(const protobuf::FieldDescriptor* field,
                                       absl::string_view class_name,
@@ -42,7 +42,6 @@ void WriteRepeatedScalarAccessor(const protobuf::Descriptor* message,
                                  absl::string_view resolved_field_name,
                                  absl::string_view class_name, Context& ctx);
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator
 
 #endif  // PROTOBUF_COMPILER_HBP_GEN_REPEATED_FIELDS_H_

--- a/hpb_generator/gen_utils.cc
+++ b/hpb_generator/gen_utils.cc
@@ -16,7 +16,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 void AddEnums(const protobuf::Descriptor* message,
               std::vector<const protobuf::EnumDescriptor*>* enums) {
@@ -127,5 +127,4 @@ std::string ToCamelCase(const absl::string_view input, bool lower_first) {
   return result;
 }
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator

--- a/hpb_generator/gen_utils.h
+++ b/hpb_generator/gen_utils.h
@@ -18,7 +18,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 enum class MessageClassType {
   kMessage,
@@ -41,7 +41,6 @@ std::vector<const protobuf::FieldDescriptor*> FieldNumberOrder(
 
 std::string ToCamelCase(absl::string_view input, bool lower_first);
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator
 
 #endif  // PROTOBUF_COMPILER_HBP_GEN_UTILS_H_

--- a/hpb_generator/keywords.cc
+++ b/hpb_generator/keywords.cc
@@ -130,5 +130,4 @@ std::string ResolveKeywordConflict(absl::string_view name) {
   return std::string(name);
 }
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator

--- a/hpb_generator/keywords.h
+++ b/hpb_generator/keywords.h
@@ -17,7 +17,6 @@ namespace google::protobuf::hpb_generator {
 // Resolves proto field name conflict with C++ reserved keywords.
 std::string ResolveKeywordConflict(absl::string_view name);
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator
 
 #endif  // PROTOBUF_COMPILER_HBP_GENERATOR_KEYWORDS_H

--- a/hpb_generator/names.cc
+++ b/hpb_generator/names.cc
@@ -15,7 +15,7 @@
 #include "google/protobuf/compiler/hpb/keywords.h"
 
 namespace google::protobuf::hpb_generator {
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 namespace {
 
@@ -180,5 +180,4 @@ std::string MessageProxyType(const protobuf::FieldDescriptor* field,
          "Proxy";
 }
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator

--- a/hpb_generator/names.h
+++ b/hpb_generator/names.h
@@ -15,7 +15,7 @@
 
 namespace google::protobuf::hpb_generator {
 
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 
 inline constexpr absl::string_view kNoPackageNamePrefix = "hpb_";
 
@@ -45,7 +45,6 @@ std::string MessageCProxyType(const protobuf::FieldDescriptor* field,
 std::string MessageProxyType(const protobuf::FieldDescriptor* field,
                              bool is_const);
 
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator
 
 #endif  // PROTOBUF_COMPILER_HBP_GEN_NAMES_H_

--- a/hpb_generator/protoc-gen-hpb.cc
+++ b/hpb_generator/protoc-gen-hpb.cc
@@ -26,7 +26,7 @@ namespace google::protobuf::hpb_generator {
 namespace {
 
 namespace protoc = ::google::protobuf::compiler;
-namespace protobuf = ::proto2;
+namespace protobuf = ::google::protobuf;
 using FileDescriptor = ::google::protobuf::FileDescriptor;
 using google::protobuf::Edition;
 
@@ -277,8 +277,7 @@ void WriteHeaderMessageForwardDecls(const protobuf::FileDescriptor* file,
 }
 
 }  // namespace
-}  // namespace protobuf
-}  // namespace google::hpb_generator
+}  // namespace google::protobuf::hpb_generator
 
 int main(int argc, char** argv) {
   google::protobuf::hpb_generator::Generator generator_cc;


### PR DESCRIPTION
The wrong namespaces were being used, and the wrong number of curly braces (!!!) terminated namespaced code. Presumably this is an artifact of a refactor; here is a fix.
