### PR TITLE
Ignore files that are generated files by the protocol buffer compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,11 @@ ruby/tests/multi_level_nesting_test_pb.rb
 ruby/tests/service_test_pb.rb
 ruby/tests/test_import_proto2_pb.rb
 ruby/tests/test_ruby_package_proto2_pb.rb
+ruby/tests/basic_test_features_pb.rb
+ruby/tests/generated_code_editions_pb.rb
+ruby/tests/repeated_field_test_pb.rb
+ruby/tests/stress_pb.rb
+ruby/tests/utf8_pb.rb
 ruby/compatibility_tests/v3.0.0/protoc
 ruby/compatibility_tests/v3.0.0/tests/generated_code_pb.rb
 ruby/compatibility_tests/v3.0.0/tests/test_import_pb.rb


### PR DESCRIPTION
It seems that some files that are generated by the compiler for tests aren't ignored correctly. So I always get the untracked files when I run the tests.
https://github.com/protocolbuffers/protobuf/blob/59a8de6610b6adbd49211a7805c505877f3ace0c/ruby/Rakefile#L23-L39

This PR ignores those files to avoid treating them as untracked files.