### PR TITLE
Remove reference to rules_rust from .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,9 +3,6 @@ build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 # TODO: ErrorProne's SelfAssertions are violated in protobuf's test
 build --javacopt=-Xep:SelfAssertion:WARN
 
-# This flag works around some issues with Rust linking.
-build --@rules_rust//rust/settings:experimental_use_cc_common_link=True
-
 build:dbg --compilation_mode=dbg
 
 build:opt --compilation_mode=opt


### PR DESCRIPTION
I missed this when I removed the rules_rust dependency from MODULE.bazel in b8248f687f07d78a4baedd1581843883544ae239. We need to drop this flag because it's an error to reference it when rules_rust is not available.