### PR TITLE
[Ruby]Implement `#to_hash` for message classes

### DIFF
--- a/ruby/lib/google/protobuf/message_exts.rb
+++ b/ruby/lib/google/protobuf/message_exts.rb
@@ -25,6 +25,10 @@ module Google
         self.class.encode(self, options)
       end
 
+      def to_hash
+        self.to_h
+      end
+
     end
     class AbstractMessage
       include MessageExts

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -496,6 +496,16 @@ module BasicTest
       assert_equal expected_result, m.to_h
     end
 
+    def test_to_hash
+      m = TestMessage.new(
+        :optional_bool => true,
+        :optional_double => -10.100001,
+        :optional_string => 'foo',
+        :repeated_string => ['bar1', 'bar2'],
+        :repeated_msg => [TestMessage2.new(:foo => 100)]
+      )
+      assert_equal m.to_hash, m.to_h
+    end
 
     def test_json_maps
       m = MapMessage.new(:map_string_int32 => {"a" => 1})


### PR DESCRIPTION
In Ruby, `#to_hash` is used for implicit conversion. https://bugs.ruby-lang.org/issues/10180

For example, Active Support uses `#to_hash` when converting an object to JSON. https://github.com/rails/rails/blob/621aa49cefce3313fbc672e2f3681103da686a0e/activesupport/lib/active_support/core_ext/object/json.rb#L60

This PR adds `#to_hash` as the alias of `#to_h`. This allows message objects to convert implicitly to other formats correctly.

Fixes #17037