### PR TITLE
Avoid including windows.h directly in time_util

### DIFF
--- a/src/google/protobuf/io/BUILD.bazel
+++ b/src/google/protobuf/io/BUILD.bazel
@@ -212,6 +212,7 @@ cc_test(
         "//src/google/protobuf/stubs",
         "//src/google/protobuf/testing",
         "//src/google/protobuf/testing:file",
+        "//src/google/protobuf/util:internal_timeval",
         "@abseil-cpp//absl/base",
         "@abseil-cpp//absl/base:core_headers",
         "@abseil-cpp//absl/base:log_severity",

--- a/src/google/protobuf/io/zero_copy_stream_unittest.cc
+++ b/src/google/protobuf/io/zero_copy_stream_unittest.cc
@@ -57,6 +57,7 @@
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/io_win32.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "google/protobuf/util/internal_timeval.h"     // IWYU pragma: keep for timeval
 #include "google/protobuf/port.h"
 #include "google/protobuf/test_util2.h"
 

--- a/src/google/protobuf/util/BUILD.bazel
+++ b/src/google/protobuf/util/BUILD.bazel
@@ -151,6 +151,14 @@ cc_test(
 )
 
 cc_library(
+    name = "internal_timeval",
+    hdrs = ["internal_timeval.h"],
+    copts = COPTS,
+    strip_include_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+)
+
+cc_library(
     name = "json_util",
     hdrs = ["json_util.h"],
     copts = COPTS,
@@ -169,6 +177,7 @@ cc_library(
         "//visibility:public",
     ],
     deps = [
+        ":internal_timeval",
         "//src/google/protobuf",
         "//src/google/protobuf:duration_cc_proto",
         "//src/google/protobuf:port",
@@ -186,6 +195,7 @@ cc_test(
     name = "time_util_test",
     srcs = ["time_util_test.cc"],
     deps = [
+        ":internal_timeval",
         ":time_util",
         "//src/google/protobuf",
         "//src/google/protobuf:duration_cc_proto",

--- a/src/google/protobuf/util/internal_timeval.h
+++ b/src/google/protobuf/util/internal_timeval.h
@@ -1,0 +1,28 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+// Sets up the definition of struct timeval. This may result in the inclusion of
+// windows.h, so it should be avoided inside of other headers; instead, just use
+// `struct timeval` explicitly in definitions.
+
+#ifndef GOOGLE_PROTOBUF_UTIL_INTERNAL_TIMEVAL_H__
+#define GOOGLE_PROTOBUF_UTIL_INTERNAL_TIMEVAL_H__
+
+#ifdef _MSC_VER
+#ifdef _XBOX_ONE
+struct timeval {
+  int64_t tv_sec;  /* seconds */
+  int64_t tv_usec; /* and microseconds */
+};
+#else
+#include <winsock2.h>
+#endif  // _XBOX_ONE
+#else
+#include <sys/time.h>
+#endif
+
+#endif  // GOOGLE_PROTOBUF_UTIL_INTERNAL_TIMEVAL_H__

--- a/src/google/protobuf/util/time_util.cc
+++ b/src/google/protobuf/util/time_util.cc
@@ -12,6 +12,7 @@
 
 #include "google/protobuf/duration.pb.h"
 #include "google/protobuf/timestamp.pb.h"
+#include "google/protobuf/util/internal_timeval.h"  // IWYU pragma: keep for timeval
 #include "absl/log/absl_check.h"
 #include "absl/numeric/int128.h"
 #include "absl/strings/str_cat.h"
@@ -389,25 +390,25 @@ time_t TimeUtil::TimestampToTimeT(const Timestamp& value) {
   return static_cast<time_t>(value.seconds());
 }
 
-Timestamp TimeUtil::TimevalToTimestamp(const timeval& value) {
+Timestamp TimeUtil::TimevalToTimestamp(const struct timeval& value) {
   return CreateNormalized<Timestamp>(value.tv_sec,
                                      value.tv_usec * kNanosPerMicrosecond);
 }
 
-timeval TimeUtil::TimestampToTimeval(const Timestamp& value) {
-  timeval result;
+struct timeval TimeUtil::TimestampToTimeval(const Timestamp& value) {
+  struct timeval result;
   result.tv_sec = value.seconds();
   result.tv_usec = RoundTowardZero(value.nanos(), kNanosPerMicrosecond);
   return result;
 }
 
-Duration TimeUtil::TimevalToDuration(const timeval& value) {
+Duration TimeUtil::TimevalToDuration(const struct timeval& value) {
   return CreateNormalized<Duration>(value.tv_sec,
                                     value.tv_usec * kNanosPerMicrosecond);
 }
 
-timeval TimeUtil::DurationToTimeval(const Duration& value) {
-  timeval result;
+struct timeval TimeUtil::DurationToTimeval(const Duration& value) {
+  struct timeval result;
   result.tv_sec = value.seconds();
   result.tv_usec = RoundTowardZero(value.nanos(), kNanosPerMicrosecond);
   // timeval.tv_usec's range is [0, 1000000)

--- a/src/google/protobuf/util/time_util.h
+++ b/src/google/protobuf/util/time_util.h
@@ -14,18 +14,6 @@
 #include <ctime>
 #include <ostream>
 #include <string>
-#ifdef _MSC_VER
-#ifdef _XBOX_ONE
-struct timeval {
-  int64_t tv_sec;  /* seconds */
-  int64_t tv_usec; /* and microseconds */
-};
-#else
-#include <winsock2.h>
-#endif  // _XBOX_ONE
-#else
-#include <sys/time.h>
-#endif
 
 #include "google/protobuf/duration.pb.h"
 #include "google/protobuf/timestamp.pb.h"
@@ -153,10 +141,10 @@ class PROTOBUF_EXPORT TimeUtil {
   static time_t TimestampToTimeT(const Timestamp& value);
 
   // Conversion to/from timeval
-  static Timestamp TimevalToTimestamp(const timeval& value);
-  static timeval TimestampToTimeval(const Timestamp& value);
-  static Duration TimevalToDuration(const timeval& value);
-  static timeval DurationToTimeval(const Duration& value);
+  static Timestamp TimevalToTimestamp(const struct timeval& value);
+  static struct timeval TimestampToTimeval(const Timestamp& value);
+  static Duration TimevalToDuration(const struct timeval& value);
+  static struct timeval DurationToTimeval(const Duration& value);
 };
 
 }  // namespace util

--- a/src/google/protobuf/util/time_util_test.cc
+++ b/src/google/protobuf/util/time_util_test.cc
@@ -13,6 +13,7 @@
 #include "google/protobuf/duration.pb.h"
 #include "google/protobuf/timestamp.pb.h"
 #include "google/protobuf/testing/googletest.h"
+#include "google/protobuf/util/internal_timeval.h"  // IWYU pragma: keep for timeval
 #include <gtest/gtest.h>
 
 namespace google {


### PR DESCRIPTION
Closes #21301.

Moves the old logic for including the definition of `timeval` to a separate header, then includes that from the couple of places where it's needed. In some cases `sys/time.h` will already be included, so the IWYU pragma is added to make an explicit note of why the header is there.