### PR TITLE
Update ubuntu20 to ubuntu22

### DIFF
--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -66,7 +66,7 @@ jobs:
 
   linux-32bit:
     name: Linux 32-bit
-    runs-on: ubuntu-20-4core
+    runs-on: ubuntu-22-4core
     steps:
       - name: Checkout pending changes
         uses: protocolbuffers/protobuf-ci/checkout@v3


### PR DESCRIPTION
Ubuntu 20 is going to be deprecated in the near future, update all references to it.