### PR TITLE
Pin Rust googletest dependency to 0.13.0

### DIFF
--- a/rust/cargo/Cargo.toml
+++ b/rust/cargo/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/shared.rs"
 paste = "1.0.15"
 
 [dev-dependencies]
-googletest = {git = "https://github.com/google/googletest-rust.git" }
+googletest = "0.13.0"
 
 [build-dependencies]
 cc = "1.1.6"


### PR DESCRIPTION
The Cargo test on the 29.x branch seems to have started failing because of an issue with googletest 0.13.1, so this should fix it.