### PR TITLE
Patch `rules_ruby` to apply `neverlink = True` to the `jars` rule

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -67,6 +67,7 @@ single_version_override(
     patch_strip = 1,
     patches = [
         "@com_google_protobuf//:Disable_bundle_install.patch",
+        "@com_google_protobuf//:Neverlink_jruby_jars.patch",
     ],
     version = "0.17.3",
 )

--- a/Neverlink_jruby_jars.patch
+++ b/Neverlink_jruby_jars.patch
@@ -1,0 +1,16 @@
+Index: ruby/private/download/BUILD.tpl
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/ruby/private/download/BUILD.tpl b/ruby/private/download/BUILD.tpl
+--- a/ruby/private/download/BUILD.tpl	(revision 26e0ba621cb82933f28a59373cb6a7afe54fae95)
++++ b/ruby/private/download/BUILD.tpl	(date 1745340325192)
+@@ -33,6 +33,7 @@
+         ["dist/lib/**/*.jar"],
+         allow_empty = True,
+     ),
++    neverlink = True,
+ )
+
+ rb_toolchain(


### PR DESCRIPTION
Fixes #21369