### PR TITLE
fix(example): go version is too low

### DIFF
--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -1,5 +1,5 @@
 module github.com/protocolbuffers/protobuf/examples/go
 
-go 1.14
+go 1.18
 
 require google.golang.org/protobuf v1.27.1


### PR DESCRIPTION
[bug] tutorialpb/addressbook.pb.go:317:40: predeclared any requires go1.18 or later (-lang was set to go1.14; check go.mod)