### PR TITLE
Remove Bazel 6 in BCR presubmits

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -10,7 +10,6 @@ tasks:
     build_flags:
     - '--host_cxxopt=-std=c++14'
     - '--cxxopt=-std=c++14'
-    - '--experimental_google_legacy_api'
     build_targets:
     - '@protobuf//:protobuf'
     - '@protobuf//:protobuf_lite'
@@ -33,6 +32,5 @@ bcr_test_module:
       build_flags:
       - '--host_cxxopt=-std=c++14'
       - '--cxxopt=-std=c++14'
-      - '--experimental_google_legacy_api'
       build_targets:
       - "//..."

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform: ["debian10", "macos", "ubuntu2004", "windows"]
-  bazel: [6.x, 7.x]
+  bazel: [7.x]
 
 tasks:
   verify_targets:
@@ -10,6 +10,7 @@ tasks:
     build_flags:
     - '--host_cxxopt=-std=c++14'
     - '--cxxopt=-std=c++14'
+    - '--experimental_google_legacy_api'
     build_targets:
     - '@protobuf//:protobuf'
     - '@protobuf//:protobuf_lite'
@@ -23,7 +24,7 @@ bcr_test_module:
   module_path: "examples"
   matrix:
     platform: ["debian10", "macos", "ubuntu2004", "windows"]
-    bazel: [6.x, 7.x]
+    bazel: [7.x]
   tasks:
     run_test_module:
       name: "Run test module"
@@ -32,5 +33,6 @@ bcr_test_module:
       build_flags:
       - '--host_cxxopt=-std=c++14'
       - '--cxxopt=-std=c++14'
+      - '--experimental_google_legacy_api'
       build_targets:
       - "//..."


### PR DESCRIPTION
rules_jvm_external uses use_repo_rule which is not compatible with bazel 6. This was applied for BCR PR for 29.0-rc2 and landed in main, but wasn't backported properly to 29.x.