### PR TITLE
Add `preserve_descriptor_field_order` option to PrintOptions

### DIFF
--- a/src/google/protobuf/json/internal/unparser.cc
+++ b/src/google/protobuf/json/internal/unparser.cc
@@ -469,10 +469,12 @@ absl::Status WriteFields(JsonWriter& writer, const Msg<Traits>& msg,
   // Add extensions *before* sorting.
   Traits::FindAndAppendExtensions(msg, fields);
 
-  // Fields are guaranteed to be serialized in field number order.
-  absl::c_sort(fields, [](const auto& a, const auto& b) {
-    return Traits::FieldNumber(a) < Traits::FieldNumber(b);
-  });
+  if (!writer.options().preserve_descriptor_field_order) {
+    // Serialize in field number order.
+    absl::c_sort(fields, [](const auto& a, const auto& b) {
+      return Traits::FieldNumber(a) < Traits::FieldNumber(b);
+    });
+  }
 
   for (auto field : fields) {
     RETURN_IF_ERROR(WriteField<Traits>(writer, msg, field, first));

--- a/src/google/protobuf/json/internal/writer.h
+++ b/src/google/protobuf/json/internal/writer.h
@@ -56,6 +56,10 @@ struct WriterOptions {
   // in the unit tests; we intend to remove this setting eventually. See
   // b/234868512.
   bool allow_legacy_syntax = false;
+  // If set, the fields are ordered by their index in the descriptor.
+  // Otherwise, the fields are ordered by their tag number.
+  // This is useful to control the order of fields in the output.
+  bool preserve_descriptor_field_order = false;
 };
 
 template <typename Tuple, typename F, size_t... i>

--- a/src/google/protobuf/json/json.cc
+++ b/src/google/protobuf/json/json.cc
@@ -36,6 +36,7 @@ absl::Status BinaryToJsonStream(google::protobuf::util::TypeResolver* resolver,
   opts.always_print_fields_with_no_presence =
       options.always_print_fields_with_no_presence;
   opts.unquote_int64_if_possible = options.unquote_int64_if_possible;
+  opts.preserve_descriptor_field_order = options.preserve_descriptor_field_order;
 
   // TODO: Drop this setting.
   opts.allow_legacy_syntax = true;
@@ -91,6 +92,7 @@ absl::Status MessageToJsonString(const Message& message, std::string* output,
   opts.always_print_fields_with_no_presence =
       options.always_print_fields_with_no_presence;
   opts.unquote_int64_if_possible = options.unquote_int64_if_possible;
+  opts.preserve_descriptor_field_order = options.preserve_descriptor_field_order;
 
   // TODO: Drop this setting.
   opts.allow_legacy_syntax = true;

--- a/src/google/protobuf/json/json.h
+++ b/src/google/protobuf/json/json.h
@@ -52,6 +52,10 @@ struct PrintOptions {
   // If set, int64 values that can be represented exactly as a double are
   // printed without quotes.
   bool unquote_int64_if_possible = false;
+  // If set, the fields are ordered by their location in the descriptor.
+  // Otherwise, the fields are ordered by their tag number.
+  // This is useful to control the order of fields in the output.
+  bool preserve_descriptor_field_order = false;
 };
 
 // Converts from protobuf message to JSON and appends it to |output|. This is a

--- a/src/google/protobuf/json/json_test.cc
+++ b/src/google/protobuf/json/json_test.cc
@@ -49,6 +49,7 @@ using ::proto3::TestAny;
 using ::proto3::TestEnumValue;
 using ::proto3::TestMap;
 using ::proto3::TestMessage;
+using ::proto3::TestUnorderedMessage;
 using ::proto3::TestOneof;
 using ::proto3::TestWrapper;
 using ::testing::ContainsRegex;
@@ -1272,6 +1273,25 @@ TEST_P(JsonTest, FieldOrder) {
   ASSERT_OK(s);
   EXPECT_EQ(
       out, R"({"boolValue":true,"int64Value":"3","repeatedInt32Value":[2,2]})");
+}
+
+TEST_P(JsonTest, PreserveDescriptorFieldOrder) {
+  TestUnorderedMessage m;
+  m.set_first(1);
+  m.set_second(2);
+  m.set_third(3);
+
+  EXPECT_THAT(
+      ToJson(m),
+      IsOkAndHolds(
+          R"({"second":2,"first":1,"third":3})"));
+
+  PrintOptions options;
+  options.preserve_descriptor_field_order = true;
+  EXPECT_THAT(
+      ToJson(m, options),
+      IsOkAndHolds(
+          R"({"first":1,"second":2,"third":3})"));
 }
 
 TEST_P(JsonTest, UnknownGroupField) {

--- a/src/google/protobuf/util/json_format_proto3.proto
+++ b/src/google/protobuf/util/json_format_proto3.proto
@@ -68,6 +68,12 @@ message TestMessage {
   optional MessageType optional_message_value = 51;
 }
 
+message TestUnorderedMessage {
+  int32 first = 10;
+  int32 second = 1;
+  int32 third = 100;
+}
+
 message TestOneof {
   // In JSON format oneof fields behave mostly the same as optional
   // fields except that:


### PR DESCRIPTION
This is useful to control the order of the fields in output json.

Default false - so does not affect current users of the library.