### PR TITLE
reserve new extensions for aep.dev

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -536,3 +536,8 @@ with info about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/open-toast/protokt
     *   Extensions: 1253-1263
+
+1.  aep.dev Extensions
+
+    *   Website: https://github.com/aep-dev
+    *   Extensions: 1264-1274


### PR DESCRIPTION
We'd like to add a new extension (1264), but would like to reserve 10 for future additions, which should make this a one-time request.

Thank you!