### PR TITLE
Fix link errors when building `libprotoc` using latest LLVM-MinGW toolchain

### DIFF
--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -804,7 +804,7 @@ inline void RepeatedPtrFieldBase::MergeFrom<Message>(
 }
 
 // Appends all `std::string` values from `from` to this instance.
-template <>
+template <> PROTOBUF_EXPORT
 void RepeatedPtrFieldBase::MergeFrom<std::string>(
     const RepeatedPtrFieldBase& from);
 


### PR DESCRIPTION
The problem manifests in some of our (https://github.com/warzone2100/warzone2100) CI builds:

```
  [216/217] C:\Windows\system32\cmd.exe /C "cd . && D:\a\warzone2100\warzone2100\buildtools\llvm-mingw\llvm-mingw-20240619-ucrt-x86_64\bin\x86_64-w64-mingw32-g++.exe --target=x86_64-w64-windows-gnu -gcodeview -g -O3 -DNDEBUG  -Wl,-pdb= -shared -o libprotoc.dll -Wl,--out-implib,libprotoc.dll.a -Wl,--major-image-version,25,--minor-image-version,1 @CMakeFiles\libprotoc.rsp && cd ."
  FAILED: libprotoc.dll libprotoc.dll.a 
  C:\Windows\system32\cmd.exe /C "cd . && D:\a\warzone2100\warzone2100\buildtools\llvm-mingw\llvm-mingw-20240619-ucrt-x86_64\bin\x86_64-w64-mingw32-g++.exe --target=x86_64-w64-windows-gnu -gcodeview -g -O3 -DNDEBUG  -Wl,-pdb= -shared -o libprotoc.dll -Wl,--out-implib,libprotoc.dll.a -Wl,--major-image-version,25,--minor-image-version,1 @CMakeFiles\libprotoc.rsp && cd ."
  clang-18: warning: argument unused during compilation: '-gcodeview' [-Wunused-command-line-argument]
  ld.lld: error: undefined symbol: void google::protobuf::internal::RepeatedPtrFieldBase::MergeFrom<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(google::protobuf::internal::RepeatedPtrFieldBase const&)
  >>> referenced by D:\a\warzone2100\warzone2100\build\vcpkg\buildtrees\protobuf\src\v4.25.1-984c7075eb.clean\src\google\protobuf\compiler\plugin.pb.cc:663
  >>>               CMakeFiles/libprotoc.dir/src/google/protobuf/compiler/plugin.pb.cc.obj:(google::protobuf::compiler::CodeGeneratorRequest::CodeGeneratorRequest(google::protobuf::Arena*, google::protobuf::compiler::CodeGeneratorRequest const&))
  >>> referenced by D:\a\warzone2100\warzone2100\build\vcpkg\buildtrees\protobuf\src\v4.25.1-984c7075eb.clean\src\google\protobuf\compiler\plugin.pb.cc:904
  >>>               CMakeFiles/libprotoc.dir/src/google/protobuf/compiler/plugin.pb.cc.obj:(google::protobuf::compiler::CodeGeneratorRequest::MergeImpl(google::protobuf::Message&, google::protobuf::Message const&))
  clang-18: error: linker command failed with exit code 1 (use -v to see invocation)
  
  ninja: build stopped: subcommand failed.
```

Initially happened with `4.25.1` protobuf version, but also known to happen for `5.29.3` (and, presumably, for `main` branch, too).

Looks like Clang in MinGW mode doesn't add explicit instantiations of a template function (defined in a separate translation unit) to the overall export set of the library, despite the enclosing class having `PROTOBUF_EXPORT` attribute.

This happens when building `libprotoc` with LLVM-MinGW toolchain, e.g., while trying to build/install protobuf via vcpkg for one of the `*-mingw-dynamic` triples.

So, add another `PROTOBUF_EXPORT` to the explicit instantiation declaration for `RepeatedPtrFieldBase::MergeFrom<std::string>`. This won't hurt in either case, but resolves the link issue for llvm-mingw builds of the `libprotoc` library.