### PR TITLE
ruby: make it possible to specify compiler for C extension

### DIFF
--- a/ruby/ext/google/protobuf_c/extconf.rb
+++ b/ruby/ext/google/protobuf_c/extconf.rb
@@ -6,6 +6,18 @@ ext_name = "google/protobuf_c"
 
 dir_config(ext_name)
 
+if ENV["CC"]
+  RbConfig::CONFIG["CC"] = RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"]
+end
+
+if ENV["CXX"]
+  RbConfig::CONFIG["CXX"] = RbConfig::MAKEFILE_CONFIG["CXX"] = ENV["CXX"]
+end
+
+if ENV["LD"]
+  RbConfig::CONFIG["LD"] = RbConfig::MAKEFILE_CONFIG["LD"] = ENV["LD"]
+end
+
 if RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/ || RUBY_PLATFORM =~ /freebsd/
   $CFLAGS += " -std=gnu99 -O3 -DNDEBUG -fvisibility=hidden -Wall -Wsign-compare -Wno-declaration-after-statement"
 else


### PR DESCRIPTION
Previously running `gem install google-protobuf --platform ruby` used the default C compiler specified by `mkmf`, which uses `RbConfig::MAKEFILE_CONFIG["CC"]` and `RbConfig::MAKEFILE_CONFIG["CXX"]`.

This commit supports using `CC`, `CXX`, and `LD` from the environment:

```shell
export CC=my-custom-gcc
export CXX=my-custom-g++
gem install google-protobuf --platform ruby
```

Most native gems, such as grpc and nokogiri, allow for this.