### PR TITLE
Fix deprecated usage of `MutableRepeatedPtrField` by implementing iterator for `MutableRepeatedFieldRef`

### DIFF
--- a/src/google/protobuf/reflection_visit_field_info.h
+++ b/src/google/protobuf/reflection_visit_field_info.h
@@ -25,6 +25,7 @@
 
 // clang-format off
 #include "google/protobuf/port_def.inc"
+#include "reflection.h"
 // clang-format on
 
 namespace google {
@@ -708,12 +709,12 @@ struct RepeatedEntityDynamicFieldInfoBase {
   iterator_range<typename RepeatedField<FieldT>::const_iterator> Get() const {
     return {const_repeated.cbegin(), const_repeated.cend()};
   }
-  iterator_range<typename RepeatedField<FieldT>::iterator> Mutable() {
-    auto& rep = *reflection->MutableRepeatedField<FieldT>(&message, field);
+  iterator_range<typename MutableRepeatedFieldRef<FieldT>::iterator> Mutable() {
+    auto rep = reflection->GetMutableRepeatedFieldRef<FieldT>(&message, field);
     return {rep.begin(), rep.end()};
   }
   void Clear() {
-    reflection->MutableRepeatedField<FieldT>(&message, field)->Clear();
+    reflection->GetMutableRepeatedFieldRef<FieldT>(&message, field).Clear();
   }
 
   const Reflection* reflection;
@@ -808,12 +809,12 @@ struct RepeatedPtrEntityDynamicFieldInfoBase {
       const {
     return {const_repeated.cbegin(), const_repeated.cend()};
   }
-  iterator_range<typename RepeatedPtrField<FieldT>::iterator> Mutable() {
-    auto& rep = *reflection->MutableRepeatedPtrField<FieldT>(&message, field);
+  iterator_range<typename MutableRepeatedFieldRef<FieldT>::iterator> Mutable() {
+    auto rep = reflection->GetMutableRepeatedFieldRef<FieldT>(&message, field);
     return {rep.begin(), rep.end()};
   }
   void Clear() {
-    reflection->MutableRepeatedPtrField<FieldT>(&message, field)->Clear();
+    reflection->GetMutableRepeatedFieldRef<FieldT>(&message, field).Clear();
   }
 
   const Reflection* reflection;


### PR DESCRIPTION
Couldn't replace the deprecated usage of `MutableRepeatedPtrField` in `src/google/protobuf/reflection_visit_field_info.h` with `MutableRepeatedFieldRef` as the warning suggested because it did not implemet an iterator, so I implemented the iterator.
