### PR TITLE
Upgrade rules_cc 0.0.16 and rules_java 8.3.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_cc",
-    version = "0.0.13",
+    version = "0.0.16",
 )
 
 bazel_dep(
@@ -40,7 +40,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_java",
-    version = "7.12.2",
+    version = "8.3.2",
 )
 
 bazel_dep(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,10 +5,6 @@ workspace(name = "com_google_protobuf")
 # buildifier: disable=duplicated-name
 local_repository(name = "com_google_protobuf", path = ".")
 
-# Second self-reference that makes it possible to load proto rules from @protobuf.
-# buildifier: disable=duplicated-name
-local_repository(name = "protobuf", path = ".")
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
@@ -93,6 +89,12 @@ apple_rules_dependencies()
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
 
 apple_support_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+rules_java_toolchains()
 
 load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
 

--- a/benchmarks/BUILD.googleapis
+++ b/benchmarks/BUILD.googleapis
@@ -29,7 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 load(
-    "@protobuf//bazel:proto_library.bzl",
+    "@com_google_protobuf//bazel:proto_library.bzl",
     "proto_library",
 )
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -5,10 +5,10 @@
 # example.
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@protobuf//bazel:java_lite_proto_library.bzl", "java_lite_proto_library")
-load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
-load("@protobuf//bazel:proto_library.bzl", "proto_library")
-load("@protobuf//bazel:py_proto_library.bzl", "py_proto_library")
+load("@com_google_protobuf//bazel:java_lite_proto_library.bzl", "java_lite_proto_library")
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:py_proto_library.bzl", "py_proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_python//python:py_binary.bzl", "py_binary")
@@ -25,7 +25,7 @@ load("@rules_python//python:py_binary.bzl", "py_binary")
 proto_library(
     name = "addressbook_proto",
     srcs = ["addressbook.proto"],
-    deps = ["@protobuf//:timestamp_proto"],
+    deps = ["@com_google_protobuf//:timestamp_proto"],
 )
 
 # The cc_proto_library rule generates C++ code for a proto_library rule. It
@@ -45,8 +45,8 @@ cc_binary(
     srcs = ["add_person.cc"],
     deps = [
         ":addressbook_cc_proto",
-        "@protobuf",
-        "@protobuf//src/google/protobuf/util:time_util",
+        "@com_google_protobuf//:protobuf",
+        "@com_google_protobuf//src/google/protobuf/util:time_util",
     ],
 )
 
@@ -55,8 +55,8 @@ cc_binary(
     srcs = ["list_people.cc"],
     deps = [
         ":addressbook_cc_proto",
-        "@protobuf",
-        "@protobuf//src/google/protobuf/util:time_util",
+        "@com_google_protobuf//:protobuf",
+        "@com_google_protobuf//src/google/protobuf/util:time_util",
     ],
 )
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,13 +1,13 @@
 """Bazel module dependencies"""
-bazel_dep(name = "protobuf", version = "0.0.0", dev_dependency = True)
 
+bazel_dep(name = "protobuf", version = "0.0.0", repo_name = "com_google_protobuf")
 local_path_override(
     module_name = "protobuf",
     path = "..",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
-bazel_dep(name = "rules_cc", version = "0.0.1")
-bazel_dep(name = "rules_java", version = "7.3.0")
+bazel_dep(name = "rules_cc", version = "0.0.16")
+bazel_dep(name = "rules_java", version = "8.3.2")
 bazel_dep(name = "rules_pkg", version = "0.7.0")
 bazel_dep(name = "rules_python", version = "0.25.0")

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -9,7 +9,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # before they get merged. You'll want to use the following instead:
 #
 # http_archive(
-#     name = "protobuf",
+#     name = "com_google_protobuf",
 #     sha256 = "c29d8b4b79389463c546f98b15aa4391d4ed7ec459340c47bffe15db63eb9126",
 #     strip_prefix = "protobuf-3.21.3",
 #     urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.21.3.tar.gz"],
@@ -17,11 +17,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
     name = "com_google_protobuf",
-    path = "..",
-)
-
-local_repository(
-    name = "protobuf",
     path = "..",
 )
 
@@ -42,6 +37,20 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.25.0/rules_python-0.25.0.tar.gz",
 )
 
-load("@protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
+
+http_archive(
+    name = "rules_java",
+    sha256 = "9b9614f8a7f7b7ed93cb7975d227ece30fe7daed2c0a76f03a5ee37f69e437de",
+    urls = [
+        "https://github.com/bazelbuild/rules_java/releases/download/8.3.2/rules_java-8.3.2.tar.gz",
+    ],
+)
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+rules_java_toolchains()

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -92,16 +92,16 @@ def protobuf_deps():
     if not native.existing_rule("rules_cc"):
         http_archive(
             name = "rules_cc",
-            urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz"],
-            sha256 = "d9bdd3ec66b6871456ec9c965809f43a0901e692d754885e89293807762d3d80",
-            strip_prefix = "rules_cc-0.0.13",
+            urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.16/rules_cc-0.0.16.tar.gz"],
+            sha256 = "bbf1ae2f83305b7053b11e4467d317a7ba3517a12cef608543c1b1c5bf48a4df",
+            strip_prefix = "rules_cc-0.0.16",
         )
 
     if not native.existing_rule("rules_java"):
         http_archive(
             name = "rules_java",
-            url = "https://github.com/bazelbuild/rules_java/releases/download/7.12.2/rules_java-7.12.2.tar.gz",
-            sha256 = "a9690bc00c538246880d5c83c233e4deb83fe885f54c21bb445eb8116a180b83",
+            url = "https://github.com/bazelbuild/rules_java/releases/download/8.3.2/rules_java-8.3.2.tar.gz",
+            sha256 = "9b9614f8a7f7b7ed93cb7975d227ece30fe7daed2c0a76f03a5ee37f69e437de",
         )
 
     if not native.existing_rule("rules_shell"):


### PR DESCRIPTION
Both versions are again compatible with WORKSPACE mode on Bazel 8 (and previous versions).