### PR TITLE
Update artifact actions to v4 

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,7 +47,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/test_php_ext.yml
+++ b/.github/workflows/test_php_ext.yml
@@ -31,7 +31,7 @@ jobs:
             bazel build //php:release $BAZEL_FLAGS;
             cp bazel-bin/php/protobuf-*.tgz .
 
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: protobuf-php-release
           path: protobuf-*.tgz
@@ -45,7 +45,7 @@ jobs:
     name: Build ${{ matrix.version }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #4.1.8
         with:
           name: protobuf-php-release
 

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -147,11 +147,11 @@ jobs:
           bazel: build --crosstool_top=//toolchain:clang_suite --//toolchain:release=true --symlink_prefix=/ -c dbg //python/dist //python/dist:test_wheel //python/dist:source_wheel
       - name: Move Wheels
         run: mkdir wheels && find _build/out \( -name 'protobuf*.whl' -o -name 'protobuf-*.tar.gz' \) -exec mv '{}' wheels ';'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: python-wheels
           path: wheels/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: requirements
           # Tests shouldn't have access to the whole upb repo, upload the one file we need
@@ -194,12 +194,12 @@ jobs:
         shell: bash
     steps:
       - name: Download Wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #4.1.8
         with:
           name: python-wheels
           path: wheels
       - name: Download Requirements
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #4.1.8
         with:
           name: requirements
           path: requirements
@@ -252,7 +252,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request_target' }}
     steps:
       - name: Download Wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #4.1.8
         with:
           name: python-wheels
           path: wheels


### PR DESCRIPTION
Artifact actions v3 are going to be deprecated in January: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Update all usages to v4