### PR TITLE
Add some missing tests to the test setting of Bazel for Ruby

### DIFF
--- a/ruby/tests/BUILD.bazel
+++ b/ruby/tests/BUILD.bazel
@@ -162,6 +162,26 @@ ruby_test(
     ],
 )
 
+ruby_test(
+    name = "service_test",
+    srcs = ["service_test.rb"],
+    deps = [
+        ":test_ruby_protos",
+        "//ruby:protobuf",
+        "@protobuf_bundle//:test-unit",
+    ],
+)
+
+ruby_test(
+    name = "memory_test",
+    srcs = ["memory_test.rb"],
+    deps = [
+        ":test_ruby_protos",
+        "//ruby:protobuf",
+        "@protobuf_bundle//:test-unit",
+    ],
+)
+
 pkg_files(
     name = "dist_files",
     srcs = glob([

--- a/ruby/tests/memory_test.rb
+++ b/ruby/tests/memory_test.rb
@@ -7,6 +7,8 @@ require 'test/unit'
 require 'objspace'
 require 'test_import_pb'
 
+return if defined?(JRUBY_VERSION) || Google::Protobuf::IMPLEMENTATION != :NATIVE
+
 $is_64bit = Google::Protobuf::Internal::SIZEOF_LONG == 8
 
 class MemoryTest < Test::Unit::TestCase

--- a/ruby/tests/service_test.rb
+++ b/ruby/tests/service_test.rb
@@ -33,6 +33,7 @@ class ServiceTest < Test::Unit::TestCase
   end
 
   def test_service_options_extensions
+    omit "JRuby and FFI do not support service options extensions" if defined?(JRUBY_VERSION) || Google::Protobuf::IMPLEMENTATION != :NATIVE
     extension_field = Google::Protobuf::DescriptorPool.generated_pool.lookup('service_test_protos.test_options')
     assert_equal 8325, extension_field.get(@test_service.options).int_option_value
   end


### PR DESCRIPTION
I'm not sure why, but it seems that some tests are not running via Bazel. CI uses Bazel. So I think we should add those to test correctly.

Also, I fixed some tests to pass.

* Run memory tests against CRuby native implementation
  * These tests are for CRuby native implementation. So this doesn't work with FFI and JRuby.
  * Ref: https://github.com/protocolbuffers/protobuf/pull/15840/
* Run service options extension test against CRuby native implementation
  * It seems that JRuby doesn't support this so far.
  * And, service options are frozen objects. But, in CRuby FFI, can't get a Message instance if the message is frozen. So this doesn't work.
    * https://github.com/protocolbuffers/protobuf/blob/d406cae0138f4f1f283a22be9474bef1f48bb0dc/ruby/lib/google/protobuf/ffi/message.rb#L419
  * So the service options extension test only passes in CRuby native.   
   