### PR TITLE
Remove javaopts requiring java8 in non-release builds.

### DIFF
--- a/build_defs/java_opts.bzl
+++ b/build_defs/java_opts.bzl
@@ -5,7 +5,7 @@ load("@rules_jvm_external//:defs.bzl", "java_export")
 load("//:protobuf_version.bzl", "PROTOBUF_JAVA_VERSION")
 load("//java/osgi:osgi.bzl", "osgi_java_library")
 
-JAVA_OPTS = [
+JAVA_RELEASE_OPTS = [
     "-source 8",
     "-target 8",
     "-Xep:Java8ApiChecker:ERROR",
@@ -16,13 +16,12 @@ BUNDLE_LICENSE = "https://opensource.org/licenses/BSD-3-Clause"
 
 def protobuf_java_export(**kwargs):
     java_export(
-        javacopts = JAVA_OPTS,
+        javacopts = JAVA_RELEASE_OPTS,
         **kwargs
     )
 
 def protobuf_java_library(**kwargs):
     java_library(
-        javacopts = JAVA_OPTS,
         **kwargs
     )
 
@@ -68,7 +67,7 @@ def protobuf_versioned_java_library(
             java_library target.
     """
     osgi_java_library(
-        javacopts = JAVA_OPTS,
+        javacopts = JAVA_RELEASE_OPTS,
         automatic_module_name = automatic_module_name,
         bundle_doc_url = BUNDLE_DOC_URL,
         bundle_license = BUNDLE_LICENSE,


### PR DESCRIPTION
Adding java8 tests as a presubmit test to ensure no regression on java8 compatibility since the option will no longer apply to tests.

Cherry-pick of https://github.com/protocolbuffers/protobuf/commit/59e469d5b090ac804317dc7a6201c556f438358d

PiperOrigin-RevId: 681615348