### PR TITLE
Remove redundant version check

### DIFF
--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -16,12 +16,6 @@
 #undef NDEBUG
 #endif
 
-#include <ruby/version.h>
-
-#if RUBY_API_VERSION_CODE < 20700
-#error Protobuf requires Ruby >= 2.7
-#endif
-
 #include <assert.h>  // Must be included after the NDEBUG logic above.
 #include <ruby/encoding.h>
 #include <ruby/vm.h>


### PR DESCRIPTION
This was added by 3f98af287b8b1919e1efb65d5f5851ff1e7628ce. I'm not sure why it was needed. But, currently, the supported version is specified in the gemspec(`required_ruby_version`) correctly. So no need to check it inside code.