### PR TITLE
[25.x backport] Fixed compiler warnings in the Ruby C extension.

### DIFF
--- a/ruby/ext/google/protobuf_c/convert.c
+++ b/ruby/ext/google/protobuf_c/convert.c
@@ -208,7 +208,8 @@ upb_MessageValue Convert_RubyToUpb(VALUE value, const char* name,
       }
       break;
     default:
-      break;
+      rb_raise(cTypeError,
+                "Convert_RubyToUpb(): Unexpected type %d", (int)type_info.type);
   }
 
   return ret;
@@ -296,7 +297,8 @@ bool Msgval_IsEqual(upb_MessageValue val1, upb_MessageValue val2,
   if (upb_Status_IsOk(&status)) {
     return return_value;
   } else {
-    rb_raise(rb_eRuntimeError, upb_Status_ErrorMessage(&status));
+    rb_raise(rb_eRuntimeError, "Msgval_IsEqual(): %s",
+             upb_Status_ErrorMessage(&status));
   }
 }
 
@@ -309,6 +311,7 @@ uint64_t Msgval_GetHash(upb_MessageValue val, TypeInfo type_info,
   if (upb_Status_IsOk(&status)) {
     return return_value;
   } else {
-    rb_raise(rb_eRuntimeError, upb_Status_ErrorMessage(&status));
+    rb_raise(rb_eRuntimeError, "Msgval_GetHash(): %s",
+             upb_Status_ErrorMessage(&status));
   }
 }

--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -862,7 +862,7 @@ static VALUE FieldDescriptor_get(VALUE _self, VALUE msg_rb) {
 static VALUE FieldDescriptor_has(VALUE _self, VALUE msg_rb) {
   FieldDescriptor* self = ruby_to_FieldDescriptor(_self);
   const upb_MessageDef* m;
-  const upb_MessageDef* msg = Message_Get(msg_rb, &m);
+  const upb_Message* msg = Message_Get(msg_rb, &m);
 
   if (m != upb_FieldDef_ContainingType(self->fielddef)) {
     rb_raise(cTypeError, "has method called on wrong message type");
@@ -882,7 +882,7 @@ static VALUE FieldDescriptor_has(VALUE _self, VALUE msg_rb) {
 static VALUE FieldDescriptor_clear(VALUE _self, VALUE msg_rb) {
   FieldDescriptor* self = ruby_to_FieldDescriptor(_self);
   const upb_MessageDef* m;
-  upb_MessageDef* msg = Message_GetMutable(msg_rb, &m);
+  upb_Message* msg = Message_GetMutable(msg_rb, &m);
 
   if (m != upb_FieldDef_ContainingType(self->fielddef)) {
     rb_raise(cTypeError, "has method called on wrong message type");
@@ -903,7 +903,7 @@ static VALUE FieldDescriptor_clear(VALUE _self, VALUE msg_rb) {
 static VALUE FieldDescriptor_set(VALUE _self, VALUE msg_rb, VALUE value) {
   FieldDescriptor* self = ruby_to_FieldDescriptor(_self);
   const upb_MessageDef* m;
-  upb_MessageDef* msg = Message_GetMutable(msg_rb, &m);
+  upb_Message* msg = Message_GetMutable(msg_rb, &m);
   upb_Arena* arena = Arena_get(Message_GetArena(msg_rb));
   upb_MessageValue msgval;
 

--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -212,7 +212,7 @@ static VALUE Map_merge_into_self(VALUE _self, VALUE hashmap) {
     Map* self = ruby_to_Map(_self);
     Map* other = ruby_to_Map(hashmap);
     upb_Arena* arena = Arena_get(self->arena);
-    upb_Message* self_msg = Map_GetMutable(_self);
+    upb_Map* self_map = Map_GetMutable(_self);
 
     Arena_fuse(other->arena, arena);
 
@@ -225,7 +225,7 @@ static VALUE Map_merge_into_self(VALUE _self, VALUE hashmap) {
     size_t iter = kUpb_Map_Begin;
     upb_MessageValue key, val;
     while (upb_Map_Next(other->map, &key, &val, &iter)) {
-      upb_Map_Set(self_msg, key, val, arena);
+      upb_Map_Set(self_map, key, val, arena);
     }
   } else {
     rb_raise(rb_eArgError, "Unknown type merging into Map");

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -488,7 +488,8 @@ static int Map_initialize_kwarg(VALUE key, VALUE val, VALUE _self) {
   k = Convert_RubyToUpb(key, "", map_init->key_type, NULL);
 
   if (map_init->val_type.type == kUpb_CType_Message && TYPE(val) == T_HASH) {
-    upb_MiniTable* t = upb_MessageDef_MiniTable(map_init->val_type.def.msgdef);
+    const upb_MiniTable* t =
+        upb_MessageDef_MiniTable(map_init->val_type.def.msgdef);
     upb_Message* msg = upb_Message_New(t, map_init->arena);
     Message_InitFromValue(msg, map_init->val_type.def.msgdef, val,
                           map_init->arena);
@@ -519,7 +520,7 @@ static upb_MessageValue MessageValue_FromValue(VALUE val, TypeInfo info,
                                                upb_Arena* arena) {
   if (info.type == kUpb_CType_Message) {
     upb_MessageValue msgval;
-    upb_MiniTable* t = upb_MessageDef_MiniTable(info.def.msgdef);
+    const upb_MiniTable* t = upb_MessageDef_MiniTable(info.def.msgdef);
     upb_Message* msg = upb_Message_New(t, arena);
     Message_InitFromValue(msg, info.def.msgdef, val, arena);
     msgval.msg_val = msg;
@@ -635,7 +636,7 @@ static VALUE Message_initialize(int argc, VALUE* argv, VALUE _self) {
   Message* self = ruby_to_Message(_self);
   VALUE arena_rb = Arena_new();
   upb_Arena* arena = Arena_get(arena_rb);
-  upb_MiniTable* t = upb_MessageDef_MiniTable(self->msgdef);
+  const upb_MiniTable* t = upb_MessageDef_MiniTable(self->msgdef);
   upb_Message* msg = upb_Message_New(t, arena);
 
   Message_InitPtr(_self, msg, arena_rb);
@@ -678,7 +679,8 @@ bool Message_Equal(const upb_Message* m1, const upb_Message* m2,
   if (upb_Status_IsOk(&status)) {
     return return_value;
   } else {
-    rb_raise(cParseError, upb_Status_ErrorMessage(&status));
+    rb_raise(cParseError, "Message_Equal(): %s",
+             upb_Status_ErrorMessage(&status));
   }
 }
 
@@ -709,7 +711,8 @@ uint64_t Message_Hash(const upb_Message* msg, const upb_MessageDef* m,
   if (upb_Status_IsOk(&status)) {
     return return_value;
   } else {
-    rb_raise(cParseError, upb_Status_ErrorMessage(&status));
+    rb_raise(cParseError, "Message_Hash(): %s",
+             upb_Status_ErrorMessage(&status));
   }
 }
 

--- a/ruby/ext/google/protobuf_c/shared_convert.c
+++ b/ruby/ext/google/protobuf_c/shared_convert.c
@@ -12,7 +12,7 @@
 #include "shared_convert.h"
 
 bool shared_Msgval_IsEqual(upb_MessageValue val1, upb_MessageValue val2,
-                           upb_CType type, upb_MessageDef* msgdef,
+                           upb_CType type, const upb_MessageDef* msgdef,
                            upb_Status* status) {
   switch (type) {
     case kUpb_CType_Bool:
@@ -39,7 +39,7 @@ bool shared_Msgval_IsEqual(upb_MessageValue val1, upb_MessageValue val2,
 }
 
 uint64_t shared_Msgval_GetHash(upb_MessageValue val, upb_CType type,
-                               upb_MessageDef* msgdef, uint64_t seed,
+                               const upb_MessageDef* msgdef, uint64_t seed,
                                upb_Status* status) {
   switch (type) {
     case kUpb_CType_Bool:

--- a/ruby/ext/google/protobuf_c/shared_convert.h
+++ b/ruby/ext/google/protobuf_c/shared_convert.h
@@ -16,11 +16,11 @@
 #include "shared_message.h"
 
 bool shared_Msgval_IsEqual(upb_MessageValue val1, upb_MessageValue val2,
-                           upb_CType type, upb_MessageDef* msgdef,
+                           upb_CType type, const upb_MessageDef* msgdef,
                            upb_Status* status);
 
 uint64_t shared_Msgval_GetHash(upb_MessageValue val, upb_CType type,
-                               upb_MessageDef* msgdef, uint64_t seed,
+                               const upb_MessageDef* msgdef, uint64_t seed,
                                upb_Status* status);
 
 #endif  // RUBY_PROTOBUF_SHARED_CONVERT_H_

--- a/ruby/ext/google/protobuf_c/shared_message.c
+++ b/ruby/ext/google/protobuf_c/shared_message.c
@@ -32,6 +32,7 @@ uint64_t shared_Message_Hash(const upb_Message* msg, const upb_MessageDef* m,
   } else {
     upb_Arena_Free(arena);
     upb_Status_SetErrorMessage(status, "Error calculating hash");
+    return 0;
   }
 }
 


### PR DESCRIPTION
PiperOrigin-RevId: 594106078

Fixes https://github.com/protocolbuffers/protobuf/issues/19938