### PR TITLE
Update rules_pkg to get fix for timestamp warning

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,7 +60,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_pkg",
-    version = "0.7.0",
+    version = "1.0.1",
 )
 
 bazel_dep(

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -150,10 +150,10 @@ def protobuf_deps():
         http_archive(
             name = "rules_pkg",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
-                "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
+                "https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
             ],
-            sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
+            sha256 = "d20c951960ed77cb7b341c2a59488534e494d5ad1d30c4818c736d57772a9fef",
         )
 
     if not native.existing_rule("build_bazel_rules_apple"):


### PR DESCRIPTION
Without this, we get many warnings about deprecated timestamp methods in python.
