### PR TITLE
feat(python_pyi): add generated pyi to py_proto_library

### DIFF
--- a/bazel/common/proto_common.bzl
+++ b/bazel/common/proto_common.bzl
@@ -186,6 +186,8 @@ def _compile(
 
     if plugin_output:
         args.add(plugin_output, format = proto_lang_toolchain_info.out_replacement_format_flag)
+        if proto_lang_toolchain_info.out_replacement_format_flag.startswith("--python"):
+            args.add(plugin_output, format = "--pyi_out=%s")
     if proto_lang_toolchain_info.plugin:
         tools.append(proto_lang_toolchain_info.plugin)
         args.add(proto_lang_toolchain_info.plugin.executable, format = proto_lang_toolchain_info.plugin_format_flag)

--- a/bazel/py_proto_library.bzl
+++ b/bazel/py_proto_library.bzl
@@ -64,12 +64,16 @@ def _py_proto_aspect_impl(target, ctx):
     proto_root = proto_info.proto_source_root
     if proto_info.direct_sources:
         # Generate py files
-        generated_sources = proto_common.declare_generated_files(
-            actions = ctx.actions,
-            proto_info = proto_info,
-            extension = "_pb2.py",
-            name_mapper = lambda name: name.replace("-", "_").replace(".", "/"),
-        )
+        generated_sources = []
+        for extension in ["_pb2.py", "_pb2.pyi"]:
+            generated_sources.extend(
+                proto_common.declare_generated_files(
+                    actions = ctx.actions,
+                    proto_info = proto_info,
+                    extension = extension,
+                    name_mapper = lambda name: name.replace("-", "_").replace(".", "/"),
+                ),
+            )
 
         # Handles multiple repository and virtual import cases
         if proto_root.startswith(ctx.bin_dir.path):


### PR DESCRIPTION
Since protoc supports `pyi_out`, allow py_proto_library to generate the pyi files for editor support (otherwise, most editors cannot autocomplete with proto python output).

References: https://github.com/protocolbuffers/protobuf/pull/1293

Testing:

There are no tests specifically for py_proto_library, but when I run:

`~/protobuf/examples$ bazel build //:addressbook_py_pb2`

I get:

```
INFO: Analyzed target //:addressbook_py_pb2 (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:addressbook_py_pb2 up-to-date:
  bazel-bin/external/protobuf~/src/google/protobuf/_virtual_imports/timestamp_proto/google/protobuf/timestamp_pb2.py
  bazel-bin/external/protobuf~/src/google/protobuf/_virtual_imports/timestamp_proto/google/protobuf/timestamp_pb2.pyi
  bazel-bin/addressbook_pb2.py
  bazel-bin/addressbook_pb2.pyi
```