### PR TITLE
Extend JsonFormatter with an optional ShouldSerializeField delegate function to determine when a field is serialized

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonFormatterSettingsTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonFormatterSettingsTest.cs
@@ -18,12 +18,22 @@ namespace Google.Protobuf
 {
     public class JsonFormatterSettingsTest
     {
+        static JsonFormatter.Settings.ShouldSerializeFieldDelegate shouldSerializeField = (IMessage message, FieldDescriptor field, object value) => true;
+
         [Test]
         public void WithIndentation()
         {
             var settings = JsonFormatter.Settings.Default.WithIndentation("\t");
             Assert.AreEqual("\t", settings.Indentation);
         }
+
+        [Test]
+        public void WithFormatField()
+        {
+            var settings = JsonFormatter.Settings.Default.WithShouldSerializeField(shouldSerializeField);
+            Assert.AreEqual(shouldSerializeField, settings.ShouldSerializeField);
+        }
+
 
         [Test]
         public void WithTypeRegistry()
@@ -62,19 +72,22 @@ namespace Google.Protobuf
                 .WithFormatDefaultValues(true)
                 .WithFormatEnumsAsIntegers(true)
                 .WithTypeRegistry(typeRegistry)
-                .WithPreserveProtoFieldNames(true);
+                .WithPreserveProtoFieldNames(true)
+                .WithShouldSerializeField(shouldSerializeField);
 
             var settings1 = baseSettings.WithIndentation("\t");
             var settings2 = baseSettings.WithFormatDefaultValues(true);
             var settings3 = baseSettings.WithFormatEnumsAsIntegers(true);
             var settings4 = baseSettings.WithTypeRegistry(typeRegistry);
             var settings5 = baseSettings.WithPreserveProtoFieldNames(true);
+            var settings6 = baseSettings.WithShouldSerializeField(shouldSerializeField);
 
             AssertAreEqual(baseSettings, settings1);
             AssertAreEqual(baseSettings, settings2);
             AssertAreEqual(baseSettings, settings3);
             AssertAreEqual(baseSettings, settings4);
             AssertAreEqual(baseSettings, settings5);
+            AssertAreEqual(baseSettings, settings6);
         }
 
         private static void AssertAreEqual(JsonFormatter.Settings settings, JsonFormatter.Settings other)
@@ -83,6 +96,7 @@ namespace Google.Protobuf
             Assert.AreEqual(settings.FormatDefaultValues, other.FormatDefaultValues);
             Assert.AreEqual(settings.FormatEnumsAsIntegers, other.FormatEnumsAsIntegers);
             Assert.AreEqual(settings.TypeRegistry, other.TypeRegistry);
+            Assert.AreEqual(settings.ShouldSerializeField, other.ShouldSerializeField);
         }
     }
 }

--- a/csharp/src/Google.Protobuf.Test/JsonFormatterTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonFormatterTest.cs
@@ -950,6 +950,76 @@ namespace Google.Protobuf
             AssertWriteValue(value, "{ 'FieldName13': 0 }");
         }
 
+        [Test]
+        public void WithFormatField_Message()
+        {
+            JsonFormatter.Settings.ShouldSerializeFieldDelegate shouldSerializeField =
+                (IMessage message, FieldDescriptor field, object value) =>           
+                    message.Descriptor.Name == "TestProto3Optional";
+
+            var formatter = new JsonFormatter(
+                JsonFormatter.Settings.Default
+                    .WithShouldSerializeField(shouldSerializeField)
+                    .WithFormatDefaultValues(true)
+            );
+
+            var message1 = new TestAllTypes();
+            var json1 = formatter.Format(message1);
+            AssertJson("{ }", json1);
+
+            var message2 = new TestProto3Optional { OptionalInt32 = 2 };
+            var json2 = formatter.Format(message2);
+            AssertJson(
+                "{ \"optionalInt32\": 2, \"singularInt32\": 0, \"singularInt64\": \"0\" }",
+                json2
+            );
+        }
+
+        [Test]
+        public void WithFormatField_Field()
+        {
+            JsonFormatter.Settings.ShouldSerializeFieldDelegate shouldSerializeField =
+                (IMessage message, FieldDescriptor field, object value) =>
+                    field.Name == "optional_int32";
+
+            var formatter = new JsonFormatter(
+                JsonFormatter.Settings.Default
+                    .WithShouldSerializeField(shouldSerializeField)
+                    .WithFormatDefaultValues(true)
+            );
+
+            var message1 = new TestAllTypes();
+            var json1 = formatter.Format(message1);
+            AssertJson("{ }", json1);
+
+            var message2 = new TestProto3Optional { OptionalInt32 = 2 };
+            var json2 = formatter.Format(message2);
+            AssertJson("{ \"optionalInt32\": 2 }", json2);
+        }
+
+        [Test]
+        public void WithFormatField_Value()
+        {
+            JsonFormatter.Settings.ShouldSerializeFieldDelegate shouldSerializeField =
+                (IMessage message, FieldDescriptor field, object value) =>
+                    Convert.ToString(value) == "2";
+
+            var formatter = new JsonFormatter(
+                JsonFormatter.Settings.Default
+                    .WithShouldSerializeField(shouldSerializeField)
+                    .WithFormatDefaultValues(true)
+            );
+
+            var message1 = new TestAllTypes();
+            var json1 = formatter.Format(message1);
+            AssertJson("{ }", json1);
+
+            var message2 = new TestProto3Optional { OptionalInt32 = 2 };
+            var json2 = formatter.Format(message2);
+            AssertJson("{ \"optionalInt32\": 2 }", json2);
+        }
+
+
         private static void AssertWriteValue(object value, string expectedJson, JsonFormatter.Settings settings = null)
         {
             var writer = new StringWriter { NewLine = "\n" };

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -888,7 +888,6 @@ namespace Google.Protobuf {
                         PreserveProtoFieldNames, Indentation, shouldSerializeField);
     }
 
-
     // Effectively a cache of mapping from enum values to the original name as specified in the
     // proto file, fetched by reflection. The need for this is unfortunate, as is its unbounded
     // size, but realistically it shouldn't cause issues.

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -889,10 +889,10 @@ namespace Google.Protobuf {
     }
 
 
-        // Effectively a cache of mapping from enum values to the original name as specified in the
-        // proto file, fetched by reflection. The need for this is unfortunate, as is its unbounded
-        // size, but realistically it shouldn't cause issues.
-        private static class OriginalEnumValueHelper {
+    // Effectively a cache of mapping from enum values to the original name as specified in the
+    // proto file, fetched by reflection. The need for this is unfortunate, as is its unbounded
+    // size, but realistically it shouldn't cause issues.
+    private static class OriginalEnumValueHelper {
       private static readonly ConcurrentDictionary<System.Type, Dictionary<object, string>>
           dictionaries = new ConcurrentDictionary<System.Type, Dictionary<object, string>>();
 


### PR DESCRIPTION
JsonFormatter is very handy to serialize the request or response payload in logs but it serializes the whole message including sensitive fields.

This PR adds an optional ```ShouldSerializeField``` delegate function to the Settings class to indicate when it should be done

For example
```csharp
static String RemoveSensitiveData(IMessage message)
{
    JsonFormatter.Settings.ShouldSerializeFieldDelegate shouldSerializeField =
        (IMessage message, FieldDescriptor field, object value) => field.Name != "password";

    var formatter = new JsonFormatter(JsonFormatter.Settings.Default.WithShouldSerializeField(shouldSerializeField));

    return formatter.Format(message);
}
```