### PR TITLE
utf8_range: add version marker to library

### DIFF
--- a/third_party/utf8_range/CMakeLists.txt
+++ b/third_party/utf8_range/CMakeLists.txt
@@ -19,6 +19,15 @@ add_library (utf8_range
 # A heavier-weight C++ wrapper that supports Abseil.
 add_library (utf8_validity utf8_validity.cc utf8_range.c)
 
+set_target_properties(utf8_range PROPERTIES
+	VERSION ${protobuf_VERSION}
+	OUTPUT_NAME ${LIB_PREFIX}utf8_range
+)
+set_target_properties(utf8_validity PROPERTIES
+	VERSION ${protobuf_VERSION}
+	OUTPUT_NAME ${LIB_PREFIX}utf8_validity
+)
+
 # Load Abseil dependency.
 if (NOT TARGET absl::strings)
   if (NOT ABSL_ROOT_DIR)


### PR DESCRIPTION
Unversioned libraries / libraries without due ABI indicators are not allowed in certain Linux distributions because it precludes the concurrent presence of multiple versions.

If you have both /usr/lib/libprotobuf-lite.so.28.3.0 and /usr/lib/libprotobuf-lite.so.29.0.0, both of them want libutf8_validity.so, but if the ABI is different between utf8_range 28 and utf8_range 29, that's a problem.