### PR TITLE
dotnet: Dispose StringWriters. Microoptimizations

### DIFF
--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -140,7 +140,7 @@ namespace Google.Protobuf
         {
             // By handling the empty string explicitly, we not only optimize but we fix a
             // problem on CF 2.0. See issue 61 for details.
-            return bytes == "" ? Empty : new ByteString(Convert.FromBase64String(bytes));
+            return bytes.Length == 0 ? Empty : new ByteString(Convert.FromBase64String(bytes));
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/Collections/MapField.cs
+++ b/csharp/src/Google.Protobuf/Collections/MapField.cs
@@ -526,7 +526,7 @@ namespace Google.Protobuf.Collections
         /// </summary>
         public override string ToString()
         {
-            var writer = new StringWriter();
+            using var writer = new StringWriter();
             JsonFormatter.Default.WriteDictionary(writer, this);
             return writer.ToString();
         }
@@ -590,7 +590,7 @@ namespace Google.Protobuf.Collections
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
         #endregion
 
-        private class DictionaryEnumerator : IDictionaryEnumerator
+        private sealed class DictionaryEnumerator : IDictionaryEnumerator
         {
             private readonly IEnumerator<KeyValuePair<TKey, TValue>> enumerator;
 

--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -355,7 +355,7 @@ namespace Google.Protobuf.Collections
             if (index == -1)
             {
                 return false;
-            }            
+            }
             Array.Copy(array, index + 1, array, index, count - index - 1);
             count--;
             array[count] = default;
@@ -463,7 +463,7 @@ namespace Google.Protobuf.Collections
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj) => Equals(obj as RepeatedField<T>);
-        
+
         /// <summary>
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
@@ -476,7 +476,7 @@ namespace Google.Protobuf.Collections
         /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
         public override int GetHashCode()
         {
@@ -577,7 +577,7 @@ namespace Google.Protobuf.Collections
         /// </summary>
         public override string ToString()
         {
-            var writer = new StringWriter();
+            using var writer = new StringWriter();
             JsonFormatter.Default.WriteList(writer, this);
             return writer.ToString();
         }
@@ -645,7 +645,7 @@ namespace Google.Protobuf.Collections
                 Remove(t);
             }
         }
-        #endregion        
+        #endregion
 
         private sealed class RepeatedFieldDebugView
         {

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -85,7 +85,7 @@ namespace Google.Protobuf {
 
     static JsonFormatter() {
       for (int i = 0; i < CommonRepresentations.Length; i++) {
-        if (CommonRepresentations[i] == "") {
+        if (CommonRepresentations[i].Length == 0) {
           CommonRepresentations[i] = ((char)i).ToString();
         }
       }
@@ -123,7 +123,7 @@ namespace Google.Protobuf {
     /// </remarks>
     /// <returns>The formatted message.</returns>
     public string Format(IMessage message, int indentationLevel) {
-      var writer = new StringWriter();
+      using var writer = new StringWriter();
       Format(message, writer, indentationLevel);
       return writer.ToString();
     }
@@ -291,7 +291,7 @@ namespace Google.Protobuf {
       return descriptor.FieldType switch {
         FieldType.Bool => (bool)value == false,
         FieldType.Bytes => (ByteString)value == ByteString.Empty,
-        FieldType.String => (string)value == "",
+        FieldType.String => ((string)value).Length == 0,
         FieldType.Double => (double)value == 0.0,
         FieldType.SInt32 or FieldType.Int32 or FieldType.SFixed32 or FieldType.Enum =>
             (int)value == 0,
@@ -497,7 +497,7 @@ namespace Google.Protobuf {
       WriteBracketClose(writer, ObjectCloseBracket, true, indentationLevel);
     }
 
-    private void WriteDiagnosticOnlyAny(TextWriter writer, IMessage value) {
+    private static void WriteDiagnosticOnlyAny(TextWriter writer, IMessage value) {
       string typeUrl =
           (string)value.Descriptor.Fields[Any.TypeUrlFieldNumber].Accessor.GetValue(value);
       ByteString data =

--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -830,7 +830,7 @@ namespace Google.Protobuf
                 // TODO: It would be nice not to have to create all these objects... easy to optimize later though.
                 Timestamp timestamp = Timestamp.FromDateTime(parsed);
                 int nanosToAdd = 0;
-                if (subseconds != "")
+                if (subseconds.Length != 0)
                 {
                     // This should always work, as we've got 1-9 digits.
                     int parsedFraction = int.Parse(subseconds.Substring(1), CultureInfo.InvariantCulture);
@@ -906,7 +906,7 @@ namespace Google.Protobuf
             {
                 long seconds = long.Parse(secondsText, CultureInfo.InvariantCulture) * multiplier;
                 int nanos = 0;
-                if (subseconds != "")
+                if (subseconds.Length != 0)
                 {
                     // This should always work, as we've got 1-9 digits.
                     int parsedFraction = int.Parse(subseconds.Substring(1));

--- a/csharp/src/Google.Protobuf/JsonTokenizer.cs
+++ b/csharp/src/Google.Protobuf/JsonTokenizer.cs
@@ -413,7 +413,7 @@ namespace Google.Protobuf
                 var builder = StringBuilderCache.Acquire();
                 if (initialCharacter == '-')
                 {
-                    builder.Append("-");
+                    builder.Append('-');
                 }
                 else
                 {

--- a/csharp/src/Google.Protobuf/Reflection/DescriptorPool.cs
+++ b/csharp/src/Google.Protobuf/Reflection/DescriptorPool.cs
@@ -279,7 +279,7 @@ namespace Google.Protobuf.Reflection
                 {
                     // Chop off the last component of the scope.
 
-                    int dotpos = scopeToTry.ToString().LastIndexOf(".");
+                    int dotpos = scopeToTry.ToString().LastIndexOf('.');
                     if (dotpos == -1)
                     {
                         result = FindSymbol<IDescriptor>(name);

--- a/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
@@ -120,7 +120,7 @@ namespace Google.Protobuf.Reflection
             // a MapField, but that feels a tad nasty.
             PropertyName = propertyName;
             Extension = extension;
-            JsonName =  Proto.JsonName == "" ? JsonFormatter.ToJsonName(Proto.Name) : Proto.JsonName;
+            JsonName =  Proto.JsonName.Length == 0 ? JsonFormatter.ToJsonName(Proto.Name) : Proto.JsonName;
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
@@ -63,7 +63,7 @@ namespace Google.Protobuf.Reflection
 
         private readonly Lazy<Dictionary<IDescriptor, DescriptorDeclaration>> declarations;
 
-        private FileDescriptor(ByteString descriptorData, FileDescriptorProto proto, IEnumerable<FileDescriptor> dependencies, DescriptorPool pool, bool allowUnknownDependencies, GeneratedClrTypeInfo generatedCodeInfo)
+        private FileDescriptor(ByteString descriptorData, FileDescriptorProto proto, IList<FileDescriptor> dependencies, DescriptorPool pool, bool allowUnknownDependencies, GeneratedClrTypeInfo generatedCodeInfo)
         {
             SerializedData = descriptorData;
             DescriptorPool = pool;
@@ -71,7 +71,7 @@ namespace Google.Protobuf.Reflection
             // Note: the Edition property relies on the proto being set first, so this line
             // has to come after Proto = proto.
             Features = FeatureSetDescriptor.GetEditionDefaults(Edition).MergedWith(proto.Options?.Features);
-            Dependencies = new ReadOnlyCollection<FileDescriptor>(dependencies.ToList());
+            Dependencies = new ReadOnlyCollection<FileDescriptor>(dependencies);
 
             PublicDependencies = DeterminePublicDependencies(this, proto, dependencies, allowUnknownDependencies);
 
@@ -128,7 +128,7 @@ namespace Google.Protobuf.Reflection
             return current;
         }
 
-        private DescriptorBase GetDescriptorFromList(IReadOnlyList<DescriptorBase> list, int index)
+        private static DescriptorBase GetDescriptorFromList(IReadOnlyList<DescriptorBase> list, int index)
         {
             // This is fine: it may be a newer version of protobuf than we understand, with a new descriptor
             // field.
@@ -419,7 +419,7 @@ namespace Google.Protobuf.Reflection
         {
             ExtensionRegistry registry = new ExtensionRegistry();
             registry.AddRange(GetAllExtensions(dependencies, generatedCodeInfo));
-    
+
             FileDescriptorProto proto;
             try
             {

--- a/csharp/src/Google.Protobuf/WellKnownTypes/FieldMaskPartial.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/FieldMaskPartial.cs
@@ -39,7 +39,7 @@ namespace Google.Protobuf.WellKnownTypes
             var firstInvalid = paths.FirstOrDefault(p => !IsPathValid(p));
             if (firstInvalid == null)
             {
-                var writer = new StringWriter();
+                using var writer = new StringWriter();
                 JsonFormatter.WriteString(writer, string.Join(",", paths.Select(JsonFormatter.ToJsonName)));
                 return writer.ToString();
             }
@@ -47,7 +47,7 @@ namespace Google.Protobuf.WellKnownTypes
             {
                 if (diagnosticOnly)
                 {
-                    var writer = new StringWriter();
+                    using var writer = new StringWriter();
                     writer.Write("{ \"@warning\": \"Invalid FieldMask\", \"paths\": ");
                     JsonFormatter.Default.WriteList(writer, (IList)paths);
                     writer.Write(" }");


### PR DESCRIPTION
Comparing against empty string will first do a reference comparison, then value comparison.

Whitespace changes are caused by `trim_trailing_whitespace = true` in  `.editorconfig`