### PR TITLE
Explicitly convert an enum to an int

### DIFF
--- a/src/google/protobuf/message_lite.h
+++ b/src/google/protobuf/message_lite.h
@@ -1258,7 +1258,7 @@ PROTOBUF_ALWAYS_INLINE MessageLite* MessageCreator::PlacementNew(
   constexpr bool kMustBeFunc = !test_call && !internal::EnableCustomNew();
   static_assert(kFunc < 0 && !(kZeroInit < 0) && !(kMemcpy < 0),
                 "Only kFunc must be the only negative value");
-  if (ABSL_PREDICT_FALSE(kMustBeFunc || as_tag < 0)) {
+  if (ABSL_PREDICT_FALSE(kMustBeFunc || (int8_t)as_tag < 0)) {
     PROTOBUF_DEBUG_COUNTER("MessageCreator.Func").Inc();
     return static_cast<MessageLite*>(func_(prototype_for_func, mem, arena));
   }


### PR DESCRIPTION
Resolves the following comiler error, encountered with some client code:

`/usr/x86_64-pc-linux-gnu/include/google/protobuf/message_lite.h:1202:7:
    error: ambiguous overload for 'operator<' (operand types are
    'const google::protobuf::internal::MessageCreator::Tag' and 'int')
 1202 |   if (ABSL_PREDICT_FALSE(kMustBeFunc || as_tag < 0)) {
      |       ^~~~~~~~~~~~~~~~~~`