### PR TITLE
Fix a python bug when assign an empty Struct at creation.

### DIFF
--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -568,7 +568,7 @@ def _AddInitMethod(message_descriptor, cls):
               )
           )
 
-        if new_val:
+        if new_val != None:
           try:
             field_copy.MergeFrom(new_val)
           except TypeError:

--- a/python/google/protobuf/internal/well_known_types_test.py
+++ b/python/google/protobuf/internal/well_known_types_test.py
@@ -13,6 +13,7 @@ import collections.abc as collections_abc
 import datetime
 import unittest
 
+from google.protobuf import json_format
 from google.protobuf import text_format
 from google.protobuf.internal import more_messages_pb2
 from google.protobuf.internal import well_known_types
@@ -1039,6 +1040,36 @@ class AnyTest(unittest.TestCase):
               b'\x05\n\x015\x10\n\x1a\x05\n\x016\x10\x0c\x1a\x05\n\x017\x10'
               b'\x0e\x1a\x05\n\x018\x10\x10\x1a\x05\n\x019\x10\x12')
     self.assertEqual(golden, serialized)
+
+  def testJsonStruct(self):
+    value = struct_pb2.Value(struct_value=struct_pb2.Struct())
+    value_dict = json_format.MessageToDict(
+        value,
+        always_print_fields_with_no_presence=True,
+        preserving_proto_field_name=True,
+        use_integers_for_enums=True,
+    )
+    self.assertDictEqual(value_dict, {})
+
+    s = struct_pb2.Struct(
+        fields={
+            'a': struct_pb2.Value(struct_value=struct_pb2.Struct()),
+        },
+    )
+
+    sdict = json_format.MessageToDict(
+        s,
+        always_print_fields_with_no_presence=True,
+        preserving_proto_field_name=True,
+        use_integers_for_enums=True,
+    )
+
+    self.assertDictEqual(
+        sdict,
+        {
+            'a': {},
+        },
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
PiperOrigin-RevId: 689211445

cherry-pick https://github.com/protocolbuffers/protobuf/commit/47613cf7ad4180f5e7b4ba6324a95288e8383840