### PR TITLE
Remove CMake downgrade workaround from Windows CI tests

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -407,12 +407,6 @@ jobs:
           arch: ${{ matrix.windows-arch || 'x64' }}
           vsversion: ${{ matrix.vsversion }}
 
-      # Workaround for Abseil incompatibility with CMake 3.30 (b/352354235).
-      - name: Downgrade CMake
-        if: ${{ runner.os == 'Windows' }}
-        run: choco install cmake --version 3.29.6 --force
-        shell: bash
-
       # Workaround for incompatibility between gcloud and windows-2019 runners.
       - name: Install Python
         if: ${{ matrix.python-version }}


### PR DESCRIPTION
This should fix some Windows tests that are failing to install a downgraded CMake version.