### PR TITLE
Give Kotlin jars an OSGi Manifest

### DIFF
--- a/build_defs/kotlin_opts.bzl
+++ b/build_defs/kotlin_opts.bzl
@@ -1,7 +1,7 @@
 """Protobuf-specific kotlin build rules."""
 
 load("//:protobuf_version.bzl", "PROTOBUF_JAVA_VERSION")
-load("//java/osgi:osgi.bzl", "osgi_kt_jvm_library")
+load("//java/osgi:kotlin_osgi.bzl", "osgi_kt_jvm_library")
 
 
 BUNDLE_DOC_URL = "https://developers.google.com/protocol-buffers/"

--- a/build_defs/kotlin_opts.bzl
+++ b/build_defs/kotlin_opts.bzl
@@ -1,0 +1,62 @@
+"""Protobuf-specific kotlin build rules."""
+
+load("//:protobuf_version.bzl", "PROTOBUF_JAVA_VERSION")
+load("//java/osgi:osgi.bzl", "osgi_kt_jvm_library")
+
+
+BUNDLE_DOC_URL = "https://developers.google.com/protocol-buffers/"
+BUNDLE_LICENSE = "https://opensource.org/licenses/BSD-3-Clause"
+
+def protobuf_versioned_kt_jvm_library(
+        automatic_module_name,
+        bundle_description,
+        bundle_name,
+        bundle_symbolic_name,
+        bundle_additional_imports = [],
+        bundle_additional_exports = [],
+        **kwargs):
+    """Extends `kt_jvm_library` to add OSGi headers to the MANIFEST.MF using bndlib
+
+    This macro should be usable as a drop-in replacement for kt_jvm_library.
+
+    The additional arguments are given the bndlib tool to generate an OSGi-compliant manifest file.
+    See [bnd documentation](https://bnd.bndtools.org/chapters/110-introduction.html)
+
+    Takes all the args that are standard for a kt_jvm_library target plus the following.
+    Args:
+        bundle_description: (required) The Bundle-Description header defines a short
+            description of this bundle.
+        automatic_module_name: (required) The Automatic-Module-Name header that represents
+            the name of the module when this bundle is used as an automatic
+            module.
+        bundle_name: (required) The Bundle-Name header defines a readable name for this
+            bundle. This should be a short, human-readable name that can
+            contain spaces.
+        bundle_symbolic_name: (required) The Bundle-SymbolicName header specifies a
+            non-localizable name for this bundle. The bundle symbolic name
+            together with a version must identify a unique bundle though it can
+            be installed multiple times in a framework. The bundle symbolic
+            name should be based on the reverse domain name convention.
+        bundle_additional_exports: The Export-Package header contains a
+            declaration of exported packages. These are additional export
+            package statements to be added before the default wildcard export
+            "*;version={$Bundle-Version}".
+        bundle_additional_imports: The Import-Package header declares the
+            imported packages for this bundle. These are additional import
+            package statements to be added before the default wildcard import
+            "*".
+        **kwargs: Additional key-word arguments that are passed to the internal
+            kt_jvm_library target.
+    """
+    osgi_kt_jvm_library(
+        automatic_module_name = automatic_module_name,
+        bundle_doc_url = BUNDLE_DOC_URL,
+        bundle_license = BUNDLE_LICENSE,
+        bundle_version = PROTOBUF_JAVA_VERSION,
+        bundle_description = bundle_description,
+        bundle_name = bundle_name,
+        bundle_symbolic_name = bundle_symbolic_name,
+        bundle_additional_exports = bundle_additional_exports,
+        bundle_additional_imports = bundle_additional_imports + ["sun.misc;resolution:=optional"],
+        **kwargs
+    )

--- a/java/kotlin-lite/BUILD.bazel
+++ b/java/kotlin-lite/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("//:protobuf.bzl", "internal_gen_kt_protos")
 load("//:protobuf_version.bzl", "PROTOBUF_JAVA_VERSION")
 load("//bazel:java_lite_proto_library.bzl", "java_lite_proto_library")
+load("//build_defs:kotlin_opts.bzl", "protobuf_versioned_kt_jvm_library")
 
 java_lite_proto_library(
     name = "example_extensible_message_java_proto_lite",
@@ -47,6 +48,24 @@ kt_jvm_library(
     ],
 )
 
+protobuf_versioned_kt_jvm_library(
+    name = "kotlin-lite_bundle",
+    automatic_module_name = "com.google.protobuf",
+    bundle_description = "Kotlin lite Protocol Buffers library. Protocol " +
+                         "Buffers are a way of encoding structured data in " +
+                         "an efficient yet extensible format.",
+    bundle_name = "Protocol Buffers [Kotlin-Lite]",
+    bundle_symbolic_name = "com.google.protobuf",
+    visibility = ["//visibility:public"],
+    exports = [
+        ":lite_extensions",
+        ":well_known_protos_kotlin_lite",
+        "//java/kotlin:bytestring_lib",
+        "//java/kotlin:only_for_use_in_proto_generated_code_its_generator_and_tests",
+        "//java/kotlin:shared_runtime",
+    ],
+)
+
 kt_jvm_export(
     name = "kotlin-lite_mvn",
     deploy_env = [
@@ -62,11 +81,7 @@ kt_jvm_export(
     ],
     tags = ["manual"],
     runtime_deps = [
-        ":lite_extensions",
-        ":well_known_protos_kotlin_lite",
-        "//java/kotlin:bytestring_lib",
-        "//java/kotlin:only_for_use_in_proto_generated_code_its_generator_and_tests",
-        "//java/kotlin:shared_runtime",
+        ":kotlin-lite_bundle",
     ],
 )
 

--- a/java/kotlin/BUILD.bazel
+++ b/java/kotlin/BUILD.bazel
@@ -5,6 +5,7 @@ load("//:protobuf.bzl", "internal_gen_kt_protos")
 load("//:protobuf_version.bzl", "PROTOBUF_JAVA_VERSION")
 load("//bazel:java_proto_library.bzl", "java_proto_library")
 load("//bazel:proto_library.bzl", "proto_library")
+load("//build_defs:kotlin_opts.bzl", "protobuf_versioned_kt_jvm_library")
 
 exports_files([
     "src/test/kotlin/com/google/protobuf/Proto3Test.kt",
@@ -50,6 +51,24 @@ kt_jvm_library(
     deps = ["//java/core"],
 )
 
+protobuf_versioned_kt_jvm_library(
+    name = "kotlin_bundle",
+    automatic_module_name = "com.google.protobuf",
+    bundle_description = "Kotlin core Protocol Buffers library. Protocol " +
+                         "Buffers are a way of encoding structured data in an" +
+                         "efficient yet extensible format.",
+    bundle_name = "Protocol Buffers [Kotlin-Core]",
+    bundle_symbolic_name = "com.google.protobuf",
+    visibility = ["//visibility:public"],
+    exports = [
+        ":bytestring_lib",
+        ":full_extensions",
+        ":only_for_use_in_proto_generated_code_its_generator_and_tests",
+        ":shared_runtime",
+        ":well_known_protos_kotlin",
+    ]
+)
+
 kt_jvm_export(
     name = "kotlin_mvn",
     deploy_env = [
@@ -65,11 +84,7 @@ kt_jvm_export(
     ],
     tags = ["manual"],
     runtime_deps = [
-        ":bytestring_lib",
-        ":full_extensions",
-        ":only_for_use_in_proto_generated_code_its_generator_and_tests",
-        ":shared_runtime",
-        ":well_known_protos_kotlin",
+        ":kotlin_bundle",
     ],
 )
 

--- a/java/osgi/osgi.bzl
+++ b/java/osgi/osgi.bzl
@@ -1,7 +1,6 @@
 """ Custom rule to generate OSGi Manifest """
 
 load("@rules_java//java:defs.bzl", "JavaInfo", "java_library")
-load("@rules_kotlin//kotlin/internal:defs.bzl", "KtJvmInfo")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 # Note that this rule is currently agnostic of protobuf concerns and could be


### PR DESCRIPTION
Extend our Java OSGi library to have a version that works for Kotlin. Add a `protobuf_versioned_kt_jvm_library` that creates a bundle with the OSGi manifest and call that instead of `kt_jvm_library` for all our kotlin maven release targets.