### PR TITLE
Fix typo in BCR maintainer name config for acozzette@

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -22,9 +22,9 @@
       "name": "Jerry Berg"
     },
     {
-      "email": "acozette@google.com",
-      "github": "acozette",
-      "name": "Adam Cozette",
+      "email": "acozzette@google.com",
+      "github": "acozzette",
+      "name": "Adam Cozzette",
       "do_not_notify": true
     },
     {


### PR DESCRIPTION
This was updated in BCR in https://github.com/bazelbuild/bazel-central-registry/pull/3057, but gets clobbered by this template on release.

Will be backported to old branches so patches e.g. 29.x don't clobber this as well.

PiperOrigin-RevId: 697765355