### PR TITLE
Reserve new extensions for protokt v1

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -255,7 +255,7 @@ with info about your project (name and website) so we can add an entry for you.
     *   Website: https://github.com/bufbuild/protoc-gen-validate
     *   Extensions: 1071
 
-1.  Protokt
+1.  Protokt (pre 1.0.0)
 
     *   Website: https://github.com/open-toast/protokt
     *   Extensions: 1072
@@ -531,3 +531,8 @@ with info about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/jaiarobotics/jaiabot
     *   Extensions: 1252
+  
+1.  Protokt (1.0.0 and up)
+
+    *   Website: https://github.com/open-toast/protokt
+    *   Extensions: 1253-1263


### PR DESCRIPTION
We'd like to add new extensions backwards-incompatibly with a new extension number (and reserve a few for the future if we want to do this again). Thanks!