### PR TITLE
Fix lite classes in the protobuf-java Maven release to be JDK8 compat…

### DIFF
--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -147,6 +147,7 @@ java_library(
     deps = [":lite_runtime_only"],
 )
 
+# Bazel users, don't depend on this target, use //java/lite.
 protobuf_versioned_java_library(
     name = "lite_bundle",
     srcs = LITE_SRCS + [
@@ -268,22 +269,17 @@ java_library(
     ],
 )
 
+# Bazel users, don't depend on this target, use :core.
 protobuf_versioned_java_library(
     name = "core_bundle",
-    srcs = FULL_SRCS,
+    srcs = FULL_SRCS + LITE_SRCS,
     automatic_module_name = "com.google.protobuf",
     bundle_description = "Core Protocol Buffers library. Protocol Buffers " +
                          "are a way of encoding structured data in an " +
                          "efficient yet extensible format.",
     bundle_name = "Protocol Buffers [Core]",
     bundle_symbolic_name = "com.google.protobuf",
-    visibility = ["//visibility:public"],
-    exports = [
-        ":lite_runtime_only",
-    ],
-    deps = [
-        ":lite_runtime_only",
-    ],
+    visibility = ["//visibility:private"],
 )
 
 # Bazel users, don't depend on this target, use :core.


### PR DESCRIPTION
…ible.

Adds LITE_SRCS to core_bundle which seems to be sufficient to ensure these are compiled targeting Java 8 in //java/core:core_mvn Bazel 7. Note this changes the output of `//java/core:core_bundle`, which should only be used for `//java/core:core_mvn` anyways.

This seems to have been broken originally by commit (https://github.com/protocolbuffers/protobuf/commit/c820dd0ca69b19b142fc9d8a6635530b5a5fc93b) when using bazel 7 image.

Fixes https://github.com/protocolbuffers/protobuf/issues/20580

PiperOrigin-RevId: 740372071

Cherry-pick 47b60e9d405076a3ff3abe00ddce70a578923985