### PR TITLE
Improve performace of repeated packed fixedSize fields

### DIFF
--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -258,16 +258,12 @@ namespace Google.Protobuf.Collections
                 ctx.WriteTag(tag);
                 ctx.WriteLength(size);
 
-                if(BitConverter.IsLittleEndian && codec.FixedSize > 0 && ctx.buffer.Length - ctx.state.position >= size)
+                if(BitConverter.IsLittleEndian && codec.FixedSize > 0)
                 {
                     GCHandle handle = AsSpanPinnedUnsafe(out Span<byte> span, codec);
                     span = span.Slice(0, Count * codec.FixedSize);
 
-                    var destination = ctx.buffer.Slice(ctx.state.position, size);
-                    Debug.Assert(span.Length == destination.Length);
-                    span.CopyTo(destination);
-                    ctx.state.position += size;
-
+                    WritingPrimitives.WriteRawBytes(ref ctx.buffer, ref ctx.state, span);
                     handle.Free();
                 }
                 else

--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -119,7 +119,7 @@ namespace Google.Protobuf.Collections
                         EnsureSize(count + (length / codec.FixedSize));
 
 
-                        // if little endian try to copy packed buffer into RepeatedField array
+                        // if littleEndian treat array as bytes and directly copy from buffer for improved performance
                         if(BitConverter.IsLittleEndian)
                         {
                             GCHandle handle = AsSpanPinnedUnsafe(out Span<byte> span, codec);
@@ -258,6 +258,7 @@ namespace Google.Protobuf.Collections
                 ctx.WriteTag(tag);
                 ctx.WriteLength(size);
 
+                // if littleEndian and elements has fixed size, treat array as bytes (and write it as bytes to buffer) for improved performance
                 if(BitConverter.IsLittleEndian && codec.FixedSize > 0)
                 {
                     GCHandle handle = AsSpanPinnedUnsafe(out Span<byte> span, codec);

--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -711,7 +711,7 @@ namespace Google.Protobuf.Collections
             // 1. protobuf wire bytes is LittleEndian only
             // 2. validate that size of csharp element T is matching the size of protobuf wire size
             //    NOTE: cannot use bool with this span because csharp marshal it as 4 bytes
-            if (BitConverter.IsLittleEndian && (codec.FixedSize > 0 && Marshal.SizeOf<T>() == codec.FixedSize))
+            if (BitConverter.IsLittleEndian && (codec.FixedSize > 0 && Marshal.SizeOf(typeof(T)) == codec.FixedSize))
             {
                 handle = GCHandle.Alloc(array, GCHandleType.Pinned);
                 span = new Span<byte>(handle.AddrOfPinnedObject().ToPointer(), array.Length * codec.FixedSize);


### PR DESCRIPTION
## Changes
Improve performance of packed RepeatedField that has fixed size, by coping `LEN` bytes from serialzied buffer to RepeatedField array (like c memcpy).

## Relevant Information
As the docs [here](https://protobuf.dev/programming-guides/encoding/#cheat-sheet) notes, fixed size value is `memcpy of the equivalent C types (u?int64_t, double)`

You can see benchmark code and results [here](https://github.com/YarinOmesi/protobuf/blob/feature-with-benchmark/csharp/src/Benchmark)

## Summarized result:
| Method               | Job                          | Size   |         Mean |    Ratio | Allocated |
|----------------------|------------------------------|--------|-------------:|---------:|----------:|
| Parse_RepeatedFloats | 3.29.0                       | 100000 | 416,582.7 ns | baseline |  400297 B |
| Parse_RepeatedFloats | improved-fixed-size-repeated | 100000 | 134,671.7 ns |     -68% |  400776 B |
| Write_RepeatedFloats | 3.29.0                       | 100000 | 340.549 us | baseline | 391.57 KB |
| Write_RepeatedFloats | improved-fixed-size-repeated | 100000 | 106.577 us |     -69% |  391.5 KB |

---
I am pretty new to this repo to tell me what to you think about this.
