### PR TITLE
Re-enable aarch64 tests.

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -100,8 +100,7 @@ jobs:
     strategy:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
-        # TODO: Re-enable once aarch64 is fixed.
-        arch: [x86_64]
+        arch: [x86_64, aarch64]
     name: Linux Release ${{ matrix.arch }}
     runs-on: ubuntu-22-4core
     steps:

--- a/.github/workflows/test_php.yml
+++ b/.github/workflows/test_php.yml
@@ -139,43 +139,42 @@ jobs:
             composer update --ignore-platform-reqs;
             composer ${{ matrix.test }}'
 
-  # TODO: Re-enable once aarch64 is fixed.
-  # linux-aarch64:
-  #   name: Linux aarch64
-  #   runs-on: ubuntu-22-4core
-  #   steps:
-  #     - name: Checkout pending changes
-  #       uses: protocolbuffers/protobuf-ci/checkout@v4
-  #       with:
-  #         ref: ${{ inputs.safe-checkout }}
-  #
-  #     - name: Cross compile protoc for aarch64
-  #       id: cross-compile
-  #       uses: protocolbuffers/protobuf-ci/cross-compile-protoc@v4
-  #       with:
-  #         image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:6.4.0-cf84e92285ca133b9c8104ad7b14d70e953cbb8e
-  #         credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
-  #         architecture: linux-aarch64
-  #
-  #     - name: Setup composer
-  #       uses: protocolbuffers/protobuf-ci/composer-setup@v4
-  #       with:
-  #         cache-prefix: php-8.1
-  #         directory: php
-  #
-  #     - name: Run tests
-  #       uses: protocolbuffers/protobuf-ci/docker@v4
-  #       with:
-  #         image: us-docker.pkg.dev/protobuf-build/containers/test/linux/php-aarch64@sha256:77ff9fdec867bbfb290ee0b10d8b7a3e5e434155daa5ec93de7341c7592b858d
-  #         platform: linux/arm64
-  #         credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
-  #         extra-flags: -e COMPOSER_HOME=/workspace/composer-cache -e PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }}
-  #         command: >-
-  #           -c '
-  #           cd php;
-  #           composer update --ignore-platform-reqs;
-  #           composer test;
-  #           composer test_c'
+  linux-aarch64:
+    name: Linux aarch64
+    runs-on: ubuntu-22-4core
+    steps:
+      - name: Checkout pending changes
+        uses: protocolbuffers/protobuf-ci/checkout@v4
+        with:
+          ref: ${{ inputs.safe-checkout }}
+
+      - name: Cross compile protoc for aarch64
+        id: cross-compile
+        uses: protocolbuffers/protobuf-ci/cross-compile-protoc@v4
+        with:
+          image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:7.1.2-bec4e87effd62da1d4f9a13d377e37bcb80376c9
+          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          architecture: linux-aarch64
+
+      - name: Setup composer
+        uses: protocolbuffers/protobuf-ci/composer-setup@v4
+        with:
+          cache-prefix: php-8.1
+          directory: php
+
+      - name: Run tests
+        uses: protocolbuffers/protobuf-ci/docker@v4
+        with:
+          image: us-docker.pkg.dev/protobuf-build/containers/test/linux/php-aarch64@sha256:77ff9fdec867bbfb290ee0b10d8b7a3e5e434155daa5ec93de7341c7592b858d
+          platform: linux/arm64
+          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          extra-flags: -e COMPOSER_HOME=/workspace/composer-cache -e PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }}
+          command: >-
+            -cex '
+            cd php;
+            composer update --ignore-platform-reqs;
+            composer test;
+            composer test_c'
 
   macos:
     strategy:

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -95,37 +95,36 @@ jobs:
             rake clobber_package gem;
             PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }} rake test'
 
-  # TODO: Re-enable once aarch64 is fixed.
-  # linux-aarch64:
-  #   name: Linux aarch64
-  #   runs-on: ubuntu-22-4core
-  #   steps:
-  #     - name: Checkout pending changes
-  #       uses: protocolbuffers/protobuf-ci/checkout@v4
-  #       with:
-  #         ref: ${{ inputs.safe-checkout }}
-  #
-  #     - name: Cross compile protoc for aarch64
-  #       id: cross-compile
-  #       uses: protocolbuffers/protobuf-ci/cross-compile-protoc@v4
-  #       with:
-  #         image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:6.4.0-cf84e92285ca133b9c8104ad7b14d70e953cbb8e
-  #         credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
-  #         architecture: linux-aarch64
-  #
-  #     - name: Run tests
-  #       uses: protocolbuffers/protobuf-ci/docker@v4
-  #       with:
-  #         image: arm64v8/ruby:3.0.2-buster
-  #         credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
-  #         command: >-
-  #           /bin/bash -cex '
-  #           gem install bundler -v 2.5.13;
-  #           cd /workspace/ruby;
-  #           bundle;
-  #           PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }} rake;
-  #           rake clobber_package gem;
-  #           PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }} rake test'
+  linux-aarch64:
+    name: Linux aarch64
+    runs-on: ubuntu-22-4core
+    steps:
+      - name: Checkout pending changes
+        uses: protocolbuffers/protobuf-ci/checkout@v4
+        with:
+          ref: ${{ inputs.safe-checkout }}
+
+      - name: Cross compile protoc for aarch64
+        id: cross-compile
+        uses: protocolbuffers/protobuf-ci/cross-compile-protoc@v4
+        with:
+          image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:6.4.0-cf84e92285ca133b9c8104ad7b14d70e953cbb8e
+          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          architecture: linux-aarch64
+
+      - name: Run tests
+        uses: protocolbuffers/protobuf-ci/docker@v4
+        with:
+          image: arm64v8/ruby:3.0.2-buster
+          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          command: >-
+            /bin/bash -cex '
+            gem install bundler -v 2.5.13;
+            cd /workspace/ruby;
+            bundle;
+            PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }} rake;
+            rake clobber_package gem;
+            PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }} rake test'
 
   macos:
     strategy:


### PR DESCRIPTION
These were broken by a QEMU bug that appears to have been broken by a recent hardening added to the ubuntu kernel rolled out to the github runner images.

See https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2096782 and https://github.com/tonistiigi/binfmt/issues/215 for more information.

PiperOrigin-RevId: 740819705