### PR TITLE
Security fix to stop initializing a class before checking that it is assignable to MessageLite

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java
@@ -1451,7 +1451,7 @@ public abstract class GeneratedMessageLite<
           throw new ClassNotFoundException();
         }
       }
-      return messageClass
+      return messageClass;
     }
   }
 

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java
@@ -1445,7 +1445,13 @@ public abstract class GeneratedMessageLite<
     }
 
     private Class<?> resolveMessageClass() throws ClassNotFoundException {
-      return messageClass != null ? messageClass : Class.forName(messageClassName);
+      if (messageClass == null) {
+        Class messageClass = Class.forName(messageClass, false, getClass().getClassLoader()); 
+        if (!MessageLite.class.isAssignableFrom(c)) {
+          throw new ClassNotFoundException();
+        }
+      }
+      return messageClass
     }
   }
 

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageLite.java
@@ -1447,7 +1447,7 @@ public abstract class GeneratedMessageLite<
     private Class<?> resolveMessageClass() throws ClassNotFoundException {
       if (messageClass == null) {
         Class messageClass = Class.forName(messageClass, false, getClass().getClassLoader()); 
-        if (!MessageLite.class.isAssignableFrom(c)) {
+        if (!MessageLite.class.isAssignableFrom(messageClass)) {
           throw new ClassNotFoundException();
         }
       }


### PR DESCRIPTION
I have submitted a related bug report to OSS VRP. This is a fairly simple fix, which stops arbitrary classes from being initialized. Only classes which implement MessageLite are now allowed. If there is a reason that classes should be deserialized even when they do not implement MessageLite, then this fix will break them, but I do not see how that would ever be the case.