### PR TITLE
upb: Implement decoding of zero id fields

### DIFF
--- a/upb/message/test.cc
+++ b/upb/message/test.cc
@@ -646,6 +646,32 @@ TEST(MessageTest, MaxRequiredFields) {
   ASSERT_TRUE(serialized != nullptr);
 }
 
+TEST(MessageTest, ZeroIdField) {
+  upb::Arena arena;
+
+  // ID of zero with wire type of VARINT
+  const char zero[] = { 0x00, 0x00 };
+
+  // Should return parse error, not valid proto
+  EXPECT_EQ(nullptr, upb_test_EmptyMessage_parse(
+                         zero, sizeof(zero), arena.ptr()));
+
+  upb_test_EmptyMessage* decoded = upb_test_EmptyMessage_parse_ex(
+      zero, sizeof(zero), nullptr,
+      kUpb_DecodeOption_AllowZeroIdFields, arena.ptr());
+
+  // Should parse, allowing unknown zero id field
+  ASSERT_TRUE(decoded != nullptr);
+
+  // Should serialize identically to input
+  size_t len;
+  char* serialized = upb_test_EmptyMessage_serialize(decoded, arena.ptr(), &len);
+
+  ASSERT_TRUE(serialized != nullptr);
+  ASSERT_TRUE(len == 2);
+  ASSERT_TRUE(serialized[0] == 0 && serialized[1] == 0);
+}
+
 TEST(MessageTest, MapField) {
   upb::Arena arena;
   upb_test_TestMapFieldExtra* test_msg_extra =

--- a/upb/wire/decode.c
+++ b/upb/wire/decode.c
@@ -1224,7 +1224,8 @@ static const char* _upb_Decoder_DecodeUnknownField(upb_Decoder* d,
                                                    upb_Message* msg,
                                                    int field_number,
                                                    int wire_type, wireval val) {
-  if (field_number == 0) _upb_Decoder_ErrorJmp(d, kUpb_DecodeStatus_Malformed);
+  if (field_number == 0 && !(d->options & kUpb_DecodeOption_AllowZeroIdFields))
+    _upb_Decoder_ErrorJmp(d, kUpb_DecodeStatus_ZeroIdField);
 
   // Since unknown fields are the uncommon case, we do a little extra work here
   // to walk backwards through the buffer to find the field start.  This frees
@@ -1475,6 +1476,8 @@ const char* upb_DecodeStatus_String(upb_DecodeStatus status) {
       return "Missing required field";
     case kUpb_DecodeStatus_UnlinkedSubMessage:
       return "Unlinked sub-message field was present";
+    case kUpb_DecodeStatus_ZeroIdField:
+      return "Field with an id of zero was present";
     default:
       return "Unknown decode status";
   }

--- a/upb/wire/decode.h
+++ b/upb/wire/decode.h
@@ -93,6 +93,12 @@ enum {
    * as non-UTF-8 proto3 string fields.
    */
   kUpb_DecodeOption_AlwaysValidateUtf8 = 8,
+
+  /* EXPERIMENTAL:
+   *
+   * If set, decoding will allow unknown fields with an id of 0.
+   */
+  kUpb_DecodeOption_AllowZeroIdFields = 16,
 };
 
 UPB_INLINE uint32_t upb_DecodeOptions_MaxDepth(uint16_t depth) {
@@ -129,6 +135,10 @@ typedef enum {
   // kUpb_DecodeOptions_ExperimentalAllowUnlinked was not specified in the list
   // of options.
   kUpb_DecodeStatus_UnlinkedSubMessage = 6,
+
+  // An unknown field with an id of zero was present, but
+  // kUpb_DecodeOption_AllowZeroId was not specified in the list of options.
+  kUpb_DecodeStatus_ZeroIdField = 7,
 } upb_DecodeStatus;
 // LINT.ThenChange(//depot/google3/third_party/protobuf/rust/upb.rs:decode_status)
 


### PR DESCRIPTION
Added option to allow decoding of fields with an id of zero and saving them to unknown fields. This appears to be an arbitrary restriction on the library and caused incompatibility with a legacy system for me. I am unsure about the specific testing required but I implemented a unit test to ensure that the fields properly decode/encode with and without the option.

See related issue https://github.com/protocolbuffers/protobuf/issues/20595