### PR TITLE
Optimize varint decoding without intrinsics

### DIFF
--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -873,6 +873,16 @@ static const char* VarintParseSlowArm(const char* p, uint64_t* out,
 }
 #endif
 
+// Helper function for preventing inlining
+template <typename T>
+ABSL_ATTRIBUTE_COLD
+PROTOBUF_NOINLINE
+static const char* VarintParseCold(const char* p, T* out) {
+  auto ptr = reinterpret_cast<const uint8_t*>(p);
+
+  return VarintParseSlow(p, ptr[0], out);
+}
+
 // The caller must ensure that p points to at least 10 valid bytes.
 template <typename T>
 [[nodiscard]] const char* VarintParse(const char* p, T* out) {
@@ -895,7 +905,54 @@ template <typename T>
     return p + 2;
   }
   return VarintParseSlowArm(p, out, first8);
-#else   // __aarch64__
+#elif defined(__x86_64__) // __aarch64__
+  // Hot path: try to parse a 28 bit varint
+  // Range: 0..268,435,456
+  // Tagged: 0..33,554,432
+  //
+  // Messages longer than 128 bytes are not uncommon, so this
+  // should be faster in the general case
+
+  // Input is guaranteed atleast 10 bytes
+  uint32_t value = *reinterpret_cast<const uint32_t*>(p);
+
+  // Bit is 0 if continuation bit is not set
+  // 1 byte: ?000_000 ?000_000 ?000_000 1000_000
+  // 2 byte: ?000_000 ?000_000 1000_000 0000_000
+  // 3 byte: ?000_000 1000_000 0000_000 0000_000
+  // 4 byte: 1000_000 0000_000 0000_000 0000_000
+  // ? byte: 0000_000 0000_000 0000_000 0000_000
+  uint32_t mask = (~value) & 0x8080'8080;
+
+  // This has weird codegen on x86_64 clang 19
+  // For details, see https://godbolt.org/z/rPvKePY9a
+  if ABSL_PREDICT_FALSE(mask == 0) {
+    // All continuation bits set, fall back to default implementation
+    return VarintParseCold(p, out);
+  }
+
+  // Use the mask to get the length
+  uint32_t len = absl::countr_zero(mask);
+
+  // See mask table above
+  mask -= 1;
+  // Discard irrelevant bits
+  value &= 0x7f7f'7f7f;
+  value &= mask;
+
+  // https://github.com/protocolbuffers/protobuf/pull/10646#issuecomment-1275499255
+  value += value & 0x00ff'00ff;
+  value += (value & 0x0000'ffff) * 0b0011;
+  value >>= 3;
+
+  // Bit length to byte length
+  len >>= 3;
+  len += 1;
+
+  *out = (T)value;
+
+  return p + len;
+#else // __x86_64__
   auto ptr = reinterpret_cast<const uint8_t*>(p);
   uint32_t res = ptr[0];
   if ((res & 0x80) == 0) {
@@ -903,7 +960,7 @@ template <typename T>
     return p + 1;
   }
   return VarintParseSlow(p, res, out);
-#endif  // __aarch64__
+#endif  // __x86_64__
 }
 
 // Used for tags, could read up to 5 bytes which must be available.


### PR DESCRIPTION
This PR builds on https://github.com/protocolbuffers/protobuf/pull/10646 and https://github.com/protocolbuffers/protobuf/pull/13158 to provide a more optimized varint decoder.

This code does not use any intrinsics and is concise in order to fit in a single cache line for maximum efficiency.

See https://godbolt.org/z/rPvKePY9a for more details.

### Explanation

We read a uint32 and extracts relevant bits via bit manipulation, taking the cold path only if the varint is longer than 4 bytes. This integer size is picked because it strikes a reasonable balance bit manip overhead and branch probability. 

This gives us a range of `0..268,435,456` on the hot path, or `0..33,554,432` if it's tagged for a field.

### Benchmarking details

libprotobuf compiler: gcc 11.4
allocator: jemalloc
cpu: amd 5800x
linking: static
lto: no

input message: ~40kb, varies in message types, varints, and bytes
results: average of 10 runs, each run is 500,000 iterations
op: construct, parse from memory array, destruct
control: 23.2 microsecs/op
with changes: 22.4 microsecs/op

microbench: 1.7-2ns/call

About a 3-4% improvement overall. Not much but for servers which may parse millions of protobuf messages, it's not insignificant