### PR TITLE
Re-enable aarch64 tests.

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false   # Don't cancel all jobs if one fails.
       matrix:
-        arch: [x86_64]
+        arch: [x86_64, aarch64]
     name: Linux Release ${{ matrix.arch }}
     runs-on: ubuntu-20-4core
     steps:

--- a/.github/workflows/test_php.yml
+++ b/.github/workflows/test_php.yml
@@ -148,6 +148,43 @@ jobs:
             composer update --ignore-platform-reqs;
             composer ${{ matrix.test }}'
 
+  linux-aarch64:
+    name: Linux aarch64
+    runs-on: ubuntu-22-4core
+    steps:
+      - name: Checkout pending changes
+        uses: protocolbuffers/protobuf-ci/checkout@v4
+        with:
+          ref: ${{ inputs.safe-checkout }}
+
+      - name: Cross compile protoc for aarch64
+        id: cross-compile
+        uses: protocolbuffers/protobuf-ci/cross-compile-protoc@v4
+        with:
+          image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:7.1.2-bec4e87effd62da1d4f9a13d377e37bcb80376c9
+          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          architecture: linux-aarch64
+
+      - name: Setup composer
+        uses: protocolbuffers/protobuf-ci/composer-setup@v4
+        with:
+          cache-prefix: php-8.1
+          directory: php
+
+      - name: Run tests
+        uses: protocolbuffers/protobuf-ci/docker@v4
+        with:
+          image: us-docker.pkg.dev/protobuf-build/containers/test/linux/php-aarch64@sha256:77ff9fdec867bbfb290ee0b10d8b7a3e5e434155daa5ec93de7341c7592b858d
+          platform: linux/arm64
+          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          extra-flags: -e COMPOSER_HOME=/workspace/composer-cache -e PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }}
+          command: >-
+            -cex '
+            cd php;
+            composer update --ignore-platform-reqs;
+            composer test;
+            composer test_c'
+
   macos:
     strategy:
       fail-fast: false   # Don't cancel all jobs if one fails.

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -96,6 +96,37 @@ jobs:
             rake clobber_package gem;
             PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }} rake test'
 
+  linux-aarch64:
+    name: Linux aarch64
+    runs-on: ubuntu-22-4core
+    steps:
+      - name: Checkout pending changes
+        uses: protocolbuffers/protobuf-ci/checkout@v4
+        with:
+          ref: ${{ inputs.safe-checkout }}
+
+      - name: Cross compile protoc for aarch64
+        id: cross-compile
+        uses: protocolbuffers/protobuf-ci/cross-compile-protoc@v4
+        with:
+          image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:7.1.2-cf84e92285ca133b9c8104ad7b14d70e953cbb8e
+          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          architecture: linux-aarch64
+
+      - name: Run tests
+        uses: protocolbuffers/protobuf-ci/docker@v4
+        with:
+          image: arm64v8/ruby:3.1.4-buster
+          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          command: >-
+            /bin/bash -cex '
+            gem install bundler -v 2.6.6;
+            cd /workspace/ruby;
+            bundle;
+            PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }} rake;
+            rake clobber_package gem;
+            PROTOC=/workspace/${{ steps.cross-compile.outputs.protoc }} rake test'
+
   macos:
     strategy:
       fail-fast: false   # Don't cancel all jobs if one fails.


### PR DESCRIPTION
These were broken by a QEMU bug that appears to have been broken by a recent hardening added to the ubuntu kernel rolled out to the github runner images.

PiperOrigin-RevId: 740819705