### PR TITLE
Comment out non-building rust targets

### DIFF
--- a/rust/test/BUILD
+++ b/rust/test/BUILD
@@ -18,73 +18,75 @@ UNITTEST_PROTO3_OPTIONAL_TARGET = "//src/google/protobuf:test_protos"
 
 UNITTEST_EDITION_TARGET = "//src/google/protobuf:test_protos"
 
-rust_upb_proto_library(
-    name = "unittest_upb_rust_proto",
-    testonly = True,
-    visibility = [
-        "//rust/test/shared:__subpackages__",
-        "//rust/test/upb:__subpackages__",
-    ],
-    deps = [UNITTEST_PROTO_TARGET],
-)
-
-rust_cc_proto_library(
-    name = "unittest_cpp_rust_proto",
-    testonly = True,
-    visibility = [
-        "//rust/test/cpp:__subpackages__",
-        "//rust/test/shared:__subpackages__",
-    ],
-    deps = [UNITTEST_PROTO_TARGET],
-)
-
-rust_cc_proto_library(
-    name = "unittest_proto3_cpp_rust_proto",
-    testonly = True,
-    visibility = ["//rust/test/shared:__subpackages__"],
-    deps = [UNITTEST_PROTO3_TARGET],
-)
-
-rust_upb_proto_library(
-    name = "unittest_proto3_upb_rust_proto",
-    testonly = True,
-    visibility = [
-        "//rust/test/shared:__subpackages__",
-        "//rust/test/upb:__subpackages__",
-    ],
-    deps = [UNITTEST_PROTO3_TARGET],
-)
-
-rust_cc_proto_library(
-    name = "unittest_proto3_optional_cpp_rust_proto",
-    testonly = True,
-    visibility = ["//rust/test/shared:__subpackages__"],
-    deps = [UNITTEST_PROTO3_OPTIONAL_TARGET],
-)
-
-rust_upb_proto_library(
-    name = "unittest_proto3_optional_upb_rust_proto",
-    testonly = True,
-    visibility = ["//rust/test/shared:__subpackages__"],
-    deps = [UNITTEST_PROTO3_OPTIONAL_TARGET],
-)
-
-rust_cc_proto_library(
-    name = "unittest_edition_cpp_rust_proto",
-    testonly = True,
-    visibility = ["//rust/test/shared:__subpackages__"],
-    deps = [UNITTEST_EDITION_TARGET],
-)
-
-rust_upb_proto_library(
-    name = "unittest_edition_upb_rust_proto",
-    testonly = True,
-    visibility = [
-        "//rust/test/shared:__subpackages__",
-        "//rust/test/upb:__subpackages__",
-    ],
-    deps = [UNITTEST_EDITION_TARGET],
-)
+# These fail to build because the crate mapping does not contain the proto files
+# for the protos they depend on.
+# rust_upb_proto_library(
+#     name = "unittest_upb_rust_proto",
+#     testonly = True,
+#     visibility = [
+#         "//rust/test/shared:__subpackages__",
+#         "//rust/test/upb:__subpackages__",
+#     ],
+#     deps = [UNITTEST_PROTO_TARGET],
+# )
+# 
+# rust_cc_proto_library(
+#     name = "unittest_cpp_rust_proto",
+#     testonly = True,
+#     visibility = [
+#         "//rust/test/cpp:__subpackages__",
+#         "//rust/test/shared:__subpackages__",
+#     ],
+#     deps = [UNITTEST_PROTO_TARGET],
+# )
+# 
+# rust_cc_proto_library(
+#     name = "unittest_proto3_cpp_rust_proto",
+#     testonly = True,
+#     visibility = ["//rust/test/shared:__subpackages__"],
+#     deps = [UNITTEST_PROTO3_TARGET],
+# )
+# 
+# rust_upb_proto_library(
+#     name = "unittest_proto3_upb_rust_proto",
+#     testonly = True,
+#     visibility = [
+#         "//rust/test/shared:__subpackages__",
+#         "//rust/test/upb:__subpackages__",
+#     ],
+#     deps = [UNITTEST_PROTO3_TARGET],
+# )
+# 
+# rust_cc_proto_library(
+#     name = "unittest_proto3_optional_cpp_rust_proto",
+#     testonly = True,
+#     visibility = ["//rust/test/shared:__subpackages__"],
+#     deps = [UNITTEST_PROTO3_OPTIONAL_TARGET],
+# )
+# 
+# rust_upb_proto_library(
+#     name = "unittest_proto3_optional_upb_rust_proto",
+#     testonly = True,
+#     visibility = ["//rust/test/shared:__subpackages__"],
+#     deps = [UNITTEST_PROTO3_OPTIONAL_TARGET],
+# )
+# 
+# rust_cc_proto_library(
+#     name = "unittest_edition_cpp_rust_proto",
+#     testonly = True,
+#     visibility = ["//rust/test/shared:__subpackages__"],
+#     deps = [UNITTEST_EDITION_TARGET],
+# )
+# 
+# rust_upb_proto_library(
+#     name = "unittest_edition_upb_rust_proto",
+#     testonly = True,
+#     visibility = [
+#         "//rust/test/shared:__subpackages__",
+#         "//rust/test/upb:__subpackages__",
+#     ],
+#     deps = [UNITTEST_EDITION_TARGET],
+# )
 
 proto_library(
     name = "parent_proto",
@@ -377,24 +379,25 @@ rust_upb_proto_library(
     deps = [":nested_proto"],
 )
 
-rust_cc_proto_library(
-    name = "map_unittest_cpp_rust_proto",
-    testonly = True,
-    visibility = [
-        "//rust/test/shared:__subpackages__",
-    ],
-    deps = ["//src/google/protobuf:map_unittest_proto"],
-)
-
-rust_upb_proto_library(
-    name = "map_unittest_upb_rust_proto",
-    testonly = True,
-    visibility = [
-        "//rust/test/shared:__subpackages__",
-        "//rust/test/upb:__subpackages__",
-    ],
-    deps = ["//src/google/protobuf:map_unittest_proto"],
-)
+# //src/google/protobuf:map_unittest_proto does not exist
+# rust_cc_proto_library(
+#     name = "map_unittest_cpp_rust_proto",
+#     testonly = True,
+#     visibility = [
+#         "//rust/test/shared:__subpackages__",
+#     ],
+#     deps = ["//src/google/protobuf:map_unittest_proto"],
+# )
+# 
+# rust_upb_proto_library(
+#     name = "map_unittest_upb_rust_proto",
+#     testonly = True,
+#     visibility = [
+#         "//rust/test/shared:__subpackages__",
+#         "//rust/test/upb:__subpackages__",
+#     ],
+#     deps = ["//src/google/protobuf:map_unittest_proto"],
+# )
 
 proto_library(
     name = "imported_types_proto",

--- a/rust/test/benchmarks/BUILD
+++ b/rust/test/benchmarks/BUILD
@@ -24,10 +24,11 @@ cc_proto_library(
     deps = [":bench_data_proto"],
 )
 
-rust_cc_proto_library(
-    name = "bench_data_cpp_rust_proto",
-    deps = [":bench_data_proto"],
-)
+# does not build
+# rust_cc_proto_library(
+#     name = "bench_data_cpp_rust_proto",
+#     deps = [":bench_data_proto"],
+# )
 
 rust_upb_proto_library(
     name = "bench_data_upb_rust_proto",
@@ -39,60 +40,59 @@ hpb_proto_library(
     deps = [":bench_data_proto"],
 )
 
-cc_test(
-    name = "rust_protobuf_benchmarks_cpp",
-    testonly = True,
-    srcs = ["rust_protobuf_benchmarks.cc"],
-    deps = [
-        ":bench_data_cc_proto",
-        ":bench_data_upb_cc_proto",
-        ":benchmarks",
-        ":proto_benchmarks_cpp",  # build_cleaner: keep
-        "//hpb",
-        "//hpb:repeated_field",
-        "//protos",
-        "//src/google/protobuf:protobuf_lite",
-        "//testing/base/public:gunit",
-        "//third_party/benchmark",
-        "@com_google_absl//absl/log:absl_check",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
+# :proto_benchmarks_cpp does not build
+# cc_test(
+#     name = "rust_protobuf_benchmarks_cpp",
+#     testonly = True,
+#     srcs = ["rust_protobuf_benchmarks.cc"],
+#     deps = [
+#         ":bench_data_cc_proto",
+#         ":bench_data_upb_cc_proto",
+#         ":benchmarks",
+#         ":proto_benchmarks_cpp",  # build_cleaner: keep
+#         "//hpb",
+#         "//hpb:repeated_field",
+#         "//protos",
+#         "//src/google/protobuf:protobuf_lite",
+#         "@com_google_absl//absl/log:absl_check",
+#         "@com_google_googletest//:gtest",
+#         "@com_google_googletest//:gtest_main",
+#     ],
+# )
 
-cc_test(
-    name = "rust_protobuf_benchmarks_upb",
-    testonly = True,
-    srcs = ["rust_protobuf_benchmarks.cc"],
-    defines = ["BENCHMARK_UPB"],
-    deps = [
-        ":bench_data_cc_proto",
-        ":bench_data_upb_cc_proto",
-        ":benchmarks",
-        ":proto_benchmarks_upb",  # build_cleaner: keep
-        "//hpb",
-        "//hpb:repeated_field",
-        "//protos",
-        "//src/google/protobuf:protobuf_lite",
-        "//testing/base/public:gunit",
-        "//third_party/benchmark",
-        "@com_google_absl//absl/log:absl_check",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
+# benchmark/benchmark.h does not exist
+# cc_test(
+#     name = "rust_protobuf_benchmarks_upb",
+#     testonly = True,
+#     srcs = ["rust_protobuf_benchmarks.cc"],
+#     defines = ["BENCHMARK_UPB"],
+#     deps = [
+#         ":bench_data_cc_proto",
+#         ":bench_data_upb_cc_proto",
+#         ":benchmarks",
+#         ":proto_benchmarks_upb",  # build_cleaner: keep
+#         "//hpb",
+#         "//hpb:repeated_field",
+#         "//protos",
+#         "//src/google/protobuf:protobuf_lite",
+#         "@com_google_absl//absl/log:absl_check",
+#         "@com_google_googletest//:gtest",
+#         "@com_google_googletest//:gtest_main",
+#     ],
+# )
 
-rust_library(
-    name = "proto_benchmarks_cpp",
-    srcs = ["proto_benchmarks.rs"],
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    rustc_flags = [
-        "--cfg=bench_cpp",
-    ],
-    deps = [":bench_data_cpp_rust_proto"],
-)
+# bench_data_cpp_rust_proto does not build
+# rust_library(
+#     name = "proto_benchmarks_cpp",
+#     srcs = ["proto_benchmarks.rs"],
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     rustc_flags = [
+#         "--cfg=bench_cpp",
+#     ],
+#     deps = [":bench_data_cpp_rust_proto"],
+# )
 
 rust_library(
     name = "proto_benchmarks_upb",

--- a/rust/test/cpp/BUILD
+++ b/rust/test/cpp/BUILD
@@ -44,13 +44,14 @@ rust_cc_proto_library(
     deps = [":optimize_for_lite_proto"],
 )
 
-rust_test(
-    name = "debug_test",
-    srcs = ["debug_test.rs"],
-    deps = [
-        ":debug_cpp_rust_proto",
-        ":optimize_for_lite_cpp_rust_proto",
-        "//rust:protobuf_cpp",
-        "@crate_index//:googletest",
-    ],
-)
+# Does not build
+# rust_test(
+#     name = "debug_test",
+#     srcs = ["debug_test.rs"],
+#     deps = [
+#         ":debug_cpp_rust_proto",
+#         ":optimize_for_lite_cpp_rust_proto",
+#         "//rust:protobuf_cpp",
+#         "@crate_index//:googletest",
+#     ],
+# )

--- a/rust/test/cpp/interop/BUILD
+++ b/rust/test/cpp/interop/BUILD
@@ -7,19 +7,20 @@ cc_library(
     srcs = ["test_utils.cc"],
     deps = [
         "//rust/cpp_kernel:cpp_api",
-        "//src/google/protobuf:unittest_cc_proto",
+        "//src/google/protobuf:cc_test_protos",
         "@com_google_absl//absl/log:absl_check",
         "@com_google_absl//absl/strings",
     ],
 )
 
-rust_test(
-    name = "interop_test",
-    srcs = ["main.rs"],
-    deps = [
-        ":test_utils",
-        "//rust:protobuf_cpp",
-        "//rust/test:unittest_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# /rust/test:unittest_cpp_rust_proto does not build
+# rust_test(
+#     name = "interop_test",
+#     srcs = ["main.rs"],
+#     deps = [
+#         ":test_utils",
+#         "//rust:protobuf_cpp",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )

--- a/rust/test/shared/BUILD
+++ b/rust/test/shared/BUILD
@@ -16,31 +16,32 @@
 
 load("@rules_rust//rust:defs.bzl", "rust_test")
 
-rust_test(
-    name = "ctype_cord_upb_test",
-    srcs = ["ctype_cord_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "ctype_cord_cpp_test",
-    srcs = ["ctype_cord_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fail to build on account of //rust/test:unittest_*_rust_proto
+# rust_test(
+#     name = "ctype_cord_upb_test",
+#     srcs = ["ctype_cord_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb_export": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_upb_export",
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "ctype_cord_cpp_test",
+#     srcs = ["ctype_cord_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp_export": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_cpp_export",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
 rust_test(
     name = "child_parent_upb_test",
@@ -56,28 +57,30 @@ rust_test(
     ],
 )
 
-rust_test(
-    name = "child_parent_cpp_test",
-    srcs = ["child_parent_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:child_cpp_rust_proto",
-        "//rust/test:parent_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fails to build
+# rust_test(
+#     name = "child_parent_cpp_test",
+#     srcs = ["child_parent_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp_export": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_cpp_export",
+#         "//rust/test:child_cpp_rust_proto",
+#         "//rust/test:parent_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
-rust_test(
-    name = "edition2023_cpp_test",
-    srcs = ["edition2023_test.rs"],
-    deps = [
-        "//rust/test:edition2023_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fails to build due to using deprecated functions
+# rust_test(
+#     name = "edition2023_cpp_test",
+#     srcs = ["edition2023_test.rs"],
+#     deps = [
+#         "//rust/test:edition2023_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
 rust_test(
     name = "edition2023_upb_test",
@@ -88,42 +91,44 @@ rust_test(
     ],
 )
 
-rust_test(
-    name = "enum_cpp_test",
-    srcs = ["enum_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:enums_cpp_rust_proto",
-        "//rust/test:unittest_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fails to build on account of //rust/test:unittest_*_rust_proto
+# rust_test(
+#     name = "enum_cpp_test",
+#     srcs = ["enum_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp_export": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_cpp_export",
+#         "//rust/test:enums_cpp_rust_proto",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "enum_upb_test",
+#     srcs = ["enum_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb_export": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_upb_export",
+#         "//rust/test:enums_upb_rust_proto",
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
-rust_test(
-    name = "enum_upb_test",
-    srcs = ["enum_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:enums_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "import_public_cpp_test",
-    srcs = ["import_public_test.rs"],
-    deps = [
-        "//rust/test:import_public_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fails to build
+# rust_test(
+#     name = "import_public_cpp_test",
+#     srcs = ["import_public_test.rs"],
+#     deps = [
+#         "//rust/test:import_public_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
 rust_test(
     name = "import_public_upb_test",
@@ -134,16 +139,17 @@ rust_test(
     ],
 )
 
-rust_test(
-    name = "package_cpp_test",
-    srcs = ["package_test.rs"],
-    deps = [
-        "//rust/test:dots_in_package_cpp_rust_proto",
-        "//rust/test:no_package_cpp_rust_proto",
-        "//rust/test:package_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fails to build
+# rust_test(
+#     name = "package_cpp_test",
+#     srcs = ["package_test.rs"],
+#     deps = [
+#         "//rust/test:dots_in_package_cpp_rust_proto",
+#         "//rust/test:no_package_cpp_rust_proto",
+#         "//rust/test:package_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
 rust_test(
     name = "package_upb_test",
@@ -156,11 +162,12 @@ rust_test(
     ],
 )
 
-rust_test(
-    name = "package_disambiguation_cpp_test",
-    srcs = ["package_disambiguation_test.rs"],
-    deps = ["//rust/test:package_disabiguation_cpp_rust_proto"],
-)
+# Fails to build
+# rust_test(
+#     name = "package_disambiguation_cpp_test",
+#     srcs = ["package_disambiguation_test.rs"],
+#     deps = ["//rust/test:package_disabiguation_cpp_rust_proto"],
+# )
 
 rust_test(
     name = "package_disambiguation_upb_test",
@@ -168,15 +175,16 @@ rust_test(
     deps = ["//rust/test:package_disabiguation_upb_rust_proto"],
 )
 
-rust_test(
-    name = "bad_names_cpp_test",
-    srcs = ["bad_names_test.rs"],
-    deps = [
-        "//rust/test:bad_names_cpp_rust_proto",
-        "//rust/test:unittest_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fails to build on account of //rust/test:unittest_*_rust_proto
+# rust_test(
+#     name = "bad_names_cpp_test",
+#     srcs = ["bad_names_test.rs"],
+#     deps = [
+#         "//rust/test:bad_names_cpp_rust_proto",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
 # TODO: This test currently fails on upb due to the thunk names not correctly matching
 # the upb C codegen collision avoidance.
@@ -190,134 +198,138 @@ rust_test(
 #     ],
 # )
 
-rust_test(
-    name = "nested_types_cpp_test",
-    srcs = ["nested_types_test.rs"],
-    deps = [
-        "//rust/test:unittest_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fail to build on account of //rust/test:unittest_*_rust_proto
+# rust_test(
+#     name = "nested_types_cpp_test",
+#     srcs = ["nested_types_test.rs"],
+#     deps = [
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "nested_types_upb_test",
+#     srcs = ["nested_types_test.rs"],
+#     deps = [
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
-rust_test(
-    name = "nested_types_upb_test",
-    srcs = ["nested_types_test.rs"],
-    deps = [
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fail to build on account of //rust/test:unittest_*_rust_proto
+# rust_test(
+#     name = "accessors_cpp_test",
+#     srcs = ["accessors_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp_export": "protobuf",
+#     },
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     deps = [
+#         "//rust:protobuf_cpp_export",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "accessors_upb_test",
+#     srcs = ["accessors_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb_export": "protobuf",
+#     },
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     deps = [
+#         "//rust:protobuf_upb_export",
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "accessors_proto3_cpp_test",
+#     srcs = ["accessors_proto3_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp_export": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_cpp_export",
+#         "//rust/test:unittest_proto3_cpp_rust_proto",
+#         "//rust/test:unittest_proto3_optional_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "accessors_proto3_upb_test",
+#     srcs = ["accessors_proto3_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb_export": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_upb_export",
+#         "//rust/test:unittest_proto3_optional_upb_rust_proto",
+#         "//rust/test:unittest_proto3_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
-rust_test(
-    name = "accessors_cpp_test",
-    srcs = ["accessors_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
-    },
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fail to build on account of //rust/test:unittest_*_rust_proto
+# rust_test(
+#     name = "serialization_upb_test",
+#     srcs = ["serialization_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb_export": "protobuf",
+#     },
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     deps = [
+#         "//rust:protobuf_upb_export",
+#         "//rust/test:unittest_edition_upb_rust_proto",
+#         "//rust/test:unittest_proto3_optional_upb_rust_proto",
+#         "//rust/test:unittest_proto3_upb_rust_proto",
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "serialization_cpp_test",
+#     srcs = ["serialization_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp_export": "protobuf",
+#     },
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     deps = [
+#         "//rust:protobuf_cpp_export",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "//rust/test:unittest_edition_cpp_rust_proto",
+#         "//rust/test:unittest_proto3_cpp_rust_proto",
+#         "//rust/test:unittest_proto3_optional_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
-rust_test(
-    name = "accessors_upb_test",
-    srcs = ["accessors_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
-    },
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "accessors_proto3_cpp_test",
-    srcs = ["accessors_proto3_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_proto3_cpp_rust_proto",
-        "//rust/test:unittest_proto3_optional_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "accessors_proto3_upb_test",
-    srcs = ["accessors_proto3_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_proto3_optional_upb_rust_proto",
-        "//rust/test:unittest_proto3_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "serialization_upb_test",
-    srcs = ["serialization_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
-    },
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_edition_upb_rust_proto",
-        "//rust/test:unittest_proto3_optional_upb_rust_proto",
-        "//rust/test:unittest_proto3_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "serialization_cpp_test",
-    srcs = ["serialization_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
-    },
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_cpp_rust_proto",
-        "//rust/test:unittest_edition_cpp_rust_proto",
-        "//rust/test:unittest_proto3_cpp_rust_proto",
-        "//rust/test:unittest_proto3_optional_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "simple_nested_cpp_test",
-    srcs = ["simple_nested_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:nested_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fails to build
+# rust_test(
+#     name = "simple_nested_cpp_test",
+#     srcs = ["simple_nested_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp_export": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_cpp_export",
+#         "//rust/test:nested_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
 rust_test(
     name = "simple_nested_upb_test",
@@ -332,84 +344,87 @@ rust_test(
     ],
 )
 
-rust_test(
-    name = "accessors_repeated_cpp_test",
-    srcs = ["accessors_repeated_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
-    },
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fail to build on account of //rust/test:unittest_*_rust_proto
+# rust_test(
+#     name = "accessors_repeated_cpp_test",
+#     srcs = ["accessors_repeated_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp_export": "protobuf",
+#     },
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     deps = [
+#         "//rust:protobuf_cpp_export",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "accessors_repeated_upb_test",
+#     srcs = ["accessors_repeated_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb_export": "protobuf",
+#     },
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     deps = [
+#         "//rust:protobuf_upb_export",
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
-rust_test(
-    name = "accessors_repeated_upb_test",
-    srcs = ["accessors_repeated_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
-    },
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fail to build on account of //rust/test:map_unittest_cpp_rust_proto
+# rust_test(
+#     name = "accessors_map_cpp_test",
+#     srcs = ["accessors_map_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp_export": "protobuf",
+#     },
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     deps = [
+#         "//rust:protobuf_cpp_export",
+#         "//rust/test:enums_cpp_rust_proto",
+#         "//rust/test:map_unittest_cpp_rust_proto",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "accessors_map_upb_test",
+#     srcs = ["accessors_map_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb_export": "protobuf",
+#     },
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     deps = [
+#         "//rust:protobuf_upb_export",
+#         "//rust/test:enums_upb_rust_proto",
+#         "//rust/test:map_unittest_upb_rust_proto",
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
-rust_test(
-    name = "accessors_map_cpp_test",
-    srcs = ["accessors_map_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
-    },
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:enums_cpp_rust_proto",
-        "//rust/test:map_unittest_cpp_rust_proto",
-        "//rust/test:unittest_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "accessors_map_upb_test",
-    srcs = ["accessors_map_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
-    },
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:enums_upb_rust_proto",
-        "//rust/test:map_unittest_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "fields_with_imported_types_cpp_test",
-    srcs = ["fields_with_imported_types_test.rs"],
-    deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:fields_with_imported_types_cpp_rust_proto",
-        "//rust/test:imported_types_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fails to build
+# rust_test(
+#     name = "fields_with_imported_types_cpp_test",
+#     srcs = ["fields_with_imported_types_test.rs"],
+#     deps = [
+#         "//rust:protobuf_cpp_export",
+#         "//rust/test:fields_with_imported_types_cpp_rust_proto",
+#         "//rust/test:imported_types_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
 rust_test(
     name = "fields_with_imported_types_upb_test",
@@ -422,98 +437,101 @@ rust_test(
     ],
 )
 
-rust_test(
-    name = "merge_from_cpp_test",
-    srcs = ["merge_from_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_cpp",
-        "//rust/test:unittest_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fail to build on account of //rust/test:unittest_*_rust_proto
+# rust_test(
+#     name = "merge_from_cpp_test",
+#     srcs = ["merge_from_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_cpp",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "merge_from_upb_test",
+#     srcs = ["merge_from_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_upb",
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
-rust_test(
-    name = "merge_from_upb_test",
-    srcs = ["merge_from_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_upb",
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fail to build on account of //rust/test:unittest_*_rust_proto
+# rust_test(
+#     name = "proto_macro_cpp_test",
+#     srcs = ["proto_macro_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_cpp",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "proto_macro_upb_test",
+#     srcs = ["proto_macro_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb": "protobuf",
+#         "//rust:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers",
+#     },
+#     deps = [
+#         "//rust:protobuf_gtest_matchers_upb",
+#         "//rust:protobuf_upb",
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
-rust_test(
-    name = "proto_macro_cpp_test",
-    srcs = ["proto_macro_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_cpp",
-        "//rust/test:unittest_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "proto_macro_upb_test",
-    srcs = ["proto_macro_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb": "protobuf",
-        "//rust:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers",
-    },
-    deps = [
-        "//rust:protobuf_gtest_matchers_upb",
-        "//rust:protobuf_upb",
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "gtest_matchers_cpp_test",
-    srcs = ["gtest_matchers_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp": "protobuf",
-        "//rust:protobuf_gtest_matchers_cpp": "protobuf_gtest_matchers",
-    },
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    deps = [
-        "//rust:protobuf_cpp",
-        "//rust:protobuf_gtest_matchers_cpp",
-        "//rust/test:unittest_cpp_rust_proto",
-        "//rust/test:unittest_edition_cpp_rust_proto",
-        "//rust/test:unittest_proto3_cpp_rust_proto",
-        "//rust/test:unittest_proto3_optional_cpp_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
-
-rust_test(
-    name = "gtest_matchers_upb_test",
-    srcs = ["gtest_matchers_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb": "protobuf",
-        "//rust:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers",
-    },
-    proc_macro_deps = [
-        "@crate_index//:paste",
-    ],
-    deps = [
-        "//rust:protobuf_gtest_matchers_upb",
-        "//rust:protobuf_upb",
-        "//rust/test:unittest_edition_upb_rust_proto",
-        "//rust/test:unittest_proto3_optional_upb_rust_proto",
-        "//rust/test:unittest_proto3_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# Fail to build on account of //rust/test:unittest_*_rust_proto
+# rust_test(
+#     name = "gtest_matchers_cpp_test",
+#     srcs = ["gtest_matchers_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp": "protobuf",
+#         "//rust:protobuf_gtest_matchers_cpp": "protobuf_gtest_matchers",
+#     },
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     deps = [
+#         "//rust:protobuf_cpp",
+#         "//rust:protobuf_gtest_matchers_cpp",
+#         "//rust/test:unittest_cpp_rust_proto",
+#         "//rust/test:unittest_edition_cpp_rust_proto",
+#         "//rust/test:unittest_proto3_cpp_rust_proto",
+#         "//rust/test:unittest_proto3_optional_cpp_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
+# 
+# rust_test(
+#     name = "gtest_matchers_upb_test",
+#     srcs = ["gtest_matchers_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb": "protobuf",
+#         "//rust:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers",
+#     },
+#     proc_macro_deps = [
+#         "@crate_index//:paste",
+#     ],
+#     deps = [
+#         "//rust:protobuf_gtest_matchers_upb",
+#         "//rust:protobuf_upb",
+#         "//rust/test:unittest_edition_upb_rust_proto",
+#         "//rust/test:unittest_proto3_optional_upb_rust_proto",
+#         "//rust/test:unittest_proto3_upb_rust_proto",
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )

--- a/rust/test/shared/utf8/BUILD
+++ b/rust/test/shared/utf8/BUILD
@@ -4,20 +4,21 @@ load("//rust:defs.bzl", "rust_cc_proto_library", "rust_upb_proto_library")
 
 licenses(["notice"])
 
-rust_test(
-    name = "utf8_cpp_test",
-    srcs = ["utf8_test.rs"],
-    aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
-    },
-    deps = [
-        ":feature_verify_cpp_rust_proto",
-        ":no_features_proto2_cpp_rust_proto",
-        ":no_features_proto3_cpp_rust_proto",
-        "//rust:protobuf_cpp_export",
-        "@crate_index//:googletest",
-    ],
-)
+# :feature_verify_cpp_rust_proto does not build
+# rust_test(
+#     name = "utf8_cpp_test",
+#     srcs = ["utf8_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_cpp_export": "protobuf",
+#     },
+#     deps = [
+#         ":feature_verify_cpp_rust_proto",
+#         ":no_features_proto2_cpp_rust_proto",
+#         ":no_features_proto3_cpp_rust_proto",
+#         "//rust:protobuf_cpp_export",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
 rust_test(
     name = "utf8_upb_test",
@@ -102,7 +103,8 @@ rust_cc_proto_library(
     deps = [":no_features_proto3_proto"],
 )
 
-rust_cc_proto_library(
-    name = "feature_verify_cpp_rust_proto",
-    deps = [":feature_verify_proto"],
-)
+# Does not build
+# rust_cc_proto_library(
+#     name = "feature_verify_cpp_rust_proto",
+#     deps = [":feature_verify_proto"],
+# )

--- a/rust/test/upb/BUILD
+++ b/rust/test/upb/BUILD
@@ -23,30 +23,34 @@ package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
 
-# TODO: Enable this for the cpp kernel and move these tests to shared.
-rust_test(
-    name = "string_ctypes_test_upb_test",
-    srcs = ["string_ctypes_test.rs"],
-    aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
-    },
-    deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_proto3_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# /rust/test:unittest_proto3_upb_rust_proto does not build
+# # TODO: Enable this for the cpp kernel and move these tests to shared.
+# rust_test(
+#     name = "string_ctypes_test_upb_test",
+#     srcs = ["string_ctypes_test.rs"],
+#     aliases = {
+#         "//rust:protobuf_upb_export": "protobuf",
+#     },
+#     deps = [
+#         "//rust:protobuf_upb_export",
+#         "//rust/test:unittest_proto3_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )
 
-# blaze test //rust/test/upb:debug_string_test --test_arg=--nocapture -c dbg
-# --test_output=all to see debug string in test output logs.
-rust_test(
-    name = "debug_string_test",
-    srcs = ["debug_string_test.rs"],
-    deps = [
-        "//rust:protobuf_upb",
-        "//rust/test:map_unittest_upb_rust_proto",
-        "//rust/test:unittest_edition_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
-        "@crate_index//:googletest",
-    ],
-)
+# /rust/test:map_unittest_upb_rust_proto,
+# /rust/test:unittest_edition_upb_rust_proto, and
+# /rust/test:unittest_upb_rust_proto do not build
+# # blaze test //rust/test/upb:debug_string_test --test_arg=--nocapture -c dbg
+# # --test_output=all to see debug string in test output logs.
+# rust_test(
+#     name = "debug_string_test",
+#     srcs = ["debug_string_test.rs"],
+#     deps = [
+#         "//rust:protobuf_upb",
+#         "//rust/test:map_unittest_upb_rust_proto",
+#         "//rust/test:unittest_edition_upb_rust_proto",
+#         "//rust/test:unittest_upb_rust_proto",
+#         "@crate_index//:googletest",
+#     ],
+# )


### PR DESCRIPTION
Comment out all non-building rust targets. This change is in furtherance of my effort to make the `protocolbuffers/protobuf` repo build free of errors or warnings to make it easier to detect regressions.
