### PR TITLE
C#: Option to validate duplicate fields during json deserialization

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
@@ -979,6 +979,27 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void DuplicateField_IgnoreDuplicateFields([Values(false, true, null)] bool? ignoreDuplicateFields)
+        {
+            string json = "{ \"singleString\": \"x\", \"single_string\": \"y\" }";
+            var jsonParserSettings = JsonParser.Settings.Default;
+            if (ignoreDuplicateFields.HasValue)
+            {
+                jsonParserSettings = jsonParserSettings.WithIgnoreDuplicateFields(ignoreDuplicateFields.Value);
+            }
+            var jsonParser = new JsonParser(jsonParserSettings);
+            TestDelegate act = () => jsonParser.Parse<TestAllTypes>(json);
+            if (!ignoreDuplicateFields.HasValue || ignoreDuplicateFields.Value)
+            {
+                Assert.DoesNotThrow(act);
+            }
+            else
+            {
+                Assert.Throws<InvalidProtocolBufferException>(act);
+            }
+        }
+
+        [Test]
         public void UnknownField_NotIgnored()
         {
             string json = "{ \"unknownField\": 10, \"singleString\": \"x\" }";


### PR DESCRIPTION
### The issue

Proto:
```
syntax = "proto3";

package test;

message User {
  string first_name = 1 [json_name = "first_name"];
  string last_name = 2;
}
```

Code:
```
using Google.Protobuf;
using Test;

const string json =
    """
    {
        "first_name": "John",
        "first_name": "Alan",
        "last_name": "Doe",
        "lastName": "Smith"
    }
    """;

var user = JsonParser.Default.Parse<User>(json);
Console.WriteLine($"{user.FirstName} {user.LastName}");
```

Output:
```
Alan Smith
```

### Why is this a problem?

This is a pretty unexpected behavior. Even using `json_name` cannot fully prevent one from using duplicate fields in json

### What about implementations in other languages?

`protobuf-go` features a specific [check](https://github.com/protocolbuffers/protobuf-go/blob/259e665f26b1019a88c9ed6c7f16f01242838720/encoding/protojson/decode.go#L212) for duplicate fields

###  What does this PR do?

This PR introduces an optional setting `IgnoreDuplicateFields` (`true` by default). If set to `false`, it makes `JsonParser` validate duplicate fields. Coming back to out example:

Code:
```
using Test;

const string json =
    """
    {
        "first_name": "John",
        "first_name": "Alan",
        "last_name": "Doe",
        "lastName": "Smith"
    }
    """;

var user = JsonParser.Default.WithIgnoreDuplicateFields(false).Parse<User>(json);
Console.WriteLine($"{user.FirstName} {user.LastName}");
```

Output:
```
Google.Protobuf.InvalidProtocolBufferException: Multiple values specified for field first_name
```