### PR TITLE
PkgConfig: account for possible debug postfix in library name

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -20,6 +20,10 @@ if (protobuf_BUILD_SHARED_LIBS)
   set(_protobuf_PC_CFLAGS -DPROTOBUF_USE_DLLS)
 endif ()
 
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+  # attach debug postfix only in debug mode
+  set(protobuf_LIBRARY_POSTFIX ${protobuf_DEBUG_POSTFIX})
+endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/protobuf.pc.cmake
                ${CMAKE_CURRENT_BINARY_DIR}/protobuf.pc @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/protobuf-lite.pc.cmake

--- a/cmake/protobuf.pc.cmake
+++ b/cmake/protobuf.pc.cmake
@@ -7,6 +7,6 @@ Name: Protocol Buffers
 Description: Google's Data Interchange Format
 Version: @protobuf_VERSION@
 Requires: @_protobuf_PC_REQUIRES@
-Libs: -L${libdir} -lprotobuf @CMAKE_THREAD_LIBS_INIT@
+Libs: -L${libdir} -lprotobuf@protobuf_LIBRARY_POSTFIX@ @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir} @_protobuf_PC_CFLAGS@
 Conflicts: protobuf-lite


### PR DESCRIPTION
PkgConfig: account for possible debug postfix in library name, this fixes #19325 