### PR TITLE
Add a multi-platform Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,7 +184,6 @@ ruby/tests/utf8_pb.rb
 ruby/compatibility_tests/v3.0.0/protoc
 ruby/compatibility_tests/v3.0.0/tests/generated_code_pb.rb
 ruby/compatibility_tests/v3.0.0/tests/test_import_pb.rb
-ruby/Gemfile.lock
 
 # IntelliJ CLion Config files and build output
 cmake/.idea

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,0 +1,50 @@
+PATH
+  remote: .
+  specs:
+    google-protobuf (4.30.0-java)
+      ffi (~> 1)
+      ffi-compiler (~> 1)
+      rake (>= 13)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bigdecimal (3.1.8)
+    bigdecimal (3.1.8-java)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-java)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    ffi-compiler (1.3.2)
+      ffi (>= 1.15.5)
+      rake
+    power_assert (2.0.5)
+    rake (13.2.1)
+    rake-compiler (1.1.9)
+      rake
+    test-unit (3.6.7)
+      power_assert
+
+PLATFORMS
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  arm64-linux
+  java
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  bigdecimal
+  ffi (~> 1)
+  ffi-compiler (~> 1)
+  google-protobuf!
+  rake-compiler (~> 1.1.0)
+  test-unit (~> 3.0, >= 3.0.9)
+
+BUNDLED WITH
+   2.4.10

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -11,13 +11,7 @@ GEM
   specs:
     bigdecimal (3.1.8)
     bigdecimal (3.1.8-java)
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-arm-linux-gnu)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-java)
-    ffi (1.17.0-x86-linux-gnu)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -34,7 +28,10 @@ PLATFORMS
   arm64-darwin
   arm64-linux
   java
+  x64-mingw-ucrt
+  x64-mingw32
   x86-linux
+  x86-mingw32
   x86_64-darwin
   x86_64-linux
 


### PR DESCRIPTION
Prerequisite for adopting https://github.com/bazel-contrib/rules_ruby to help resolve issues with building for Ruby 3.4.x

#test-continuous