### PR TITLE
Fix includes for rust-related cpp files

### DIFF
--- a/rust/test/fields_with_imported_types.proto
+++ b/rust/test/fields_with_imported_types.proto
@@ -9,7 +9,7 @@ syntax = "proto2";
 
 package main;
 
-import "google/protobuf/rust/test/imported_types.proto";
+import "rust/test/imported_types.proto";
 
 message MsgWithFieldsWithImportedTypes {
   optional imported_types.ImportedMessage imported_message_field = 1;

--- a/rust/test/import_public.proto
+++ b/rust/test/import_public.proto
@@ -9,4 +9,4 @@ syntax = "proto2";
 
 package import_public;
 
-import public "google/protobuf/rust/test/import_public_primary_src.proto";
+import public "rust/test/import_public_primary_src.proto";

--- a/rust/test/import_public2.proto
+++ b/rust/test/import_public2.proto
@@ -9,5 +9,5 @@ syntax = "proto2";
 
 package import_public;
 
-import public "google/protobuf/rust/test/import_public_non_primary_src1.proto";
-import public "google/protobuf/rust/test/import_public_non_primary_src2.proto";
+import public "rust/test/import_public_non_primary_src1.proto";
+import public "rust/test/import_public_non_primary_src2.proto";

--- a/rust/test/import_public_primary_src.proto
+++ b/rust/test/import_public_primary_src.proto
@@ -9,7 +9,7 @@ syntax = "proto2";
 
 package primary_src_testing_packages;
 
-import public "google/protobuf/rust/test/import_public_grandparent.proto";
+import public "rust/test/import_public_grandparent.proto";
 
 message PrimarySrcPubliclyImportedMsg {}
 

--- a/rust/test/no_package.proto
+++ b/rust/test/no_package.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto2";
 
-import public "google/protobuf/rust/test/no_package_import.proto";
+import public "rust/test/no_package_import.proto";
 
 message MsgWithoutPackage {}
 

--- a/rust/test/package.proto
+++ b/rust/test/package.proto
@@ -9,7 +9,7 @@ syntax = "proto2";
 
 package testing_packages;
 
-import public "google/protobuf/rust/test/package_import.proto";
+import public "rust/test/package_import.proto";
 
 message MsgWithPackage {}
 

--- a/rust/test/package_disabiguation2.proto
+++ b/rust/test/package_disabiguation2.proto
@@ -9,7 +9,7 @@ syntax = "proto2";
 
 package package2;
 
-import "google/protobuf/rust/test/package_disabiguation1.proto";
+import "rust/test/package_disabiguation1.proto";
 
 message YayConflict {
   optional .package1.YayConflict other_message = 1;


### PR DESCRIPTION
Many include paths pointed to files supposedly relative to `google/protobuf/` that were actually relative to the repository root.
