### PR TITLE
Cherry-pick fix for empty map check crash to 30.x

### DIFF
--- a/python/google/protobuf/internal/well_known_types_test.py
+++ b/python/google/protobuf/internal/well_known_types_test.py
@@ -683,6 +683,11 @@ class TimeUtilTest(TimeUtilTestBase):
 
 class StructTest(unittest.TestCase):
 
+  def testEmptyDict(self):
+    # in operator for empty initialized struct
+    msg = well_known_types_test_pb2.WKTMessage(optional_struct={})
+    self.assertNotIn('key', msg.optional_struct)
+
   def testStruct(self):
     struct = struct_pb2.Struct()
     self.assertIsInstance(struct, collections_abc.Mapping)

--- a/python/message.c
+++ b/python/message.c
@@ -1110,6 +1110,7 @@ static PyObject* PyUpb_Message_Contains(PyObject* _self, PyObject* arg) {
       upb_Message* msg = PyUpb_Message_GetMsg(self);
       const upb_FieldDef* f = upb_MessageDef_FindFieldByName(msgdef, "fields");
       const upb_Map* map = upb_Message_GetFieldByDef(msg, f).map_val;
+      if (!map || upb_Map_Size(map) == 0) Py_RETURN_FALSE;
       const upb_MessageDef* entry_m = upb_FieldDef_MessageSubDef(f);
       const upb_FieldDef* key_f = upb_MessageDef_Field(entry_m, 0);
       upb_MessageValue u_key;


### PR DESCRIPTION
Cherry-pick #20446 to the 30.x branch. This is a fix for a crash on valid input, so I think it merits being cherry-picked to supported stable release branches.