### PR TITLE
Revert "Remove deprecated service.py usages from test". For 29.x only

### DIFF
--- a/python/google/protobuf/internal/generator_test.py
+++ b/python/google/protobuf/internal/generator_test.py
@@ -19,6 +19,7 @@ __author__ = 'robinson@google.com (Will Robinson)'
 import unittest
 
 from google.protobuf.internal import test_bad_identifiers_pb2
+from google.protobuf import service
 from google.protobuf import symbol_database
 from google.protobuf import unittest_import_pb2
 from google.protobuf import unittest_import_public_pb2
@@ -281,6 +282,12 @@ class GeneratorTest(unittest.TestCase):
     self.assertTrue(hasattr(unittest_no_generic_services_pb2, "TestMessage"))
     self.assertTrue(hasattr(unittest_no_generic_services_pb2, "FOO"))
     self.assertTrue(hasattr(unittest_no_generic_services_pb2, "test_extension"))
+
+    # Make sure unittest_no_generic_services_pb2 has no services subclassing
+    # Proto2 Service class.
+    if hasattr(unittest_no_generic_services_pb2, "TestService"):
+      self.assertFalse(issubclass(unittest_no_generic_services_pb2.TestService,
+                                  service.Service))
 
   def testMessageTypesByName(self):
     file_type = unittest_pb2.DESCRIPTOR

--- a/python/google/protobuf/internal/service_reflection_test.py
+++ b/python/google/protobuf/internal/service_reflection_test.py
@@ -13,21 +13,21 @@ __author__ = 'petar@google.com (Petar Petrov)'
 import unittest
 
 from google.protobuf import service_reflection
+from google.protobuf import service
 from google.protobuf import unittest_pb2
 
 
 class FooUnitTest(unittest.TestCase):
 
   def testService(self):
-
-    class MockRpcChannel:
+    class MockRpcChannel(service.RpcChannel):
       def CallMethod(self, method, controller, request, response, callback):
         self.method = method
         self.controller = controller
         self.request = request
         callback(response)
 
-    class MockRpcController:
+    class MockRpcController(service.RpcController):
       def SetFailed(self, msg):
         self.failure_message = msg
 
@@ -81,8 +81,7 @@ class FooUnitTest(unittest.TestCase):
     self.assertEqual(True, srvc.bar_called)
 
   def testServiceStub(self):
-
-    class MockRpcChannel:
+    class MockRpcChannel(service.RpcChannel):
       def CallMethod(self, method, controller, request,
                      response_class, callback):
         self.method = method

--- a/python/google/protobuf/service.py
+++ b/python/google/protobuf/service.py
@@ -70,12 +70,12 @@ class Service(object):
     Postconditions:
 
     * "done" will be called when the method is complete.  This may be
-     before CallMethod() returns or it may be at some point in the future.
+      before CallMethod() returns or it may be at some point in the future.
     * If the RPC failed, the response value passed to "done" will be None.
-     Further details about the failure can be found by querying the
-     RpcController.
+      Further details about the failure can be found by querying the
+      RpcController.
     """
-   raise NotImplementedError
+    raise NotImplementedError
 
   def GetRequestClass(self, method_descriptor):
     """Returns the class of the request message for the specified method.


### PR DESCRIPTION
This reverts commit 471ff7727031d7ca17c62f34c38314758142393e.

Add the service test back and fix indent issue only for 29.x for https://github.com/protocolbuffers/protobuf/issues/19430