### PR TITLE
fix(php): update composer.json.dist

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -14,6 +14,9 @@
   "require-dev": {
     "phpunit/phpunit": ">=5.0.0 <8.5.27"
   },
+  "suggest": {
+    "ext-bcmath": "Need to support JSON deserialization"
+  },
   "autoload": {
     "psr-4": {
       "Google\\Protobuf\\": "src/Google/Protobuf",

--- a/php/composer.json.dist
+++ b/php/composer.json.dist
@@ -6,10 +6,13 @@
   "homepage": "https://developers.google.com/protocol-buffers/",
   "license": "BSD-3-Clause",
   "require": {
-    "php": ">=7.0.0"
+    "php": ">=8.1.0"
+  },
+  "provide": {
+    "ext-protobuf": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=5.0.0"
+    "phpunit/phpunit": ">=5.0.0 <8.5.27"
   },
   "suggest": {
     "ext-bcmath": "Need to support JSON deserialization"
@@ -21,3 +24,4 @@
     }
   }
 }
+

--- a/php/tests/ComposerJsonTest.php
+++ b/php/tests/ComposerJsonTest.php
@@ -1,0 +1,18 @@
+<?php
+
+require_once('test_base.php');
+require_once('test_util.php');
+
+class ComposerJsonTest extends TestBase
+{
+    public function testComposerJsonDistIsUpToDate()
+    {
+        $composerJson = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true);
+        $composerJsonDist = json_decode(file_get_contents(__DIR__ . '/../composer.json.dist'), true);
+
+        // We don't want the subrepo to have "scripts" or "config"
+        unset($composerJson['scripts'], $composerJson['config'], $composerJson['autoload-dev']);
+
+        $this->assertEquals($composerJson, $composerJsonDist);
+    }
+}


### PR DESCRIPTION
`php/composer.json/dist` is 3 years out of date - changes have been made to `composer.json` which were not moved to `composer.json.dist` (which corresponds to the `composer.json` in the sub-repo [here](https://github.com/protocolbuffers/protobuf-php)).

The missed changes which are being included in this PR are:

 - https://github.com/protocolbuffers/protobuf/commit/3c8a3d27f7c035e977e2eb5226e4154f129a573b
 - https://github.com/protocolbuffers/protobuf/commit/d603b4199e42d18a6ed433f47bdf8e5042900588
 - https://github.com/protocolbuffers/protobuf/commit/75cc3a2af4693f14b27c7290d7f2148c77bce3d7