### PR TITLE
Remove CMake downgrade workaround from Windows CI tests

### DIFF
--- a/.github/workflows/test_bazel.yml
+++ b/.github/workflows/test_bazel.yml
@@ -36,9 +36,11 @@ jobs:
             # Not running Bazel 6 with bzlmod, because it doesn't support use_repo_rule in rules_jvm_external
             bzlmod: false
           - runner: ubuntu
+            bazelversion: '7.1.2'
             bzlmod: false
             toolchain_resolution: --incompatible_enable_proto_toolchain_resolution=true
           - runner: ubuntu
+            bazelversion: '7.1.2'
             bzlmod: true
             toolchain_resolution: --incompatible_enable_proto_toolchain_resolution=true
     runs-on: ${{ matrix.runner }}-latest

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -470,12 +470,6 @@ jobs:
           arch: ${{ matrix.windows-arch || 'x64' }}
           vsversion: ${{ matrix.vsversion }}
 
-      # Workaround for Abseil incompatibility with CMake 3.30 (b/352354235).
-      - name: Downgrade CMake
-        if: ${{ runner.os == 'Windows' && (!matrix.continuous-only || inputs.continuous-run)}}
-        run: choco install cmake --version 3.29.6 --force
-        shell: bash
-
       # Workaround for incompatibility between gcloud and windows-2019 runners.
       - name: Install Python
         if: ${{ matrix.python-version && (!matrix.continuous-only || inputs.continuous-run) }}


### PR DESCRIPTION
This should fix some Windows tests that are failing to install a downgraded CMake version.

#test-continuous