### PR TITLE
Prevent Bazel lockfile non reproducibility for end users

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -68,9 +68,10 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 use_repo(pip, "pip_deps")
 
 crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
-# As of rules_rust@0.52.2 crate.from_specs specifies the crate module extension
-# as non reproducible and non os/arch dependent, which can cause bazel lockfile
-# non reproducibility between platforms for users of the `protobuf` module.
+# As of rules_rust@0.52.2 crate.from_specs still specifies the crate
+# module extension as non reproducible and non os/arch dependent, which can
+# cause bazel lockfile non reproducibility between platforms for users of the
+#`protobuf` module.
 #
 # crate.from_cargo is specified reproducible since using Cargo.lock mechanism
 # directly and does not result in a Bazel lockfile entry for the crate module

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -68,15 +68,20 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 use_repo(pip, "pip_deps")
 
 crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
-crate.spec(
-    package = "googletest",
-    version = ">0.0.0",
+# As of rules_rust@0.52.2 crate.from_specs specifies the crate module extension
+# as non reproducible and non os/arch dependent, which can cause bazel lockfile
+# non reproducibility between platforms for users of the `protobuf` module.
+#
+# crate.from_cargo is specified reproducible since using Cargo.lock mechanism
+# directly and does not result in a Bazel lockfile entry for the crate module
+# extension.
+crate.from_cargo(
+    name = "crates",
+    cargo_lockfile = "Cargo.lock",
+    manifests = [
+        "//rust/cargo:Cargo.toml",
+    ],
 )
-crate.spec(
-    package = "paste",
-    version = ">=1",
-)
-crate.from_specs()
 use_repo(crate, crate_index = "crates")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")

--- a/rust/cargo/BUILD
+++ b/rust/cargo/BUILD
@@ -1,0 +1,3 @@
+exports_files([
+    "Cargo.toml",
+])


### PR DESCRIPTION
Using `crate.from_specs` results in non reproducible `MODULE.bazel.lock` between platforms for end users of the `protobuf` bazel module.

Using `crate.from_cargo` instead (which marks the crate module extension as reproducible) makes bazel skips the entry in the lockfile altogether and allows reproducible lockfiles for end users of the `protobuf` bazel module.

cc @fmeum