### PR TITLE
[php][ext] Support NULL values conversion

### DIFF
--- a/php/ext/google/protobuf/convert.c
+++ b/php/ext/google/protobuf/convert.c
@@ -281,6 +281,9 @@ static bool to_double(zval* php_val, double* dbl) {
 
 static bool to_bool(zval* from, bool* to) {
   switch (Z_TYPE_P(from)) {
+    case IS_NULL:
+      *to = false;
+      return true;
     case IS_TRUE:
       *to = true;
       return true;
@@ -314,6 +317,9 @@ static bool to_string(zval* from) {
 
   switch (Z_TYPE_P(from)) {
     case IS_STRING:
+      return true;
+    case IS_NULL:
+      ZVAL_EMPTY_STRING(from);
       return true;
     case IS_TRUE:
     case IS_FALSE:

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -210,6 +210,63 @@ class GeneratedClassTest extends TestBase
     }
 
     #########################################################
+    # Test values that are converted by setter
+    #########################################################
+
+    public function testConvertValueSetter()
+    {
+        // convert null
+        $m_null = new TestMessage();
+
+        $m_null->setOptionalBool(null);
+        $m_null->setOptionalBytes(null);
+        $m_null->setOptionalString(null);
+        $m_null->setTrueOptionalBool(null);
+        $m_null->setTrueOptionalBytes(null);
+        $m_null->setTrueOptionalString(null);
+        // allow null message
+        $m_null->setOptionalMessage(null);
+        $m_null->setTrueOptionalMessage(null);
+
+        $this->assertSame(false, $m_null->getOptionalBool());
+        $this->assertSame('', $m_null->getOptionalString());
+        $this->assertSame('', $m_null->getOptionalBytes());
+        $this->assertNull($m_null->getOptionalMessage());
+
+        $this->assertSame(false, $m_null->getTrueOptionalBool());
+        $this->assertSame('', $m_null->getTrueOptionalString());
+        $this->assertSame('', $m_null->getTrueOptionalBytes());
+        $this->assertNull($m_null->getTrueOptionalMessage());
+
+        // Convert int
+        $m_number = new TestMessage();
+
+        $m_number->setOptionalBool(0);
+        $m_number->setOptionalBytes(0);
+        $m_number->setOptionalString(0);
+        $m_number->setTrueOptionalBool(1);
+        $m_number->setTrueOptionalBytes(1);
+        $m_number->setTrueOptionalString(1);
+
+        $this->assertSame(false, $m_number->getOptionalBool());
+        $this->assertSame('0', $m_number->getOptionalString());
+        $this->assertSame('0', $m_number->getOptionalBytes());
+
+        $this->assertSame(true, $m_number->getTrueOptionalBool());
+        $this->assertSame('1', $m_number->getTrueOptionalString());
+        $this->assertSame('1', $m_number->getTrueOptionalBytes());
+
+        // Convert str
+        $m_number_str = new TestMessage();
+
+        $m_number_str->setOptionalBool('');
+        $m_number_str->setTrueOptionalBool('STR');
+
+        $this->assertSame(false, $m_number_str->getOptionalBool());
+        $this->assertSame(true, $m_number_str->getTrueOptionalBool());
+    }
+
+    #########################################################
     # Test uint32 field.
     #########################################################
 


### PR DESCRIPTION
* Handle NULL values in the PHP extension's conversion functions.
* Tests that verify the behavior of converting supported types.

Should fix : https://github.com/protocolbuffers/protobuf/issues/20000