### PR TITLE
Fix PHP 8.4 deprecation in GPBDecodeException

### DIFF
--- a/php/src/Google/Protobuf/Internal/GPBDecodeException.php
+++ b/php/src/Google/Protobuf/Internal/GPBDecodeException.php
@@ -14,7 +14,7 @@ class GPBDecodeException extends \Exception
     public function __construct(
         $message,
         $code = 0,
-        \Exception $previous = null)
+        ?\Exception $previous = null)
     {
         parent::__construct(
             "Error occurred during parsing: " . $message,


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameter declarations. This patch addresses an issue in `Google\Protobuf\Internal\GPBDecodeException` which triggers a deprecation warning.

The deprecation warning that's fixed is:

```
vendor/google/protobuf/src/Google/Protobuf/Internal/GPBDecodeException.php:14
Google\Protobuf\Internal\GPBDecodeException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead
```

See also: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

There are no automated tests to be added here since it simply fixes the deprecation warning.