### PR TITLE
Add protobuf_maven artifacts to protobuf_maven_dev as well so they ca…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -85,16 +85,18 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_depen
 
 use_repo(pip, "protobuf_pip_deps")
 
+PROTOBUF_MAVEN_ARTIFACTS = [
+    "com.google.code.findbugs:jsr305:3.0.2",
+    "com.google.code.gson:gson:2.8.9",
+    "com.google.errorprone:error_prone_annotations:2.5.1",
+    "com.google.j2objc:j2objc-annotations:2.8",
+    "com.google.guava:guava:32.0.1-jre",
+]
+
 protobuf_maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 protobuf_maven.install(
     name = "protobuf_maven",
-    artifacts = [
-        "com.google.code.findbugs:jsr305:3.0.2",
-        "com.google.code.gson:gson:2.8.9",
-        "com.google.errorprone:error_prone_annotations:2.5.1",
-        "com.google.j2objc:j2objc-annotations:2.8",
-        "com.google.guava:guava:32.0.1-jre",
-    ],
+    artifacts = PROTOBUF_MAVEN_ARTIFACTS,
     repositories = [
         "https://repo1.maven.org/maven2",
         "https://repo.maven.apache.org/maven2",
@@ -106,7 +108,7 @@ use_repo(protobuf_maven, "protobuf_maven")
 protobuf_maven_dev = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
 protobuf_maven_dev.install(
     name = "protobuf_maven_dev",
-    artifacts = [
+    artifacts = PROTOBUF_MAVEN_ARTIFACTS + [
         "com.google.caliper:caliper:1.0-beta-3",
         "com.google.guava:guava-testlib:32.0.1-jre",
         "com.google.testparameterinjector:test-parameter-injector:1.18",

--- a/java/util/BUILD.bazel
+++ b/java/util/BUILD.bazel
@@ -34,11 +34,11 @@ protobuf_versioned_java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//java/core",
-        "@protobuf_maven_dev//:com_google_code_findbugs_jsr305",
-        "@protobuf_maven_dev//:com_google_code_gson_gson",
-        "@protobuf_maven_dev//:com_google_errorprone_error_prone_annotations",
-        "@protobuf_maven_dev//:com_google_guava_guava",
-        "@protobuf_maven_dev//:com_google_j2objc_j2objc_annotations",
+        "@protobuf_maven//:com_google_code_findbugs_jsr305",
+        "@protobuf_maven//:com_google_code_gson_gson",
+        "@protobuf_maven//:com_google_errorprone_error_prone_annotations",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:com_google_j2objc_j2objc_annotations",
     ],
 )
 


### PR DESCRIPTION
…n still be referenced correctly using the dev namespace for dev-only targets.

Otherwise, protobuf_maven_dev may provide a different version from a transitive dep, which can result in the wrong version being selected (e.g. when used for bazel-generated maven artifacts).

Also updates protobuf_util_bundle to use protobuf_maven instead of protobuf_maven_dev which is probably more appropriate since its control the deps in the pom.xml file for maven users (though this is functionally the same rn).

Fixes https://github.com/protocolbuffers/protobuf/issues/20710

PiperOrigin-RevId: 738887165

Cherry-pick of f4713e28c67a0455dbcb0812645e7cb2c7e8035e