### PR TITLE
Add missing copts flags to compiler BUILD files.

### DIFF
--- a/src/google/protobuf/compiler/java/full/BUILD.bazel
+++ b/src/google/protobuf/compiler/java/full/BUILD.bazel
@@ -1,8 +1,12 @@
 # We use abbreviated target names in this directory to work around:
 #     https://github.com/bazelbuild/bazel/issues/18683
+
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
 cc_library(
     name = "fg",
     hdrs = ["field_generator.h"],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = ["//src/google/protobuf/compiler/kotlin:__subpackages__"],
     deps = [
@@ -29,6 +33,7 @@ cc_library(
         "primitive_field.h",
         "string_field.h",
     ],
+    copts = COPTS,
     strip_include_prefix = "/src",
     deps = [
         ":fg",
@@ -49,6 +54,7 @@ cc_library(
     name = "mfg",
     srcs = ["make_field_gens.cc"],
     hdrs = ["make_field_gens.h"],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = ["//src/google/protobuf/compiler/kotlin:__subpackages__"],
     deps = [
@@ -64,6 +70,7 @@ cc_library(
     name = "service",
     srcs = ["service.cc"],
     hdrs = ["service.h"],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = ["//src/google/protobuf/compiler/java/lite:__pkg__"],
     deps = [
@@ -81,6 +88,7 @@ cc_library(
     name = "eg",
     srcs = ["enum.cc"],
     hdrs = ["enum.h"],
+    copts = COPTS,
     strip_include_prefix = "/src",
     deps = [
         "//src/google/protobuf",
@@ -113,6 +121,7 @@ cc_library(
         "extension.h",
         "message_builder.h",
     ],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = [
         "//src/google/protobuf/compiler/java:__pkg__",

--- a/src/google/protobuf/compiler/java/lite/BUILD.bazel
+++ b/src/google/protobuf/compiler/java/lite/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
 cc_library(
     name = "field_generators",
     srcs = [
@@ -23,6 +25,7 @@ cc_library(
         "primitive_field.h",
         "string_field.h",
     ],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = [
         "//src/google/protobuf/compiler/java:__subpackages__",
@@ -62,6 +65,7 @@ cc_library(
         "message.h",
         "message_builder.h",
     ],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = [
         "//src/google/protobuf/compiler/java:__subpackages__",

--- a/src/google/protobuf/compiler/kotlin/BUILD.bazel
+++ b/src/google/protobuf/compiler/kotlin/BUILD.bazel
@@ -1,7 +1,10 @@
+load("//build_defs:cpp_opts.bzl", "COPTS")
+
 cc_library(
     name = "kotlin",
     srcs = ["generator.cc"],
     hdrs = ["generator.h"],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = [
         "//pkg:__pkg__",
@@ -31,6 +34,7 @@ cc_library(
         "file.h",
         "message.h",
     ],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = [
         "//pkg:__pkg__",

--- a/src/google/protobuf/compiler/rust/BUILD.bazel
+++ b/src/google/protobuf/compiler/rust/BUILD.bazel
@@ -46,6 +46,7 @@ cc_library(
     name = "crate_mapping",
     srcs = ["crate_mapping.cc"],
     hdrs = ["crate_mapping.h"],
+    copts = COPTS,
     strip_include_prefix = "/src",
     deps = [
         ":context",
@@ -207,6 +208,7 @@ cc_library(
     name = "relative_path",
     srcs = ["relative_path.cc"],
     hdrs = ["relative_path.h"],
+    copts = COPTS,
     strip_include_prefix = "/src",
     deps = [
         "@com_google_absl//absl/algorithm:container",
@@ -229,6 +231,7 @@ cc_library(
     name = "rust_field_type",
     srcs = ["rust_field_type.cc"],
     hdrs = ["rust_field_type.h"],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = [
         "//src/google/protobuf/compiler/rust:__subpackages__",
@@ -244,6 +247,7 @@ cc_library(
     name = "upb_helpers",
     srcs = ["upb_helpers.cc"],
     hdrs = ["upb_helpers.h"],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = [
         "//src/google/protobuf/compiler/rust:__subpackages__",


### PR DESCRIPTION
protobuf has standard compiler flags, but this were not consistenly applied to the compiler directory.