### PR TITLE
Ruby | Add support for a protobuf debug build

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -89,6 +89,12 @@ Then build the Gem:
     $ rake clobber_package gem
     $ gem install `ls pkg/google-protobuf-*.gem`
 
+If you intend to debug the protobuf_c Ruby bindings with `gdb`, you can also
+build a version with debug symbols enabled by setting the `PROTOBUF_CONFIG`
+enviroment variable when you build the native extension:
+
+    $ PROTOBUF_CONFIG=dbg rake
+
 To run the specs:
 
     $ rake test

--- a/ruby/ext/google/protobuf_c/extconf.rb
+++ b/ruby/ext/google/protobuf_c/extconf.rb
@@ -18,10 +18,14 @@ if ENV["LD"]
   RbConfig::CONFIG["LD"] = RbConfig::MAKEFILE_CONFIG["LD"] = ENV["LD"]
 end
 
+debug_enabled = ENV["PROTOBUF_CONFIG"] == "dbg"
+
+additional_c_flags = debug_enabled ? "-O0 -fno-omit-frame-pointer -fvisibility=default -g" : "-O3 -DNDEBUG -fvisibility=hidden"
+
 if RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/ || RUBY_PLATFORM =~ /freebsd/
-  $CFLAGS += " -std=gnu99 -O3 -DNDEBUG -fvisibility=hidden -Wall -Wsign-compare -Wno-declaration-after-statement"
+  $CFLAGS += " -std=gnu99 -Wall -Wsign-compare -Wno-declaration-after-statement #{additional_c_flags}"
 else
-  $CFLAGS += " -std=gnu99 -O3 -DNDEBUG"
+  $CFLAGS += " -std=gnu99 #{additional_c_flags}"
 end
 
 if RUBY_PLATFORM =~ /linux/


### PR DESCRIPTION
This PR makes a small change to `extconf.rb` so we can easily build the `protobuf_c` Ruby bindings with all debug symbols included.  We used [grpc](https://github.com/grpc/grpc/blob/master/src/ruby/ext/grpc/extconf.rb) as a guide, which will produce a debug build if `rake` is run with `GRPC_CONFIG=dbg`.  Unlike `grpc`, the `protobuf_c` build doesn't explicitly strip symbols from the resulting library, but values will be optimized out when stepping through with `gdb`.