### PR TITLE
Revert upgrade to rules_java 8.3.1. 

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,7 +40,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_java",
-    version = "8.3.2",
+    version = "7.12.2",
 )
 
 bazel_dep(

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -8,6 +8,6 @@ local_path_override(
 
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
 bazel_dep(name = "rules_cc", version = "0.0.16")
-bazel_dep(name = "rules_java", version = "8.3.2")
+bazel_dep(name = "rules_java", version = "7.12.2")
 bazel_dep(name = "rules_pkg", version = "0.7.0")
 bazel_dep(name = "rules_python", version = "0.25.0")

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -40,17 +40,3 @@ http_archive(
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-http_archive(
-    name = "rules_java",
-    sha256 = "9b9614f8a7f7b7ed93cb7975d227ece30fe7daed2c0a76f03a5ee37f69e437de",
-    urls = [
-        "https://github.com/bazelbuild/rules_java/releases/download/8.3.2/rules_java-8.3.2.tar.gz",
-    ],
-)
-
-load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
-
-rules_java_dependencies()
-
-rules_java_toolchains()

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -100,8 +100,8 @@ def protobuf_deps():
     if not native.existing_rule("rules_java"):
         http_archive(
             name = "rules_java",
-            url = "https://github.com/bazelbuild/rules_java/releases/download/8.3.2/rules_java-8.3.2.tar.gz",
-            sha256 = "9b9614f8a7f7b7ed93cb7975d227ece30fe7daed2c0a76f03a5ee37f69e437de",
+            url = "https://github.com/bazelbuild/rules_java/releases/download/7.12.2/rules_java-7.12.2.tar.gz",
+            sha256 = "a9690bc00c538246880d5c83c233e4deb83fe885f54c21bb445eb8116a180b83",
         )
 
     if not native.existing_rule("rules_shell"):


### PR DESCRIPTION
This reverts protobuf's `rules_java` dependency back to 7.12.2 to remove the need for existing Bazel 6 / 7 WORKSPACE users to add additional loads for the 29.x minor release.

```
load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")

rules_java_dependencies()
rules_java_toolchains()
```

This is a partial roll-back of fb8ee79.

Note that `rules_java` will likely still be upgrade in the 30.x release instead.