### PR TITLE
Fix uses of __cpp_lib_constexpr_string

### DIFF
--- a/src/google/protobuf/port.cc
+++ b/src/google/protobuf/port.cc
@@ -97,7 +97,7 @@ void RealDebugCounter::Register(absl::string_view name) {
   }
 }
 
-#if defined(__cpp_lib_constexpr_string)
+#if defined(__cpp_lib_constexpr_string) && __cpp_lib_constexpr_string >= 201907L
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT const GlobalEmptyString
     fixed_address_empty_string{};
 #else

--- a/src/google/protobuf/port.h
+++ b/src/google/protobuf/port.h
@@ -454,7 +454,7 @@ class NoopDebugCounter {
 // Default empty string object. Don't use this directly. Instead, call
 // GetEmptyString() to get the reference. This empty string is aligned with a
 // minimum alignment of 8 bytes to match the requirement of ArenaStringPtr.
-#if defined(__cpp_lib_constexpr_string)
+#if defined(__cpp_lib_constexpr_string) && __cpp_lib_constexpr_string >= 201907L
 // Take advantage of C++20 constexpr support in std::string.
 class alignas(8) GlobalEmptyString {
  public:


### PR DESCRIPTION
The intent of these checks was that if the C++20 version of this feature
are enabled to execute the top codepath. libstdc++ 12 defines this
feature as:

```cpp
// in: /usr/include/c++/12/bits/basic_string.h

#ifdef __cpp_lib_is_constant_evaluated
// Support P0980R1 in C++20.
# define __cpp_lib_constexpr_string 201907L
#elif __cplusplus >= 201703L && _GLIBCXX_HAVE_IS_CONSTANT_EVALUATED
// Support P0426R1 changes to char_traits in C++17.
# define __cpp_lib_constexpr_string 201611L
#endif
```

So this codepath was always being hit even with -std=c++17 and then
resulted in a failure because the string wasn't actually constinit. This
matches the other use of this feature check in `inlined_string_field.h`
