### PR TITLE
Ruby: Remove condition for unsupported JRuby

### DIFF
--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -37,10 +37,7 @@ module BasicTest
       msg = TestMessage.new
       msg.repeated_int32 = ::Google::Protobuf::RepeatedField.new(:int32, [1, 2, 3])
 
-      # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
-      if cruby_or_jruby_9_3_or_higher?
-        GC.start(full_mark: true, immediate_sweep: true)
-      end
+      GC.start(full_mark: true, immediate_sweep: true)
       TestMessage.encode(msg)
     end
 

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -252,7 +252,7 @@ module CommonTests
     l3 = l + l.dup
     assert_equal l3.count, l.count * 2
     l.count.times do |i|
-      assert_equal l[i], l3[i] 
+      assert_equal l[i], l3[i]
       assert_equal l[i], l3[l.count + i]
     end
 
@@ -1751,34 +1751,24 @@ module CommonTests
     assert_nil h[m2]
   end
 
-  def cruby_or_jruby_9_3_or_higher?
-    # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
-    match = RUBY_PLATFORM == "java" &&
-      JRUBY_VERSION.match(/^(\d+)\.(\d+)\.\d+\.\d+$/)
-    match && (match[1].to_i > 9 || (match[1].to_i == 9 && match[2].to_i >= 3))
-  end
-
   def test_object_gc
     m = proto_module::TestMessage.new(optional_msg: proto_module::TestMessage2.new)
     m.optional_msg
-    # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
-    GC.start(full_mark: true, immediate_sweep: true) if cruby_or_jruby_9_3_or_higher?
+    GC.start(full_mark: true, immediate_sweep: true)
     m.optional_msg.inspect
   end
 
   def test_object_gc_freeze
     m = proto_module::TestMessage.new
     m.repeated_float.freeze
-    # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
-    GC.start(full_mark: true) if cruby_or_jruby_9_3_or_higher?
+    GC.start(full_mark: true)
 
     # Make sure we remember that the object is frozen.
     # The wrapper object contains this information, so we need to ensure that
     # the previous GC did not collect it.
     assert m.repeated_float.frozen?
 
-    # https://github.com/jruby/jruby/issues/6818 was fixed in JRuby 9.3.0.0
-    GC.start(full_mark: true, immediate_sweep: true) if cruby_or_jruby_9_3_or_higher?
+    GC.start(full_mark: true, immediate_sweep: true)
     assert m.repeated_float.frozen?
   end
 


### PR DESCRIPTION
`google-protobuf` only support JRuby >= 9.4(Ruby 3.1 compatibility). So there is no need to consider versions under it.