### PR TITLE
Fix an UBSAN error

### DIFF
--- a/src/google/protobuf/descriptor_database.cc
+++ b/src/google/protobuf/descriptor_database.cc
@@ -506,7 +506,7 @@ class EncodedDescriptorDatabase::DescriptorIndex {
         // If the packages already differ, exit early.
         return res < 0;
       } else if (lhs_parts.first.size() == rhs_parts.first.size()) {
-        return lhs_parts.second < rhs_parts.second;
+        return lhs_parts.second.data() != nullptr && rhs_parts.second.data() != nullptr && lhs_parts.second < rhs_parts.second;
       }
       return AsString(lhs) < AsString(rhs);
     }


### PR DESCRIPTION
external/com_google_protobuf/src/google/protobuf/stubs/stringpiece.h:362:23: runtime error: null pointer passed as argument 1, which is declared to never be null
external/com_google_protobuf/src/google/protobuf/stubs/stringpiece.h:362:23: runtime error: null pointer passed as argument 2, which is declared to never be null