### PR TITLE
get rid of warning in zero_copy_stream_impl_lite.cc

### DIFF
--- a/src/google/protobuf/io/zero_copy_stream_impl_lite.cc
+++ b/src/google/protobuf/io/zero_copy_stream_impl_lite.cc
@@ -356,7 +356,7 @@ bool CopyingOutputStreamAdaptor::WriteAliasedRaw(const void* data, int size) {
     if (size <= out_size) {
       std::memcpy(out, data, size);
       BackUp(out_size - size);
-      return true;
+      break;
     }
 
     std::memcpy(out, data, out_size);


### PR DESCRIPTION
```c
warning: 'return' will never be executed [-Wunreachable-code-return]
```

Fixes #10154
re #21205

**EDIT:** hopefully it's obvious why it's not marked "on behalf of" ... guess can't really be anon if wanting to contribute to random projects, eventually. (dang it)