### PR TITLE
[29.x] Add missing java load

### DIFF
--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_java//java:java_library.bzl", "java_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("//:protobuf.bzl", "internal_gen_well_known_protos_java")
 load("//:protobuf_version.bzl", "PROTOBUF_JAVA_VERSION")

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -706,3 +706,4 @@ pkg_files(
     strip_prefix = strip_prefix.from_root(""),
     visibility = ["//java:__pkg__"],
 )
+


### PR DESCRIPTION
(cherry-pick of 89533c743fc7cbec48c1298a043451caada061f1)

For most _native_ loads of Java rules (e.g. java_library), these can be automatically handled by Bazel 8's autoload feature.

However, this is not the case when the main repository (IOW, the repository currently being built) is a rule repo itself. In those cases, module dependencies are not automatically loaded.

This PR fixes a compatibility issue of OSS protobuf Bazel rules with other Bazel rule repositories such as bazelbuild/rules_android.

Without this PR, builds within rules repositories with Bazel 8 will fail like so:

```
external/protobuf+/java/core/BUILD.bazel:142:13: @@protobuf+//java/core:lite: no such attribute 'srcs' in 'java_library' rule
```

PiperOrigin-RevId: 690735533