### PR TITLE
Re-add `system_python` repo alias to MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -67,6 +67,11 @@ python = use_extension("@rules_python//python/extensions:python.bzl", "python")
     for python_version in SUPPORTED_PYTHON_VERSIONS
 ]
 
+use_repo(
+    python,
+    system_python = "python_{}".format(SUPPORTED_PYTHON_VERSIONS[-1].replace(".", "_")),
+)
+
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
 
 [


### PR DESCRIPTION
PiperOrigin-RevId: 735391105

Note this is still not fully functional in bzlmod for most usage of system_python (e.g. for //python/dist and python c++ / upb implementations) but is sufficient for use of //python:proto_api reported internally.