### PR TITLE
Add basic bzlmod support to 25.x branch

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,2 +1,32 @@
 # TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
 # https://github.com/protocolbuffers/protobuf/issues/14313
+
+module(
+    name = "com_google_protobuf",
+    version = "25.7-dev",
+    compatibility_level = 1,
+    repo_name = "com_google_protobuf",
+)
+
+# LOWER BOUND dependency versions.
+# Bzlmod follows MVS:
+# https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
+# Thus the highest version in their module graph is resolved.
+bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "jsoncpp", version = "1.9.5")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_jvm_external", version = "5.1")
+bazel_dep(name = "rules_pkg", version = "0.7.0")
+bazel_dep(name = "rules_python", version = "0.10.2")
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "zlib", version = "1.2.11")
+
+# TODO: remove after toolchain types are moved to protobuf
+bazel_dep(name = "rules_proto", version = "4.0.0")
+
+# Do not take the effort to convert utf8_range to Bzlmod as this has been moved to protobuf/third_party
+# See https://github.com/protocolbuffers/utf8_range/commit/1d1ea7e3fedf482d4a12b473c1ed25fe0f371a45
+non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
+use_repo(non_module_deps, "utf8_range")

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,0 +1,10 @@
+bazel_dep(name = "rules_cc", version = "0.0.1")
+bazel_dep(name = "rules_proto", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "7.3.0")
+bazel_dep(name = "rules_pkg", version = "0.7.0")
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf")
+
+local_path_override(
+    module_name = "protobuf",
+    path = "..",
+)

--- a/non_module_deps.bzl
+++ b/non_module_deps.bzl
@@ -1,0 +1,19 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def _github_archive(repo, commit, **kwargs):
+    repo_name = repo.split("/")[-1]
+    http_archive(
+        urls = [repo + "/archive/" + commit + ".zip"],
+        strip_prefix = repo_name + "-" + commit,
+        **kwargs
+    )
+
+def _non_module_deps_impl(ctx):
+    _github_archive(
+        name = "utf8_range",
+        repo = "https://github.com/protocolbuffers/utf8_range",
+        commit = "de0b4a8ff9b5d4c98108bdfe723291a33c52c54f",
+        sha256 = "5da960e5e5d92394c809629a03af3c7709d2d3d0ca731dacb3a9fb4bf28f7702",
+    )
+
+non_module_deps = module_extension(implementation = _non_module_deps_impl)

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -493,8 +493,8 @@ def internal_ruby_proto_library(
         srcs = [],
         deps = [],
         includes = ["."],
-        default_runtime = "@com_google_protobuf//ruby:protobuf",
-        protoc = "@com_google_protobuf//:protoc",
+        default_runtime = "//ruby:protobuf",
+        protoc = "//:protoc",
         testonly = None,
         visibility = ["//visibility:public"],
         **kwargs):


### PR DESCRIPTION
This change just applies the [patches](https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/protobuf/25.6/patches) from BCR, with the exception of the `rules_ruby` patch which has already landed on 25.x. I also updated the version in `MODULE.bazel` to `25.7-dev`.