### PR TITLE
Add toolchain type for remaining actions

### DIFF
--- a/python/internal.bzl
+++ b/python/internal.bzl
@@ -45,6 +45,7 @@ def _internal_copy_files_impl(ctx):
             mnemonic = "InternalCopyFile",
             progress_message = "Copying files",
             use_default_shell_env = True,
+            toolchain = None,
         )
 
     else:
@@ -65,6 +66,7 @@ def _internal_copy_files_impl(ctx):
             mnemonic = "InternalCopyFile",
             progress_message = "Copying files",
             use_default_shell_env = True,
+            toolchain = None,
         )
 
     return [


### PR DESCRIPTION
This is the first step for migrating to Automatic Exec Groups (check #19261). 

I tried migrating with `bazel build ... --incompatible_auto_exec_groups`, fixed two actions added in this PR, and was stopped by the error:
```
ERROR: /usr/local/google/home/kotlaja/.cache/bazel/_bazel_kotlaja/3b1d6911411754876f642abf5e6636f0/external/rules_kotlin/kotlin/compiler/BUILD.bazel:22:22: in kt_js_import rule @@rules_kotlin//kotlin/compiler:kotlin-stdlib-js: 
Traceback (most recent call last):
	File "/usr/local/google/home/kotlaja/.cache/bazel/_bazel_kotlaja/3b1d6911411754876f642abf5e6636f0/external/rules_kotlin/kotlin/internal/js/impl.bzl", line 137, column 20, in kt_js_import_impl
		ctx.actions.run(
Error in run: Couldn't identify if tools are from implicit dependencies or a toolchain. Please set the toolchain parameter. If you're not using a toolchain, set it to 'None'.
```

Still, I think this error will be fixed with upgrading to rules_kotlin [2.0.0](https://github.com/bazelbuild/rules_kotlin/releases).