### PR TITLE
Remove Java runtime classes from kotlin release.

### DIFF
--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -141,12 +141,10 @@ internal_gen_well_known_protos_java(
 # Should be used as `//java/lite`.
 java_library(
     name = "lite",
-    srcs = LITE_SRCS + [
-        ":gen_well_known_protos_javalite",
-    ],
-    visibility = [
-        "//java/lite:__pkg__",
-    ],
+    srcs = [":gen_well_known_protos_javalite"],
+    visibility = ["//java/lite:__pkg__"],
+    exports = [":lite_runtime_only"],
+    deps = [":lite_runtime_only"],
 )
 
 protobuf_versioned_java_library(
@@ -182,6 +180,7 @@ protobuf_java_export(
 protobuf_java_library(
     name = "lite_runtime_only",
     srcs = LITE_SRCS,
+    visibility = ["//java/kotlin:__pkg__"],
 )
 
 proto_library(

--- a/java/kotlin/BUILD.bazel
+++ b/java/kotlin/BUILD.bazel
@@ -26,7 +26,7 @@ kt_jvm_library(
     visibility = ["//visibility:public"],
     deps = [
         ":only_for_use_in_proto_generated_code_its_generator_and_tests",
-        "//java/lite",
+        "//java/core:lite_runtime_only",
     ],
 )
 
@@ -40,7 +40,7 @@ kt_jvm_library(
     name = "bytestring_lib",
     srcs = ["src/main/kotlin/com/google/protobuf/ByteStrings.kt"],
     visibility = ["//java:__subpackages__"],
-    deps = ["//java/lite"],
+    deps = ["//java/core:lite_runtime_only"],
 )
 
 kt_jvm_library(
@@ -116,7 +116,7 @@ kt_jvm_library(
     srcs = ["src/test/kotlin/com/google/protobuf/ByteStringsTest.kt"],
     deps = [
         ":bytestring_lib",
-        "//java/lite",
+        "//java/core:lite_runtime_only",
         "@protobuf_maven//:com_google_truth_truth",
         "@protobuf_maven//:junit_junit",
         "@rules_kotlin//kotlin/compiler:kotlin-test",


### PR DESCRIPTION
Because we build lite and core totally separately, they can't both be depended on without producing conflicts.  Our kotlin setup has been doing exactly this for a long time though, in order to share code between kotlin and kotlin-lite.  Even *with* this change, it's invalid to depend on both lite and core, because they contain different builds of our boostrapped protos.  However, they now share the internal `lite_runtime_only` target, which kotlin can reuse to share code.

This prevents `lite` from getting linked into kotlin, allowing kt_jvm_export to properly strip out all classes from the Java runtime.

Fixes #20566

PiperOrigin-RevId: 734375729