### PR TITLE
Backport upgrade of macOS runner images to macos-13 to 25.x 

### DIFF
--- a/.github/BUILD.bazel
+++ b/.github/BUILD.bazel
@@ -1,5 +1,5 @@
 # This information is extracted from the MacOS runner specs located at:
-# https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
+# https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
 #
 # When updating, also ensure the "xcode_destination" entries in
 # `.github/workflows/test_objectivec.yml` are supported for the given versions

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -314,12 +314,12 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-12
-            cache_key: macos-12
+            os: macos-13
+            cache_key: macos-13
             bazel: test //src/...
           - name: MacOS Apple Silicon (build only)
-            os: macos-12
-            cache_key: macos-12-arm
+            os: macos-13
+            cache_key: macos-13-arm
             # Current github runners are all Intel based, so just build/compile
             # for Apple Silicon to detect issues there.
             bazel: build --cpu=darwin_arm64 //src/...

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -346,11 +346,11 @@ jobs:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
         include:
-          # TODO: investigate and fix
-          # - name: MacOS CMake
-          #   os: macos-12
-          #   flags: -DCMAKE_CXX_STANDARD=14
-          #   cache-prefix: macos-cmake
+          - name: MacOS CMake
+            os: macos-13
+            flags: -DCMAKE_CXX_STANDARD=14
+            cache-prefix: macos-cmake
+            continuous-only: true
           - name: Windows CMake
             os: windows-2022
             flags: >-

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -350,7 +350,6 @@ jobs:
             os: macos-13
             flags: -DCMAKE_CXX_STANDARD=14
             cache-prefix: macos-cmake
-            continuous-only: true
           - name: Windows CMake
             os: windows-2022
             flags: >-

--- a/.github/workflows/test_objectivec.yml
+++ b/.github/workflows/test_objectivec.yml
@@ -25,11 +25,11 @@ jobs:
           destination: "platform=macOS"
           xc_project: "ProtocolBuffers_OSX.xcodeproj"
         - platform: "iOS"
-          destination: "platform=iOS Simulator,name=iPhone 13,OS=latest"
+          destination: "platform=iOS Simulator,name=iPhone 14,OS=latest"
           xc_project: "ProtocolBuffers_iOS.xcodeproj"
 
     name: Xcode ${{ matrix.platform}} ${{ matrix.xc_config }}
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
     steps:
@@ -72,7 +72,7 @@ jobs:
         PLATFORM: ["ios", "macos", "tvos"]
         CONFIGURATION: ["Debug", "Release"]
     name: CocoaPods ${{ matrix.PLATFORM}} ${{ matrix.CONFIGURATION}}
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
     steps:
@@ -115,7 +115,7 @@ jobs:
         - platform: "macOS"
           bazel_targets: //objectivec/...
     name: Bazel ${{ matrix.platform }} ${{ matrix.config.name }}
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout pending changes
         uses: protocolbuffers/protobuf-ci/checkout@v2

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -64,7 +64,7 @@ jobs:
             flags: --define=use_fast_cpp_protos=true
 
     name: MacOS ${{ matrix.type }} ${{ matrix.version }}
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout pending changes
         uses: protocolbuffers/protobuf-ci/checkout@v2

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -125,7 +125,7 @@ jobs:
         #- { version: "3.2", ffi: FFI }
 
     name: MacOS Ruby ${{ matrix.version }}${{ matrix.ffi == 'FFI' && ' FFI' || '' }}
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout pending changes
         uses: protocolbuffers/protobuf-ci/checkout@v2

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -133,7 +133,7 @@ jobs:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Pin Ruby version
-        uses: ruby/setup-ruby@ee26e27437bde475b19a6bf8cb73c9fa658876a2 # v1.134.0
+        uses: ruby/setup-ruby@961f85197f92e4842e3cb92a4f97bd8e010cdbaf # v1.165.0
         with:
           ruby-version: ${{ matrix.version }}
 

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -89,7 +89,7 @@ jobs:
           - { name: "macOS", bazel-command: "test" }
           - { name: "macOS ARM (build only)", bazel-command: "build", flags: "--cpu=darwin_arm64" }
     name: ${{ matrix.config.name }}
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout pending changes
         uses: protocolbuffers/protobuf-ci/checkout@v2

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -169,13 +169,13 @@ jobs:
           # supported Python versions and assume this gives us sufficient test
           # coverage.
           - { os: ubuntu-latest, python-version: "3.8", architecture: x64, type: 'binary' }
-          - { os: macos-12, python-version: "3.8", architecture: x64, type: 'binary' }
+          - { os: macos-13, python-version: "3.8", architecture: x64, type: 'binary' }
           - { os: ubuntu-latest, python-version: "3.11", architecture: x64, type: 'binary' }
-          - { os: macos-12, python-version: "3.11", architecture: x64, type: 'binary' }
+          - { os: macos-13, python-version: "3.11", architecture: x64, type: 'binary' }
           - { os: ubuntu-latest, python-version: "3.8", architecture: x64, type: 'source' }
-          - { os: macos-12, python-version: "3.8", architecture: x64, type: 'source' }
+          - { os: macos-13, python-version: "3.8", architecture: x64, type: 'source' }
           - { os: ubuntu-latest, python-version: "3.11", architecture: x64, type: 'source' }
-          - { os: macos-12, python-version: "3.11", architecture: x64, type: 'source' }
+          - { os: macos-13, python-version: "3.11", architecture: x64, type: 'source' }
 
           # Windows uses the full API up until Python 3.10, so each of these
           # jobs tests a distinct binary wheel.


### PR DESCRIPTION
Cherry-pick of https://github.com/protocolbuffers/protobuf/commit/fe683705a1536fa17743b5efacc220b445dd6bd1, https://github.com/protocolbuffers/protobuf/commit/87de73d8e8a7a9eb48d889e286c51c7c484717ad, https://github.com/protocolbuffers/protobuf/commit/fac03254840830eafe400790cf6de7e60647d4bc

Note there were lots of merge conflicts.