### PR TITLE
[ObjC] Disabling visionOS on CI.

### DIFF
--- a/.github/workflows/test_objectivec.yml
+++ b/.github/workflows/test_objectivec.yml
@@ -68,15 +68,17 @@ jobs:
     strategy:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
-        PLATFORM: ["ios", "macos", "tvos", "watchos", "visionos"]
+        # Disabling visionOS for now: https://github.com/actions/runner-images/issues/10559
+        PLATFORM: ["ios", "macos", "tvos", "watchos"]
         CONFIGURATION: ["Debug", "Release"]
         include:
           - OS: macos-12
             XCODE: "14.1"
-          - OS: macos-14
-            PLATFORM: "visionos"
-            XCODE: "15.2"
-    name: CocoaPods ${{ matrix.PLATFORM }} ${{ matrix.CONFIGURATION }}
+          # We run presubmits on all "Debug" entries, but not on "Release" entries
+          - CONFIGURATION: "Debug"
+          - CONFIGURATION: "Release"
+            continuous-only: true
+    name: ${{ matrix.continuous-only && inputs.continuous-prefix || '' }} CocoaPods ${{ matrix.PLATFORM }} ${{ matrix.CONFIGURATION }}
     runs-on: ${{ matrix.OS }}
     steps:
       - name: Checkout pending changes


### PR DESCRIPTION
Github dropped support for the current image:
https://github.com/actions/runner-images/issues/10559

There is a new image that has visionOS, but it is listed as "beta", so it might make sense to wait and revisit when generally updating the macOS images/tools.

PiperOrigin-RevId: 679264196