### PR TITLE
Cherry-pick: Fix Bazel dependency cycle issue affecting Kythe

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -266,7 +266,7 @@ alias(
 
 alias(
     name = "protobuf_nowkt",
-    actual = "//src/google/protobuf:protobuf_layering_check_legacy",
+    actual = "//src/google/protobuf",
     deprecation = "Use //:protobuf instead",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The fact that our `:protobuf_nowkt` target actually does depend on the well-known types is causing a dependency cycle for Kythe. This fixes that so that `:protobuf_nowkt` no longer depends on the well-known types.

PiperOrigin-RevId: 684160567