### PR TITLE
Make rust includes point to existing proto header files

### DIFF
--- a/src/google/protobuf/compiler/rust/naming.cc
+++ b/src/google/protobuf/compiler/rust/naming.cc
@@ -62,7 +62,7 @@ std::string GetThunkCcFile(Context& ctx, const FileDescriptor& file) {
 
 std::string GetHeaderFile(Context& ctx, const FileDescriptor& file) {
   auto basename = StripProto(file.name());
-  return absl::StrCat(basename, ".proto.h");
+  return absl::StrCat(basename, ".pb.h");
 }
 
 std::string RawMapThunk(Context& ctx, const Descriptor& msg,


### PR DESCRIPTION
The files that were being pointed to did not exist.
