### PR TITLE
Fix proto_info_bzl

### DIFF
--- a/bazel/common/BUILD
+++ b/bazel/common/BUILD
@@ -23,7 +23,8 @@ bzl_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//bazel/private:native_bzl",
+        "//bazel/private:proto_info_bzl",
+        "@proto_bazel_features//:features",
     ],
 )
 


### PR DESCRIPTION
Needed for generating proto docs.

PiperOrigin-RevId: 687840303