### PR TITLE
Python: Option to validate duplicate fields during json deserialization

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -1739,5 +1739,21 @@ class JsonFormatTest(JsonFormatBase):
     with self.assertRaises(json_format.ParseError):
       json_format.Parse(text, json_format_proto3_pb2.TestMessage())
 
+  def testParseDuplicateJsonFields(self):
+    data = json.dumps({"self_": 1, "self_underscore": 2})
+
+    with self.assertRaises():
+      json_format.Parse(
+          data, test_proto2_pb2.MessageWithSelfAndSelfUnderscoreField()
+      )
+
+  def testParseDictDuplicateJsonFields(self):
+    data = {"self_": 1, "self_underscore": 2}
+
+    with self.assertRaises():
+      json_format.ParseDict(
+          data, test_proto2_pb2.MessageWithSelfAndSelfUnderscoreField()
+      )
+
 if __name__ == '__main__':
   unittest.main()

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -594,7 +594,7 @@ class _Parser(object):
                   [f.json_name for f in message_descriptor.fields],
               )
           )
-        if name in names:
+        if field.name in names:
           raise ParseError(
               'Message type "{0}" should not have multiple '
               '"{1}" fields at "{2}".'.format(


### PR DESCRIPTION
## The issue

Proto:
```proto
syntax = "proto3";

package test;

message User {
  string first_name = 1 [json_name = "first_name"];
  string last_name = 2;
}
```

Code:
```python
from google.protobuf.json_format import ParseDict
import test_pb2

data = {"first_name": "Aaron", "last_name": "Surname", "lastName": "Fake"}

message = ParseDict(data, test_pb2.User())

print(message)
```
Output:
```
first_name: "Aaron"
last_name: "Fake"
```

## Why is this a problem?

This is a pretty unexpected behavior. Even using json_name cannot fully prevent one from using duplicate fields in json.

## What about implementations in other languages?

protobuf-go features a specific [check](https://github.com/protocolbuffers/protobuf-go/blob/259e665f26b1019a88c9ed6c7f16f01242838720/encoding/protojson/decode.go#L212) for duplicate fields. 
This PR is created similarly to [C# PR](https://github.com/protocolbuffers/protobuf/pull/20288)

## What does this PR do?

This PR improves checks for fields already used during JSON parsing. Back to the example, the result will be as follows:

Code:

```python
from google.protobuf.json_format import ParseDict
import test_pb2

data = {"first_name": "Aaron", "last_name": "Surname", "lastName": "Fake"}

message = ParseDict(data, test_pb2.User())

print(message)
```

Output:

```
Traceback (most recent call last):
  File "/Users/sersh4nt/Projects/protobuf/venv/lib/python3.12/site-packages/google/protobuf/json_format.py", line 597, in _ConvertFieldValuePair
    raise ParseError(
google.protobuf.json_format.ParseError: Message type "test.User" should not have multiple "lastName" fields at "User".
```
