### PR TITLE
Make μpb descriptor library targets public.

### DIFF
--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -228,19 +228,19 @@ proto_library(
 
 upb_c_proto_library(
     name = "descriptor_upb_c_proto",
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [":descriptor_proto"],
 )
 
 upb_minitable_proto_library(
     name = "descriptor_upb_minitable_proto",
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [":descriptor_proto"],
 )
 
 upb_proto_reflection_library(
     name = "descriptor_upb_reflection_proto",
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [":descriptor_proto"],
 )
 


### PR DESCRIPTION
Otherwise there’s no public target for descriptor.proto after commit eab1fa2765cc5fe21128fe92f1acbb6c2f8f73c2.