### PR TITLE
Add cc_proto_aspect_hint to allow copts on cc_proto_library

### DIFF
--- a/bazel/cc_proto_library.bzl
+++ b/bazel/cc_proto_library.bzl
@@ -1,6 +1,6 @@
 """cc_proto_library rule"""
 
-load("//bazel/private:bazel_cc_proto_library.bzl", _cc_proto_library = "cc_proto_library")  # buildifier: disable=bzl-visibility
+load("//bazel/private:bazel_cc_proto_library.bzl", _cc_proto_aspect_hint = "cc_proto_aspect_hint", _cc_proto_library = "cc_proto_library")  # buildifier: disable=bzl-visibility
 
 def cc_proto_library(**kwattrs):
     # Only use Starlark rules when they are removed from Bazel
@@ -8,3 +8,9 @@ def cc_proto_library(**kwattrs):
         _cc_proto_library(**kwattrs)
     else:
         native.cc_proto_library(**kwattrs)  # buildifier: disable=native-cc-proto
+
+def cc_proto_aspect_hint(**kwattrs):
+    if hasattr(native, "cc_proto_library"):
+        fail("cc_proto_aspect_hint requires bazel 8.x+")
+    else:
+        _cc_proto_aspect_hint(**kwattrs)


### PR DESCRIPTION
This new `cc_proto_aspect_hint` allows users to specify `copts` that are
then used when compiling the generated C++ code.

This is a potential solution to https://github.com/bazelbuild/bazel/issues/4446

In that discussion the primary concern was that if you have multiple
`cc_proto_library` targets that depend on the same `proto_library`
targets, if the `copts` was part of `cc_proto_library` you'd have to be
sure to duplicate that to all `cc_proto_library` targets in the
dependency tree. Using the relatively new `aspect_hints` functionality
in bazel we can instead attach that info to the `proto_library` target
itself, without adding C++ specific attributes to the `proto_library`
rule.
