### PR TITLE
Remove javaopts requiring java8 in non-release builds.

### DIFF
--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -34,7 +34,6 @@ jobs:
             # TODO: b/318555165 - enable the layering check. Currently it does
             # not work correctly with the toolchain in this Docker image.
             targets: //java/... //java/internal:java_version //compatibility/... --features=-layering_check
-            continuous-only: true
           - name: OpenJDK 11
             cache_key: '11'
             image: us-docker.pkg.dev/protobuf-build/containers/test/linux/java:6.4.0-11-27cf7b86212020d7e552bc13b1e084abb971da75

--- a/build_defs/java_opts.bzl
+++ b/build_defs/java_opts.bzl
@@ -5,7 +5,7 @@ load("@rules_jvm_external//:defs.bzl", "java_export")
 load("//:protobuf_version.bzl", "PROTOBUF_JAVA_VERSION")
 load("//java/osgi:osgi.bzl", "osgi_java_library")
 
-JAVA_OPTS = [
+JAVA_RELEASE_OPTS = [
     "-source 8",
     "-target 8",
     "-Xep:Java8ApiChecker:ERROR",
@@ -16,7 +16,7 @@ BUNDLE_LICENSE = "https://opensource.org/licenses/BSD-3-Clause"
 
 def protobuf_java_export(**kwargs):
     java_export(
-        javacopts = JAVA_OPTS,
+        javacopts = JAVA_RELEASE_OPTS,
         # https://github.com/bazelbuild/rules_jvm_external/issues/1245
         javadocopts = [
             "-notimestamp",
@@ -31,7 +31,6 @@ def protobuf_java_export(**kwargs):
 
 def protobuf_java_library(**kwargs):
     java_library(
-        javacopts = JAVA_OPTS,
         **kwargs
     )
 
@@ -77,7 +76,7 @@ def protobuf_versioned_java_library(
             java_library target.
     """
     osgi_java_library(
-        javacopts = JAVA_OPTS,
+        javacopts = JAVA_RELEASE_OPTS,
         automatic_module_name = automatic_module_name,
         bundle_doc_url = BUNDLE_DOC_URL,
         bundle_license = BUNDLE_LICENSE,


### PR DESCRIPTION
Adding java8 tests as a presubmit test to ensure no regression on java8 compatibility since the option will no longer apply to tests.

Cherry-pick of https://github.com/protocolbuffers/protobuf/commit/59e469d5b090ac804317dc7a6201c556f438358d

PiperOrigin-RevId: 681615348