### PR TITLE
Remove `--copt="-Werror"` from `.bazelrc`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,8 +1,5 @@
 build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 
-build --copt="-Werror" --copt="-Wno-sign-compare" --copt="-Wno-sign-conversion" --copt="-Wno-error=sign-conversion"  --copt="-Wno-deprecated-declarations"
-
-
 build:dbg --compilation_mode=dbg
 
 build:opt --compilation_mode=opt


### PR DESCRIPTION
This appears to be causing a bunch of errors during our release process, but I don't think it's critical to have this flag in `.bazelrc`. We should still be able to get about the same test coverage since we also set `-Werror` in the `bazelrc` files in the `ci/` directory.

PiperOrigin-RevId: 672673187