### PR TITLE
Pin staleness check to Bazel 7

### DIFF
--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -50,6 +50,7 @@ jobs:
         # commit.
         uses: protocolbuffers/protobuf-ci/bazel@v3
         with:
+          version: 7.1.2 # Bazel version
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: staleness
           bash: >


### PR DESCRIPTION
Automatic upgrade to Bazel 8 seems to be causing tests to fail: https://github.com/protocolbuffers/protobuf/actions/runs/12359015750/job/34490821736