### PR TITLE
Fixes -lpthread problem when building with android_arm64 config

### DIFF
--- a/build_defs/cpp_opts.bzl
+++ b/build_defs/cpp_opts.bzl
@@ -23,6 +23,7 @@ COPTS = select({
 
 # Android and MSVC builds do not need to link in a separate pthread library.
 LINK_OPTS = select({
+    "@platforms//os:android": [],
     "//build_defs:config_android": [],
     "//build_defs:config_android-legacy-default-crosstool": [],
     "//build_defs:config_android-stlport": [],


### PR DESCRIPTION
When using `--platforms=//:android_arm64` on command line, the build fails to match any android condition.

```
platform(
    name = "android_arm64",
    constraint_values = [
        "@platforms//os:android",
        "@platforms//cpu:arm64",
    ],
)
```