### PR TITLE
Change `bigdecimal` to development dependency

### DIFF
--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -32,8 +32,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency "rake-compiler-dock", "= 1.2.1"
   end
   s.required_ruby_version = '>= 3.0'
-  # bigdecimal must be used as a non-built in gem as of ruby-3.4
-  s.add_dependency "bigdecimal"
   # TODO: evaluate removing Rakefile and moving logic to extconf.rb, so that we
   # can remove this runtime dependency on rake. See the discussion here for
   # more details:
@@ -43,4 +41,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ffi-compiler", "~>1"
   s.add_development_dependency "rake-compiler", "~> 1.1.0"
   s.add_development_dependency "test-unit", '~> 3.0', '>= 3.0.9'
+  # bigdecimal must be used as a non-built in gem as of ruby-3.4
+  s.add_development_dependency "bigdecimal"
 end


### PR DESCRIPTION
It seems that `bigdecimal` is only used in tests.
I think there is no need to treat it as runtime dependency.