### PR TITLE
move attribute after enum class to fix clang warning

### DIFF
--- a/src/google/protobuf/text_format.h
+++ b/src/google/protobuf/text_format.h
@@ -51,7 +51,7 @@ PROTOBUF_EXPORT int64_t GetRedactedFieldCount();
 // formats. A higher-level API must correspond to a greater number than any
 // lower-level APIs it calls under the hood (e.g kDebugString >
 // kMemberPrintToString > kPrintWithStream).
-PROTOBUF_EXPORT enum class FieldReporterLevel {
+enum class PROTOBUF_EXPORT FieldReporterLevel {
   kNoReport = 0,
   kPrintMessage = 1,
   kPrintWithGenerator = 2,


### PR DESCRIPTION
Building with clang produce the following error:
text_format.h:55:1: warning: attribute 'visibility' is ignored, place it after "enum class" to apply attribute to type declaration [-Wignored-attributes]

The warning occurs because attributes like
`__attribute__((visibility("default")))` are ignored when placed before an `enum class`. This is due to how attributes are parsed in C++.

Moving the attribute after `enum class` ensures it is applied correctly to the type declaration.