### PR TITLE
Fix linker errors on Windows with clang

### DIFF
--- a/build_defs/cpp_opts.bzl
+++ b/build_defs/cpp_opts.bzl
@@ -41,6 +41,8 @@ LINK_OPTS = select({
     ],
     "@platforms//os:windows": [
         "-ldbghelp",
+        "-lpthread",
+        "-lm",
     ],
     "//conditions:default": [
         "-lpthread",

--- a/build_defs/cpp_opts.bzl
+++ b/build_defs/cpp_opts.bzl
@@ -39,6 +39,9 @@ LINK_OPTS = select({
         "-lm",
         "-framework CoreFoundation",
     ],
+    "@platforms//os:windows": [
+        "-ldbghelp",
+    ],
     "//conditions:default": [
         "-lpthread",
         "-lm",

--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -571,7 +571,7 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
 #error PROTOBUF_DESCRIPTOR_WEAK_MESSAGES_ALLOWED was previously defined
 #endif
 #if defined(__GNUC__) && defined(__clang__) && !defined(__APPLE__) && \
-    !defined(_MSC_VER)
+    !defined(_MSC_VER) && !defined(_WIN32)
 #define PROTOBUF_DESCRIPTOR_WEAK_MESSAGES_ALLOWED
 #endif
 


### PR DESCRIPTION
- **Link with dbghelp library on Windows**
- **Do not define `PROTOBUF_DESCRIPTOR_WEAK_MESSAGES_ALLOWED` on Windows**

Fixes #16844
