### PR TITLE
Fix Java concurrency issue in feature resolution for old <=3.25.x gen…

### DIFF
--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -533,6 +533,7 @@ LITE_TEST_EXCLUSIONS = [
     "src/test/java/com/google/protobuf/CodedInputStreamTest.java",
     "src/test/java/com/google/protobuf/DeprecatedFieldTest.java",
     "src/test/java/com/google/protobuf/DebugFormatTest.java",
+    "src/test/java/com/google/protobuf/ConcurrentDescriptorsTest.java",
     "src/test/java/com/google/protobuf/DescriptorsTest.java",
     "src/test/java/com/google/protobuf/DiscardUnknownFieldsTest.java",
     "src/test/java/com/google/protobuf/DynamicMessageTest.java",

--- a/java/core/src/main/java/com/google/protobuf/Descriptors.java
+++ b/java/core/src/main/java/com/google/protobuf/Descriptors.java
@@ -537,6 +537,7 @@ public final class Descriptors {
     private final FileDescriptor[] dependencies;
     private final FileDescriptor[] publicDependencies;
     private final DescriptorPool pool;
+    private boolean featuresResolved;
 
     private FileDescriptor(
         final FileDescriptorProto proto,
@@ -547,6 +548,7 @@ public final class Descriptors {
       this.pool = pool;
       this.proto = proto;
       this.dependencies = dependencies.clone();
+      this.featuresResolved = false;
       HashMap<String, FileDescriptor> nameToFileMap = new HashMap<>();
       for (FileDescriptor file : dependencies) {
         nameToFileMap.put(file.getName(), file);
@@ -618,6 +620,7 @@ public final class Descriptors {
               .build();
       this.dependencies = new FileDescriptor[0];
       this.publicDependencies = new FileDescriptor[0];
+      this.featuresResolved = false;
 
       messageTypes = new Descriptor[] {message};
       enumTypes = EMPTY_ENUM_DESCRIPTORS;
@@ -641,12 +644,12 @@ public final class Descriptors {
      * and all of its children.
      */
     private void resolveAllFeaturesInternal() throws DescriptorValidationException {
-      if (this.features != null) {
+      if (this.featuresResolved) {
         return;
       }
 
       synchronized (this) {
-        if (this.features != null) {
+        if (this.featuresResolved) {
           return;
         }
         resolveFeatures(proto.getOptions().getFeatures());
@@ -666,6 +669,7 @@ public final class Descriptors {
         for (FieldDescriptor extension : extensions) {
           extension.resolveAllFeatures();
         }
+        this.featuresResolved = true;
       }
     }
 
@@ -2934,10 +2938,7 @@ public final class Descriptors {
       }
       if (this.features == null) {
         throw new NullPointerException(
-            String.format(
-                "Features not yet loaded for %s. This may be caused by a known issue for proto2"
-                    + " dependency descriptors obtained from proto1 (b/362326130)",
-                getFullName()));
+            String.format("Features not yet loaded for %s.", getFullName()));
       }
       return this.features;
     }

--- a/java/core/src/test/java/com/google/protobuf/ConcurrentDescriptorsTest.java
+++ b/java/core/src/test/java/com/google/protobuf/ConcurrentDescriptorsTest.java
@@ -1,0 +1,113 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2025 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package com.google.protobuf;
+
+import proto2_unittest.UnittestProto;
+import proto2_unittest.UnittestProto.TestAllTypes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ConcurrentDescriptorsTest {
+  public static final int N = 1000;
+
+  static class Worker implements Runnable {
+    private final CountDownLatch startSignal;
+    private final CountDownLatch doneSignal;
+    private final Runnable trigger;
+
+    Worker(CountDownLatch startSignal, CountDownLatch doneSignal, Runnable trigger) {
+      this.startSignal = startSignal;
+      this.doneSignal = doneSignal;
+      this.trigger = trigger;
+    }
+
+    @Override
+    public void run() {
+      try {
+        startSignal.await();
+        trigger.run();
+      } catch (InterruptedException | RuntimeException e) {
+        doneSignal.countDown();
+        throw new RuntimeException(e); // Rethrow for main thread to handle
+      }
+      doneSignal.countDown();
+    }
+  }
+
+  @Test
+  public void testSimultaneousStaticInit() throws InterruptedException {
+    ExecutorService executor = Executors.newFixedThreadPool(N);
+    CountDownLatch startSignal = new CountDownLatch(1);
+    CountDownLatch doneSignal = new CountDownLatch(N);
+    List<Future<?>> futures = new ArrayList<>(N);
+    for (int i = 0; i < N; i++) {
+      Future<?> future =
+          executor.submit(
+              new Worker(
+                  startSignal,
+                  doneSignal,
+                  // Static method invocation triggers static initialization.
+                  () -> Assert.assertNotNull(UnittestProto.getDescriptor())));
+      futures.add(future);
+    }
+    startSignal.countDown();
+    doneSignal.await();
+    System.out.println("Done with all threads...");
+    for (int i = 0; i < futures.size(); i++) {
+      try {
+        futures.get(i).get();
+      } catch (ExecutionException e) {
+        Assert.fail("Thread " + i + " failed with:" + e.getMessage());
+      }
+    }
+    executor.shutdown();
+  }
+
+  @Test
+  public void testSimultaneousFeatureAccess() throws InterruptedException {
+    ExecutorService executor = Executors.newFixedThreadPool(N);
+    CountDownLatch startSignal = new CountDownLatch(1);
+    CountDownLatch doneSignal = new CountDownLatch(N);
+    List<Future<?>> futures = new ArrayList<>(N);
+    for (int i = 0; i < N; i++) {
+      Future<?> future =
+          executor.submit(
+              new Worker(
+                  startSignal,
+                  doneSignal,
+                  // hasPresence() uses the [field_presence] feature.
+                  () ->
+                      Assert.assertTrue(
+                          TestAllTypes.getDescriptor()
+                              .findFieldByName("optional_int32")
+                              .hasPresence())));
+      futures.add(future);
+    }
+    startSignal.countDown();
+    doneSignal.await();
+    System.out.println("Done with all threads...");
+    for (int i = 0; i < futures.size(); i++) {
+      try {
+        futures.get(i).get();
+      } catch (ExecutionException e) {
+        Assert.fail("Thread " + i + " failed with:" + e.getMessage());
+      }
+    }
+    executor.shutdown();
+  }
+}


### PR DESCRIPTION
…code using lazy feature resolution.

This should not impact current gencode from >=4.x.x which resolves features in static init.

Fixes https://github.com/protocolbuffers/protobuf/issues/20599

PiperOrigin-RevId: 738467326

Cherry-pick of fafb0fd