### PR TITLE
Cherry pick: Make rules_ruby a dev-only dependency.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,7 @@ load("@rules_java//java:defs.bzl", "java_lite_proto_library", "java_proto_librar
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
 load("//build_defs:cpp_opts.bzl", "COPTS", "LINK_OPTS")
-load(":protobuf.bzl", "internal_objc_proto_library", "internal_php_proto_library", "internal_py_proto_library", "internal_ruby_proto_library")
+load(":protobuf.bzl", "internal_objc_proto_library", "internal_php_proto_library", "internal_py_proto_library")
 
 licenses(["notice"])
 
@@ -148,17 +148,6 @@ filegroup(
     ],
     deprecation = "Prefer :well_known_type_protos instead.",
     visibility = ["//visibility:public"],
-)
-
-internal_ruby_proto_library(
-    name = "well_known_ruby_protos",
-    srcs = [":well_known_protos"],
-    default_runtime = "",
-    includes = ["src"],
-    visibility = [
-        "//conformance:__pkg__",
-        "//ruby:__subpackages__",
-    ],
 )
 
 ################################################################################
@@ -523,33 +512,6 @@ internal_php_proto_library(
         "//conformance:__pkg__",
         "//php:__subpackages__",
     ],
-)
-
-internal_ruby_proto_library(
-    name = "test_messages_proto2_ruby_proto",
-    testonly = 1,
-    srcs = ["//src/google/protobuf:test_messages_proto2.proto"],
-    includes = ["src/google/protobuf"],
-    visibility = [
-        "//conformance:__pkg__",
-        "//ruby:__subpackages__",
-    ],
-)
-
-internal_ruby_proto_library(
-    name = "test_messages_proto3_ruby_proto",
-    testonly = 1,
-    srcs = ["//src/google/protobuf:test_messages_proto3.proto"],
-    includes = [
-        "src/google/protobuf",
-        # The above must come first.
-        "src",
-    ],
-    visibility = [
-        "//conformance:__pkg__",
-        "//ruby:__subpackages__",
-    ],
-    deps = [":well_known_ruby_protos"],
 )
 
 filegroup(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,6 +82,15 @@ load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 
 kt_register_toolchains()
 
+http_archive(
+    name = "rules_ruby",
+    urls = [
+      "https://github.com/protocolbuffers/rules_ruby/archive/b7f3e9756f3c45527be27bc38840d5a1ba690436.zip"
+    ],
+    strip_prefix = "rules_ruby-b7f3e9756f3c45527be27bc38840d5a1ba690436",
+    sha256 = "347927fd8de6132099fcdc58e8f7eab7bde4eb2fd424546b9cd4f1c6f8f8bad8",
+)
+
 load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
 ruby_runtime("system_ruby")

--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -2,7 +2,8 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "objc_library")
 load("@rules_ruby//ruby:defs.bzl", "ruby_binary")
-load("//:protobuf.bzl", "internal_csharp_proto_library", "internal_objc_proto_library", "internal_php_proto_library", "internal_py_proto_library", "internal_ruby_proto_library")
+load("//ruby:defs.bzl", "internal_ruby_proto_library")
+load("//:protobuf.bzl", "internal_csharp_proto_library", "internal_objc_proto_library", "internal_php_proto_library", "internal_py_proto_library")
 load("//build_defs:internal_shell.bzl", "inline_sh_binary")
 load(
     "@rules_pkg//:mappings.bzl",
@@ -331,8 +332,7 @@ ruby_binary(
     visibility = ["//ruby:__subpackages__"],
     deps = [
         ":conformance_ruby_proto",
-        "//:test_messages_proto2_ruby_proto",
-        "//:test_messages_proto3_ruby_proto",
+        "//ruby:conformance_test_ruby_proto",
     ],
 )
 

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -2,7 +2,6 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load("@rules_python//python:defs.bzl", "py_library")
-load("@rules_ruby//ruby:defs.bzl", "ruby_library")
 
 def _GetPath(ctx, path):
     if ctx.label.workspace_root:
@@ -490,6 +489,7 @@ def internal_objc_proto_library(
 
 def internal_ruby_proto_library(
         name,
+        ruby_library,
         srcs = [],
         deps = [],
         includes = ["."],
@@ -506,6 +506,7 @@ def internal_ruby_proto_library(
 
     Args:
       name: the name of the ruby_proto_library.
+      ruby_library: the ruby library rules to use.
       srcs: the .proto files to compile.
       deps: a list of dependency labels; must be a internal_ruby_proto_library.
       includes: a string indicating the include path of the .proto files.

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -109,14 +109,6 @@ def protobuf_deps():
             sha256 = "f9e4f6acf82449324d56669bda4bdb28b48688ad2990d8b39fa5b93ed39c9ad1",
         )
 
-    if not native.existing_rule("rules_ruby"):
-        _github_archive(
-            name = "rules_ruby",
-            repo = "https://github.com/protocolbuffers/rules_ruby",
-            commit = "b7f3e9756f3c45527be27bc38840d5a1ba690436",
-            sha256 = "347927fd8de6132099fcdc58e8f7eab7bde4eb2fd424546b9cd4f1c6f8f8bad8",
-        )
-
     if not native.existing_rule("rules_jvm_external"):
         _github_archive(
             name = "rules_jvm_external",

--- a/ruby/BUILD.bazel
+++ b/ruby/BUILD.bazel
@@ -7,9 +7,10 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_ruby//ruby:defs.bzl", "ruby_library")
 load("//build_defs:internal_shell.bzl", "inline_sh_binary")
-load("//:protobuf.bzl", "internal_ruby_proto_library")
-load("//conformance:defs.bzl", "conformance_test")
+load("//python:internal.bzl", "internal_copy_files")
+load("//ruby:defs.bzl", "internal_ruby_proto_library")
 load("//:protobuf_version.bzl", "PROTOBUF_RUBY_VERSION")
+load("//conformance:defs.bzl", "conformance_test")
 
 ################################################################################
 # Ruby Runtime
@@ -86,6 +87,49 @@ selects.config_setting_group(
     ],
 )
 
+internal_copy_files(
+    name = "copied_wkt_proto_files",
+    srcs = [
+        "//:well_known_type_protos",
+        "//src/google/protobuf:descriptor_proto_srcs",
+        "//src/google/protobuf/compiler:plugin.proto",
+    ],
+    strip_prefix = "src",
+)
+
+internal_ruby_proto_library(
+    name = "well_known_ruby_protos",
+    srcs = [":copied_wkt_proto_files"],
+    default_runtime = "",
+    includes = ["."],
+    visibility = [
+        "//conformance:__pkg__",
+        "//ruby:__subpackages__",
+    ],
+)
+
+internal_copy_files(
+    name = "copied_conformance_test_files",
+    testonly = 1,
+    srcs = [
+        "//src/google/protobuf:test_messages_proto2.proto",
+        "//src/google/protobuf:test_messages_proto3.proto",
+    ],
+    strip_prefix = "src",
+)
+
+internal_ruby_proto_library(
+    name = "conformance_test_ruby_proto",
+    testonly = 1,
+    srcs = [":copied_conformance_test_files"],
+    includes = ["."],
+    visibility = [
+        "//conformance:__pkg__",
+        "//ruby:__subpackages__",
+    ],
+    deps = [":well_known_ruby_protos"],
+)
+
 ruby_library(
     name = "protobuf",
     visibility = [
@@ -105,7 +149,7 @@ genrule(
         "//ruby/lib/google:copy_jar",
         "//ruby/lib/google:dist_files",
         "//ruby/ext/google/protobuf_c:dist_files",
-        "//:well_known_ruby_protos",
+        ":well_known_ruby_protos",
         "google-protobuf.gemspec",
     ],
     outs = ["google-protobuf-" + PROTOBUF_RUBY_VERSION + "-java.gem"],
@@ -119,7 +163,7 @@ genrule(
         for utf in $(execpaths @utf8_range//:utf8_range_srcs) $(execpath @utf8_range//:LICENSE); do
             mv "tmp/$$utf" "tmp/ruby/ext/google/protobuf_c/third_party/utf8_range"
         done
-        for wkt in $(execpaths //:well_known_ruby_protos); do
+        for wkt in $(execpaths :well_known_ruby_protos); do
             mv "tmp/$$wkt" "tmp/ruby/lib/google/protobuf/"
         done
         mv "tmp/$(execpath //ruby/lib/google:copy_jar)" "tmp/ruby/lib/google"
@@ -141,9 +185,9 @@ genrule(
     srcs = [
         "@utf8_range//:utf8_range_srcs",
         "@utf8_range//:LICENSE",
-        "//:well_known_ruby_protos",
         "//ruby/ext/google/protobuf_c:dist_files",
         "//ruby/lib/google:dist_files",
+        ":well_known_ruby_protos",
         "google-protobuf.gemspec",
     ],
     outs = ["google-protobuf-" + PROTOBUF_RUBY_VERSION + ".gem"],
@@ -157,7 +201,7 @@ genrule(
         for utf in $(execpaths @utf8_range//:utf8_range_srcs) $(execpath @utf8_range//:LICENSE); do
             mv "tmp/$$utf" "tmp/ruby/ext/google/protobuf_c/third_party/utf8_range"
         done
-        for wkt in $(execpaths //:well_known_ruby_protos); do
+        for wkt in $(execpaths :well_known_ruby_protos); do
             mv "tmp/$$wkt" "tmp/ruby/lib/google/protobuf/"
         done
         cd tmp/ruby
@@ -198,7 +242,7 @@ internal_ruby_proto_library(
     visibility = [
         "//ruby:__subpackages__",
     ],
-    deps = ["//:well_known_ruby_protos"],
+    deps = [":well_known_ruby_protos"],
 )
 
 conformance_test(

--- a/ruby/compatibility_tests/v3.0.0/tests/BUILD.bazel
+++ b/ruby/compatibility_tests/v3.0.0/tests/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_ruby//ruby:defs.bzl", "ruby_test")
-load("//:protobuf.bzl", "internal_ruby_proto_library")
+load("//ruby:defs.bzl", "internal_ruby_proto_library")
 
 internal_ruby_proto_library(
     name = "test_ruby_protos",

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -1,0 +1,24 @@
+"""Wrapper around internal_ruby_proto_library to supply our rules_ruby"""
+
+load("@rules_ruby//ruby:defs.bzl", "ruby_library")
+load("//:protobuf.bzl", _internal_ruby_proto_library = "internal_ruby_proto_library")
+
+def internal_ruby_proto_library(
+        name,
+        **kwargs):
+    """Bazel rule to create a Ruby protobuf library from proto source files
+
+    NOTE: the rule is only an internal workaround to generate protos. The
+    interface may change and the rule may be removed when bazel has introduced
+    the native rule.
+
+    Args:
+      name: the name of the ruby_proto_library.
+      **kwargs: other keyword arguments that are passed to ruby_library.
+
+    """
+    _internal_ruby_proto_library(
+        name,
+        ruby_library,
+        **kwargs
+    )

--- a/ruby/lib/google/BUILD.bazel
+++ b/ruby/lib/google/BUILD.bazel
@@ -76,9 +76,12 @@ ruby_library(
         "//ruby:linux_ffi_enabled": ["libprotobuf_c_ffi.so"],
         "//conditions:default": [],
     }),
-    includes = ["ruby/lib"],
+    includes = [
+        "ruby",
+        "ruby/lib",
+    ],
     visibility = ["//ruby:__pkg__"],
-    deps = ["//:well_known_ruby_protos"] + select({
+    deps = ["//ruby:well_known_ruby_protos"] + select({
         "//ruby:ffi_enabled": [
             "@protobuf_bundle//:ffi",
             "@protobuf_bundle//:ffi-compiler",

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -780,6 +780,7 @@ exports_files(
     visibility = [
         "//:__pkg__",
         "//python:__pkg__",
+        "//ruby:__pkg__",
     ],
 )
 

--- a/src/google/protobuf/compiler/BUILD.bazel
+++ b/src/google/protobuf/compiler/BUILD.bazel
@@ -226,6 +226,7 @@ exports_files(
     visibility = [
         "//:__pkg__",
         "//python:__pkg__",
+        "//ruby:__pkg__",
     ],
 )
 


### PR DESCRIPTION
There is no canonical rules_ruby repo today, and we don't want our fork to become one.  In order to unblock inclusion of Protobuf in the bzlmod registry, we're making this a dev dependency and dropping support for Bazel/Ruby.

Fixes #14569

PiperOrigin-RevId: 584393841