### PR TITLE
Remove upper bound from Guava import

### DIFF
--- a/java/util/BUILD.bazel
+++ b/java/util/BUILD.bazel
@@ -28,6 +28,7 @@ protobuf_versioned_java_library(
         "src/main/java/com/google/protobuf/util/*.java",
     ]),
     automatic_module_name = "com.google.protobuf.util",
+    bundle_additional_imports = ["com.google.common.*;version=\"${@}\""],
     bundle_description = "Utilities for Protocol Buffers",
     bundle_name = "Protocol Buffers [Util]",
     bundle_symbolic_name = "com.google.protobuf.util",


### PR DESCRIPTION
This removes the upper bound version range from the Guava package imports, which increases support for other Guava versions in the OSGi world.

Fixes #21173.