### PR TITLE
Export environment variables so bazelisk picks them up

### DIFF
--- a/ci/push_auto_update.sh
+++ b/ci/push_auto_update.sh
@@ -19,6 +19,9 @@ if (echo "$previous_commit_title" | grep -q "^Auto-generate files"); then
   exit 0
 fi
 
+export BAZEL=bazelisk
+export USE_BAZEL_VERSION=7.2.1
+
 ./regenerate_stale_files.sh
 
 # Try to determine the most recent CL or pull request.


### PR DESCRIPTION
PiperOrigin-RevId: 705148623

Cherry-pick to fix failure for staleness_refresh.yml: https://github.com/protocolbuffers/protobuf/actions/runs/12361405406/job/34498500316