### PR TITLE
Add linker flags enabling undefined dynamic_lookup for macOS for Pyth…

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -110,6 +110,7 @@ jobs:
         env:
           KOKORO_PYTHON_VERSION: ${{ matrix.version }}
         with:
+          version: 7.1.2 # Bazel version
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: python_macos/${{ matrix.type }}_${{ matrix.version }}
           bazel: >-

--- a/python/build_targets.bzl
+++ b/python/build_targets.bzl
@@ -1,11 +1,14 @@
-# Protobuf Python runtime
-#
-# See also code generation logic under /src/google/protobuf/compiler/python.
-#
-# Most users should depend upon public aliases in the root:
-#   //:protobuf_python
-#   //:well_known_types_py_pb2
+"""
+Protobuf Python runtime
 
+See also code generation logic under /src/google/protobuf/compiler/python.
+
+Most users should depend upon public aliases in the root:
+    //:protobuf_python
+    //:well_known_types_py_pb2
+"""
+
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_python//python:defs.bzl", "py_library")
 load("//:protobuf.bzl", "internal_py_proto_library")
@@ -76,6 +79,13 @@ def build_targets(name):
         copts = COPTS + [
             "-DPYTHON_PROTO2_CPP_IMPL_V2",
         ],
+        linkopts = selects.with_or({
+            (
+                "//python/dist:osx_x86_64",
+                "//python/dist:osx_aarch64",
+            ): ["-Wl,-undefined,dynamic_lookup"],
+            "//conditions:default": [],
+        }),
         linkshared = 1,
         linkstatic = 1,
         tags = [
@@ -109,6 +119,13 @@ def build_targets(name):
         ] + select({
             "//conditions:default": [],
             ":allow_oversize_protos": ["-DPROTOBUF_PYTHON_ALLOW_OVERSIZE_PROTOS=1"],
+        }),
+        linkopts = selects.with_or({
+            (
+                "//python/dist:osx_x86_64",
+                "//python/dist:osx_aarch64",
+            ): ["-Wl,-undefined,dynamic_lookup"],
+            "//conditions:default": [],
         }),
         includes = ["."],
         linkshared = 1,

--- a/python/py_extension.bzl
+++ b/python/py_extension.bzl
@@ -21,7 +21,7 @@ def py_extension(name, srcs, copts, deps = [], **kwargs):
             (
                 "//python/dist:osx_x86_64",
                 "//python/dist:osx_aarch64",
-            ): ["-undefined", "dynamic_lookup"],
+            ): ["-Wl,-undefined,dynamic_lookup"],
             "//python/dist:windows_x86_32": ["-static-libgcc"],
             "//conditions:default": [],
         }),


### PR DESCRIPTION
…on api_implementation.so and message.so

Enable Bazel 7 macOS test coverage which otherwise fails with
```
Undefined symbols for architecture arm64:
  "_PyModule_AddIntConstant", referenced from:
      _PyInit__api_implementation in api_implementation.o
  "_PyModule_Create2", referenced from:
      _PyInit__api_implementation in api_implementation.o
  "__Py_Dealloc", referenced from:
      _PyInit__api_implementation in api_implementation.o
ld: symbol(s) not found for architecture arm64
```

#test-continuous

PiperOrigin-RevId: 702103016