### PR TITLE
Cherry-picks for Bazel 8

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -45,7 +45,7 @@ jobs:
             cache_key: Bazel7
             image: "us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:7.1.2-cf84e92285ca133b9c8104ad7b14d70e953cbb8e"
             targets: "//src/... //third_party/utf8_range/..."
-          - config: { name: "Bazel7 with Bzlmod", flags: --enable_bzlmod --enable_workspace }
+          - config: { name: "Bazel7 with Bzlmod", flags: --enable_bzlmod --enable_workspace --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --cxxopt="-Wno-self-assign-overloaded" }
             cache_key: Bazel7bzlmod
             image: "us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:7.1.2-cf84e92285ca133b9c8104ad7b14d70e953cbb8e"
             targets: "//src/... //third_party/utf8_range/..."

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -45,7 +45,8 @@ jobs:
             cache_key: Bazel7
             image: "us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:7.1.2-cf84e92285ca133b9c8104ad7b14d70e953cbb8e"
             targets: "//src/... //third_party/utf8_range/..."
-          - config: { name: "Bazel7 with Bzlmod", flags: --enable_bzlmod --enable_workspace --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --cxxopt="-Wno-self-assign-overloaded" }
+            # TODO: remove -Wno-unreachable-code" when dropping C++14
+          - config: { name: "Bazel7 with Bzlmod", flags: --enable_bzlmod --enable_workspace --per_file_copt=.*/absl/strings/string_view.h@-Wno-unreachable-code --cxxopt="-Wno-self-assign-overloaded" }
             cache_key: Bazel7bzlmod
             image: "us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:7.1.2-cf84e92285ca133b9c8104ad7b14d70e953cbb8e"
             targets: "//src/... //third_party/utf8_range/..."

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_cc",
-    version = "0.0.9",
+    version = "0.0.13",
 )
 
 bazel_dep(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -84,6 +84,11 @@ bazel_dep(
     repo_name = "proto_bazel_features",
 )
 
+bazel_dep(
+    name = "rules_shell",
+    version = "0.2.0"
+)
+
 # Proto toolchains
 register_toolchains("//bazel/private/toolchains:all")
 

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -13,24 +13,31 @@ bzl_library(
     name = "proto_library_bzl",
     srcs = ["proto_library.bzl"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//bazel/private:bazel_proto_library_rule_bzl",
+        "@proto_bazel_features//:features",
+    ],
 )
 
 bzl_library(
     name = "cc_proto_library_bzl",
     srcs = ["cc_proto_library.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//bazel/private:bazel_cc_proto_library_bzl"],
 )
 
 bzl_library(
     name = "java_proto_library_bzl",
     srcs = ["java_proto_library.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//bazel/private:bazel_java_proto_library_rule_bzl"],
 )
 
 bzl_library(
     name = "java_lite_proto_library_bzl",
     srcs = ["java_lite_proto_library.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//bazel/private:java_lite_proto_library_bzl"],
 )
 
 bzl_library(
@@ -55,4 +62,20 @@ bzl_library(
     ],
     visibility = ["//visibility:public"],
     deps = ["//bazel/private:upb_proto_library_internal_bzl"],
+)
+
+# The data in this target is exposed in //bazel/private:for_bazel_tests
+filegroup(
+    name = "for_bazel_tests",
+    testonly = True,
+    srcs = [
+        "BUILD.bazel",
+        ":cc_proto_library_bzl",
+        ":java_lite_proto_library_bzl",
+        ":proto_library_bzl",
+        ":py_proto_library_bzl",
+        "//bazel/common:for_bazel_tests",
+        "//bazel/toolchains:for_bazel_tests",
+    ],
+    visibility = ["//bazel/private:__pkg__"],
 )

--- a/bazel/common/BUILD
+++ b/bazel/common/BUILD
@@ -10,6 +10,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         ":proto_lang_toolchain_info_bzl",
+        "//bazel/private:native_bzl",
         "//bazel/private:toolchain_helpers_bzl",
         "@proto_bazel_features//:features",
     ],
@@ -38,9 +39,13 @@ bzl_library(
 )
 
 filegroup(
-    name = "bazel_osx_p4deps",
-    srcs = glob(["**"]) + ["@proto_bazel_features//:features"],
-    visibility = [
-        "//bazel:__pkg__",
+    name = "for_bazel_tests",
+    testonly = True,
+    srcs = [
+        "BUILD",
+        "proto_common_bzl",
+        "proto_info_bzl",
+        "proto_lang_toolchain_info_bzl",
     ],
+    visibility = ["//bazel:__pkg__"],
 )

--- a/bazel/private/BUILD
+++ b/bazel/private/BUILD
@@ -116,6 +116,7 @@ bzl_library(
         "//bazel/common:proto_common_bzl",
         "//bazel/common:proto_info_bzl",
         "@proto_bazel_features//:features",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
 

--- a/bazel/private/BUILD
+++ b/bazel/private/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//bazel/private:native_bool_flag.bzl", "native_bool_flag")
+load(":native_bool_flag.bzl", "native_bool_flag")
 
 package(default_applicable_licenses = ["//:license"])
 
@@ -53,17 +53,68 @@ bzl_library(
 )
 
 bzl_library(
+    name = "proto_info_bzl",
+    srcs = ["proto_info.bzl"],
+    visibility = ["//bazel:__subpackages__"],
+)
+
+bzl_library(
     name = "bazel_proto_library_rule_bzl",
     srcs = [
         "bazel_proto_library_rule.bzl",
     ],
     visibility = ["//bazel:__subpackages__"],
     deps = [
+        ":toolchain_helpers_bzl",
         "//bazel/common:proto_common_bzl",
         "//bazel/common:proto_info_bzl",
-        "//bazel/private:toolchain_helpers_bzl",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//rules:common_settings",
+        "@proto_bazel_features//:features",
+    ],
+)
+
+bzl_library(
+    name = "bazel_java_proto_library_rule_bzl",
+    srcs = [
+        "bazel_java_proto_library_rule.bzl",
+        "java_proto_support.bzl",
+    ],
+    visibility = ["//bazel:__subpackages__"],
+    deps = [
+        ":toolchain_helpers_bzl",
+        "//bazel/common:proto_common_bzl",
+        "//bazel/common:proto_info_bzl",
+        "@rules_java//java/common",
+    ],
+)
+
+bzl_library(
+    name = "java_lite_proto_library_bzl",
+    srcs = [
+        "java_lite_proto_library.bzl",
+        "java_proto_support.bzl",
+    ],
+    visibility = ["//bazel:__subpackages__"],
+    deps = [
+        ":toolchain_helpers_bzl",
+        "//bazel/common:proto_common_bzl",
+        "//bazel/common:proto_info_bzl",
+        "@rules_java//java/common",
+    ],
+)
+
+bzl_library(
+    name = "bazel_cc_proto_library_bzl",
+    srcs = [
+        "bazel_cc_proto_library.bzl",
+        "cc_proto_support.bzl",
+    ],
+    visibility = ["//bazel:__subpackages__"],
+    deps = [
+        ":toolchain_helpers_bzl",
+        "//bazel/common:proto_common_bzl",
+        "//bazel/common:proto_info_bzl",
         "@proto_bazel_features//:features",
     ],
 )
@@ -75,9 +126,9 @@ bzl_library(
     ],
     visibility = ["//bazel:__subpackages__"],
     deps = [
+        ":toolchain_helpers_bzl",
         "//bazel/common:proto_common_bzl",
         "//bazel/common:proto_lang_toolchain_info_bzl",
-        "//bazel/private:toolchain_helpers_bzl",
     ],
 )
 
@@ -131,10 +182,21 @@ native_bool_flag(
     visibility = ["//bazel:__subpackages__"],
 )
 
+bzl_library(
+    name = "native_bool_flag_bzl",
+    srcs = ["native_bool_flag.bzl"],
+    visibility = ["//visibility:private"],
+    deps = ["@bazel_skylib//rules:common_settings"],
+)
+
 filegroup(
-    name = "bazel_osx_p4deps",
-    srcs = glob(["**"]),
-    visibility = [
-        "//bazel:__pkg__",
+    name = "for_bazel_tests",
+    testonly = True,
+    srcs = [
+        "BUILD",
+        ":native_bool_flag_bzl",
+        "//bazel:for_bazel_tests",
+        "//bazel/private/toolchains:for_bazel_tests",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/bazel/private/bazel_cc_proto_library.bzl
+++ b/bazel/private/bazel_cc_proto_library.bzl
@@ -13,7 +13,7 @@ load("//bazel/common:proto_info.bzl", "ProtoInfo")
 load("//bazel/private:cc_proto_support.bzl", "cc_proto_compile_and_link")
 load("//bazel/private:toolchain_helpers.bzl", "toolchains")
 
-_CC_PROTO_TOOLCHAIN = "//bazel/private:cc_toolchain_type"
+_CC_PROTO_TOOLCHAIN = Label("//bazel/private:cc_toolchain_type")
 
 _ProtoCcFilesInfo = provider(fields = ["files"], doc = "Provide cc proto files.")
 _ProtoCcHeaderInfo = provider(fields = ["headers"], doc = "Provide cc proto headers.")

--- a/bazel/private/bazel_cc_proto_library.bzl
+++ b/bazel/private/bazel_cc_proto_library.bzl
@@ -8,6 +8,7 @@
 """Bazel's implementation of cc_proto_library"""
 
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//bazel/common:proto_common.bzl", "proto_common")
 load("//bazel/common:proto_info.bzl", "ProtoInfo")
 load("//bazel/private:cc_proto_support.bzl", "cc_proto_compile_and_link")

--- a/bazel/private/bazel_java_proto_library_rule.bzl
+++ b/bazel/private/bazel_java_proto_library_rule.bzl
@@ -12,7 +12,7 @@ load("//bazel/common:proto_info.bzl", "ProtoInfo")
 load("//bazel/private:java_proto_support.bzl", "JavaProtoAspectInfo", "java_compile_for_protos", "java_info_merge_for_protos")
 load("//bazel/private:toolchain_helpers.bzl", "toolchains")
 
-_JAVA_PROTO_TOOLCHAIN = "//bazel/private:java_toolchain_type"
+_JAVA_PROTO_TOOLCHAIN = Label("//bazel/private:java_toolchain_type")
 
 def _filter_provider(provider, *attrs):
     return [dep[provider] for attr in attrs for dep in attr if provider in dep]

--- a/bazel/private/cc_proto_support.bzl
+++ b/bazel/private/cc_proto_support.bzl
@@ -9,6 +9,8 @@
 
 load("@proto_bazel_features//:features.bzl", "bazel_features")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 def get_feature_configuration(ctx, has_sources, extra_requested_features = []):
     """Returns C++ feature configuration for compiling and linking generated C++ files.

--- a/bazel/private/java_lite_proto_library.bzl
+++ b/bazel/private/java_lite_proto_library.bzl
@@ -16,7 +16,7 @@ load("//bazel/private:toolchain_helpers.bzl", "toolchains")
 
 _PROTO_TOOLCHAIN_ATTR = "_aspect_proto_toolchain_for_javalite"
 
-_JAVA_LITE_PROTO_TOOLCHAIN = "//bazel/private:javalite_toolchain_type"
+_JAVA_LITE_PROTO_TOOLCHAIN = Label("//bazel/private:javalite_toolchain_type")
 
 def _aspect_impl(target, ctx):
     """Generates and compiles Java code for a proto_library dependency graph.

--- a/bazel/private/toolchain_helpers.bzl
+++ b/bazel/private/toolchain_helpers.bzl
@@ -45,5 +45,5 @@ toolchains = struct(
     find_toolchain = _find_toolchain,
     if_legacy_toolchain = _if_legacy_toolchain,
     INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION = _incompatible_toolchain_resolution,
-    PROTO_TOOLCHAIN = "//bazel/private:proto_toolchain_type",
+    PROTO_TOOLCHAIN = Label("//bazel/private:proto_toolchain_type"),
 )

--- a/bazel/private/toolchains/BUILD.bazel
+++ b/bazel/private/toolchains/BUILD.bazel
@@ -72,3 +72,14 @@ toolchain(
     toolchain = "//java/lite:toolchain",
     toolchain_type = "@rules_java//java/proto:lite_toolchain_type",
 )
+
+filegroup(
+    name = "for_bazel_tests",
+    testonly = True,
+    srcs = [
+        "BUILD.bazel",
+    ],
+    visibility = [
+        "//bazel/private:__pkg__",
+    ],
+)

--- a/bazel/toolchains/BUILD
+++ b/bazel/toolchains/BUILD
@@ -28,8 +28,13 @@ bzl_library(
 )
 
 filegroup(
-    name = "bazel_osx_p4deps",
-    srcs = glob(["**"]),
+    name = "for_bazel_tests",
+    testonly = True,
+    srcs = [
+        "BUILD",
+        "proto_lang_toolchain_bzl",
+        "proto_toolchain_bzl",
+    ],
     visibility = [
         "//bazel:__pkg__",
     ],

--- a/build_defs/internal_shell.bzl
+++ b/build_defs/internal_shell.bzl
@@ -3,6 +3,9 @@ Internal tools to migrate shell commands to Bazel as an intermediate step
 to wider Bazelification.
 """
 
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 def inline_sh_binary(
         name,
         srcs = [],
@@ -41,7 +44,7 @@ def inline_sh_binary(
         testonly = kwargs["testonly"] if "testonly" in kwargs else None,
     )
 
-    native.sh_binary(
+    sh_binary(
         name = name,
         srcs = [name + "_genrule"],
         data = srcs + tools + deps,
@@ -86,7 +89,7 @@ def inline_sh_test(
         testonly = kwargs["testonly"] if "testonly" in kwargs else None,
     )
 
-    native.sh_test(
+    sh_test(
         name = name,
         srcs = [name + "_genrule"],
         data = srcs + tools + deps,

--- a/conformance/defs.bzl
+++ b/conformance/defs.bzl
@@ -3,6 +3,8 @@
 PLEASE DO NOT DEPEND ON THE CONTENTS OF THIS FILE, IT IS UNSTABLE.
 """
 
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 def conformance_test(
         name,
         testee,
@@ -31,7 +33,7 @@ def conformance_test(
     if maximum_edition:
         args = args + ["--maximum_edition %s" % maximum_edition]
 
-    native.sh_test(
+    sh_test(
         name = name,
         srcs = ["//conformance:bazel_conformance_test_runner.sh"],
         data = [testee] + failure_lists + [

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -90,11 +90,11 @@ def protobuf_deps():
         )
 
     if not native.existing_rule("rules_cc"):
-        _github_archive(
+        http_archive(
             name = "rules_cc",
-            repo = "https://github.com/bazelbuild/rules_cc",
-            commit = "c8c38f8c710cbbf834283e4777916b68261b359c",  # 0.0.9
-            sha256 = "5f862a44bbd032e1b48ed53c9c211ba2a1da60e10c5baa01c97369c249299ecb",
+            urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz"],
+            sha256 = "d9bdd3ec66b6871456ec9c965809f43a0901e692d754885e89293807762d3d80",
+            strip_prefix = "rules_cc-0.0.13",
         )
 
     if not native.existing_rule("rules_java"):

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -104,6 +104,14 @@ def protobuf_deps():
             sha256 = "6f3ce0e9fba979a844faba2d60467843fbf5191d8ca61fa3d2ea17655b56bb8c",
         )
 
+    if not native.existing_rule("rules_shell"):
+        http_archive(
+            name = "rules_shell",
+            sha256 = "410e8ff32e018b9efd2743507e7595c26e2628567c42224411ff533b57d27c28",
+            strip_prefix = "rules_shell-0.2.0",
+            url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.2.0/rules_shell-v0.2.0.tar.gz",
+        )
+
     if not native.existing_rule("proto_bazel_features"):
         proto_bazel_features(name = "proto_bazel_features")
 

--- a/python/internal.bzl
+++ b/python/internal.bzl
@@ -2,6 +2,8 @@
 Internal helpers for building the Python protobuf runtime.
 """
 
+load("@rules_python//python:py_test.bzl", "py_test")
+
 def _remove_cross_repo_path(path):
     components = path.split("/")
     if components[0] == "..":
@@ -123,7 +125,7 @@ def internal_py_test(deps = [], **kwargs):
       deps: any additional dependencies of the test.
       **kwargs: arguments forwarded to py_test.
     """
-    native.py_test(
+    py_test(
         imports = ["."],
         deps = deps + ["//python:python_test_lib"],
         target_compatible_with = select({

--- a/python/pb_unit_tests/pyproto_test_wrapper.bzl
+++ b/python/pb_unit_tests/pyproto_test_wrapper.bzl
@@ -1,8 +1,10 @@
 """Wrapper for another py_test to run with upb, possibly with a set of expected failures."""
 
+load("@rules_python//python:py_test.bzl", "py_test")
+
 def pyproto_test_wrapper(name, deps = []):
     src = name + "_wrapper.py"
-    native.py_test(
+    py_test(
         name = name,
         srcs = [src],
         legacy_create_init = False,

--- a/python/py_extension.bzl
+++ b/python/py_extension.bzl
@@ -1,6 +1,7 @@
 """Macro to support py_extension """
 
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@rules_python//python:py_library.bzl", "py_library")
 
 def py_extension(name, srcs, copts, deps = [], **kwargs):
     """Creates a C++ library to extend python
@@ -50,7 +51,7 @@ def py_extension(name, srcs, copts, deps = [], **kwargs):
         visibility = ["//python:__subpackages__"],
     )
 
-    native.py_library(
+    py_library(
         name = name,
         data = [output_file],
         imports = ["."],

--- a/upb/cmake/build_defs.bzl
+++ b/upb/cmake/build_defs.bzl
@@ -4,8 +4,9 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
-
 """Bazel support functions related to CMake support."""
+
+load("@rules_python//python:py_test.bzl", "py_test")
 
 def staleness_test(name, outs, generated_pattern, target_files = None, tags = [], **kwargs):
     """Tests that checked-in file(s) match the contents of generated file(s).
@@ -46,7 +47,7 @@ def staleness_test(name, outs, generated_pattern, target_files = None, tags = []
               "sed -i.bak -e 's|INSERT_FILE_LIST_HERE|" + "\\\n  ".join(file_list) + "|' $@",
     )
 
-    native.py_test(
+    py_test(
         name = name,
         srcs = [script_name],
         data = existing_outs + [generated_pattern % file for file in outs],


### PR DESCRIPTION
Commits:
9c4f3b817ed0b1cfcfdca66c2c29874a5bbb51fd Prepare supporting targets for testing 
b00dca3665b872f280702283be831bad6607d86c Load Python rules everywhere in protobuf 
5aa7abc659f727de9ca90ca37a3a3187d88a790f Upgrade rules_cc to 0.0.13 
8ec13ede1f4e07ca88a71d02aca004e3c281700a  Load Shell rules everywhere in protobuf
a0eb24061f3850824eaba4b9e8c627aa2b4257ff Replace use of C++17 with disabling a warning

Pending commits:
a03850971866aa61f3e2966eaca3db3ee2ed19d9 Convert proto toolchain string to Label (cl/684391633)
f484e9caf77e1550ca65cfe67a674cb979dd62c1 Use rules_cc everywhere in protobuf (cl/674352147)

