### PR TITLE
Add additional approvers to metadata.template.json

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -2,6 +2,11 @@
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "maintainers": [
     {
+      "email": "protobuf-packages@google.com",
+      "github": "protobuf-team-bot",
+      "name": "Protobuf Team"
+    },
+    {
       "email": "sandyzhang@google.com",
       "github": "zhangskz",
       "name": "Sandy Zhang"
@@ -15,6 +20,78 @@
       "email": "gberg@google.com",
       "github": "googleberg",
       "name": "Jerry Berg"
+    },
+    {
+      "email": "acozette@google.com",
+      "github": "acozette",
+      "name": "Adam Cozette",
+      "do_not_notify": true
+    },
+    {
+      "email": "deannagarcia@google.com",
+      "github": "deannagarcia",
+      "name": "Deanna Garcia",
+      "do_not_notify": true
+    },
+    {
+      "email": "esrauch@google.com",
+      "github": "esrauchg",
+      "name": "Em Rauch",
+      "do_not_notify": true
+    },
+    {
+      "email": "haberman@google.com",
+      "github": "haberman",
+      "name": "Josh Haberman",
+      "do_not_notify": true
+    },
+    {
+      "email": "hongshin@google.com",
+      "github": "honglooker",
+      "name": "Hong Shin",
+      "do_not_notify": true
+    },
+    {
+      "email": "jatl@google.com",
+      "github": "JasonLunn",
+      "name": "Jason Lunn",
+      "do_not_notify": true
+    },
+    {
+      "email": "jieluo@google.com",
+      "github": "anandolee",
+      "name": "Jie Luo",
+      "do_not_notify": true
+    },
+    {
+      "email": "salo@google.com",
+      "github": "salo",
+      "name": "Eric Salo",
+      "do_not_notify": true
+    },
+    {
+      "email": "sbenza@google.com",
+      "github": "sbenza",
+      "name": "Samuel Benzaquen",
+      "do_not_notify": true
+    },
+    {
+      "email": "shaod@google.com",
+      "github": "shaod2",
+      "name": "Dennis Shao",
+      "do_not_notify": true
+    },
+    {
+      "email": "theodorerose@google.com",
+      "github": "theodorerose",
+      "name": "Theodore Rose",
+      "do_not_notify": true
+    },
+    {
+      "email": "tonyliaoss@google.com",
+      "github": "tonyliaoss",
+      "name": "Tony Liao",
+      "do_not_notify": true
     }
   ],
   "repository": ["github:protocolbuffers/protobuf"],


### PR DESCRIPTION
This allows releasers to approve PRs to Bazel Central Registry, and ensures that we don't clobber the actual metadata.json to remove this change when making patches from 28.x

Cherry-pick of 773e931

PiperOrigin-RevId: 676549386