### PR TITLE
Restore JDK8 compatibility in Bazel for libraries with dependencies f…

### DIFF
--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -34,8 +34,7 @@ jobs:
             # TODO: b/318555165 - enable the layering check. Currently it does
             # not work correctly with the toolchain in this Docker image.
             targets: //java/... //java/internal:java_version //compatibility/... --features=-layering_check
-            # TODO: b/393604460 - enable bzlmod once coursier error is fixed.
-            flags: --java_language_version=8 --noenable_bzlmod
+            flags: --java_language_version=8
           - name: OpenJDK 11
             cache_key: '11'
             image: us-docker.pkg.dev/protobuf-build/containers/test/linux/java:7.1.2-11-d9624f2aa83cba3eaf906f751d75b36aacb9aa82

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -97,6 +97,7 @@ protobuf_maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 protobuf_maven.install(
     name = "protobuf_maven",
     artifacts = PROTOBUF_MAVEN_ARTIFACTS,
+    lock_file = "//:maven_install.json",
     repositories = [
         "https://repo1.maven.org/maven2",
         "https://repo.maven.apache.org/maven2",
@@ -118,6 +119,7 @@ protobuf_maven_dev.install(
         "biz.aQute.bnd:biz.aQute.bndlib:6.4.0",
         "info.picocli:picocli:4.6.3",
     ],
+    lock_file = "//:maven_dev_install.json",
     repositories = [
         "https://repo1.maven.org/maven2",
         "https://repo.maven.apache.org/maven2",


### PR DESCRIPTION
…rom Maven (e.g. //java/util)

Adds lock_files to MODULE.bazel for maven dependencies to bypass rules_jvm_external's use of coursier to resolve dependency which is no longer JDK 8 compatible.

```
ERROR: An error occurred during the fetch of repository 'rules_jvm_external~~maven~protobuf_maven':
   Traceback (most recent call last):
	File "/workspace/_build/out/external/rules_jvm_external~/private/rules/coursier.bzl", line 993, column 38, in _coursier_fetch_impl
		dep_tree = make_coursier_dep_tree(
	File "/workspace/_build/out/external/rules_jvm_external~/private/rules/coursier.bzl", line 926, column 13, in make_coursier_dep_tree
		fail("Error while fetching artifact with coursier: " + exec_result.stderr)
Error in fail: Error while fetching artifact with coursier: Error: Could not find or load main class @.workspace._build.out.external.rules_jvm_external~~maven~protobuf_maven.java_argsfile
ERROR: <builtin>: fetching coursier_fetch rule //:rules_jvm_external~~maven~protobuf_maven: Traceback (most recent call last):
	File "/workspace/_build/out/external/rules_jvm_external~/private/rules/coursier.bzl", line 993, column 38, in _coursier_fetch_impl
		dep_tree = make_coursier_dep_tree(
	File "/workspace/_build/out/external/rules_jvm_external~/private/rules/coursier.bzl", line 926, column 13, in make_coursier_dep_tree
		fail("Error while fetching artifact with coursier: " + exec_result.stderr)
Error in fail: Error while fetching artifact with coursier: Error: Could not find or load main class @.workspace._build.out.external.rules_jvm_external~~maven~protobuf_maven.java_argsfile
ERROR: no such package '@@rules_jvm_external~~maven~protobuf_maven//': Error while fetching artifact with coursier: Error: Could not find or load main class @.workspace._build.out.external.rules_jvm_external~~maven~protobuf_maven.java_argsfile
ERROR: /workspace/java/util/BUILD.bazel:9:13: //java/util:util depends on @@rules_jvm_external~~maven~protobuf_maven//:com_google_j2objc_j2objc_annotations in repository @@rules_jvm_external~~maven~protobuf_maven which failed to fetch. no such package '@@rules_jvm_external~~maven~protobuf_maven//': Error while fetching artifact with coursier: Error: Could not find or load main class @.workspace._build.out.external.rules_jvm_external~~maven~protobuf_maven.java_argsfile
ERROR: Analysis of target '//java/util:util' failed; build aborted: Analysis failed
```
PiperOrigin-RevId: 739323125