### PR TITLE
Upgrade rules_java and remove experimental_google_legacy_api flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,8 +1,7 @@
 build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 
-# Needed for java_lite_proto_library, that's using ProguardSpecProvider
-# Once the provider is ported to Starlark the flag may be removed.
-common --experimental_google_legacy_api
+# TODO: ErrorProne's SelfAssertions are violated in protobuf's test
+build --javacopt=-Xep:SelfAssertion:WARN
 
 build:dbg --compilation_mode=dbg
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,7 +40,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_java",
-    version = "7.11.1",
+    version = "7.12.2",
 )
 
 bazel_dep(

--- a/ci/common.bazelrc
+++ b/ci/common.bazelrc
@@ -1,6 +1,5 @@
-# Needed for java_lite_proto_library, that's using ProguardSpecProvider
-# TODO: Once the provider is ported to Starlark the flag may be removed.
-common --experimental_google_legacy_api
+# TODO: ErrorProne's SelfAssertions are violated in tests
+build --javacopt=-Xep:SelfAssertion:WARN
 
 build:dbg --compilation_mode=dbg
 

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -1,9 +1,5 @@
 common --enable_platform_specific_config
 
-# Needed for java_lite_proto_library, that's using ProguardSpecProvider
-# TODO: Once the provider is ported to Starlark the flag may be removed.
-common --experimental_google_legacy_api
-
 build:linux --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 build:macos --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -100,8 +100,8 @@ def protobuf_deps():
     if not native.existing_rule("rules_java"):
         http_archive(
             name = "rules_java",
-            url = "https://github.com/bazelbuild/rules_java/releases/download/7.11.1/rules_java-7.11.1.tar.gz",
-            sha256 = "6f3ce0e9fba979a844faba2d60467843fbf5191d8ca61fa3d2ea17655b56bb8c",
+            url = "https://github.com/bazelbuild/rules_java/releases/download/7.12.2/rules_java-7.12.2.tar.gz",
+            sha256 = "a9690bc00c538246880d5c83c233e4deb83fe885f54c21bb445eb8116a180b83",
         )
 
     if not native.existing_rule("rules_shell"):


### PR DESCRIPTION
The upgrade of rules_java also upgrades error prone and this resulted in some additional errors reported in Protobuf's tests. Set the flag to report those as warning, but they should be cleaned up eventually.

PiperOrigin-RevId: 686565803