### PR TITLE
Fixed parsing bool value from query string

### DIFF
--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -795,8 +795,7 @@ class Message
     private function convertJsonValueToProtoValue(
         $value,
         $field,
-        $ignore_unknown,
-        $is_map_key = false)
+        $ignore_unknown)
     {
         switch ($field->getType()) {
             case GPBType::MESSAGE:
@@ -892,21 +891,20 @@ class Message
                 if (is_null($value)) {
                     return $this->defaultValue($field);
                 }
-                if ($is_map_key) {
-                    if ($value === "true") {
+                if (is_bool($value)) {
+                    return $value;
+                }
+                if (is_string($value)) {
+                    if ($value === 'true') {
                         return true;
                     }
-                    if ($value === "false") {
+                    if ($value === 'false') {
                         return false;
                     }
-                    throw new GPBDecodeException(
-                        "Bool field only accepts bool value");
                 }
-                if (!is_bool($value)) {
-                    throw new GPBDecodeException(
-                        "Bool field only accepts bool value");
-                }
-                return $value;
+
+                throw new GPBDecodeException(
+                    "Bool field only accepts bool value");
             case GPBType::FLOAT:
             case GPBType::DOUBLE:
                 if (is_null($value)) {
@@ -1249,8 +1247,7 @@ class Message
                     $proto_key = $this->convertJsonValueToProtoValue(
                         $tmp_key,
                         $key_field,
-                        $ignore_unknown,
-                        true);
+                        $ignore_unknown);
                     $proto_value = $this->convertJsonValueToProtoValue(
                         $tmp_value,
                         $value_field,


### PR DESCRIPTION
When boolean value comes from query it is represented as 'true' or 'false string. However, it is not parsed until it is not a key for a map field. As a result, error message is thrown when boolean values are passed in GET requests (e.g. when some rest service is mapped to grpc one).
My suggestion: as long as field is defined as boolean, let's accept string 'true' or 'false' values too.