### PR TITLE
fix(example): c++14 limitation

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -46,11 +46,11 @@ protoc_middleman_ruby: addressbook.proto
 
 add_person_cpp: add_person.cc protoc_middleman
 	pkg-config --cflags protobuf  # fails if protobuf is not installed
-	c++ -std=c++14 add_person.cc addressbook.pb.cc -o add_person_cpp `pkg-config --cflags --libs protobuf`
+	c++ add_person.cc addressbook.pb.cc -o add_person_cpp `pkg-config --cflags --libs protobuf`
 
 list_people_cpp: list_people.cc protoc_middleman
 	pkg-config --cflags protobuf  # fails if protobuf is not installed
-	c++ -std=c++14 list_people.cc addressbook.pb.cc -o list_people_cpp `pkg-config --cflags --libs protobuf`
+	c++ list_people.cc addressbook.pb.cc -o list_people_cpp `pkg-config --cflags --libs protobuf`
 
 add_person_dart: add_person.dart protoc_middleman_dart
 


### PR DESCRIPTION
fix the bug: 

```shell
‘std::string_view’ is only available from C++17 onwards
```

The error occurs because the code is being compiled using the C++14 standard, which does not include the std::string_view type introduced in C++17. The Abseil library (absl), used by Protocol Buffers, includes absl/strings/string_view.h, which uses std::string_view. This causes the compilation to fail in environments configured with C++14 or earlier.

In the provided build system, the file add_person.cc is being compiled using the -std=c++14 flag, which is incompatible with code depending on features from C++17 (e.g., std::string_view).