### PR TITLE
Loosen py_proto_library check to be on the import path instead of full directory (i.e. excluding external/module-name prefix).

### DIFF
--- a/.github/workflows/test_bazel.yml
+++ b/.github/workflows/test_bazel.yml
@@ -69,4 +69,6 @@ jobs:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: examples
           version: ${{ matrix.bazelversion }}
-          bash: cd examples && bazel build //... $BAZEL_FLAGS --enable_bzlmod=${{ matrix.bzlmod }} --enable_workspace=${{ !matrix.bzlmod }} ${{ matrix.toolchain_resolution }}
+          bash: >
+            cd examples;
+            bazel build //... @com_google_protobuf-examples-with-hyphen//... $BAZEL_FLAGS --enable_bzlmod=${{ matrix.bzlmod }} --enable_workspace=${{ !matrix.bzlmod }} ${{ matrix.toolchain_resolution }};

--- a/bazel/py_proto_library.bzl
+++ b/bazel/py_proto_library.bzl
@@ -44,8 +44,9 @@ def _py_proto_aspect_impl(target, ctx):
 
     # Check Proto file names
     for proto in target[ProtoInfo].direct_sources:
-        if proto.is_source and "-" in proto.dirname:
-            fail("Cannot generate Python code for a .proto whose path contains '-' ({}).".format(
+        import_path = proto_common.get_import_path(proto)
+        if proto.is_source and "-" in import_path:
+            fail("Cannot generate Python code for a .proto whose python import path contains '-' ({}).".format(
                 proto.path,
             ))
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -12,6 +12,12 @@ local_path_override(
     path = "..",
 )
 
+bazel_dep(name = "com_google_protobuf-examples-with-hyphen", version = "0.0.0", dev_dependency = True)
+local_path_override(
+    module_name = "com_google_protobuf-examples-with-hyphen",
+    path = "examples_with_hyphen",
+)
+
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -20,6 +20,11 @@ local_repository(
     path = "..",
 )
 
+local_repository(
+    name = "com_google_protobuf-examples-with-hyphen",
+    path = "examples_with_hyphen",
+)
+
 # Similar to com_google_protobuf but for Java lite. If you are building
 # for Android, the lite version should be preferred because it has a much
 # smaller code size.
@@ -38,7 +43,7 @@ http_archive(
     ],
 )
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps", "PROTOBUF_MAVEN_ARTIFACTS")
+load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS", "protobuf_deps")
 
 protobuf_deps()
 
@@ -61,12 +66,15 @@ rules_cc_dependencies()
 rules_cc_toolchains()
 
 load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+
 rules_jvm_external_deps()
 
 load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+
 rules_jvm_external_setup()
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+
 maven_install(
     name = "maven",
     artifacts = PROTOBUF_MAVEN_ARTIFACTS,

--- a/examples/examples_with_hyphen/BUILD.bazel
+++ b/examples/examples_with_hyphen/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:py_proto_library.bzl", "py_proto_library")
+
+proto_library(
+    name = "empty_proto",
+    srcs = ["empty.proto"],
+)
+
+# py_proto_library rule with hyphen in @com_google_protobuf-examples-with-hyphen module name.
+py_proto_library(
+    name = "empty_py_pb2",
+    visibility = ["//visibility:public"],
+    deps = [":empty_proto"],
+)

--- a/examples/examples_with_hyphen/MODULE.bazel
+++ b/examples/examples_with_hyphen/MODULE.bazel
@@ -1,0 +1,13 @@
+"""Bazel module dependencies"""
+
+module(
+    name = "com_google_protobuf-examples-with-hyphen",
+    version = "0.0.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "protobuf", version = "0.0.0", repo_name = "com_google_protobuf")
+local_path_override(
+    module_name = "protobuf",
+    path = "..",
+)

--- a/examples/examples_with_hyphen/empty.proto
+++ b/examples/examples_with_hyphen/empty.proto
@@ -1,0 +1,5 @@
+edition = "2023";
+
+package examples.with.hyphen;
+
+message EmptyMessage {}


### PR DESCRIPTION
The module name does not actually make it into the name used in python imports, so this should allow py_proto_library to work for modules with hyphens in their name (i.e. `bazel build @com_google_protobuf-examples//:addressbook_py_pb2`).

PiperOrigin-RevId: 733763224