### PR TITLE
Make ParseDict nondestructive for Any

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -1601,6 +1601,27 @@ class JsonFormatTest(JsonFormatBase):
         'TestAny.any_value.',
     )
 
+  def testParseDictNestedAnyDescriptorPoolMissingType(self):
+    # Confirm that ParseDict nondestructive with empty pool
+    js_dict = {
+        '@type': 'type.googleapis.com/google.protobuf.Any',
+        'value': {
+            '@type': 'type.googleapis.com/protobuf_unittest.TestAny',
+            'any_value': {
+                '@type': 'type.googleapis.com/UnknownMessageType',
+            }
+        }
+    }
+    js_dict_copy = json.loads(json.dumps(js_dict))
+    with self.assertRaises(json_format.ParseError) as cm:
+      json_format.ParseDict(js_dict_copy, any_pb2.Any())
+    self.assertEqual(
+        str(cm.exception),
+        'Failed to parse any_value field: Can not find message descriptor by'
+        ' type_url: type.googleapis.com/UnknownMessageType at Any.value.any_value.',
+    )
+    self.assertEqual(js_dict, js_dict_copy)
+
   def testParseDictUnknownValueType(self):
     class UnknownClass(object):
 

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -734,8 +734,10 @@ class _Parser(object):
       )(self)
     else:
       del value['@type']
-      self._ConvertFieldValuePair(value, sub_message, path)
-      value['@type'] = type_url
+      try:
+        self._ConvertFieldValuePair(value, sub_message, path)
+      finally:
+        value['@type'] = type_url
     # Sets Any message
     message.value = sub_message.SerializeToString()
     message.type_url = type_url


### PR DESCRIPTION
Found this bug where if `_ConvertFieldValuePair` fails while parsing an
Any from a dictionary value then the `@type` field gets removed from
the original object. Adding a simple `try/finally` to ensure we always
restore the original object.