### PR TITLE
PROTOC_EXPORT in java/names.h to expose symbols

### DIFF
--- a/src/google/protobuf/compiler/java/names.h
+++ b/src/google/protobuf/compiler/java/names.h
@@ -41,87 +41,87 @@ namespace java {
 //
 // Returns:
 //   The fully-qualified Java class name.
-std::string ClassName(const Descriptor* descriptor);
+PROTOC_EXPORT std::string ClassName(const Descriptor* descriptor);
 
 // Requires:
 //   descriptor != NULL
 //
 // Returns:
 //   The fully-qualified Java class name.
-std::string ClassName(const EnumDescriptor* descriptor);
+PROTOC_EXPORT std::string ClassName(const EnumDescriptor* descriptor);
 
 // Requires:
 //   descriptor != NULL
 //
 // Returns:
 //   The fully-qualified Java class name.
-std::string ClassName(const FileDescriptor* descriptor);
+PROTOC_EXPORT std::string ClassName(const FileDescriptor* descriptor);
 
 // Requires:
 //   descriptor != NULL
 //
 // Returns:
 //   The fully-qualified Java class name.
-std::string ClassName(const ServiceDescriptor* descriptor);
+PROTOC_EXPORT std::string ClassName(const ServiceDescriptor* descriptor);
 
 // Requires:
 //   descriptor != NULL
 //
 // Returns:
 //   Java package name.
-std::string FileJavaPackage(const FileDescriptor* descriptor,
-                            Options options = {});
+PROTOC_EXPORT std::string FileJavaPackage(const FileDescriptor* descriptor,
+                                          Options options = {});
 
 // Requires:
 //   descriptor != NULL
 //
 // Returns:
 //   Java package directory.
-std::string JavaPackageDirectory(const FileDescriptor* file);
+PROTOC_EXPORT std::string JavaPackageDirectory(const FileDescriptor* file);
 
 // Requires:
 //   descriptor != NULL
 //
 // Returns:
 //   The unqualified Java class name.
-std::string FileClassName(const FileDescriptor* file);
+PROTOC_EXPORT std::string FileClassName(const FileDescriptor* file);
 
 // Requires:
 //   descriptor != NULL
 // Returns:
 //   Capitalized camel case field name.
-std::string CapitalizedFieldName(const FieldDescriptor* field);
+PROTOC_EXPORT std::string CapitalizedFieldName(const FieldDescriptor* field);
 
 // Requires:
 //   descriptor != NULL
 // Returns:
 //   Capitalized camel case oneof name.
-std::string CapitalizedOneofName(const OneofDescriptor* oneof);
+PROTOC_EXPORT std::string CapitalizedOneofName(const OneofDescriptor* oneof);
 
 // Returns:
 //   Converts a name to camel-case. If cap_first_letter is true, capitalize the
 //   first letter.
-std::string UnderscoresToCamelCase(absl::string_view input,
-                                   bool cap_next_letter);
+PROTOC_EXPORT std::string UnderscoresToCamelCase(absl::string_view input,
+                                                 bool cap_next_letter);
 // Requires:
 //   field != NULL
 // Returns:
 //   Converts the field's name to camel-case, e.g. "foo_bar_baz" becomes
 //   "fooBarBaz" or "FooBarBaz", respectively.
-std::string UnderscoresToCamelCase(const FieldDescriptor* field);
+PROTOC_EXPORT std::string UnderscoresToCamelCase(const FieldDescriptor* field);
 
 // Requires:
 //   method != NULL
 // Returns:
 //   Similar, but for method names.  (Typically, this merely has the effect
 //   of lower-casing the first letter of the name.)
-std::string UnderscoresToCamelCase(const MethodDescriptor* method);
+PROTOC_EXPORT std::string UnderscoresToCamelCase(const MethodDescriptor* method);
 
 // Requires:
 //   field != NULL
 // Returns:
 //   Same as UnderscoresToCamelCase, but checks for reserved keywords
-std::string UnderscoresToCamelCaseCheckReserved(const FieldDescriptor* field);
+PROTOC_EXPORT std::string UnderscoresToCamelCaseCheckReserved(const FieldDescriptor* field);
 
 
 }  // namespace java


### PR DESCRIPTION
Otherwise libprotoc built by CMake hides symbols needed by grpc-java (https://github.com/grpc/grpc-java/issues/11475)

---

I wasn't sure if other functions should be exposed, but just added them based on objectivec/names.h where everything is PROTOC_EXPORT.

Can restrict to only minimum if preferred (for grpc-java, this would be `ClassName`) 