### PR TITLE
[C#] Adding Clear mechanism to IMessage

### DIFF
--- a/csharp/src/AddressBook/Addressbook.pb.cs
+++ b/csharp/src/AddressBook/Addressbook.pb.cs
@@ -99,6 +99,21 @@ namespace Google.Protobuf.Examples.AddressBook {
       return new Person(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      id_ = 0;
+      email_ = "";
+      phones_.Clear();
+      if (lastUpdated_ != null) {
+        lastUpdated_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private string name_ = "";
@@ -452,6 +467,16 @@ namespace Google.Protobuf.Examples.AddressBook {
           return new PhoneNumber(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          number_ = "";
+          type_ = global::Google.Protobuf.Examples.AddressBook.Person.Types.PhoneType.Mobile;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "number" field.</summary>
         public const int NumberFieldNumber = 1;
         private string number_ = "";
@@ -692,6 +717,15 @@ namespace Google.Protobuf.Examples.AddressBook {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public AddressBook Clone() {
       return new AddressBook(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      people_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "people" field.</summary>

--- a/csharp/src/Google.Protobuf.Conformance/Conformance.pb.cs
+++ b/csharp/src/Google.Protobuf.Conformance/Conformance.pb.cs
@@ -160,6 +160,17 @@ namespace Conformance {
       return new TestStatus(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      failureMessage_ = "";
+      matchedName_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private string name_ = "";
@@ -439,6 +450,15 @@ namespace Conformance {
       return new FailureSet(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      test_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "test" field.</summary>
     public const int TestFieldNumber = 2;
     private static readonly pb::FieldCodec<global::Conformance.TestStatus> _repeated_test_codec
@@ -650,6 +670,23 @@ namespace Conformance {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ConformanceRequest Clone() {
       return new ConformanceRequest(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      requestedOutputFormat_ = global::Conformance.WireFormat.Unspecified;
+      messageType_ = "";
+      testCategory_ = global::Conformance.TestCategory.UnspecifiedTest;
+      if (jspbEncodingOptions_ != null) {
+        jspbEncodingOptions_.Clear();
+      }
+      printUnknownFields_ = false;
+      payloadCase_ = PayloadOneofCase.None;
+      payload_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "protobuf_payload" field.</summary>
@@ -1287,6 +1324,16 @@ namespace Conformance {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ConformanceResponse Clone() {
       return new ConformanceResponse(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      resultCase_ = ResultOneofCase.None;
+      result_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "parse_error" field.</summary>
@@ -1978,6 +2025,15 @@ namespace Conformance {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public JspbEncodingConfig Clone() {
       return new JspbEncodingConfig(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      useJspbArrayAnyFormat_ = false;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "use_jspb_array_any_format" field.</summary>

--- a/csharp/src/Google.Protobuf.Test.TestProtos/MapUnittestProto3.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/MapUnittestProto3.pb.cs
@@ -238,6 +238,31 @@ namespace Google.Protobuf.TestProtos {
       return new TestMap(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      mapInt32Int32_.Clear();
+      mapInt64Int64_.Clear();
+      mapUint32Uint32_.Clear();
+      mapUint64Uint64_.Clear();
+      mapSint32Sint32_.Clear();
+      mapSint64Sint64_.Clear();
+      mapFixed32Fixed32_.Clear();
+      mapFixed64Fixed64_.Clear();
+      mapSfixed32Sfixed32_.Clear();
+      mapSfixed64Sfixed64_.Clear();
+      mapInt32Float_.Clear();
+      mapInt32Double_.Clear();
+      mapBoolBool_.Clear();
+      mapStringString_.Clear();
+      mapInt32Bytes_.Clear();
+      mapInt32Enum_.Clear();
+      mapInt32ForeignMessage_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "map_int32_int32" field.</summary>
     public const int MapInt32Int32FieldNumber = 1;
     private static readonly pbc::MapField<int, int>.Codec _map_mapInt32Int32_codec
@@ -825,6 +850,17 @@ namespace Google.Protobuf.TestProtos {
       return new TestMapSubmessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (testMap_ != null) {
+        testMap_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "test_map" field.</summary>
     public const int TestMapFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.TestMap testMap_;
@@ -1032,6 +1068,15 @@ namespace Google.Protobuf.TestProtos {
       return new TestMessageMap(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      mapInt32Message_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "map_int32_message" field.</summary>
     public const int MapInt32MessageFieldNumber = 1;
     private static readonly pbc::MapField<int, global::Google.Protobuf.TestProtos.TestAllTypes>.Codec _map_mapInt32Message_codec
@@ -1221,6 +1266,16 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestSameTypeMap Clone() {
       return new TestSameTypeMap(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      map1_.Clear();
+      map2_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "map1" field.</summary>
@@ -1447,6 +1502,29 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestArenaMap Clone() {
       return new TestArenaMap(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      mapInt32Int32_.Clear();
+      mapInt64Int64_.Clear();
+      mapUint32Uint32_.Clear();
+      mapUint64Uint64_.Clear();
+      mapSint32Sint32_.Clear();
+      mapSint64Sint64_.Clear();
+      mapFixed32Fixed32_.Clear();
+      mapFixed64Fixed64_.Clear();
+      mapSfixed32Sfixed32_.Clear();
+      mapSfixed64Sfixed64_.Clear();
+      mapInt32Float_.Clear();
+      mapInt32Double_.Clear();
+      mapBoolBool_.Clear();
+      mapInt32Enum_.Clear();
+      mapInt32ForeignMessage_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "map_int32_int32" field.</summary>
@@ -1990,6 +2068,15 @@ namespace Google.Protobuf.TestProtos {
       return new MessageContainingEnumCalledType(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      type_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "type" field.</summary>
     public const int TypeFieldNumber = 1;
     private static readonly pbc::MapField<int, global::Google.Protobuf.TestProtos.MessageContainingEnumCalledType>.Codec _map_type_codec
@@ -2190,6 +2277,15 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public MessageContainingMapCalledEntry Clone() {
       return new MessageContainingMapCalledEntry(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      entry_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "entry" field.</summary>

--- a/csharp/src/Google.Protobuf.Test.TestProtos/OldExtensions1.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/OldExtensions1.cs
@@ -74,6 +74,13 @@ namespace Google.Protobuf.TestProtos.OldGenerator {
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void Clear() {
+      if(_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestMessage);
     }

--- a/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesEdition2023.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesEdition2023.pb.cs
@@ -276,6 +276,16 @@ namespace ProtobufTestMessages.Editions {
       return new ComplexMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      d_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "d" field.</summary>
     public const int DFieldNumber = 1;
     private readonly static int DDefaultValue = 0;
@@ -613,6 +623,122 @@ namespace ProtobufTestMessages.Editions {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestAllTypesEdition2023 Clone() {
       return new TestAllTypesEdition2023(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      optionalInt32_ = 0;
+      optionalInt64_ = 0L;
+      optionalUint32_ = 0;
+      optionalUint64_ = 0UL;
+      optionalSint32_ = 0;
+      optionalSint64_ = 0L;
+      optionalFixed32_ = 0;
+      optionalFixed64_ = 0UL;
+      optionalSfixed32_ = 0;
+      optionalSfixed64_ = 0L;
+      optionalFloat_ = 0F;
+      optionalDouble_ = 0D;
+      optionalBool_ = false;
+      optionalString_ = "";
+      optionalBytes_ = pb::ByteString.Empty;
+      if (optionalNestedMessage_ != null) {
+        optionalNestedMessage_.Clear();
+      }
+      if (optionalForeignMessage_ != null) {
+        optionalForeignMessage_.Clear();
+      }
+      optionalNestedEnum_ = global::ProtobufTestMessages.Editions.TestAllTypesEdition2023.Types.NestedEnum.Foo;
+      optionalForeignEnum_ = global::ProtobufTestMessages.Editions.ForeignEnumEdition2023.ForeignFoo;
+      optionalStringPiece_ = "";
+      optionalCord_ = "";
+      if (recursiveMessage_ != null) {
+        recursiveMessage_.Clear();
+      }
+      repeatedInt32_.Clear();
+      repeatedInt64_.Clear();
+      repeatedUint32_.Clear();
+      repeatedUint64_.Clear();
+      repeatedSint32_.Clear();
+      repeatedSint64_.Clear();
+      repeatedFixed32_.Clear();
+      repeatedFixed64_.Clear();
+      repeatedSfixed32_.Clear();
+      repeatedSfixed64_.Clear();
+      repeatedFloat_.Clear();
+      repeatedDouble_.Clear();
+      repeatedBool_.Clear();
+      repeatedString_.Clear();
+      repeatedBytes_.Clear();
+      repeatedNestedMessage_.Clear();
+      repeatedForeignMessage_.Clear();
+      repeatedNestedEnum_.Clear();
+      repeatedForeignEnum_.Clear();
+      repeatedStringPiece_.Clear();
+      repeatedCord_.Clear();
+      packedInt32_.Clear();
+      packedInt64_.Clear();
+      packedUint32_.Clear();
+      packedUint64_.Clear();
+      packedSint32_.Clear();
+      packedSint64_.Clear();
+      packedFixed32_.Clear();
+      packedFixed64_.Clear();
+      packedSfixed32_.Clear();
+      packedSfixed64_.Clear();
+      packedFloat_.Clear();
+      packedDouble_.Clear();
+      packedBool_.Clear();
+      packedNestedEnum_.Clear();
+      unpackedInt32_.Clear();
+      unpackedInt64_.Clear();
+      unpackedUint32_.Clear();
+      unpackedUint64_.Clear();
+      unpackedSint32_.Clear();
+      unpackedSint64_.Clear();
+      unpackedFixed32_.Clear();
+      unpackedFixed64_.Clear();
+      unpackedSfixed32_.Clear();
+      unpackedSfixed64_.Clear();
+      unpackedFloat_.Clear();
+      unpackedDouble_.Clear();
+      unpackedBool_.Clear();
+      unpackedNestedEnum_.Clear();
+      mapInt32Int32_.Clear();
+      mapInt64Int64_.Clear();
+      mapUint32Uint32_.Clear();
+      mapUint64Uint64_.Clear();
+      mapSint32Sint32_.Clear();
+      mapSint64Sint64_.Clear();
+      mapFixed32Fixed32_.Clear();
+      mapFixed64Fixed64_.Clear();
+      mapSfixed32Sfixed32_.Clear();
+      mapSfixed64Sfixed64_.Clear();
+      mapInt32Float_.Clear();
+      mapInt32Double_.Clear();
+      mapBoolBool_.Clear();
+      mapStringString_.Clear();
+      mapStringBytes_.Clear();
+      mapStringNestedMessage_.Clear();
+      mapStringForeignMessage_.Clear();
+      mapStringNestedEnum_.Clear();
+      mapStringForeignEnum_.Clear();
+      if (groupLikeType_ != null) {
+        groupLikeType_.Clear();
+      }
+      if (delimitedField_ != null) {
+        delimitedField_.Clear();
+      }
+      oneofFieldCase_ = OneofFieldOneofCase.None;
+      oneofField_ = null;
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "optional_int32" field.</summary>
@@ -4338,6 +4464,19 @@ namespace ProtobufTestMessages.Editions {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (corecursive_ != null) {
+            corecursive_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 1;
         private readonly static int ADefaultValue = 0;
@@ -4600,6 +4739,17 @@ namespace ProtobufTestMessages.Editions {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public GroupLikeType Clone() {
           return new GroupLikeType(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          groupInt32_ = 0;
+          groupUint32_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "group_int32" field.</summary>
@@ -4873,6 +5023,16 @@ namespace ProtobufTestMessages.Editions {
       return new ForeignMessageEdition2023(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      c_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "c" field.</summary>
     public const int CFieldNumber = 1;
     private readonly static int CDefaultValue = 0;
@@ -5086,6 +5246,16 @@ namespace ProtobufTestMessages.Editions {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public GroupLikeType Clone() {
       return new GroupLikeType(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      c_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "c" field.</summary>

--- a/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto2.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto2.pb.cs
@@ -577,6 +577,161 @@ namespace ProtobufTestMessages.Proto2 {
       return new TestAllTypesProto2(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      _hasBits1 = 0;
+      optionalInt32_ = 0;
+      optionalInt64_ = 0L;
+      optionalUint32_ = 0;
+      optionalUint64_ = 0UL;
+      optionalSint32_ = 0;
+      optionalSint64_ = 0L;
+      optionalFixed32_ = 0;
+      optionalFixed64_ = 0UL;
+      optionalSfixed32_ = 0;
+      optionalSfixed64_ = 0L;
+      optionalFloat_ = 0F;
+      optionalDouble_ = 0D;
+      optionalBool_ = false;
+      optionalString_ = "";
+      optionalBytes_ = pb::ByteString.Empty;
+      if (optionalNestedMessage_ != null) {
+        optionalNestedMessage_.Clear();
+      }
+      if (optionalForeignMessage_ != null) {
+        optionalForeignMessage_.Clear();
+      }
+      optionalNestedEnum_ = global::ProtobufTestMessages.Proto2.TestAllTypesProto2.Types.NestedEnum.Foo;
+      optionalForeignEnum_ = global::ProtobufTestMessages.Proto2.ForeignEnumProto2.ForeignFoo;
+      optionalStringPiece_ = "";
+      optionalCord_ = "";
+      if (recursiveMessage_ != null) {
+        recursiveMessage_.Clear();
+      }
+      repeatedInt32_.Clear();
+      repeatedInt64_.Clear();
+      repeatedUint32_.Clear();
+      repeatedUint64_.Clear();
+      repeatedSint32_.Clear();
+      repeatedSint64_.Clear();
+      repeatedFixed32_.Clear();
+      repeatedFixed64_.Clear();
+      repeatedSfixed32_.Clear();
+      repeatedSfixed64_.Clear();
+      repeatedFloat_.Clear();
+      repeatedDouble_.Clear();
+      repeatedBool_.Clear();
+      repeatedString_.Clear();
+      repeatedBytes_.Clear();
+      repeatedNestedMessage_.Clear();
+      repeatedForeignMessage_.Clear();
+      repeatedNestedEnum_.Clear();
+      repeatedForeignEnum_.Clear();
+      repeatedStringPiece_.Clear();
+      repeatedCord_.Clear();
+      packedInt32_.Clear();
+      packedInt64_.Clear();
+      packedUint32_.Clear();
+      packedUint64_.Clear();
+      packedSint32_.Clear();
+      packedSint64_.Clear();
+      packedFixed32_.Clear();
+      packedFixed64_.Clear();
+      packedSfixed32_.Clear();
+      packedSfixed64_.Clear();
+      packedFloat_.Clear();
+      packedDouble_.Clear();
+      packedBool_.Clear();
+      packedNestedEnum_.Clear();
+      unpackedInt32_.Clear();
+      unpackedInt64_.Clear();
+      unpackedUint32_.Clear();
+      unpackedUint64_.Clear();
+      unpackedSint32_.Clear();
+      unpackedSint64_.Clear();
+      unpackedFixed32_.Clear();
+      unpackedFixed64_.Clear();
+      unpackedSfixed32_.Clear();
+      unpackedSfixed64_.Clear();
+      unpackedFloat_.Clear();
+      unpackedDouble_.Clear();
+      unpackedBool_.Clear();
+      unpackedNestedEnum_.Clear();
+      mapInt32Int32_.Clear();
+      mapInt64Int64_.Clear();
+      mapUint32Uint32_.Clear();
+      mapUint64Uint64_.Clear();
+      mapSint32Sint32_.Clear();
+      mapSint64Sint64_.Clear();
+      mapFixed32Fixed32_.Clear();
+      mapFixed64Fixed64_.Clear();
+      mapSfixed32Sfixed32_.Clear();
+      mapSfixed64Sfixed64_.Clear();
+      mapInt32Bool_.Clear();
+      mapInt32Float_.Clear();
+      mapInt32Double_.Clear();
+      mapInt32NestedMessage_.Clear();
+      mapBoolBool_.Clear();
+      mapStringString_.Clear();
+      mapStringBytes_.Clear();
+      mapStringNestedMessage_.Clear();
+      mapStringForeignMessage_.Clear();
+      mapStringNestedEnum_.Clear();
+      mapStringForeignEnum_.Clear();
+      if (data_ != null) {
+        data_.Clear();
+      }
+      if (multiWordGroupField_ != null) {
+        multiWordGroupField_.Clear();
+      }
+      defaultInt32_ = -123456789;
+      defaultInt64_ = -9123456789123456789L;
+      defaultUint32_ = 2123456789;
+      defaultUint64_ = 10123456789123456789UL;
+      defaultSint32_ = -123456789;
+      defaultSint64_ = -9123456789123456789L;
+      defaultFixed32_ = 2123456789;
+      defaultFixed64_ = 10123456789123456789UL;
+      defaultSfixed32_ = -123456789;
+      defaultSfixed64_ = -9123456789123456789L;
+      defaultFloat_ = 9e+09F;
+      defaultDouble_ = 7e+22D;
+      defaultBool_ = true;
+      defaultString_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("Um9zZWJ1ZA=="), 0, 7);
+      defaultBytes_ = pb::ByteString.FromBase64("am9zaHVh");
+      fieldname1_ = 0;
+      fieldName2_ = 0;
+      FieldName3_ = 0;
+      fieldName4_ = 0;
+      field0Name5_ = 0;
+      field0Name6_ = 0;
+      fieldName7_ = 0;
+      fieldName8_ = 0;
+      fieldName9_ = 0;
+      fieldName10_ = 0;
+      fIELDNAME11_ = 0;
+      fIELDName12_ = 0;
+      FieldName13_ = 0;
+      FieldName14_ = 0;
+      fieldName15_ = 0;
+      fieldName16_ = 0;
+      fieldName17_ = 0;
+      fieldName18_ = 0;
+      if (messageSetCorrect_ != null) {
+        messageSetCorrect_.Clear();
+      }
+      oneofFieldCase_ = OneofFieldOneofCase.None;
+      oneofField_ = null;
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "optional_int32" field.</summary>
     public const int OptionalInt32FieldNumber = 1;
     private readonly static int OptionalInt32DefaultValue = 0;
@@ -6083,6 +6238,19 @@ namespace ProtobufTestMessages.Proto2 {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (corecursive_ != null) {
+            corecursive_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 1;
         private readonly static int ADefaultValue = 0;
@@ -6345,6 +6513,17 @@ namespace ProtobufTestMessages.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public Data Clone() {
           return new Data(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          groupInt32_ = 0;
+          groupUint32_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "group_int32" field.</summary>
@@ -6612,6 +6791,17 @@ namespace ProtobufTestMessages.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public MultiWordGroupField Clone() {
           return new MultiWordGroupField(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          groupInt32_ = 0;
+          groupUint32_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "group_int32" field.</summary>
@@ -6885,6 +7075,17 @@ namespace ProtobufTestMessages.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_extensions != null) {
+            _extensions.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as MessageSetCorrect);
         }
@@ -7085,6 +7286,15 @@ namespace ProtobufTestMessages.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public MessageSetCorrectExtension1 Clone() {
           return new MessageSetCorrectExtension1(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          str_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "str" field.</summary>
@@ -7309,6 +7519,16 @@ namespace ProtobufTestMessages.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public MessageSetCorrectExtension2 Clone() {
           return new MessageSetCorrectExtension2(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          i_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "i" field.</summary>
@@ -7540,6 +7760,16 @@ namespace ProtobufTestMessages.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public ExtensionWithOneof Clone() {
           return new ExtensionWithOneof(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          oneofFieldCase_ = OneofFieldOneofCase.None;
+          oneofField_ = null;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "a" field.</summary>
@@ -7847,6 +8077,16 @@ namespace ProtobufTestMessages.Proto2 {
       return new ForeignMessageProto2(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      c_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "c" field.</summary>
     public const int CFieldNumber = 1;
     private readonly static int CDefaultValue = 0;
@@ -8061,6 +8301,17 @@ namespace ProtobufTestMessages.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public GroupField Clone() {
       return new GroupField(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      groupInt32_ = 0;
+      groupUint32_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "group_int32" field.</summary>
@@ -8332,6 +8583,25 @@ namespace ProtobufTestMessages.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public UnknownToTestAllTypes Clone() {
       return new UnknownToTestAllTypes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      optionalInt32_ = 0;
+      optionalString_ = "";
+      if (nestedMessage_ != null) {
+        nestedMessage_.Clear();
+      }
+      if (optionalGroup_ != null) {
+        optionalGroup_.Clear();
+      }
+      optionalBool_ = false;
+      repeatedInt32_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "optional_int32" field.</summary>
@@ -8784,6 +9054,16 @@ namespace ProtobufTestMessages.Proto2 {
           return new OptionalGroup(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 1;
         private readonly static int ADefaultValue = 0;
@@ -9003,6 +9283,14 @@ namespace ProtobufTestMessages.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as NullHypothesisProto2);
     }
@@ -9160,6 +9448,14 @@ namespace ProtobufTestMessages.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public EnumOnlyProto2 Clone() {
       return new EnumOnlyProto2(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9335,6 +9631,15 @@ namespace ProtobufTestMessages.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public OneStringProto2 Clone() {
       return new OneStringProto2(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "data" field.</summary>
@@ -9551,6 +9856,18 @@ namespace ProtobufTestMessages.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ProtoWithKeywords Clone() {
       return new ProtoWithKeywords(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      inline_ = 0;
+      concept_ = "";
+      requires_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "inline" field.</summary>
@@ -9882,6 +10199,67 @@ namespace ProtobufTestMessages.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestAllRequiredTypesProto2 Clone() {
       return new TestAllRequiredTypesProto2(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      requiredInt32_ = 0;
+      requiredInt64_ = 0L;
+      requiredUint32_ = 0;
+      requiredUint64_ = 0UL;
+      requiredSint32_ = 0;
+      requiredSint64_ = 0L;
+      requiredFixed32_ = 0;
+      requiredFixed64_ = 0UL;
+      requiredSfixed32_ = 0;
+      requiredSfixed64_ = 0L;
+      requiredFloat_ = 0F;
+      requiredDouble_ = 0D;
+      requiredBool_ = false;
+      requiredString_ = "";
+      requiredBytes_ = pb::ByteString.Empty;
+      if (requiredNestedMessage_ != null) {
+        requiredNestedMessage_.Clear();
+      }
+      if (requiredForeignMessage_ != null) {
+        requiredForeignMessage_.Clear();
+      }
+      requiredNestedEnum_ = global::ProtobufTestMessages.Proto2.TestAllRequiredTypesProto2.Types.NestedEnum.Foo;
+      requiredForeignEnum_ = global::ProtobufTestMessages.Proto2.ForeignEnumProto2.ForeignFoo;
+      requiredStringPiece_ = "";
+      requiredCord_ = "";
+      if (recursiveMessage_ != null) {
+        recursiveMessage_.Clear();
+      }
+      if (optionalRecursiveMessage_ != null) {
+        optionalRecursiveMessage_.Clear();
+      }
+      if (data_ != null) {
+        data_.Clear();
+      }
+      defaultInt32_ = -123456789;
+      defaultInt64_ = -9123456789123456789L;
+      defaultUint32_ = 2123456789;
+      defaultUint64_ = 10123456789123456789UL;
+      defaultSint32_ = -123456789;
+      defaultSint64_ = -9123456789123456789L;
+      defaultFixed32_ = 2123456789;
+      defaultFixed64_ = 10123456789123456789UL;
+      defaultSfixed32_ = -123456789;
+      defaultSfixed64_ = -9123456789123456789L;
+      defaultFloat_ = 9e+09F;
+      defaultDouble_ = 7e+22D;
+      defaultBool_ = true;
+      defaultString_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("Um9zZWJ1ZA=="), 0, 7);
+      defaultBytes_ = pb::ByteString.FromBase64("am9zaHVh");
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "required_int32" field.</summary>
@@ -12078,6 +12456,22 @@ namespace ProtobufTestMessages.Proto2 {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (corecursive_ != null) {
+            corecursive_.Clear();
+          }
+          if (optionalCorecursive_ != null) {
+            optionalCorecursive_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 1;
         private readonly static int ADefaultValue = 0;
@@ -12387,6 +12781,17 @@ namespace ProtobufTestMessages.Proto2 {
           return new Data(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          groupInt32_ = 0;
+          groupUint32_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "group_int32" field.</summary>
         public const int GroupInt32FieldNumber = 202;
         private readonly static int GroupInt32DefaultValue = 0;
@@ -12658,6 +13063,17 @@ namespace ProtobufTestMessages.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_extensions != null) {
+            _extensions.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as MessageSetCorrect);
         }
@@ -12858,6 +13274,15 @@ namespace ProtobufTestMessages.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public MessageSetCorrectExtension1 Clone() {
           return new MessageSetCorrectExtension1(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          str_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "str" field.</summary>
@@ -13082,6 +13507,16 @@ namespace ProtobufTestMessages.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public MessageSetCorrectExtension2 Clone() {
           return new MessageSetCorrectExtension2(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          i_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "i" field.</summary>
@@ -13327,6 +13762,16 @@ namespace ProtobufTestMessages.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestLargeOneof Clone() {
       return new TestLargeOneof(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      largeOneofCase_ = LargeOneofOneofCase.None;
+      largeOneof_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "a1" field.</summary>
@@ -13769,6 +14214,14 @@ namespace ProtobufTestMessages.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as A1);
         }
@@ -13926,6 +14379,14 @@ namespace ProtobufTestMessages.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public A2 Clone() {
           return new A2(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14091,6 +14552,14 @@ namespace ProtobufTestMessages.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as A3);
         }
@@ -14252,6 +14721,14 @@ namespace ProtobufTestMessages.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as A4);
         }
@@ -14409,6 +14886,14 @@ namespace ProtobufTestMessages.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public A5 Clone() {
           return new A5(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto2Editions.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto2Editions.pb.cs
@@ -600,6 +600,161 @@ namespace ProtobufTestMessages.Editions.Proto2 {
       return new TestAllTypesProto2(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      _hasBits1 = 0;
+      optionalInt32_ = 0;
+      optionalInt64_ = 0L;
+      optionalUint32_ = 0;
+      optionalUint64_ = 0UL;
+      optionalSint32_ = 0;
+      optionalSint64_ = 0L;
+      optionalFixed32_ = 0;
+      optionalFixed64_ = 0UL;
+      optionalSfixed32_ = 0;
+      optionalSfixed64_ = 0L;
+      optionalFloat_ = 0F;
+      optionalDouble_ = 0D;
+      optionalBool_ = false;
+      optionalString_ = "";
+      optionalBytes_ = pb::ByteString.Empty;
+      if (optionalNestedMessage_ != null) {
+        optionalNestedMessage_.Clear();
+      }
+      if (optionalForeignMessage_ != null) {
+        optionalForeignMessage_.Clear();
+      }
+      optionalNestedEnum_ = global::ProtobufTestMessages.Editions.Proto2.TestAllTypesProto2.Types.NestedEnum.Foo;
+      optionalForeignEnum_ = global::ProtobufTestMessages.Editions.Proto2.ForeignEnumProto2.ForeignFoo;
+      optionalStringPiece_ = "";
+      optionalCord_ = "";
+      if (recursiveMessage_ != null) {
+        recursiveMessage_.Clear();
+      }
+      repeatedInt32_.Clear();
+      repeatedInt64_.Clear();
+      repeatedUint32_.Clear();
+      repeatedUint64_.Clear();
+      repeatedSint32_.Clear();
+      repeatedSint64_.Clear();
+      repeatedFixed32_.Clear();
+      repeatedFixed64_.Clear();
+      repeatedSfixed32_.Clear();
+      repeatedSfixed64_.Clear();
+      repeatedFloat_.Clear();
+      repeatedDouble_.Clear();
+      repeatedBool_.Clear();
+      repeatedString_.Clear();
+      repeatedBytes_.Clear();
+      repeatedNestedMessage_.Clear();
+      repeatedForeignMessage_.Clear();
+      repeatedNestedEnum_.Clear();
+      repeatedForeignEnum_.Clear();
+      repeatedStringPiece_.Clear();
+      repeatedCord_.Clear();
+      packedInt32_.Clear();
+      packedInt64_.Clear();
+      packedUint32_.Clear();
+      packedUint64_.Clear();
+      packedSint32_.Clear();
+      packedSint64_.Clear();
+      packedFixed32_.Clear();
+      packedFixed64_.Clear();
+      packedSfixed32_.Clear();
+      packedSfixed64_.Clear();
+      packedFloat_.Clear();
+      packedDouble_.Clear();
+      packedBool_.Clear();
+      packedNestedEnum_.Clear();
+      unpackedInt32_.Clear();
+      unpackedInt64_.Clear();
+      unpackedUint32_.Clear();
+      unpackedUint64_.Clear();
+      unpackedSint32_.Clear();
+      unpackedSint64_.Clear();
+      unpackedFixed32_.Clear();
+      unpackedFixed64_.Clear();
+      unpackedSfixed32_.Clear();
+      unpackedSfixed64_.Clear();
+      unpackedFloat_.Clear();
+      unpackedDouble_.Clear();
+      unpackedBool_.Clear();
+      unpackedNestedEnum_.Clear();
+      mapInt32Int32_.Clear();
+      mapInt64Int64_.Clear();
+      mapUint32Uint32_.Clear();
+      mapUint64Uint64_.Clear();
+      mapSint32Sint32_.Clear();
+      mapSint64Sint64_.Clear();
+      mapFixed32Fixed32_.Clear();
+      mapFixed64Fixed64_.Clear();
+      mapSfixed32Sfixed32_.Clear();
+      mapSfixed64Sfixed64_.Clear();
+      mapInt32Bool_.Clear();
+      mapInt32Float_.Clear();
+      mapInt32Double_.Clear();
+      mapInt32NestedMessage_.Clear();
+      mapBoolBool_.Clear();
+      mapStringString_.Clear();
+      mapStringBytes_.Clear();
+      mapStringNestedMessage_.Clear();
+      mapStringForeignMessage_.Clear();
+      mapStringNestedEnum_.Clear();
+      mapStringForeignEnum_.Clear();
+      if (data_ != null) {
+        data_.Clear();
+      }
+      if (multiWordGroupField_ != null) {
+        multiWordGroupField_.Clear();
+      }
+      defaultInt32_ = -123456789;
+      defaultInt64_ = -9123456789123456789L;
+      defaultUint32_ = 2123456789;
+      defaultUint64_ = 10123456789123456789UL;
+      defaultSint32_ = -123456789;
+      defaultSint64_ = -9123456789123456789L;
+      defaultFixed32_ = 2123456789;
+      defaultFixed64_ = 10123456789123456789UL;
+      defaultSfixed32_ = -123456789;
+      defaultSfixed64_ = -9123456789123456789L;
+      defaultFloat_ = 9e+09F;
+      defaultDouble_ = 7e+22D;
+      defaultBool_ = true;
+      defaultString_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("Um9zZWJ1ZA=="), 0, 7);
+      defaultBytes_ = pb::ByteString.FromBase64("am9zaHVh");
+      fieldname1_ = 0;
+      fieldName2_ = 0;
+      FieldName3_ = 0;
+      fieldName4_ = 0;
+      field0Name5_ = 0;
+      field0Name6_ = 0;
+      fieldName7_ = 0;
+      fieldName8_ = 0;
+      fieldName9_ = 0;
+      fieldName10_ = 0;
+      fIELDNAME11_ = 0;
+      fIELDName12_ = 0;
+      FieldName13_ = 0;
+      FieldName14_ = 0;
+      fieldName15_ = 0;
+      fieldName16_ = 0;
+      fieldName17_ = 0;
+      fieldName18_ = 0;
+      if (messageSetCorrect_ != null) {
+        messageSetCorrect_.Clear();
+      }
+      oneofFieldCase_ = OneofFieldOneofCase.None;
+      oneofField_ = null;
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "optional_int32" field.</summary>
     public const int OptionalInt32FieldNumber = 1;
     private readonly static int OptionalInt32DefaultValue = 0;
@@ -6106,6 +6261,19 @@ namespace ProtobufTestMessages.Editions.Proto2 {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (corecursive_ != null) {
+            corecursive_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 1;
         private readonly static int ADefaultValue = 0;
@@ -6368,6 +6536,17 @@ namespace ProtobufTestMessages.Editions.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public Data Clone() {
           return new Data(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          groupInt32_ = 0;
+          groupUint32_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "group_int32" field.</summary>
@@ -6635,6 +6814,17 @@ namespace ProtobufTestMessages.Editions.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public MultiWordGroupField Clone() {
           return new MultiWordGroupField(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          groupInt32_ = 0;
+          groupUint32_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "group_int32" field.</summary>
@@ -6908,6 +7098,17 @@ namespace ProtobufTestMessages.Editions.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_extensions != null) {
+            _extensions.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as MessageSetCorrect);
         }
@@ -7108,6 +7309,15 @@ namespace ProtobufTestMessages.Editions.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public MessageSetCorrectExtension1 Clone() {
           return new MessageSetCorrectExtension1(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          str_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "str" field.</summary>
@@ -7332,6 +7542,16 @@ namespace ProtobufTestMessages.Editions.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public MessageSetCorrectExtension2 Clone() {
           return new MessageSetCorrectExtension2(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          i_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "i" field.</summary>
@@ -7563,6 +7783,16 @@ namespace ProtobufTestMessages.Editions.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public ExtensionWithOneof Clone() {
           return new ExtensionWithOneof(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          oneofFieldCase_ = OneofFieldOneofCase.None;
+          oneofField_ = null;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "a" field.</summary>
@@ -7870,6 +8100,16 @@ namespace ProtobufTestMessages.Editions.Proto2 {
       return new ForeignMessageProto2(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      c_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "c" field.</summary>
     public const int CFieldNumber = 1;
     private readonly static int CDefaultValue = 0;
@@ -8084,6 +8324,17 @@ namespace ProtobufTestMessages.Editions.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public GroupField Clone() {
       return new GroupField(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      groupInt32_ = 0;
+      groupUint32_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "group_int32" field.</summary>
@@ -8355,6 +8606,25 @@ namespace ProtobufTestMessages.Editions.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public UnknownToTestAllTypes Clone() {
       return new UnknownToTestAllTypes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      optionalInt32_ = 0;
+      optionalString_ = "";
+      if (nestedMessage_ != null) {
+        nestedMessage_.Clear();
+      }
+      if (optionalGroup_ != null) {
+        optionalGroup_.Clear();
+      }
+      optionalBool_ = false;
+      repeatedInt32_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "optional_int32" field.</summary>
@@ -8807,6 +9077,16 @@ namespace ProtobufTestMessages.Editions.Proto2 {
           return new OptionalGroup(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 1;
         private readonly static int ADefaultValue = 0;
@@ -9026,6 +9306,14 @@ namespace ProtobufTestMessages.Editions.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as NullHypothesisProto2);
     }
@@ -9183,6 +9471,14 @@ namespace ProtobufTestMessages.Editions.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public EnumOnlyProto2 Clone() {
       return new EnumOnlyProto2(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9358,6 +9654,15 @@ namespace ProtobufTestMessages.Editions.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public OneStringProto2 Clone() {
       return new OneStringProto2(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "data" field.</summary>
@@ -9574,6 +9879,18 @@ namespace ProtobufTestMessages.Editions.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ProtoWithKeywords Clone() {
       return new ProtoWithKeywords(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      inline_ = 0;
+      concept_ = "";
+      requires_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "inline" field.</summary>
@@ -9905,6 +10222,67 @@ namespace ProtobufTestMessages.Editions.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestAllRequiredTypesProto2 Clone() {
       return new TestAllRequiredTypesProto2(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      requiredInt32_ = 0;
+      requiredInt64_ = 0L;
+      requiredUint32_ = 0;
+      requiredUint64_ = 0UL;
+      requiredSint32_ = 0;
+      requiredSint64_ = 0L;
+      requiredFixed32_ = 0;
+      requiredFixed64_ = 0UL;
+      requiredSfixed32_ = 0;
+      requiredSfixed64_ = 0L;
+      requiredFloat_ = 0F;
+      requiredDouble_ = 0D;
+      requiredBool_ = false;
+      requiredString_ = "";
+      requiredBytes_ = pb::ByteString.Empty;
+      if (requiredNestedMessage_ != null) {
+        requiredNestedMessage_.Clear();
+      }
+      if (requiredForeignMessage_ != null) {
+        requiredForeignMessage_.Clear();
+      }
+      requiredNestedEnum_ = global::ProtobufTestMessages.Editions.Proto2.TestAllRequiredTypesProto2.Types.NestedEnum.Foo;
+      requiredForeignEnum_ = global::ProtobufTestMessages.Editions.Proto2.ForeignEnumProto2.ForeignFoo;
+      requiredStringPiece_ = "";
+      requiredCord_ = "";
+      if (recursiveMessage_ != null) {
+        recursiveMessage_.Clear();
+      }
+      if (optionalRecursiveMessage_ != null) {
+        optionalRecursiveMessage_.Clear();
+      }
+      if (data_ != null) {
+        data_.Clear();
+      }
+      defaultInt32_ = -123456789;
+      defaultInt64_ = -9123456789123456789L;
+      defaultUint32_ = 2123456789;
+      defaultUint64_ = 10123456789123456789UL;
+      defaultSint32_ = -123456789;
+      defaultSint64_ = -9123456789123456789L;
+      defaultFixed32_ = 2123456789;
+      defaultFixed64_ = 10123456789123456789UL;
+      defaultSfixed32_ = -123456789;
+      defaultSfixed64_ = -9123456789123456789L;
+      defaultFloat_ = 9e+09F;
+      defaultDouble_ = 7e+22D;
+      defaultBool_ = true;
+      defaultString_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("Um9zZWJ1ZA=="), 0, 7);
+      defaultBytes_ = pb::ByteString.FromBase64("am9zaHVh");
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "required_int32" field.</summary>
@@ -12101,6 +12479,22 @@ namespace ProtobufTestMessages.Editions.Proto2 {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (corecursive_ != null) {
+            corecursive_.Clear();
+          }
+          if (optionalCorecursive_ != null) {
+            optionalCorecursive_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 1;
         private readonly static int ADefaultValue = 0;
@@ -12410,6 +12804,17 @@ namespace ProtobufTestMessages.Editions.Proto2 {
           return new Data(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          groupInt32_ = 0;
+          groupUint32_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "group_int32" field.</summary>
         public const int GroupInt32FieldNumber = 202;
         private readonly static int GroupInt32DefaultValue = 0;
@@ -12681,6 +13086,17 @@ namespace ProtobufTestMessages.Editions.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_extensions != null) {
+            _extensions.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as MessageSetCorrect);
         }
@@ -12881,6 +13297,15 @@ namespace ProtobufTestMessages.Editions.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public MessageSetCorrectExtension1 Clone() {
           return new MessageSetCorrectExtension1(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          str_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "str" field.</summary>
@@ -13105,6 +13530,16 @@ namespace ProtobufTestMessages.Editions.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public MessageSetCorrectExtension2 Clone() {
           return new MessageSetCorrectExtension2(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          i_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "i" field.</summary>
@@ -13350,6 +13785,16 @@ namespace ProtobufTestMessages.Editions.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestLargeOneof Clone() {
       return new TestLargeOneof(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      largeOneofCase_ = LargeOneofOneofCase.None;
+      largeOneof_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "a1" field.</summary>
@@ -13792,6 +14237,14 @@ namespace ProtobufTestMessages.Editions.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as A1);
         }
@@ -13949,6 +14402,14 @@ namespace ProtobufTestMessages.Editions.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public A2 Clone() {
           return new A2(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14114,6 +14575,14 @@ namespace ProtobufTestMessages.Editions.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as A3);
         }
@@ -14275,6 +14744,14 @@ namespace ProtobufTestMessages.Editions.Proto2 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as A4);
         }
@@ -14432,6 +14909,14 @@ namespace ProtobufTestMessages.Editions.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public A5 Clone() {
           return new A5(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto3.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto3.pb.cs
@@ -483,6 +483,175 @@ namespace ProtobufTestMessages.Proto3 {
       return new TestAllTypesProto3(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      optionalInt32_ = 0;
+      optionalInt64_ = 0L;
+      optionalUint32_ = 0;
+      optionalUint64_ = 0UL;
+      optionalSint32_ = 0;
+      optionalSint64_ = 0L;
+      optionalFixed32_ = 0;
+      optionalFixed64_ = 0UL;
+      optionalSfixed32_ = 0;
+      optionalSfixed64_ = 0L;
+      optionalFloat_ = 0F;
+      optionalDouble_ = 0D;
+      optionalBool_ = false;
+      optionalString_ = "";
+      optionalBytes_ = pb::ByteString.Empty;
+      if (optionalNestedMessage_ != null) {
+        optionalNestedMessage_.Clear();
+      }
+      if (optionalForeignMessage_ != null) {
+        optionalForeignMessage_.Clear();
+      }
+      optionalNestedEnum_ = global::ProtobufTestMessages.Proto3.TestAllTypesProto3.Types.NestedEnum.Foo;
+      optionalForeignEnum_ = global::ProtobufTestMessages.Proto3.ForeignEnum.ForeignFoo;
+      optionalAliasedEnum_ = global::ProtobufTestMessages.Proto3.TestAllTypesProto3.Types.AliasedEnum.AliasFoo;
+      optionalStringPiece_ = "";
+      optionalCord_ = "";
+      if (recursiveMessage_ != null) {
+        recursiveMessage_.Clear();
+      }
+      repeatedInt32_.Clear();
+      repeatedInt64_.Clear();
+      repeatedUint32_.Clear();
+      repeatedUint64_.Clear();
+      repeatedSint32_.Clear();
+      repeatedSint64_.Clear();
+      repeatedFixed32_.Clear();
+      repeatedFixed64_.Clear();
+      repeatedSfixed32_.Clear();
+      repeatedSfixed64_.Clear();
+      repeatedFloat_.Clear();
+      repeatedDouble_.Clear();
+      repeatedBool_.Clear();
+      repeatedString_.Clear();
+      repeatedBytes_.Clear();
+      repeatedNestedMessage_.Clear();
+      repeatedForeignMessage_.Clear();
+      repeatedNestedEnum_.Clear();
+      repeatedForeignEnum_.Clear();
+      repeatedStringPiece_.Clear();
+      repeatedCord_.Clear();
+      packedInt32_.Clear();
+      packedInt64_.Clear();
+      packedUint32_.Clear();
+      packedUint64_.Clear();
+      packedSint32_.Clear();
+      packedSint64_.Clear();
+      packedFixed32_.Clear();
+      packedFixed64_.Clear();
+      packedSfixed32_.Clear();
+      packedSfixed64_.Clear();
+      packedFloat_.Clear();
+      packedDouble_.Clear();
+      packedBool_.Clear();
+      packedNestedEnum_.Clear();
+      unpackedInt32_.Clear();
+      unpackedInt64_.Clear();
+      unpackedUint32_.Clear();
+      unpackedUint64_.Clear();
+      unpackedSint32_.Clear();
+      unpackedSint64_.Clear();
+      unpackedFixed32_.Clear();
+      unpackedFixed64_.Clear();
+      unpackedSfixed32_.Clear();
+      unpackedSfixed64_.Clear();
+      unpackedFloat_.Clear();
+      unpackedDouble_.Clear();
+      unpackedBool_.Clear();
+      unpackedNestedEnum_.Clear();
+      mapInt32Int32_.Clear();
+      mapInt64Int64_.Clear();
+      mapUint32Uint32_.Clear();
+      mapUint64Uint64_.Clear();
+      mapSint32Sint32_.Clear();
+      mapSint64Sint64_.Clear();
+      mapFixed32Fixed32_.Clear();
+      mapFixed64Fixed64_.Clear();
+      mapSfixed32Sfixed32_.Clear();
+      mapSfixed64Sfixed64_.Clear();
+      mapInt32Float_.Clear();
+      mapInt32Double_.Clear();
+      mapBoolBool_.Clear();
+      mapStringString_.Clear();
+      mapStringBytes_.Clear();
+      mapStringNestedMessage_.Clear();
+      mapStringForeignMessage_.Clear();
+      mapStringNestedEnum_.Clear();
+      mapStringForeignEnum_.Clear();
+      optionalBoolWrapper_ = false;
+      optionalInt32Wrapper_ = 0;
+      optionalInt64Wrapper_ = 0L;
+      optionalUint32Wrapper_ = 0;
+      optionalUint64Wrapper_ = 0UL;
+      optionalFloatWrapper_ = 0F;
+      optionalDoubleWrapper_ = 0D;
+      optionalStringWrapper_ = "";
+      optionalBytesWrapper_ = pb::ByteString.Empty;
+      repeatedBoolWrapper_.Clear();
+      repeatedInt32Wrapper_.Clear();
+      repeatedInt64Wrapper_.Clear();
+      repeatedUint32Wrapper_.Clear();
+      repeatedUint64Wrapper_.Clear();
+      repeatedFloatWrapper_.Clear();
+      repeatedDoubleWrapper_.Clear();
+      repeatedStringWrapper_.Clear();
+      repeatedBytesWrapper_.Clear();
+      if (optionalDuration_ != null) {
+        optionalDuration_.Clear();
+      }
+      if (optionalTimestamp_ != null) {
+        optionalTimestamp_.Clear();
+      }
+      if (optionalFieldMask_ != null) {
+        optionalFieldMask_.Clear();
+      }
+      if (optionalStruct_ != null) {
+        optionalStruct_.Clear();
+      }
+      if (optionalAny_ != null) {
+        optionalAny_.Clear();
+      }
+      if (optionalValue_ != null) {
+        optionalValue_.Clear();
+      }
+      optionalNullValue_ = global::Google.Protobuf.WellKnownTypes.NullValue.NullValue;
+      repeatedDuration_.Clear();
+      repeatedTimestamp_.Clear();
+      repeatedFieldmask_.Clear();
+      repeatedStruct_.Clear();
+      repeatedAny_.Clear();
+      repeatedValue_.Clear();
+      repeatedListValue_.Clear();
+      fieldname1_ = 0;
+      fieldName2_ = 0;
+      FieldName3_ = 0;
+      fieldName4_ = 0;
+      field0Name5_ = 0;
+      field0Name6_ = 0;
+      fieldName7_ = 0;
+      fieldName8_ = 0;
+      fieldName9_ = 0;
+      fieldName10_ = 0;
+      fIELDNAME11_ = 0;
+      fIELDName12_ = 0;
+      FieldName13_ = 0;
+      FieldName14_ = 0;
+      fieldName15_ = 0;
+      fieldName16_ = 0;
+      fieldName17_ = 0;
+      fieldName18_ = 0;
+      oneofFieldCase_ = OneofFieldOneofCase.None;
+      oneofField_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "optional_int32" field.</summary>
     public const int OptionalInt32FieldNumber = 1;
     private int optionalInt32_;
@@ -5619,6 +5788,18 @@ namespace ProtobufTestMessages.Proto3 {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          a_ = 0;
+          if (corecursive_ != null) {
+            corecursive_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 1;
         private int a_;
@@ -5867,6 +6048,15 @@ namespace ProtobufTestMessages.Proto3 {
       return new ForeignMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      c_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "c" field.</summary>
     public const int CFieldNumber = 1;
     private int c_;
@@ -6066,6 +6256,14 @@ namespace ProtobufTestMessages.Proto3 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as NullHypothesisProto3);
     }
@@ -6223,6 +6421,14 @@ namespace ProtobufTestMessages.Proto3 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public EnumOnlyProto3 Clone() {
       return new EnumOnlyProto3(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto3Editions.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/TestMessagesProto3Editions.pb.cs
@@ -491,6 +491,175 @@ namespace ProtobufTestMessages.Editions.Proto3 {
       return new TestAllTypesProto3(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      optionalInt32_ = 0;
+      optionalInt64_ = 0L;
+      optionalUint32_ = 0;
+      optionalUint64_ = 0UL;
+      optionalSint32_ = 0;
+      optionalSint64_ = 0L;
+      optionalFixed32_ = 0;
+      optionalFixed64_ = 0UL;
+      optionalSfixed32_ = 0;
+      optionalSfixed64_ = 0L;
+      optionalFloat_ = 0F;
+      optionalDouble_ = 0D;
+      optionalBool_ = false;
+      optionalString_ = "";
+      optionalBytes_ = pb::ByteString.Empty;
+      if (optionalNestedMessage_ != null) {
+        optionalNestedMessage_.Clear();
+      }
+      if (optionalForeignMessage_ != null) {
+        optionalForeignMessage_.Clear();
+      }
+      optionalNestedEnum_ = global::ProtobufTestMessages.Editions.Proto3.TestAllTypesProto3.Types.NestedEnum.Foo;
+      optionalForeignEnum_ = global::ProtobufTestMessages.Editions.Proto3.ForeignEnum.ForeignFoo;
+      optionalAliasedEnum_ = global::ProtobufTestMessages.Editions.Proto3.TestAllTypesProto3.Types.AliasedEnum.AliasFoo;
+      optionalStringPiece_ = "";
+      optionalCord_ = "";
+      if (recursiveMessage_ != null) {
+        recursiveMessage_.Clear();
+      }
+      repeatedInt32_.Clear();
+      repeatedInt64_.Clear();
+      repeatedUint32_.Clear();
+      repeatedUint64_.Clear();
+      repeatedSint32_.Clear();
+      repeatedSint64_.Clear();
+      repeatedFixed32_.Clear();
+      repeatedFixed64_.Clear();
+      repeatedSfixed32_.Clear();
+      repeatedSfixed64_.Clear();
+      repeatedFloat_.Clear();
+      repeatedDouble_.Clear();
+      repeatedBool_.Clear();
+      repeatedString_.Clear();
+      repeatedBytes_.Clear();
+      repeatedNestedMessage_.Clear();
+      repeatedForeignMessage_.Clear();
+      repeatedNestedEnum_.Clear();
+      repeatedForeignEnum_.Clear();
+      repeatedStringPiece_.Clear();
+      repeatedCord_.Clear();
+      packedInt32_.Clear();
+      packedInt64_.Clear();
+      packedUint32_.Clear();
+      packedUint64_.Clear();
+      packedSint32_.Clear();
+      packedSint64_.Clear();
+      packedFixed32_.Clear();
+      packedFixed64_.Clear();
+      packedSfixed32_.Clear();
+      packedSfixed64_.Clear();
+      packedFloat_.Clear();
+      packedDouble_.Clear();
+      packedBool_.Clear();
+      packedNestedEnum_.Clear();
+      unpackedInt32_.Clear();
+      unpackedInt64_.Clear();
+      unpackedUint32_.Clear();
+      unpackedUint64_.Clear();
+      unpackedSint32_.Clear();
+      unpackedSint64_.Clear();
+      unpackedFixed32_.Clear();
+      unpackedFixed64_.Clear();
+      unpackedSfixed32_.Clear();
+      unpackedSfixed64_.Clear();
+      unpackedFloat_.Clear();
+      unpackedDouble_.Clear();
+      unpackedBool_.Clear();
+      unpackedNestedEnum_.Clear();
+      mapInt32Int32_.Clear();
+      mapInt64Int64_.Clear();
+      mapUint32Uint32_.Clear();
+      mapUint64Uint64_.Clear();
+      mapSint32Sint32_.Clear();
+      mapSint64Sint64_.Clear();
+      mapFixed32Fixed32_.Clear();
+      mapFixed64Fixed64_.Clear();
+      mapSfixed32Sfixed32_.Clear();
+      mapSfixed64Sfixed64_.Clear();
+      mapInt32Float_.Clear();
+      mapInt32Double_.Clear();
+      mapBoolBool_.Clear();
+      mapStringString_.Clear();
+      mapStringBytes_.Clear();
+      mapStringNestedMessage_.Clear();
+      mapStringForeignMessage_.Clear();
+      mapStringNestedEnum_.Clear();
+      mapStringForeignEnum_.Clear();
+      optionalBoolWrapper_ = false;
+      optionalInt32Wrapper_ = 0;
+      optionalInt64Wrapper_ = 0L;
+      optionalUint32Wrapper_ = 0;
+      optionalUint64Wrapper_ = 0UL;
+      optionalFloatWrapper_ = 0F;
+      optionalDoubleWrapper_ = 0D;
+      optionalStringWrapper_ = "";
+      optionalBytesWrapper_ = pb::ByteString.Empty;
+      repeatedBoolWrapper_.Clear();
+      repeatedInt32Wrapper_.Clear();
+      repeatedInt64Wrapper_.Clear();
+      repeatedUint32Wrapper_.Clear();
+      repeatedUint64Wrapper_.Clear();
+      repeatedFloatWrapper_.Clear();
+      repeatedDoubleWrapper_.Clear();
+      repeatedStringWrapper_.Clear();
+      repeatedBytesWrapper_.Clear();
+      if (optionalDuration_ != null) {
+        optionalDuration_.Clear();
+      }
+      if (optionalTimestamp_ != null) {
+        optionalTimestamp_.Clear();
+      }
+      if (optionalFieldMask_ != null) {
+        optionalFieldMask_.Clear();
+      }
+      if (optionalStruct_ != null) {
+        optionalStruct_.Clear();
+      }
+      if (optionalAny_ != null) {
+        optionalAny_.Clear();
+      }
+      if (optionalValue_ != null) {
+        optionalValue_.Clear();
+      }
+      optionalNullValue_ = global::Google.Protobuf.WellKnownTypes.NullValue.NullValue;
+      repeatedDuration_.Clear();
+      repeatedTimestamp_.Clear();
+      repeatedFieldmask_.Clear();
+      repeatedStruct_.Clear();
+      repeatedAny_.Clear();
+      repeatedValue_.Clear();
+      repeatedListValue_.Clear();
+      fieldname1_ = 0;
+      fieldName2_ = 0;
+      FieldName3_ = 0;
+      fieldName4_ = 0;
+      field0Name5_ = 0;
+      field0Name6_ = 0;
+      fieldName7_ = 0;
+      fieldName8_ = 0;
+      fieldName9_ = 0;
+      fieldName10_ = 0;
+      fIELDNAME11_ = 0;
+      fIELDName12_ = 0;
+      FieldName13_ = 0;
+      FieldName14_ = 0;
+      fieldName15_ = 0;
+      fieldName16_ = 0;
+      fieldName17_ = 0;
+      fieldName18_ = 0;
+      oneofFieldCase_ = OneofFieldOneofCase.None;
+      oneofField_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "optional_int32" field.</summary>
     public const int OptionalInt32FieldNumber = 1;
     private int optionalInt32_;
@@ -5627,6 +5796,18 @@ namespace ProtobufTestMessages.Editions.Proto3 {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          a_ = 0;
+          if (corecursive_ != null) {
+            corecursive_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 1;
         private int a_;
@@ -5875,6 +6056,15 @@ namespace ProtobufTestMessages.Editions.Proto3 {
       return new ForeignMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      c_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "c" field.</summary>
     public const int CFieldNumber = 1;
     private int c_;
@@ -6074,6 +6264,14 @@ namespace ProtobufTestMessages.Editions.Proto3 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as NullHypothesisProto3);
     }
@@ -6231,6 +6429,14 @@ namespace ProtobufTestMessages.Editions.Proto3 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public EnumOnlyProto3 Clone() {
       return new EnumOnlyProto3(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/csharp/src/Google.Protobuf.Test.TestProtos/Unittest.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/Unittest.pb.cs
@@ -1255,6 +1255,101 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestAllTypes(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      _hasBits1 = 0;
+      optionalInt32_ = 0;
+      optionalInt64_ = 0L;
+      optionalUint32_ = 0;
+      optionalUint64_ = 0UL;
+      optionalSint32_ = 0;
+      optionalSint64_ = 0L;
+      optionalFixed32_ = 0;
+      optionalFixed64_ = 0UL;
+      optionalSfixed32_ = 0;
+      optionalSfixed64_ = 0L;
+      optionalFloat_ = 0F;
+      optionalDouble_ = 0D;
+      optionalBool_ = false;
+      optionalString_ = "";
+      optionalBytes_ = pb::ByteString.Empty;
+      if (optionalGroup_ != null) {
+        optionalGroup_.Clear();
+      }
+      if (optionalNestedMessage_ != null) {
+        optionalNestedMessage_.Clear();
+      }
+      if (optionalForeignMessage_ != null) {
+        optionalForeignMessage_.Clear();
+      }
+      if (optionalImportMessage_ != null) {
+        optionalImportMessage_.Clear();
+      }
+      optionalNestedEnum_ = global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedEnum.Foo;
+      optionalForeignEnum_ = global::Google.Protobuf.TestProtos.Proto2.ForeignEnum.ForeignFoo;
+      optionalImportEnum_ = global::Google.Protobuf.TestProtos.Proto2.ImportEnum.ImportFoo;
+      optionalStringPiece_ = "";
+      optionalCord_ = "";
+      if (optionalPublicImportMessage_ != null) {
+        optionalPublicImportMessage_.Clear();
+      }
+      if (optionalLazyMessage_ != null) {
+        optionalLazyMessage_.Clear();
+      }
+      repeatedInt32_.Clear();
+      repeatedInt64_.Clear();
+      repeatedUint32_.Clear();
+      repeatedUint64_.Clear();
+      repeatedSint32_.Clear();
+      repeatedSint64_.Clear();
+      repeatedFixed32_.Clear();
+      repeatedFixed64_.Clear();
+      repeatedSfixed32_.Clear();
+      repeatedSfixed64_.Clear();
+      repeatedFloat_.Clear();
+      repeatedDouble_.Clear();
+      repeatedBool_.Clear();
+      repeatedString_.Clear();
+      repeatedBytes_.Clear();
+      repeatedGroup_.Clear();
+      repeatedNestedMessage_.Clear();
+      repeatedForeignMessage_.Clear();
+      repeatedImportMessage_.Clear();
+      repeatedNestedEnum_.Clear();
+      repeatedForeignEnum_.Clear();
+      repeatedImportEnum_.Clear();
+      repeatedStringPiece_.Clear();
+      repeatedCord_.Clear();
+      repeatedLazyMessage_.Clear();
+      defaultInt32_ = 41;
+      defaultInt64_ = 42L;
+      defaultUint32_ = 43;
+      defaultUint64_ = 44UL;
+      defaultSint32_ = -45;
+      defaultSint64_ = 46L;
+      defaultFixed32_ = 47;
+      defaultFixed64_ = 48UL;
+      defaultSfixed32_ = 49;
+      defaultSfixed64_ = -50L;
+      defaultFloat_ = 51.5F;
+      defaultDouble_ = 52000D;
+      defaultBool_ = true;
+      defaultString_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("aGVsbG8="), 0, 5);
+      defaultBytes_ = pb::ByteString.FromBase64("d29ybGQ=");
+      defaultNestedEnum_ = global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedEnum.Bar;
+      defaultForeignEnum_ = global::Google.Protobuf.TestProtos.Proto2.ForeignEnum.ForeignBar;
+      defaultImportEnum_ = global::Google.Protobuf.TestProtos.Proto2.ImportEnum.ImportBar;
+      defaultStringPiece_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("YWJj"), 0, 3);
+      defaultCord_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("MTIz"), 0, 3);
+      oneofFieldCase_ = OneofFieldOneofCase.None;
+      oneofField_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "optional_int32" field.</summary>
     public const int OptionalInt32FieldNumber = 1;
     private readonly static int OptionalInt32DefaultValue = 0;
@@ -4644,6 +4739,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          bb_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "bb" field.</summary>
         public const int BbFieldNumber = 1;
         private readonly static int BbDefaultValue = 0;
@@ -4864,6 +4969,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new OptionalGroup(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 17;
         private readonly static int ADefaultValue = 0;
@@ -5077,6 +5192,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public RepeatedGroup Clone() {
           return new RepeatedGroup(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "a" field.</summary>
@@ -5300,6 +5425,21 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public NestedTestAllTypes Clone() {
       return new NestedTestAllTypes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (child_ != null) {
+        child_.Clear();
+      }
+      if (payload_ != null) {
+        payload_.Clear();
+      }
+      repeatedChild_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "child" field.</summary>
@@ -5585,6 +5725,18 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestDeprecatedFields Clone() {
       return new TestDeprecatedFields(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      deprecatedInt32_ = 0;
+      oneofFieldsCase_ = OneofFieldsOneofCase.None;
+      oneofFields_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "deprecated_int32" field.</summary>
@@ -5883,6 +6035,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as TestDeprecatedMessage);
     }
@@ -6048,6 +6208,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ForeignMessage Clone() {
       return new ForeignMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      c_ = 0;
+      d_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "c" field.</summary>
@@ -6315,6 +6486,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as TestReservedFields);
     }
@@ -6475,6 +6654,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestAllExtensions Clone() {
       return new TestAllExtensions(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6681,6 +6871,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public OptionalGroup_extension Clone() {
       return new OptionalGroup_extension(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      a_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "a" field.</summary>
@@ -6898,6 +7098,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new RepeatedGroup_extension(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      a_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "a" field.</summary>
     public const int AFieldNumber = 47;
     private readonly static int ADefaultValue = 0;
@@ -7112,6 +7322,19 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestGroup Clone() {
       return new TestGroup(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      if (optionalGroup_ != null) {
+        optionalGroup_.Clear();
+      }
+      optionalForeignEnum_ = global::Google.Protobuf.TestProtos.Proto2.ForeignEnum.ForeignFoo;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "optionalgroup" field.</summary>
@@ -7391,6 +7614,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new OptionalGroup(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 17;
         private readonly static int ADefaultValue = 0;
@@ -7613,6 +7846,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as TestGroupExtension);
     }
@@ -7816,6 +8060,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as TestNestedExtension);
     }
@@ -7979,6 +8231,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public OptionalGroup_extension Clone() {
           return new OptionalGroup_extension(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "a" field.</summary>
@@ -8264,6 +8526,49 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestRequired Clone() {
       return new TestRequired(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      _hasBits1 = 0;
+      a_ = 0;
+      dummy2_ = 0;
+      b_ = 0;
+      dummy4_ = 0;
+      dummy5_ = 0;
+      dummy6_ = 0;
+      dummy7_ = 0;
+      dummy8_ = 0;
+      dummy9_ = 0;
+      dummy10_ = 0;
+      dummy11_ = 0;
+      dummy12_ = 0;
+      dummy13_ = 0;
+      dummy14_ = 0;
+      dummy15_ = 0;
+      dummy16_ = 0;
+      dummy17_ = 0;
+      dummy18_ = 0;
+      dummy19_ = 0;
+      dummy20_ = 0;
+      dummy21_ = 0;
+      dummy22_ = 0;
+      dummy23_ = 0;
+      dummy24_ = 0;
+      dummy25_ = 0;
+      dummy26_ = 0;
+      dummy27_ = 0;
+      dummy28_ = 0;
+      dummy29_ = 0;
+      dummy30_ = 0;
+      dummy31_ = 0;
+      dummy32_ = 0;
+      c_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "a" field.</summary>
@@ -10131,6 +10436,20 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestRequiredForeign(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      if (optionalMessage_ != null) {
+        optionalMessage_.Clear();
+      }
+      repeatedMessage_.Clear();
+      dummy_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "optional_message" field.</summary>
     public const int OptionalMessageFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.Proto2.TestRequired optionalMessage_;
@@ -10416,6 +10735,21 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestRequiredMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (optionalMessage_ != null) {
+        optionalMessage_.Clear();
+      }
+      repeatedMessage_.Clear();
+      if (requiredMessage_ != null) {
+        requiredMessage_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "optional_message" field.</summary>
     public const int OptionalMessageFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.Proto2.TestRequired optionalMessage_;
@@ -10696,6 +11030,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestForeignNested(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (foreignNested_ != null) {
+        foreignNested_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "foreign_nested" field.</summary>
     public const int ForeignNestedFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage foreignNested_;
@@ -10907,6 +11252,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as TestEmptyMessage);
     }
@@ -11071,6 +11424,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestEmptyMessageWithExtensions Clone() {
       return new TestEmptyMessageWithExtensions(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11281,6 +11645,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as TestMultipleExtensionRanges);
     }
@@ -11487,6 +11862,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestReallyLargeTagNumber Clone() {
       return new TestReallyLargeTagNumber(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      a_ = 0;
+      bb_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "a" field.</summary>
@@ -11760,6 +12146,19 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestRecursiveMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      if (a_ != null) {
+        a_.Clear();
+      }
+      i_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "a" field.</summary>
     public const int AFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.Proto2.TestRecursiveMessage a_;
@@ -12020,6 +12419,20 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestMutualRecursionA Clone() {
       return new TestMutualRecursionA(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (bb_ != null) {
+        bb_.Clear();
+      }
+      if (subGroup_ != null) {
+        subGroup_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "bb" field.</summary>
@@ -12291,6 +12704,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new SubMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (b_ != null) {
+            b_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "b" field.</summary>
         public const int BFieldNumber = 1;
         private global::Google.Protobuf.TestProtos.Proto2.TestMutualRecursionB b_;
@@ -12497,6 +12921,20 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public SubGroup Clone() {
           return new SubGroup(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (subMessage_ != null) {
+            subMessage_.Clear();
+          }
+          if (notInThisScc_ != null) {
+            notInThisScc_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "sub_message" field.</summary>
@@ -12762,6 +13200,19 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestMutualRecursionB(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      if (a_ != null) {
+        a_.Clear();
+      }
+      optionalInt32_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "a" field.</summary>
     public const int AFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.Proto2.TestMutualRecursionA a_;
@@ -13020,6 +13471,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestIsInitialized(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (subMessage_ != null) {
+        subMessage_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "sub_message" field.</summary>
     public const int SubMessageFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.Proto2.TestIsInitialized.Types.SubMessage subMessage_;
@@ -13228,6 +13690,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public SubMessage Clone() {
           return new SubMessage(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (subGroup_ != null) {
+            subGroup_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "subgroup" field.</summary>
@@ -13454,6 +13927,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
             public SubGroup Clone() {
               return new SubGroup(this);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void Clear() {
+              _hasBits0 = 0;
+              i_ = 0;
+              if (_unknownFields != null) {
+                _unknownFields.Clear();
+              }
             }
 
             /// <summary>Field number for the "i" field.</summary>
@@ -13687,6 +14170,22 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestDupFieldNumber Clone() {
       return new TestDupFieldNumber(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      a_ = 0;
+      if (foo_ != null) {
+        foo_.Clear();
+      }
+      if (bar_ != null) {
+        bar_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "a" field.</summary>
@@ -14028,6 +14527,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new Foo(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 1;
         private readonly static int ADefaultValue = 0;
@@ -14241,6 +14750,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public Bar Clone() {
           return new Bar(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "a" field.</summary>
@@ -14464,6 +14983,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestEagerMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (subMessage_ != null) {
+        subMessage_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "sub_message" field.</summary>
     public const int SubMessageFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.Proto2.TestAllTypes subMessage_;
@@ -14669,6 +15199,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestLazyMessage Clone() {
       return new TestLazyMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (subMessage_ != null) {
+        subMessage_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "sub_message" field.</summary>
@@ -14881,6 +15422,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestNestedMessageHasBits(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (optionalNestedMessage_ != null) {
+        optionalNestedMessage_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "optional_nested_message" field.</summary>
     public const int OptionalNestedMessageFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.Proto2.TestNestedMessageHasBits.Types.NestedMessage optionalNestedMessage_;
@@ -15090,6 +15642,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public NestedMessage Clone() {
           return new NestedMessage(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          nestedmessageRepeatedInt32_.Clear();
+          nestedmessageRepeatedForeignmessage_.Clear();
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "nestedmessage_repeated_int32" field.</summary>
@@ -15326,6 +15888,29 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestCamelCaseFieldNames Clone() {
       return new TestCamelCaseFieldNames(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      primitiveField_ = 0;
+      stringField_ = "";
+      enumField_ = global::Google.Protobuf.TestProtos.Proto2.ForeignEnum.ForeignFoo;
+      if (messageField_ != null) {
+        messageField_.Clear();
+      }
+      stringPieceField_ = "";
+      cordField_ = "";
+      repeatedPrimitiveField_.Clear();
+      repeatedStringField_.Clear();
+      repeatedEnumField_.Clear();
+      repeatedMessageField_.Clear();
+      repeatedStringPieceField_.Clear();
+      repeatedCordField_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "PrimitiveField" field.</summary>
@@ -15953,6 +16538,24 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestFieldOrderings(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      myString_ = "";
+      myInt_ = 0L;
+      myFloat_ = 0F;
+      if (optionalNestedMessage_ != null) {
+        optionalNestedMessage_.Clear();
+      }
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "my_string" field.</summary>
     public const int MyStringFieldNumber = 11;
     private readonly static string MyStringDefaultValue = "";
@@ -16360,6 +16963,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          oo_ = 0L;
+          bb_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "oo" field.</summary>
         public const int OoFieldNumber = 2;
         private readonly static long OoDefaultValue = 0L;
@@ -16634,6 +17248,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestExtensionOrderings1(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      myString_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "my_string" field.</summary>
     public const int MyStringFieldNumber = 1;
     private readonly static string MyStringDefaultValue = "";
@@ -16856,6 +17479,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestExtensionOrderings2(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      myString_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "my_string" field.</summary>
     public const int MyStringFieldNumber = 1;
     private readonly static string MyStringDefaultValue = "";
@@ -17069,6 +17701,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public TestExtensionOrderings3 Clone() {
           return new TestExtensionOrderings3(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          myString_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "my_string" field.</summary>
@@ -17334,6 +17975,42 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestExtremeDefaultValues Clone() {
       return new TestExtremeDefaultValues(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      escapedBytes_ = pb::ByteString.FromBase64("AAEHCAwKDQkLXCci/g==");
+      largeUint32_ = 4294967295;
+      largeUint64_ = 18446744073709551615UL;
+      smallInt32_ = -2147483647;
+      smallInt64_ = -9223372036854775807L;
+      reallySmallInt32_ = -2147483648;
+      reallySmallInt64_ = -9223372036854775808L;
+      utf8String_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("4Yi0"), 0, 3);
+      zeroFloat_ = 0F;
+      oneFloat_ = 1F;
+      smallFloat_ = 1.5F;
+      negativeOneFloat_ = -1F;
+      negativeFloat_ = -1.5F;
+      largeFloat_ = 2e+08F;
+      smallNegativeFloat_ = -8e-28F;
+      infDouble_ = double.PositiveInfinity;
+      negInfDouble_ = double.NegativeInfinity;
+      nanDouble_ = double.NaN;
+      infFloat_ = float.PositiveInfinity;
+      negInfFloat_ = float.NegativeInfinity;
+      nanFloat_ = float.NaN;
+      cppTrigraph_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("PyA/ID8/ID8/ID8/PyA/Py8gPz8t"), 0, 21);
+      stringWithZero_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("aGVsAGxv"), 0, 6);
+      bytesWithZero_ = pb::ByteString.FromBase64("d29yAGxk");
+      stringPieceWithZero_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("YWIAYw=="), 0, 4);
+      cordWithZero_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("MTIAMw=="), 0, 4);
+      replacementString_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("JHt1bmtub3dufQ=="), 0, 10);
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "escaped_bytes" field.</summary>
@@ -18893,6 +19570,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new SparseEnumMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      sparseEnum_ = global::Google.Protobuf.TestProtos.Proto2.TestSparseEnum.SparseA;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "sparse_enum" field.</summary>
     public const int SparseEnumFieldNumber = 1;
     private readonly static global::Google.Protobuf.TestProtos.Proto2.TestSparseEnum SparseEnumDefaultValue = global::Google.Protobuf.TestProtos.Proto2.TestSparseEnum.SparseA;
@@ -19109,6 +19796,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new OneString(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "data" field.</summary>
     public const int DataFieldNumber = 1;
     private readonly static string DataDefaultValue = "";
@@ -19321,6 +20017,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new MoreString(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "data" field.</summary>
     public const int DataFieldNumber = 1;
     private static readonly pb::FieldCodec<string> _repeated_data_codec
@@ -19506,6 +20211,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public OneBytes Clone() {
       return new OneBytes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = pb::ByteString.Empty;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "data" field.</summary>
@@ -19720,6 +20434,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new MoreBytes(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "data" field.</summary>
     public const int DataFieldNumber = 1;
     private static readonly pb::FieldCodec<pb::ByteString> _repeated_data_codec
@@ -19910,6 +20633,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Int32Message Clone() {
       return new Int32Message(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      data_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "data" field.</summary>
@@ -20127,6 +20860,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new Uint32Message(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      data_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "data" field.</summary>
     public const int DataFieldNumber = 1;
     private readonly static uint DataDefaultValue = 0;
@@ -20340,6 +21083,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Int64Message Clone() {
       return new Int64Message(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      data_ = 0L;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "data" field.</summary>
@@ -20557,6 +21310,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new Uint64Message(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      data_ = 0UL;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "data" field.</summary>
     public const int DataFieldNumber = 1;
     private readonly static ulong DataDefaultValue = 0UL;
@@ -20770,6 +21533,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public BoolMessage Clone() {
       return new BoolMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      data_ = false;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "data" field.</summary>
@@ -21000,6 +21773,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestOneof Clone() {
       return new TestOneof(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      fooCase_ = FooOneofCase.None;
+      foo_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "foo_int" field.</summary>
@@ -21412,6 +22195,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new FooGroup(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          b_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 5;
         private readonly static int ADefaultValue = 0;
@@ -21683,6 +22477,23 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestOneofBackwardsCompatible Clone() {
       return new TestOneofBackwardsCompatible(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      fooInt_ = 0;
+      fooString_ = "";
+      if (fooMessage_ != null) {
+        fooMessage_.Clear();
+      }
+      if (fooGroup_ != null) {
+        fooGroup_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "foo_int" field.</summary>
@@ -22058,6 +22869,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new FooGroup(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          b_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 5;
         private readonly static int ADefaultValue = 0;
@@ -22378,6 +23200,21 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestOneof2 Clone() {
       return new TestOneof2(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      bazInt_ = 0;
+      bazString_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("QkFa"), 0, 3);
+      fooCase_ = FooOneofCase.None;
+      foo_ = null;
+      barCase_ = BarOneofCase.None;
+      bar_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "foo_int" field.</summary>
@@ -23485,6 +24322,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new FooGroup(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          a_ = 0;
+          b_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "a" field.</summary>
         public const int AFieldNumber = 9;
         private readonly static int ADefaultValue = 0;
@@ -23751,6 +24599,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          quxInt_ = 0L;
+          corgeInt_.Clear();
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "qux_int" field.</summary>
         public const int QuxIntFieldNumber = 1;
         private readonly static long QuxIntDefaultValue = 0L;
@@ -24005,6 +24864,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestRequiredOneof Clone() {
       return new TestRequiredOneof(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      fooCase_ = FooOneofCase.None;
+      foo_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "foo_int" field.</summary>
@@ -24350,6 +25219,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          requiredDouble_ = 0D;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "required_double" field.</summary>
         public const int RequiredDoubleFieldNumber = 1;
         private readonly static double RequiredDoubleDefaultValue = 0D;
@@ -24568,6 +25447,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestRequiredMap(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      foo_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "foo" field.</summary>
     public const int FooFieldNumber = 1;
     private static readonly pbc::MapField<int, global::Google.Protobuf.TestProtos.Proto2.TestRequiredMap.Types.NestedMessage>.Codec _map_foo_codec
@@ -24758,6 +25646,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public NestedMessage Clone() {
           return new NestedMessage(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          requiredInt32_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "required_int32" field.</summary>
@@ -24989,6 +25887,28 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestPackedTypes Clone() {
       return new TestPackedTypes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      packedInt32_.Clear();
+      packedInt64_.Clear();
+      packedUint32_.Clear();
+      packedUint64_.Clear();
+      packedSint32_.Clear();
+      packedSint64_.Clear();
+      packedFixed32_.Clear();
+      packedFixed64_.Clear();
+      packedSfixed32_.Clear();
+      packedSfixed64_.Clear();
+      packedFloat_.Clear();
+      packedDouble_.Clear();
+      packedBool_.Clear();
+      packedEnum_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "packed_int32" field.</summary>
@@ -25548,6 +26468,28 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestUnpackedTypes(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      unpackedInt32_.Clear();
+      unpackedInt64_.Clear();
+      unpackedUint32_.Clear();
+      unpackedUint64_.Clear();
+      unpackedSint32_.Clear();
+      unpackedSint64_.Clear();
+      unpackedFixed32_.Clear();
+      unpackedFixed64_.Clear();
+      unpackedSfixed32_.Clear();
+      unpackedSfixed64_.Clear();
+      unpackedFloat_.Clear();
+      unpackedDouble_.Clear();
+      unpackedBool_.Clear();
+      unpackedEnum_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "unpacked_int32" field.</summary>
     public const int UnpackedInt32FieldNumber = 90;
     private static readonly pb::FieldCodec<int> _repeated_unpackedInt32_codec
@@ -26092,6 +27034,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as TestPackedExtensions);
     }
@@ -26294,6 +27247,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestUnpackedExtensions Clone() {
       return new TestUnpackedExtensions(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -26511,6 +27475,26 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestDynamicExtensions Clone() {
       return new TestDynamicExtensions(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      scalarExtension_ = 0;
+      enumExtension_ = global::Google.Protobuf.TestProtos.Proto2.ForeignEnum.ForeignFoo;
+      dynamicEnumExtension_ = global::Google.Protobuf.TestProtos.Proto2.TestDynamicExtensions.Types.DynamicEnumType.DynamicFoo;
+      if (messageExtension_ != null) {
+        messageExtension_.Clear();
+      }
+      if (dynamicMessageExtension_ != null) {
+        dynamicMessageExtension_.Clear();
+      }
+      repeatedExtension_.Clear();
+      packedExtension_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "scalar_extension" field.</summary>
@@ -26981,6 +27965,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new DynamicMessageType(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          dynamicField_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "dynamic_field" field.</summary>
         public const int DynamicFieldFieldNumber = 2100;
         private readonly static int DynamicFieldDefaultValue = 0;
@@ -27202,6 +28196,20 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestRepeatedScalarDifferentTagSizes Clone() {
       return new TestRepeatedScalarDifferentTagSizes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      repeatedFixed32_.Clear();
+      repeatedInt32_.Clear();
+      repeatedFixed64_.Clear();
+      repeatedInt64_.Clear();
+      repeatedFloat_.Clear();
+      repeatedUint64_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "repeated_fixed32" field.</summary>
@@ -27551,6 +28559,28 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestParsingMerge Clone() {
       return new TestParsingMerge(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (requiredAllTypes_ != null) {
+        requiredAllTypes_.Clear();
+      }
+      if (optionalAllTypes_ != null) {
+        optionalAllTypes_.Clear();
+      }
+      repeatedAllTypes_.Clear();
+      if (optionalGroup_ != null) {
+        optionalGroup_.Clear();
+      }
+      repeatedGroup_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "required_all_types" field.</summary>
@@ -27972,6 +29002,21 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new RepeatedFieldsGenerator(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          field1_.Clear();
+          field2_.Clear();
+          field3_.Clear();
+          group1_.Clear();
+          group2_.Clear();
+          ext1_.Clear();
+          ext2_.Clear();
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "field1" field.</summary>
         public const int Field1FieldNumber = 1;
         private static readonly pb::FieldCodec<global::Google.Protobuf.TestProtos.Proto2.TestAllTypes> _repeated_field1_codec
@@ -28312,6 +29357,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
               return new Group1(this);
             }
 
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void Clear() {
+              if (field1_ != null) {
+                field1_.Clear();
+              }
+              if (_unknownFields != null) {
+                _unknownFields.Clear();
+              }
+            }
+
             /// <summary>Field number for the "field1" field.</summary>
             public const int Field1FieldNumber = 11;
             private global::Google.Protobuf.TestProtos.Proto2.TestAllTypes field1_;
@@ -28517,6 +29573,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
             [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
             public Group2 Clone() {
               return new Group2(this);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void Clear() {
+              if (field1_ != null) {
+                field1_.Clear();
+              }
+              if (_unknownFields != null) {
+                _unknownFields.Clear();
+              }
             }
 
             /// <summary>Field number for the "field1" field.</summary>
@@ -28731,6 +29798,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new OptionalGroup(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (optionalGroupAllTypes_ != null) {
+            optionalGroupAllTypes_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "optional_group_all_types" field.</summary>
         public const int OptionalGroupAllTypesFieldNumber = 11;
         private global::Google.Protobuf.TestProtos.Proto2.TestAllTypes optionalGroupAllTypes_;
@@ -28936,6 +30014,17 @@ namespace Google.Protobuf.TestProtos.Proto2 {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public RepeatedGroup Clone() {
           return new RepeatedGroup(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (repeatedGroupAllTypes_ != null) {
+            repeatedGroupAllTypes_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "repeated_group_all_types" field.</summary>
@@ -29162,6 +30251,15 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new TestCommentInjectionMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      a_ = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("Ki8gPC0gTmVpdGhlciBzaG91bGQgdGhpcy4="), 0, 26);
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "a" field.</summary>
     public const int AFieldNumber = 1;
     private readonly static string ADefaultValue = global::System.Text.Encoding.UTF8.GetString(global::System.Convert.FromBase64String("Ki8gPC0gTmVpdGhlciBzaG91bGQgdGhpcy4="), 0, 26);
@@ -29381,6 +30479,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as FooRequest);
     }
@@ -29538,6 +30644,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FooResponse Clone() {
       return new FooResponse(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -29703,6 +30817,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as FooClientMessage);
     }
@@ -29860,6 +30982,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FooServerMessage Clone() {
       return new FooServerMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -30025,6 +31155,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as BarRequest);
     }
@@ -30182,6 +31320,14 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public BarResponse Clone() {
       return new BarResponse(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -30351,6 +31497,21 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestJsonName Clone() {
       return new TestJsonName(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      fieldName1_ = 0;
+      fieldName2_ = 0;
+      fieldName3_ = 0;
+      FieldName4_ = 0;
+      fIELDNAME5_ = 0;
+      fieldName6_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "field_name1" field.</summary>
@@ -30848,6 +32009,34 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestHugeFieldNumbers Clone() {
       return new TestHugeFieldNumbers(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      optionalInt32_ = 0;
+      fixed32_ = 0;
+      repeatedInt32_.Clear();
+      packedInt32_.Clear();
+      optionalEnum_ = global::Google.Protobuf.TestProtos.Proto2.ForeignEnum.ForeignFoo;
+      optionalString_ = "";
+      optionalBytes_ = pb::ByteString.Empty;
+      if (optionalMessage_ != null) {
+        optionalMessage_.Clear();
+      }
+      if (optionalGroup_ != null) {
+        optionalGroup_.Clear();
+      }
+      stringStringMap_.Clear();
+      oneofFieldCase_ = OneofFieldOneofCase.None;
+      oneofField_ = null;
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "optional_int32" field.</summary>
@@ -31722,6 +32911,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
           return new OptionalGroup(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          groupA_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "group_a" field.</summary>
         public const int GroupAFieldNumber = 536870009;
         private readonly static int GroupADefaultValue = 0;
@@ -31951,6 +33150,27 @@ namespace Google.Protobuf.TestProtos.Proto2 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestExtensionInsideTable Clone() {
       return new TestExtensionInsideTable(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      field1_ = 0;
+      field2_ = 0;
+      field3_ = 0;
+      field4_ = 0;
+      field6_ = 0;
+      field7_ = 0;
+      field8_ = 0;
+      field9_ = 0;
+      field10_ = 0;
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "field1" field.</summary>

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestCustomOptionsProto3.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestCustomOptionsProto3.pb.cs
@@ -307,6 +307,17 @@ namespace UnitTest.Issues.TestProtos {
       return new TestMessageWithCustomOptions(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      field1_ = "";
+      anOneofCase_ = AnOneofOneofCase.None;
+      anOneof_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "field1" field.</summary>
     public const int Field1FieldNumber = 1;
     private string field1_ = "";
@@ -599,6 +610,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionFooRequest);
     }
@@ -756,6 +775,14 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public CustomOptionFooResponse Clone() {
       return new CustomOptionFooResponse(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -921,6 +948,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionFooClientMessage);
     }
@@ -1082,6 +1117,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionFooServerMessage);
     }
@@ -1239,6 +1282,14 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public DummyMessageContainingEnum Clone() {
       return new DummyMessageContainingEnum(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1418,6 +1469,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as DummyMessageInvalidAsOptionType);
     }
@@ -1575,6 +1634,14 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public CustomOptionMinIntegerValues Clone() {
       return new CustomOptionMinIntegerValues(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1740,6 +1807,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionMaxIntegerValues);
     }
@@ -1897,6 +1972,14 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public CustomOptionOtherValues Clone() {
       return new CustomOptionOtherValues(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2062,6 +2145,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as SettingRealsFromPositiveInts);
     }
@@ -2219,6 +2310,14 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public SettingRealsFromNegativeInts Clone() {
       return new SettingRealsFromNegativeInts(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2384,6 +2483,18 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ComplexOptionType1 Clone() {
       return new ComplexOptionType1(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      foo_ = 0;
+      foo2_ = 0;
+      foo3_ = 0;
+      foo4_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "foo" field.</summary>
@@ -2684,6 +2795,22 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ComplexOptionType2 Clone() {
       return new ComplexOptionType2(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (bar_ != null) {
+        bar_.Clear();
+      }
+      baz_ = 0;
+      if (fred_ != null) {
+        fred_.Clear();
+      }
+      barney_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "bar" field.</summary>
@@ -3002,6 +3129,15 @@ namespace UnitTest.Issues.TestProtos {
           return new ComplexOptionType4(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          waldo_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "waldo" field.</summary>
         public const int WaldoFieldNumber = 1;
         private int waldo_;
@@ -3215,6 +3351,15 @@ namespace UnitTest.Issues.TestProtos {
       return new ComplexOptionType3(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      qux_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "qux" field.</summary>
     public const int QuxFieldNumber = 1;
     private int qux_;
@@ -3417,6 +3562,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as VariousComplexOptions);
     }
@@ -3580,6 +3733,19 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Aggregate Clone() {
       return new Aggregate(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      i_ = 0;
+      s_ = "";
+      if (sub_ != null) {
+        sub_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "i" field.</summary>
@@ -3864,6 +4030,15 @@ namespace UnitTest.Issues.TestProtos {
       return new AggregateMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      fieldname_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "fieldname" field.</summary>
     public const int FieldnameFieldNumber = 1;
     private int fieldname_;
@@ -4066,6 +4241,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as NestedOptionType);
     }
@@ -4232,6 +4415,15 @@ namespace UnitTest.Issues.TestProtos {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public NestedMessage Clone() {
           return new NestedMessage(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          nestedField_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "nested_field" field.</summary>

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestFeatures.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestFeatures.pb.cs
@@ -175,6 +175,14 @@ namespace Pb {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as TestMessage);
     }
@@ -335,6 +343,14 @@ namespace Pb {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public Nested Clone() {
           return new Nested(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -540,6 +556,32 @@ namespace Pb {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestFeatures Clone() {
       return new TestFeatures(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      fileFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      extensionRangeFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      messageFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      fieldFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      oneofFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      enumFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      enumEntryFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      serviceFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      methodFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      multipleFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      boolFieldFeature_ = false;
+      sourceFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      sourceFeature2_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      removedFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      futureFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      legacyFeature_ = global::Pb.EnumFeature.TestEnumFeatureUnknown;
+      valueLifetimeFeature_ = global::Pb.ValueLifetimeFeature.TestValueLifetimeUnknown;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "file_feature" field.</summary>

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestImport.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestImport.pb.cs
@@ -106,6 +106,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new ImportMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      d_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "d" field.</summary>
     public const int DFieldNumber = 1;
     private readonly static int DDefaultValue = 0;

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestImportProto3.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestImportProto3.pb.cs
@@ -96,6 +96,15 @@ namespace Google.Protobuf.TestProtos {
       return new ImportMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      d_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "d" field.</summary>
     public const int DFieldNumber = 1;
     private int d_;

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestImportPublic.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestImportPublic.pb.cs
@@ -85,6 +85,16 @@ namespace Google.Protobuf.TestProtos.Proto2 {
       return new PublicImportMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      e_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "e" field.</summary>
     public const int EFieldNumber = 1;
     private readonly static int EDefaultValue = 0;

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestImportPublicProto3.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestImportPublicProto3.pb.cs
@@ -83,6 +83,15 @@ namespace Google.Protobuf.TestProtos {
       return new PublicImportMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      e_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "e" field.</summary>
     public const int EFieldNumber = 1;
     private int e_;

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestIssue6936B.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestIssue6936B.pb.cs
@@ -84,6 +84,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as Foo);
     }

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestIssue6936C.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestIssue6936C.pb.cs
@@ -85,6 +85,17 @@ namespace UnitTest.Issues.TestProtos {
       return new Bar(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (foo_ != null) {
+        foo_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "foo" field.</summary>
     public const int FooFieldNumber = 1;
     private global::UnitTest.Issues.TestProtos.Foo foo_;

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestIssues.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestIssues.pb.cs
@@ -160,6 +160,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as Issue307);
     }
@@ -324,6 +332,14 @@ namespace UnitTest.Issues.TestProtos {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as NestedOnce);
         }
@@ -484,6 +500,14 @@ namespace UnitTest.Issues.TestProtos {
             [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
             public NestedTwice Clone() {
               return new NestedTwice(this);
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+            [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+            public void Clear() {
+              if (_unknownFields != null) {
+                _unknownFields.Clear();
+              }
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -658,6 +682,17 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public NegativeEnumMessage Clone() {
       return new NegativeEnumMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = global::UnitTest.Issues.TestProtos.NegativeEnum.Zero;
+      values_.Clear();
+      packedValues_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "value" field.</summary>
@@ -914,6 +949,14 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as DeprecatedChild);
     }
@@ -1077,6 +1120,22 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public DeprecatedFieldsMessage Clone() {
       return new DeprecatedFieldsMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      primitiveValue_ = 0;
+      primitiveArray_.Clear();
+      if (messageValue_ != null) {
+        messageValue_.Clear();
+      }
+      messageArray_.Clear();
+      enumValue_ = global::UnitTest.Issues.TestProtos.DeprecatedEnum.DeprecatedZero;
+      enumArray_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "PrimitiveValue" field.</summary>
@@ -1446,6 +1505,15 @@ namespace UnitTest.Issues.TestProtos {
       return new ItemField(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      item_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "item" field.</summary>
     public const int ItemFieldNumber = 1;
     private int item_;
@@ -1643,6 +1711,16 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ReservedNames Clone() {
       return new ReservedNames(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      types_ = 0;
+      descriptor_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "types" field.</summary>
@@ -1886,6 +1964,14 @@ namespace UnitTest.Issues.TestProtos {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as SomeNestedType);
         }
@@ -2080,6 +2166,20 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestJsonFieldOrdering Clone() {
       return new TestJsonFieldOrdering(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      plainInt32_ = 0;
+      plainString_ = "";
+      o1Case_ = O1OneofCase.None;
+      o1_ = null;
+      o2Case_ = O2OneofCase.None;
+      o2_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "plain_int32" field.</summary>
@@ -2570,6 +2670,17 @@ namespace UnitTest.Issues.TestProtos {
       return new TestJsonName(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      description_ = "";
+      guid_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private string name_ = "";
@@ -2854,6 +2965,16 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public OneofMerging Clone() {
       return new OneofMerging(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      valueCase_ = ValueOneofCase.None;
+      value_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "text" field.</summary>
@@ -3147,6 +3268,16 @@ namespace UnitTest.Issues.TestProtos {
           return new Nested(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          x_ = 0;
+          y_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "x" field.</summary>
         public const int XFieldNumber = 1;
         private int x_;
@@ -3392,6 +3523,16 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public NullValueOutsideStruct Clone() {
       return new NullValueOutsideStruct(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      valueCase_ = ValueOneofCase.None;
+      value_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "string_value" field.</summary>
@@ -3684,6 +3825,15 @@ namespace UnitTest.Issues.TestProtos {
       return new NullValueNotInOneof(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      nullValue_ = global::Google.Protobuf.WellKnownTypes.NullValue.NullValue;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "null_value" field.</summary>
     public const int NullValueFieldNumber = 2;
     private global::Google.Protobuf.WellKnownTypes.NullValue nullValue_ = global::Google.Protobuf.WellKnownTypes.NullValue.NullValue;
@@ -3881,6 +4031,16 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public MixedRegularAndOptional Clone() {
       return new MixedRegularAndOptional(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      regularField_ = "";
+      optionalField_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "regular_field" field.</summary>
@@ -4137,6 +4297,16 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public OneofWithNoneField Clone() {
       return new OneofWithNoneField(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      testCase_ = TestOneofCase.None;
+      test_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "x" field.</summary>
@@ -4433,6 +4603,16 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public OneofWithNoneName Clone() {
       return new OneofWithNoneName(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      noneCase_ = NoneOneofCase.None;
+      none_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "x" field.</summary>
@@ -4735,6 +4915,26 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public DisambiguateCommonMembers Clone() {
       return new DisambiguateCommonMembers(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      disambiguateCommonMembers_ = 0;
+      types_ = 0;
+      descriptor_ = 0;
+      equals_ = 0;
+      toString_ = 0;
+      getHashCode_ = 0;
+      writeTo_ = 0;
+      clone_ = 0;
+      calculateSize_ = 0;
+      mergeFrom_ = 0;
+      onConstruction_ = 0;
+      parser_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "disambiguate_common_members" field.</summary>
@@ -5331,6 +5531,17 @@ namespace UnitTest.Issues.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Issue11987Message Clone() {
       return new Issue11987Message(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      a_ = 0;
+      b_ = 0;
+      c_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "a" field.</summary>

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestLegacyFeatures.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestLegacyFeatures.pb.cs
@@ -87,6 +87,19 @@ namespace LegacyFeaturesUnittest {
       return new TestEditionsMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      requiredField_ = 0;
+      if (delimitedField_ != null) {
+        delimitedField_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "required_field" field.</summary>
     public const int RequiredFieldFieldNumber = 1;
     private readonly static int RequiredFieldDefaultValue = 0;

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestProto3.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestProto3.pb.cs
@@ -358,6 +358,68 @@ namespace Google.Protobuf.TestProtos {
       return new TestAllTypes(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      singleInt32_ = 0;
+      singleInt64_ = 0L;
+      singleUint32_ = 0;
+      singleUint64_ = 0UL;
+      singleSint32_ = 0;
+      singleSint64_ = 0L;
+      singleFixed32_ = 0;
+      singleFixed64_ = 0UL;
+      singleSfixed32_ = 0;
+      singleSfixed64_ = 0L;
+      singleFloat_ = 0F;
+      singleDouble_ = 0D;
+      singleBool_ = false;
+      singleString_ = "";
+      singleBytes_ = pb::ByteString.Empty;
+      if (singleNestedMessage_ != null) {
+        singleNestedMessage_.Clear();
+      }
+      if (singleForeignMessage_ != null) {
+        singleForeignMessage_.Clear();
+      }
+      if (singleImportMessage_ != null) {
+        singleImportMessage_.Clear();
+      }
+      singleNestedEnum_ = global::Google.Protobuf.TestProtos.TestAllTypes.Types.NestedEnum.Unspecified;
+      singleForeignEnum_ = global::Google.Protobuf.TestProtos.ForeignEnum.ForeignUnspecified;
+      singleImportEnum_ = global::Google.Protobuf.TestProtos.ImportEnum.Unspecified;
+      if (singlePublicImportMessage_ != null) {
+        singlePublicImportMessage_.Clear();
+      }
+      repeatedInt32_.Clear();
+      repeatedInt64_.Clear();
+      repeatedUint32_.Clear();
+      repeatedUint64_.Clear();
+      repeatedSint32_.Clear();
+      repeatedSint64_.Clear();
+      repeatedFixed32_.Clear();
+      repeatedFixed64_.Clear();
+      repeatedSfixed32_.Clear();
+      repeatedSfixed64_.Clear();
+      repeatedFloat_.Clear();
+      repeatedDouble_.Clear();
+      repeatedBool_.Clear();
+      repeatedString_.Clear();
+      repeatedBytes_.Clear();
+      repeatedNestedMessage_.Clear();
+      repeatedForeignMessage_.Clear();
+      repeatedImportMessage_.Clear();
+      repeatedNestedEnum_.Clear();
+      repeatedForeignEnum_.Clear();
+      repeatedImportEnum_.Clear();
+      repeatedPublicImportMessage_.Clear();
+      oneofFieldCase_ = OneofFieldOneofCase.None;
+      oneofField_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "single_int32" field.</summary>
     public const int SingleInt32FieldNumber = 1;
     private int singleInt32_;
@@ -2183,6 +2245,15 @@ namespace Google.Protobuf.TestProtos {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          bb_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "bb" field.</summary>
         public const int BbFieldNumber = 1;
         private int bb_;
@@ -2394,6 +2465,21 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public NestedTestAllTypes Clone() {
       return new NestedTestAllTypes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (child_ != null) {
+        child_.Clear();
+      }
+      if (payload_ != null) {
+        payload_.Clear();
+      }
+      repeatedChild_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "child" field.</summary>
@@ -2673,6 +2759,15 @@ namespace Google.Protobuf.TestProtos {
       return new TestDeprecatedFields(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      deprecatedInt32_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "deprecated_int32" field.</summary>
     public const int DeprecatedInt32FieldNumber = 1;
     private int deprecatedInt32_;
@@ -2876,6 +2971,15 @@ namespace Google.Protobuf.TestProtos {
       return new ForeignMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      c_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "c" field.</summary>
     public const int CFieldNumber = 1;
     private int c_;
@@ -3075,6 +3179,14 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as TestReservedFields);
     }
@@ -3236,6 +3348,17 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestForeignNested Clone() {
       return new TestForeignNested(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (foreignNested_ != null) {
+        foreignNested_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "foreign_nested" field.</summary>
@@ -3447,6 +3570,16 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestReallyLargeTagNumber Clone() {
       return new TestReallyLargeTagNumber(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      a_ = 0;
+      bb_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "a" field.</summary>
@@ -3686,6 +3819,18 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestRecursiveMessage Clone() {
       return new TestRecursiveMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (a_ != null) {
+        a_.Clear();
+      }
+      i_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "a" field.</summary>
@@ -3934,6 +4079,17 @@ namespace Google.Protobuf.TestProtos {
       return new TestMutualRecursionA(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (bb_ != null) {
+        bb_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "bb" field.</summary>
     public const int BbFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.TestMutualRecursionB bb_;
@@ -4140,6 +4296,18 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestMutualRecursionB Clone() {
       return new TestMutualRecursionB(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (a_ != null) {
+        a_.Clear();
+      }
+      optionalInt32_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "a" field.</summary>
@@ -4385,6 +4553,15 @@ namespace Google.Protobuf.TestProtos {
       return new TestEnumAllowAlias(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = global::Google.Protobuf.TestProtos.TestEnumWithDupValue.Unspecified;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "value" field.</summary>
     public const int ValueFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.TestEnumWithDupValue value_ = global::Google.Protobuf.TestProtos.TestEnumWithDupValue.Unspecified;
@@ -4592,6 +4769,24 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestCamelCaseFieldNames Clone() {
       return new TestCamelCaseFieldNames(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      primitiveField_ = 0;
+      stringField_ = "";
+      enumField_ = global::Google.Protobuf.TestProtos.ForeignEnum.ForeignUnspecified;
+      if (messageField_ != null) {
+        messageField_.Clear();
+      }
+      repeatedPrimitiveField_.Clear();
+      repeatedStringField_.Clear();
+      repeatedEnumField_.Clear();
+      repeatedMessageField_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "PrimitiveField" field.</summary>
@@ -5020,6 +5215,20 @@ namespace Google.Protobuf.TestProtos {
       return new TestFieldOrderings(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      myString_ = "";
+      myInt_ = 0L;
+      myFloat_ = 0F;
+      if (singleNestedMessage_ != null) {
+        singleNestedMessage_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "my_string" field.</summary>
     public const int MyStringFieldNumber = 11;
     private string myString_ = "";
@@ -5339,6 +5548,16 @@ namespace Google.Protobuf.TestProtos {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          oo_ = 0L;
+          bb_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "oo" field.</summary>
         public const int OoFieldNumber = 2;
         private long oo_;
@@ -5583,6 +5802,15 @@ namespace Google.Protobuf.TestProtos {
       return new SparseEnumMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      sparseEnum_ = global::Google.Protobuf.TestProtos.TestSparseEnum.Unspecified;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "sparse_enum" field.</summary>
     public const int SparseEnumFieldNumber = 1;
     private global::Google.Protobuf.TestProtos.TestSparseEnum sparseEnum_ = global::Google.Protobuf.TestProtos.TestSparseEnum.Unspecified;
@@ -5784,6 +6012,15 @@ namespace Google.Protobuf.TestProtos {
       return new OneString(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "data" field.</summary>
     public const int DataFieldNumber = 1;
     private string data_ = "";
@@ -5982,6 +6219,15 @@ namespace Google.Protobuf.TestProtos {
       return new MoreString(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "data" field.</summary>
     public const int DataFieldNumber = 1;
     private static readonly pb::FieldCodec<string> _repeated_data_codec
@@ -6167,6 +6413,15 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public OneBytes Clone() {
       return new OneBytes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = pb::ByteString.Empty;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "data" field.</summary>
@@ -6365,6 +6620,15 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public MoreBytes Clone() {
       return new MoreBytes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = pb::ByteString.Empty;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "data" field.</summary>
@@ -6568,6 +6832,15 @@ namespace Google.Protobuf.TestProtos {
       return new Int32Message(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "data" field.</summary>
     public const int DataFieldNumber = 1;
     private int data_;
@@ -6764,6 +7037,15 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Uint32Message Clone() {
       return new Uint32Message(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "data" field.</summary>
@@ -6964,6 +7246,15 @@ namespace Google.Protobuf.TestProtos {
       return new Int64Message(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = 0L;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "data" field.</summary>
     public const int DataFieldNumber = 1;
     private long data_;
@@ -7162,6 +7453,15 @@ namespace Google.Protobuf.TestProtos {
       return new Uint64Message(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = 0UL;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "data" field.</summary>
     public const int DataFieldNumber = 1;
     private ulong data_;
@@ -7358,6 +7658,15 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public BoolMessage Clone() {
       return new BoolMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      data_ = false;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "data" field.</summary>
@@ -7570,6 +7879,16 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestOneof Clone() {
       return new TestOneof(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      fooCase_ = FooOneofCase.None;
+      foo_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "foo_int" field.</summary>
@@ -7921,6 +8240,28 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestPackedTypes Clone() {
       return new TestPackedTypes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      packedInt32_.Clear();
+      packedInt64_.Clear();
+      packedUint32_.Clear();
+      packedUint64_.Clear();
+      packedSint32_.Clear();
+      packedSint64_.Clear();
+      packedFixed32_.Clear();
+      packedFixed64_.Clear();
+      packedSfixed32_.Clear();
+      packedSfixed64_.Clear();
+      packedFloat_.Clear();
+      packedDouble_.Clear();
+      packedBool_.Clear();
+      packedEnum_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "packed_int32" field.</summary>
@@ -8480,6 +8821,28 @@ namespace Google.Protobuf.TestProtos {
       return new TestUnpackedTypes(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      unpackedInt32_.Clear();
+      unpackedInt64_.Clear();
+      unpackedUint32_.Clear();
+      unpackedUint64_.Clear();
+      unpackedSint32_.Clear();
+      unpackedSint64_.Clear();
+      unpackedFixed32_.Clear();
+      unpackedFixed64_.Clear();
+      unpackedSfixed32_.Clear();
+      unpackedSfixed64_.Clear();
+      unpackedFloat_.Clear();
+      unpackedDouble_.Clear();
+      unpackedBool_.Clear();
+      unpackedEnum_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "unpacked_int32" field.</summary>
     public const int UnpackedInt32FieldNumber = 90;
     private static readonly pb::FieldCodec<int> _repeated_unpackedInt32_codec
@@ -9025,6 +9388,20 @@ namespace Google.Protobuf.TestProtos {
       return new TestRepeatedScalarDifferentTagSizes(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      repeatedFixed32_.Clear();
+      repeatedInt32_.Clear();
+      repeatedFixed64_.Clear();
+      repeatedInt64_.Clear();
+      repeatedFloat_.Clear();
+      repeatedUint64_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "repeated_fixed32" field.</summary>
     public const int RepeatedFixed32FieldNumber = 12;
     private static readonly pb::FieldCodec<uint> _repeated_repeatedFixed32_codec
@@ -9363,6 +9740,15 @@ namespace Google.Protobuf.TestProtos {
       return new TestCommentInjectionMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      a_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "a" field.</summary>
     public const int AFieldNumber = 1;
     private string a_ = "";
@@ -9568,6 +9954,14 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as FooRequest);
     }
@@ -9725,6 +10119,14 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FooResponse Clone() {
       return new FooResponse(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9890,6 +10292,14 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as FooClientMessage);
     }
@@ -10047,6 +10457,14 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FooServerMessage Clone() {
       return new FooServerMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10212,6 +10630,14 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as BarRequest);
     }
@@ -10369,6 +10795,14 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public BarResponse Clone() {
       return new BarResponse(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10534,6 +10968,14 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as TestEmptyMessage);
     }
@@ -10695,6 +11137,15 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public CommentMessage Clone() {
       return new CommentMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      text_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "text" field.</summary>
@@ -10912,6 +11363,15 @@ namespace Google.Protobuf.TestProtos {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public NestedCommentMessage Clone() {
           return new NestedCommentMessage(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          nestedText_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "nested_text" field.</summary>

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestProto3Optional.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestProto3Optional.pb.cs
@@ -146,6 +146,40 @@ namespace ProtobufUnittest {
       return new TestProto3Optional(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      optionalInt32_ = 0;
+      optionalInt64_ = 0L;
+      optionalUint32_ = 0;
+      optionalUint64_ = 0UL;
+      optionalSint32_ = 0;
+      optionalSint64_ = 0L;
+      optionalFixed32_ = 0;
+      optionalFixed64_ = 0UL;
+      optionalSfixed32_ = 0;
+      optionalSfixed64_ = 0L;
+      optionalFloat_ = 0F;
+      optionalDouble_ = 0D;
+      optionalBool_ = false;
+      optionalString_ = "";
+      optionalBytes_ = pb::ByteString.Empty;
+      optionalCord_ = "";
+      if (optionalNestedMessage_ != null) {
+        optionalNestedMessage_.Clear();
+      }
+      if (lazyNestedMessage_ != null) {
+        lazyNestedMessage_.Clear();
+      }
+      optionalNestedEnum_ = global::ProtobufUnittest.TestProto3Optional.Types.NestedEnum.Unspecified;
+      singularInt32_ = 0;
+      singularInt64_ = 0L;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "optional_int32" field.</summary>
     public const int OptionalInt32FieldNumber = 1;
     private readonly static int OptionalInt32DefaultValue = 0;
@@ -1356,6 +1390,16 @@ namespace ProtobufUnittest {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          bb_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "bb" field.</summary>
         public const int BbFieldNumber = 1;
         private readonly static int BbDefaultValue = 0;
@@ -1578,6 +1622,20 @@ namespace ProtobufUnittest {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TestProto3OptionalMessage Clone() {
       return new TestProto3OptionalMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (nestedMessage_ != null) {
+        nestedMessage_.Clear();
+      }
+      if (optionalNestedMessage_ != null) {
+        optionalNestedMessage_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "nested_message" field.</summary>
@@ -1835,6 +1893,15 @@ namespace ProtobufUnittest {
           return new NestedMessage(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          s_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "s" field.</summary>
         public const int SFieldNumber = 1;
         private string s_ = "";
@@ -2035,6 +2102,14 @@ namespace ProtobufUnittest {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Proto3OptionalExtensions Clone() {
       return new Proto3OptionalExtensions(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestRetention.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestRetention.pb.cs
@@ -169,6 +169,18 @@ namespace ProtobufUnittest {
       return new OptionsMessage(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      plainField_ = 0;
+      runtimeRetentionField_ = 0;
+      sourceRetentionField_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "plain_field" field.</summary>
     public const int PlainFieldFieldNumber = 1;
     private readonly static int PlainFieldDefaultValue = 0;
@@ -488,6 +500,17 @@ namespace ProtobufUnittest {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as Extendee);
     }
@@ -699,6 +722,21 @@ namespace ProtobufUnittest {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TopLevelMessage Clone() {
       return new TopLevelMessage(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      f_ = 0F;
+      oCase_ = OOneofCase.None;
+      o_ = null;
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "f" field.</summary>
@@ -1035,6 +1073,14 @@ namespace ProtobufUnittest {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public NestedMessage Clone() {
           return new NestedMessage(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestSelfreferentialOptions.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestSelfreferentialOptions.pb.cs
@@ -115,6 +115,20 @@ namespace UnitTest.Issues.TestProtos.SelfreferentialOptions {
       return new FooOptions(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      intOpt_ = 0;
+      foo_ = 0;
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "int_opt" field.</summary>
     public const int IntOptFieldNumber = 1;
     private readonly static int IntOptDefaultValue = 0;

--- a/csharp/src/Google.Protobuf.Test.TestProtos/UnittestWellKnownTypes.pb.cs
+++ b/csharp/src/Google.Protobuf.Test.TestProtos/UnittestWellKnownTypes.pb.cs
@@ -241,6 +241,53 @@ namespace Google.Protobuf.TestProtos {
       return new TestWellKnownTypes(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (anyField_ != null) {
+        anyField_.Clear();
+      }
+      if (apiField_ != null) {
+        apiField_.Clear();
+      }
+      if (durationField_ != null) {
+        durationField_.Clear();
+      }
+      if (emptyField_ != null) {
+        emptyField_.Clear();
+      }
+      if (fieldMaskField_ != null) {
+        fieldMaskField_.Clear();
+      }
+      if (sourceContextField_ != null) {
+        sourceContextField_.Clear();
+      }
+      if (structField_ != null) {
+        structField_.Clear();
+      }
+      if (timestampField_ != null) {
+        timestampField_.Clear();
+      }
+      if (typeField_ != null) {
+        typeField_.Clear();
+      }
+      doubleField_ = 0D;
+      floatField_ = 0F;
+      int64Field_ = 0L;
+      uint64Field_ = 0UL;
+      int32Field_ = 0;
+      uint32Field_ = 0;
+      boolField_ = false;
+      stringField_ = "";
+      bytesField_ = pb::ByteString.Empty;
+      if (valueField_ != null) {
+        valueField_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "any_field" field.</summary>
     public const int AnyFieldFieldNumber = 1;
     private global::Google.Protobuf.WellKnownTypes.Any anyField_;
@@ -1272,6 +1319,32 @@ namespace Google.Protobuf.TestProtos {
       return new RepeatedWellKnownTypes(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      anyField_.Clear();
+      apiField_.Clear();
+      durationField_.Clear();
+      emptyField_.Clear();
+      fieldMaskField_.Clear();
+      sourceContextField_.Clear();
+      structField_.Clear();
+      timestampField_.Clear();
+      typeField_.Clear();
+      doubleField_.Clear();
+      floatField_.Clear();
+      int64Field_.Clear();
+      uint64Field_.Clear();
+      int32Field_.Clear();
+      uint32Field_.Clear();
+      boolField_.Clear();
+      stringField_.Clear();
+      bytesField_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "any_field" field.</summary>
     public const int AnyFieldFieldNumber = 1;
     private static readonly pb::FieldCodec<global::Google.Protobuf.WellKnownTypes.Any> _repeated_anyField_codec
@@ -1941,6 +2014,16 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public OneofWellKnownTypes Clone() {
       return new OneofWellKnownTypes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      oneofFieldCase_ = OneofFieldOneofCase.None;
+      oneofField_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "any_field" field.</summary>
@@ -2923,6 +3006,32 @@ namespace Google.Protobuf.TestProtos {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public MapWellKnownTypes Clone() {
       return new MapWellKnownTypes(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      anyField_.Clear();
+      apiField_.Clear();
+      durationField_.Clear();
+      emptyField_.Clear();
+      fieldMaskField_.Clear();
+      sourceContextField_.Clear();
+      structField_.Clear();
+      timestampField_.Clear();
+      typeField_.Clear();
+      doubleField_.Clear();
+      floatField_.Clear();
+      int64Field_.Clear();
+      uint64Field_.Clear();
+      int32Field_.Clear();
+      uint32Field_.Clear();
+      boolField_.Clear();
+      stringField_.Clear();
+      bytesField_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "any_field" field.</summary>

--- a/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.Proto2.cs
+++ b/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.Proto2.cs
@@ -400,5 +400,492 @@ namespace Google.Protobuf
             var parsed = TestAllExtensions.Parser.WithExtensionRegistry(new ExtensionRegistry() { UnittestExtensions.OptionalBoolExtension }).ParseFrom(input);
             Assert.AreEqual(message, parsed);
         }
+
+        [Test]
+        public void TestClearProto2()
+        {
+            var message = new TestAllTypes();
+
+            Assert.AreEqual(false, message.OptionalBool);
+            message.OptionalBool = true;
+            Assert.AreNotEqual(false, message.OptionalBool);
+            message.Clear();
+            Assert.AreEqual(false, message.OptionalBool);
+
+            Assert.AreEqual(ByteString.Empty, message.OptionalBytes);
+            message.OptionalBytes = ByteString.CopyFromUtf8("test1");
+            Assert.AreNotEqual(ByteString.Empty, message.OptionalBytes);
+            message.Clear();
+            Assert.AreEqual(ByteString.Empty, message.OptionalBytes);
+
+            Assert.AreEqual(0.0, message.OptionalDouble);
+            message.OptionalDouble = 123.0;
+            Assert.AreNotEqual(0.0, message.OptionalDouble);
+            message.Clear();
+            Assert.AreEqual(0.0, message.OptionalDouble);
+
+            Assert.AreEqual(0, message.OptionalFixed32);
+            message.OptionalFixed32 = 123;
+            Assert.AreNotEqual(0, message.OptionalFixed32);
+            message.Clear();
+            Assert.AreEqual(0, message.OptionalFixed32);
+
+            Assert.AreEqual(0L, message.OptionalFixed64);
+            message.OptionalFixed64 = 123L;
+            Assert.AreNotEqual(0L, message.OptionalFixed64);
+            message.Clear();
+            Assert.AreEqual(0L, message.OptionalFixed64);
+
+            Assert.AreEqual(0.0f, message.OptionalFloat);
+            message.OptionalFloat = 123.0f;
+            Assert.AreNotEqual(0.0f, message.OptionalFloat);
+            message.Clear();
+            Assert.AreEqual(0.0f, message.OptionalFloat);
+
+            Assert.AreEqual(ForeignEnum.ForeignFoo, message.OptionalForeignEnum);
+            message.OptionalForeignEnum = ForeignEnum.ForeignBar;
+            Assert.AreNotEqual(ForeignEnum.ForeignFoo, message.OptionalForeignEnum);
+            message.Clear();
+            Assert.AreEqual(ForeignEnum.ForeignFoo, message.OptionalForeignEnum);
+
+            Assert.IsNull(message.OptionalForeignMessage);
+            message.Clear();
+            Assert.IsNull(message.OptionalForeignMessage);
+            var foreignMessage = new global::Google.Protobuf.TestProtos.Proto2.ForeignMessage();
+            message.OptionalForeignMessage = foreignMessage;
+            Assert.AreEqual(foreignMessage, message.OptionalForeignMessage);
+            message.Clear();
+            Assert.AreEqual(foreignMessage, message.OptionalForeignMessage);
+
+            Assert.AreEqual(ImportEnum.ImportFoo, message.OptionalImportEnum);
+            message.OptionalImportEnum = ImportEnum.ImportBar;
+            Assert.AreNotEqual(ImportEnum.ImportFoo, message.OptionalImportEnum);
+            message.Clear();
+            Assert.AreEqual(ImportEnum.ImportFoo, message.OptionalImportEnum);
+
+            Assert.IsNull(message.OptionalImportMessage);
+            message.Clear();
+            Assert.IsNull(message.OptionalImportMessage);
+            var importMessage = new global::Google.Protobuf.TestProtos.Proto2.ImportMessage();
+            message.OptionalImportMessage = importMessage;
+            Assert.AreEqual(importMessage, message.OptionalImportMessage);
+            message.Clear();
+            Assert.AreEqual(importMessage, message.OptionalImportMessage);
+
+            Assert.AreEqual(0, message.OptionalInt32);
+            message.OptionalInt32 = 123;
+            Assert.AreNotEqual(0, message.OptionalInt32);
+            message.Clear();
+            Assert.AreEqual(0, message.OptionalInt32);
+
+            Assert.AreEqual(0L, message.OptionalInt64);
+            message.OptionalInt64 = 123L;
+            Assert.AreNotEqual(0L, message.OptionalInt64);
+            message.Clear();
+            Assert.AreEqual(0L, message.OptionalInt64);
+
+            Assert.AreEqual(Proto2.TestAllTypes.Types.NestedEnum.Foo, message.OptionalNestedEnum);
+            message.OptionalNestedEnum = Proto2.TestAllTypes.Types.NestedEnum.Bar;
+            Assert.AreNotEqual(Proto2.TestAllTypes.Types.NestedEnum.Foo, message.OptionalNestedEnum);
+            message.Clear();
+            Assert.AreEqual(Proto2.TestAllTypes.Types.NestedEnum.Foo, message.OptionalNestedEnum);
+
+            Assert.IsNull(message.OptionalNestedMessage);
+            message.Clear();
+            Assert.IsNull(message.OptionalNestedMessage);
+            var nestedMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage();
+            message.OptionalNestedMessage = nestedMessage;
+            Assert.AreEqual(nestedMessage, message.OptionalNestedMessage);
+            message.Clear();
+            Assert.AreEqual(nestedMessage, message.OptionalNestedMessage);
+
+            Assert.IsNull(message.OptionalPublicImportMessage);
+            message.Clear();
+            Assert.IsNull(message.OptionalPublicImportMessage);
+            var publicImportMessage = new global::Google.Protobuf.TestProtos.Proto2.PublicImportMessage();
+            message.OptionalPublicImportMessage = publicImportMessage;
+            Assert.AreEqual(publicImportMessage, message.OptionalPublicImportMessage);
+            message.Clear();
+            Assert.AreEqual(publicImportMessage, message.OptionalPublicImportMessage);
+
+            Assert.AreEqual(0, message.OptionalSfixed32);
+            message.OptionalSfixed32 = 123;
+            Assert.AreNotEqual(0, message.OptionalSfixed32);
+            message.Clear();
+            Assert.AreEqual(0, message.OptionalSfixed32);
+
+            Assert.AreEqual(0L, message.OptionalSfixed64);
+            message.OptionalSfixed64 = 123L;
+            Assert.AreNotEqual(0L, message.OptionalSfixed64);
+            message.Clear();
+            Assert.AreEqual(0L, message.OptionalSfixed64);
+
+            Assert.AreEqual(0, message.OptionalSint32);
+            message.OptionalSint32 = 123;
+            Assert.AreNotEqual(0, message.OptionalSint32);
+            message.Clear();
+            Assert.AreEqual(0, message.OptionalSint32);
+
+            Assert.AreEqual(0L, message.OptionalSint64);
+            message.OptionalSint64 = 123L;
+            Assert.AreNotEqual(0L, message.OptionalSint64);
+            message.Clear();
+            Assert.AreEqual(0L, message.OptionalSint64);
+
+            Assert.AreEqual("", message.OptionalString);
+            message.OptionalString = "test2";
+            Assert.AreNotEqual("", message.OptionalString);
+            message.Clear();
+            Assert.AreEqual("", message.OptionalString);
+
+            Assert.AreEqual(0U, message.OptionalUint32);
+            message.OptionalUint32 = 123U;
+            Assert.AreNotEqual(0U, message.OptionalUint32);
+            message.Clear();
+            Assert.AreEqual(0U, message.OptionalUint32);
+
+            Assert.AreEqual(0UL, message.OptionalUint64);
+            message.OptionalUint64 = 123UL;
+            Assert.AreNotEqual(0UL, message.OptionalUint64);
+            message.Clear();
+            Assert.AreEqual(0UL, message.OptionalUint64);
+        }
+        [Test]
+        public void TestClearRepeatedFieldsProto2()
+        {
+            // Repeated fields
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedBool.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedBool.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedBytes.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedBytes.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedDouble.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedDouble.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedFixed32.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedFixed32.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedFixed64.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedFixed64.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedFloat.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedFloat.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedForeignEnum.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedForeignEnum.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedForeignMessage.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedForeignMessage.Count);
+            }
+
+            {
+
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedImportEnum.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedImportEnum.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedImportMessage.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedImportMessage.Count);
+
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedNestedEnum.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedNestedEnum.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedNestedMessage.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedNestedMessage.Count);
+            }
+
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedSfixed32.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedSfixed32.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedSfixed64.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedSfixed64.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedSint32.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedSint32.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedSint64.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedSint64.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedString.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedString.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedUint32.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedUint32.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypesProto2();
+                Assert.AreNotEqual(0, message.RepeatedUint64.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedUint64.Count);
+            }
+        }
+
+        [Test]
+        public void TestClearOneofFieldsProto2()
+        {
+            // Oneof fields
+            {
+                var message = new Proto2.TestAllTypes();
+
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual(0, message.OneofUint32);
+
+                message.OneofUint32 = 123;
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.OneofUint32, message.OneofFieldCase);
+                Assert.AreEqual(123, message.OneofUint32);
+
+                message.Clear();
+
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual(0, message.OneofUint32);
+            }
+
+            {
+                var message = new Proto2.TestAllTypes();
+
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual("", message.OneofString);
+
+                message.OneofString = "test3";
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.OneofString, message.OneofFieldCase);
+                Assert.AreEqual("test3", message.OneofString);
+
+                message.Clear();
+
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual("", message.OneofString);
+            }
+
+            {
+                var message = new Proto2.TestAllTypes();
+
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual(ByteString.Empty, message.OneofBytes);
+
+                var byteString = ByteString.CopyFromUtf8("test4");
+                message.OneofBytes = byteString;
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.OneofBytes, message.OneofFieldCase);
+                Assert.AreEqual(byteString, message.OneofBytes);
+
+                message.Clear();
+
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual(ByteString.Empty, message.OneofBytes);
+            }
+
+            {
+                var message = new Proto2.TestAllTypes();
+
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.IsNull(message.OneofNestedMessage);
+
+                var nestedMessage = new global::Google.Protobuf.TestProtos.Proto2.TestAllTypes.Types.NestedMessage();
+                message.OneofNestedMessage = nestedMessage;
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.OneofNestedMessage, message.OneofFieldCase);
+                Assert.AreEqual(nestedMessage, message.OneofNestedMessage);
+
+                message.Clear();
+
+                Assert.AreEqual(Proto2.TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.IsNull(message.OneofNestedMessage);
+            }
+        }
+
+        [Test]
+        public void TestClearDefaultProto2()
+        {
+            var message = new TestAllTypes();
+
+            Assert.AreEqual(true, message.DefaultBool);
+            message.DefaultBool = false;
+            Assert.AreNotEqual(true, message.DefaultBool);
+            message.Clear();
+            Assert.AreEqual(true, message.DefaultBool);
+
+            Assert.AreEqual(ByteString.CopyFromUtf8("world"), message.DefaultBytes);
+            message.DefaultBytes = ByteString.CopyFromUtf8("test1");
+            Assert.AreNotEqual(ByteString.CopyFromUtf8("world"), message.DefaultBytes);
+            message.Clear();
+            Assert.AreEqual(ByteString.CopyFromUtf8("world"), message.DefaultBytes);
+
+            Assert.AreEqual("123", message.DefaultCord);
+            message.DefaultCord = "456";
+            Assert.AreNotEqual("123", message.DefaultCord);
+            message.Clear();
+            Assert.AreEqual("123", message.DefaultCord);
+
+            Assert.AreEqual(52e3, message.DefaultDouble);
+            message.DefaultDouble = 37e1;
+            Assert.AreNotEqual(52e3, message.DefaultDouble);
+            message.Clear();
+            Assert.AreEqual(52e3, message.DefaultDouble);
+
+            Assert.AreEqual(47, message.DefaultFixed32);
+            message.DefaultFixed32 = 23;
+            Assert.AreNotEqual(47, message.DefaultFixed32);
+            message.Clear();
+            Assert.AreEqual(47, message.DefaultFixed32);
+
+            Assert.AreEqual(48, message.DefaultFixed64);
+            message.DefaultFixed64 = 32;
+            Assert.AreNotEqual(48, message.DefaultFixed64);
+            message.Clear();
+            Assert.AreEqual(48, message.DefaultFixed64);
+
+            Assert.AreEqual(51.5f, message.DefaultFloat);
+            message.DefaultFloat = 5.15f;
+            Assert.AreNotEqual(51.5f, message.DefaultFloat);
+            message.Clear();
+            Assert.AreEqual(51.5f, message.DefaultFloat);
+
+            Assert.AreEqual(ForeignEnum.ForeignBar, message.DefaultForeignEnum);
+            message.DefaultForeignEnum = ForeignEnum.ForeignBaz;
+            Assert.AreNotEqual(ForeignEnum.ForeignBar, message.DefaultForeignEnum);
+            message.Clear();
+            Assert.AreEqual(ForeignEnum.ForeignBar, message.DefaultForeignEnum);
+
+            Assert.AreEqual(ImportEnum.ImportBar, message.DefaultImportEnum);
+            message.DefaultImportEnum = ImportEnum.ImportBaz;
+            Assert.AreNotEqual(ImportEnum.ImportBar, message.DefaultImportEnum);
+            message.Clear();
+            Assert.AreEqual(ImportEnum.ImportBar, message.DefaultImportEnum);
+
+            Assert.AreEqual(41, message.DefaultInt32);
+            message.DefaultInt32 = 4;
+            Assert.AreNotEqual(41, message.DefaultInt32);
+            message.Clear();
+            Assert.AreEqual(41, message.DefaultInt32);
+
+            Assert.AreEqual(42, message.DefaultInt64);
+            message.DefaultInt64 = 8;
+            Assert.AreNotEqual(42, message.DefaultInt64);
+            message.Clear();
+            Assert.AreEqual(42, message.DefaultInt64);
+
+            Assert.AreEqual(Proto2.TestAllTypes.Types.NestedEnum.Bar, message.DefaultNestedEnum);
+            message.DefaultNestedEnum = Proto2.TestAllTypes.Types.NestedEnum.Baz;
+            Assert.AreNotEqual(Proto2.TestAllTypes.Types.NestedEnum.Bar, message.DefaultNestedEnum);
+            message.Clear();
+            Assert.AreEqual(Proto2.TestAllTypes.Types.NestedEnum.Bar, message.DefaultNestedEnum);
+
+            Assert.AreEqual(49, message.DefaultSfixed32);
+            message.DefaultSfixed32 = 36;
+            Assert.AreNotEqual(49, message.DefaultSfixed32);
+            message.Clear();
+            Assert.AreEqual(49, message.DefaultSfixed32);
+
+            Assert.AreEqual(-50, message.DefaultSfixed64);
+            message.DefaultSfixed64 = -17;
+            Assert.AreNotEqual(-50, message.DefaultSfixed64);
+            message.Clear();
+            Assert.AreEqual(-50, message.DefaultSfixed64);
+
+            Assert.AreEqual(-45, message.DefaultSint32);
+            message.DefaultSint32 = -20;
+            Assert.AreNotEqual(-45, message.DefaultSint32);
+            message.Clear();
+            Assert.AreEqual(-45, message.DefaultSint32);
+
+            Assert.AreEqual(46, message.DefaultSint64);
+            message.DefaultSint64 = 24;
+            Assert.AreNotEqual(46, message.DefaultSint64);
+            message.Clear();
+            Assert.AreEqual(46, message.DefaultSint64);
+
+            Assert.AreEqual("hello", message.DefaultString);
+            message.DefaultString = "world";
+            Assert.AreNotEqual("hello", message.DefaultString);
+            message.Clear();
+            Assert.AreEqual("hello", message.DefaultString);
+
+            Assert.AreEqual("abc", message.DefaultStringPiece);
+            message.DefaultStringPiece = "def";
+            Assert.AreNotEqual("abc", message.DefaultStringPiece);
+            message.Clear();
+            Assert.AreEqual("abc", message.DefaultStringPiece);
+
+            Assert.AreEqual(43, message.DefaultUint32);
+            message.DefaultUint32 = 12;
+            Assert.AreNotEqual(43, message.DefaultUint32);
+            message.Clear();
+            Assert.AreEqual(43, message.DefaultUint32);
+
+            Assert.AreEqual(44, message.DefaultUint64);
+            message.DefaultUint64 = 16;
+            Assert.AreNotEqual(44, message.DefaultUint64);
+            message.Clear();
+            Assert.AreEqual(44, message.DefaultUint64);
+        }
     }
 }

--- a/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.cs
+++ b/csharp/src/Google.Protobuf.Test/GeneratedMessageTest.cs
@@ -904,5 +904,376 @@ namespace Google.Protobuf
             };
             Assert.AreEqual(expected, message1.MapStringString);
         }
+
+        [Test]
+        public void TestClearSingleFields()
+        {
+            // Single fields
+            var message = new TestAllTypes();
+
+            Assert.AreEqual(false, message.SingleBool);
+            message.SingleBool = true;
+            Assert.AreNotEqual(false, message.SingleBool);
+            message.Clear();
+            Assert.AreEqual(false, message.SingleBool);
+
+            Assert.AreEqual(ByteString.Empty, message.SingleBytes);
+            message.SingleBytes = ByteString.CopyFromUtf8("test1");
+            Assert.AreNotEqual(ByteString.Empty, message.SingleBytes);
+            message.Clear();
+            Assert.AreEqual(ByteString.Empty, message.SingleBytes);
+
+            Assert.AreEqual(0.0, message.SingleDouble);
+            message.SingleDouble = 1.23;
+            Assert.AreNotEqual(0.0, message.SingleDouble);
+            message.Clear();
+            Assert.AreEqual(0.0, message.SingleDouble);
+
+            Assert.AreEqual(0, message.SingleFixed32);
+            message.SingleFixed32 = 123;
+            Assert.AreNotEqual(0, message.SingleFixed32);
+            message.Clear();
+            Assert.AreEqual(0, message.SingleFixed32);
+
+            Assert.AreEqual(0L, message.SingleFixed64);
+            message.SingleFixed64 = 123L;
+            Assert.AreNotEqual(0L, message.SingleFixed64);
+            message.Clear();
+            Assert.AreEqual(0L, message.SingleFixed64);
+
+            Assert.AreEqual(0.0f, message.SingleFloat);
+            message.SingleFloat = 1.23f;
+            Assert.AreNotEqual(0.0f, message.SingleFloat);
+            message.Clear();
+            Assert.AreEqual(0.0f, message.SingleFloat);
+
+            Assert.AreEqual(ForeignEnum.ForeignUnspecified, message.SingleForeignEnum);
+            message.SingleForeignEnum = ForeignEnum.ForeignFoo;
+            Assert.AreNotEqual(ForeignEnum.ForeignUnspecified, message.SingleForeignEnum);
+            message.Clear();
+            Assert.AreEqual(ForeignEnum.ForeignUnspecified, message.SingleForeignEnum);
+
+            Assert.IsNull(message.SingleForeignMessage);
+            message.Clear();
+            Assert.IsNull(message.SingleForeignMessage);
+            var singleForeignMessage = new global::Google.Protobuf.TestProtos.ForeignMessage();
+            message.SingleForeignMessage = singleForeignMessage;
+            Assert.AreEqual(singleForeignMessage, message.SingleForeignMessage);
+            message.Clear();
+            Assert.AreEqual(singleForeignMessage, message.SingleForeignMessage);
+
+            Assert.AreEqual(ImportEnum.Unspecified, message.SingleImportEnum);
+            message.SingleImportEnum = ImportEnum.ImportFoo;
+            Assert.AreNotEqual(ImportEnum.Unspecified, message.SingleImportEnum);
+            message.Clear();
+            Assert.AreEqual(ImportEnum.Unspecified, message.SingleImportEnum);
+
+            Assert.IsNull(message.SingleImportMessage);
+            message.Clear();
+            Assert.IsNull(message.SingleImportMessage);
+            var importMessage = new global::Google.Protobuf.TestProtos.ImportMessage();
+            message.SingleImportMessage = importMessage;
+            Assert.AreEqual(importMessage, message.SingleImportMessage);
+            message.Clear();
+            Assert.AreEqual(importMessage, message.SingleImportMessage);
+
+            Assert.AreEqual(0, message.SingleInt32);
+            message.SingleInt32 = 123;
+            Assert.AreNotEqual(0, message.SingleInt32);
+            message.Clear();
+            Assert.AreEqual(0, message.SingleInt32);
+
+            Assert.AreEqual(0L, message.SingleInt64);
+            message.SingleInt64 = 123;
+            Assert.AreNotEqual(0L, message.SingleInt64);
+            message.Clear();
+            Assert.AreEqual(0L, message.SingleInt64);
+
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.Unspecified, message.SingleNestedEnum);
+            message.SingleNestedEnum = TestAllTypes.Types.NestedEnum.Foo;
+            Assert.AreNotEqual(TestAllTypes.Types.NestedEnum.Unspecified, message.SingleNestedEnum);
+            message.Clear();
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.Unspecified, message.SingleNestedEnum);
+
+            Assert.IsNull(message.SingleNestedMessage);
+            message.Clear();
+            Assert.IsNull(message.SingleNestedMessage);
+            var nestedMessage = new global::Google.Protobuf.TestProtos.TestAllTypes.Types.NestedMessage();
+            message.SingleNestedMessage = nestedMessage;
+            Assert.AreEqual(nestedMessage, message.SingleNestedMessage);
+            message.Clear();
+            Assert.AreEqual(nestedMessage, message.SingleNestedMessage);
+
+            Assert.IsNull(message.SinglePublicImportMessage);
+            message.Clear();
+            Assert.IsNull(message.SinglePublicImportMessage);
+            var publicImportMessage = new global::Google.Protobuf.TestProtos.PublicImportMessage();
+            message.SinglePublicImportMessage = publicImportMessage;
+            Assert.AreEqual(publicImportMessage, message.SinglePublicImportMessage);
+            message.Clear();
+            Assert.AreEqual(publicImportMessage, message.SinglePublicImportMessage);
+
+            Assert.AreEqual(0, message.SingleSfixed32);
+            message.SingleSfixed32 = 123;
+            Assert.AreNotEqual(0, message.SingleSfixed32);
+            message.Clear();
+            Assert.AreEqual(0, message.SingleSfixed32);
+
+            Assert.AreEqual(0L, message.SingleSfixed64);
+            message.SingleSfixed64 = 123L;
+            Assert.AreNotEqual(0L, message.SingleSfixed64);
+            message.Clear();
+            Assert.AreEqual(0L, message.SingleSfixed64);
+
+            Assert.AreEqual(0, message.SingleSint32);
+            message.SingleSint32 = 123;
+            Assert.AreNotEqual(0, message.SingleSint32);
+            message.Clear();
+            Assert.AreEqual(0, message.SingleSint32);
+
+            Assert.AreEqual(0L, message.SingleSint64);
+            message.SingleSint64 = 123L;
+            Assert.AreNotEqual(0L, message.SingleSint64);
+            message.Clear();
+            Assert.AreEqual(0L, message.SingleSint64);
+
+            Assert.AreEqual("", message.SingleString);
+            message.SingleString = "test2";
+            Assert.AreNotEqual("", message.SingleString);
+            message.Clear();
+            Assert.AreEqual("", message.SingleString);
+
+            Assert.AreEqual(0U, message.SingleUint32);
+            message.SingleUint32 = 123U;
+            Assert.AreNotEqual(0U, message.SingleUint32);
+            message.Clear();
+            Assert.AreEqual(0U, message.SingleUint32);
+
+            Assert.AreEqual(0UL, message.SingleUint64);
+            message.SingleUint64 = 123UL;
+            Assert.AreNotEqual(0UL, message.SingleUint64);
+            message.Clear();
+            Assert.AreEqual(0UL, message.SingleUint64);
+        }
+
+        [Test]
+        public void TestClearRepeatedFields()
+        {
+            // Repeated fields
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedBool.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedBool.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedBytes.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedBytes.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedDouble.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedDouble.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedFixed32.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedFixed32.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedFixed64.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedFixed64.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedFloat.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedFloat.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedForeignEnum.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedForeignEnum.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedForeignMessage.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedForeignMessage.Count);
+            }
+
+            {
+
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedImportEnum.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedImportEnum.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedImportMessage.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedImportMessage.Count);
+
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedNestedEnum.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedNestedEnum.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedNestedMessage.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedNestedMessage.Count);
+            }
+
+            {
+
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedPublicImportMessage.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedPublicImportMessage.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedSfixed32.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedSfixed32.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedSfixed64.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedSfixed64.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedSint32.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedSint32.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedSint64.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedSint64.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedString.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedString.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedUint32.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedUint32.Count);
+            }
+
+            {
+                var message = SampleMessages.CreateFullTestAllTypes();
+                Assert.AreNotEqual(0, message.RepeatedUint64.Count);
+                message.Clear();
+                Assert.AreEqual(0, message.RepeatedUint64.Count);
+            }
+        }
+
+
+        [Test]
+        public void TestClearOneofFields()
+        {
+            // Oneof fields
+            {
+                var message = new TestAllTypes();
+
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual(0, message.OneofUint32);
+
+                message.OneofUint32 = 123;
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.OneofUint32, message.OneofFieldCase);
+                Assert.AreEqual(123, message.OneofUint32);
+
+                message.Clear();
+
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual(0, message.OneofUint32);
+            }
+
+            {
+                var message = new TestAllTypes();
+
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual("", message.OneofString);
+
+                message.OneofString = "test3";
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.OneofString, message.OneofFieldCase);
+                Assert.AreEqual("test3", message.OneofString);
+
+                message.Clear();
+
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual("", message.OneofString);
+            }
+
+            {
+                var message = new TestAllTypes();
+
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual(ByteString.Empty, message.OneofBytes);
+
+                var byteString = ByteString.CopyFromUtf8("test4");
+                message.OneofBytes = byteString;
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.OneofBytes, message.OneofFieldCase);
+                Assert.AreEqual(byteString, message.OneofBytes);
+
+                message.Clear();
+
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.AreEqual(ByteString.Empty, message.OneofBytes);
+            }
+
+            {
+                var message = new TestAllTypes();
+
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.IsNull(message.OneofNestedMessage);
+
+                var nestedMessage = new global::Google.Protobuf.TestProtos.TestAllTypes.Types.NestedMessage();
+                message.OneofNestedMessage = nestedMessage;
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.OneofNestedMessage, message.OneofFieldCase);
+                Assert.AreEqual(nestedMessage, message.OneofNestedMessage);
+
+                message.Clear();
+
+                Assert.AreEqual(TestAllTypes.OneofFieldOneofCase.None, message.OneofFieldCase);
+                Assert.IsNull(message.OneofNestedMessage);
+            }
+        }
     }
 }

--- a/csharp/src/Google.Protobuf.Test/LegacyGeneratedCodeTest.cs
+++ b/csharp/src/Google.Protobuf.Test/LegacyGeneratedCodeTest.cs
@@ -129,6 +129,15 @@ namespace Google.Protobuf
 
           pbr::MessageDescriptor pb::IMessage.Descriptor => throw new System.NotImplementedException();
 
+          public void Clear() {
+            if (bb_ != null) {
+              bb_.Clear();
+            }
+            if (_unknownFields != null) {
+               _unknownFields.Clear();
+            }
+          }
+
           /// <summary>Field number for the "bb" field.</summary>
           public const int BbFieldNumber = 1;
           private ParseContextEnabledMessageB bb_;
@@ -185,6 +194,13 @@ namespace Google.Protobuf
           private pb::UnknownFieldSet _unknownFields;
 
           pbr::MessageDescriptor pb::IMessage.Descriptor => throw new System.NotImplementedException();
+
+          public void Clear() {
+            if (a_ != null) {
+              a_.Clear();
+            }
+            optionalInt32_ = 0;
+          }
 
           /// <summary>Field number for the "a" field.</summary>
           public const int AFieldNumber = 1;

--- a/csharp/src/Google.Protobuf/Compiler/Plugin.pb.cs
+++ b/csharp/src/Google.Protobuf/Compiler/Plugin.pb.cs
@@ -111,6 +111,19 @@ namespace Google.Protobuf.Compiler {
       return new Version(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      major_ = 0;
+      minor_ = 0;
+      patch_ = 0;
+      suffix_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "major" field.</summary>
     public const int MajorFieldNumber = 1;
     private readonly static int MajorDefaultValue = 0;
@@ -485,6 +498,21 @@ namespace Google.Protobuf.Compiler {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public CodeGeneratorRequest Clone() {
       return new CodeGeneratorRequest(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      fileToGenerate_.Clear();
+      parameter_ = "";
+      protoFile_.Clear();
+      sourceFileDescriptors_.Clear();
+      if (compilerVersion_ != null) {
+        compilerVersion_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "file_to_generate" field.</summary>
@@ -863,6 +891,20 @@ namespace Google.Protobuf.Compiler {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public CodeGeneratorResponse Clone() {
       return new CodeGeneratorResponse(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      error_ = "";
+      supportedFeatures_ = 0UL;
+      minimumEdition_ = 0;
+      maximumEdition_ = 0;
+      file_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "error" field.</summary>
@@ -1297,6 +1339,20 @@ namespace Google.Protobuf.Compiler {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public File Clone() {
           return new File(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          name_ = "";
+          insertionPoint_ = "";
+          content_ = "";
+          if (generatedCodeInfo_ != null) {
+            generatedCodeInfo_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "name" field.</summary>

--- a/csharp/src/Google.Protobuf/ExtensionSet.cs
+++ b/csharp/src/Google.Protobuf/ExtensionSet.cs
@@ -399,5 +399,13 @@ namespace Google.Protobuf
         {
             return ValuesByNumber.Values.All(v => v.IsInitialized());
         }
+
+        /// <summary>
+        /// Clear this extension set
+        /// </summary>
+        public void Clear()
+        {
+            ValuesByNumber.Clear();
+        }
     }
 }

--- a/csharp/src/Google.Protobuf/IMessage.cs
+++ b/csharp/src/Google.Protobuf/IMessage.cs
@@ -39,6 +39,11 @@ namespace Google.Protobuf
         int CalculateSize();
 
         /// <summary>
+        /// Clear current message.
+        /// </summary>
+        void Clear();
+
+        /// <summary>
         /// Descriptor for this message. All instances are expected to return the same descriptor,
         /// and for generated types this will be an explicitly-implemented member, returning the
         /// same value as the static property declared on the type.

--- a/csharp/src/Google.Protobuf/Reflection/Descriptor.pb.cs
+++ b/csharp/src/Google.Protobuf/Reflection/Descriptor.pb.cs
@@ -414,6 +414,18 @@ namespace Google.Protobuf.Reflection {
       return new FileDescriptorSet(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      file_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "file" field.</summary>
     public const int FileFieldNumber = 1;
     private static readonly pb::FieldCodec<global::Google.Protobuf.Reflection.FileDescriptorProto> _repeated_file_codec
@@ -659,6 +671,33 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FileDescriptorProto Clone() {
       return new FileDescriptorProto(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      name_ = "";
+      package_ = "";
+      dependency_.Clear();
+      publicDependency_.Clear();
+      weakDependency_.Clear();
+      optionDependency_.Clear();
+      messageType_.Clear();
+      enumType_.Clear();
+      service_.Clear();
+      extension_.Clear();
+      if (options_ != null) {
+        options_.Clear();
+      }
+      if (sourceCodeInfo_ != null) {
+        sourceCodeInfo_.Clear();
+      }
+      syntax_ = "";
+      edition_ = global::Google.Protobuf.Reflection.Edition.Unknown;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "name" field.</summary>
@@ -1377,6 +1416,28 @@ namespace Google.Protobuf.Reflection {
       return new DescriptorProto(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      name_ = "";
+      field_.Clear();
+      extension_.Clear();
+      nestedType_.Clear();
+      enumType_.Clear();
+      extensionRange_.Clear();
+      oneofDecl_.Clear();
+      if (options_ != null) {
+        options_.Clear();
+      }
+      reservedRange_.Clear();
+      reservedName_.Clear();
+      visibility_ = global::Google.Protobuf.Reflection.SymbolVisibility.VisibilityUnset;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private readonly static string NameDefaultValue = "";
@@ -1899,6 +1960,20 @@ namespace Google.Protobuf.Reflection {
           return new ExtensionRange(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          start_ = 0;
+          end_ = 0;
+          if (options_ != null) {
+            options_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "start" field.</summary>
         public const int StartFieldNumber = 1;
         private readonly static int StartDefaultValue = 0;
@@ -2222,6 +2297,17 @@ namespace Google.Protobuf.Reflection {
           return new ReservedRange(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          start_ = 0;
+          end_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "start" field.</summary>
         public const int StartFieldNumber = 1;
         private readonly static int StartDefaultValue = 0;
@@ -2503,6 +2589,24 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ExtensionRangeOptions Clone() {
       return new ExtensionRangeOptions(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      uninterpretedOption_.Clear();
+      declaration_.Clear();
+      if (features_ != null) {
+        features_.Clear();
+      }
+      verification_ = global::Google.Protobuf.Reflection.ExtensionRangeOptions.Types.VerificationState.Unverified;
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "uninterpreted_option" field.</summary>
@@ -2889,6 +2993,20 @@ namespace Google.Protobuf.Reflection {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public Declaration Clone() {
           return new Declaration(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          number_ = 0;
+          fullName_ = "";
+          type_ = "";
+          reserved_ = false;
+          repeated_ = false;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "number" field.</summary>
@@ -3345,6 +3463,28 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FieldDescriptorProto Clone() {
       return new FieldDescriptorProto(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      name_ = "";
+      number_ = 0;
+      label_ = global::Google.Protobuf.Reflection.FieldDescriptorProto.Types.Label.Optional;
+      type_ = global::Google.Protobuf.Reflection.FieldDescriptorProto.Types.Type.Double;
+      typeName_ = "";
+      extendee_ = "";
+      defaultValue_ = "";
+      oneofIndex_ = 0;
+      jsonName_ = "";
+      if (options_ != null) {
+        options_.Clear();
+      }
+      proto3Optional_ = false;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "name" field.</summary>
@@ -4191,6 +4331,18 @@ namespace Google.Protobuf.Reflection {
       return new OneofDescriptorProto(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      if (options_ != null) {
+        options_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private readonly static string NameDefaultValue = "";
@@ -4456,6 +4608,23 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public EnumDescriptorProto Clone() {
       return new EnumDescriptorProto(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      name_ = "";
+      value_.Clear();
+      if (options_ != null) {
+        options_.Clear();
+      }
+      reservedRange_.Clear();
+      reservedName_.Clear();
+      visibility_ = global::Google.Protobuf.Reflection.SymbolVisibility.VisibilityUnset;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "name" field.</summary>
@@ -4867,6 +5036,17 @@ namespace Google.Protobuf.Reflection {
           return new EnumReservedRange(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          start_ = 0;
+          end_ = 0;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "start" field.</summary>
         public const int StartFieldNumber = 1;
         private readonly static int StartDefaultValue = 0;
@@ -5147,6 +5327,20 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public EnumValueDescriptorProto Clone() {
       return new EnumValueDescriptorProto(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      name_ = "";
+      number_ = 0;
+      if (options_ != null) {
+        options_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "name" field.</summary>
@@ -5462,6 +5656,19 @@ namespace Google.Protobuf.Reflection {
       return new ServiceDescriptorProto(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      method_.Clear();
+      if (options_ != null) {
+        options_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private readonly static string NameDefaultValue = "";
@@ -5752,6 +5959,23 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public MethodDescriptorProto Clone() {
       return new MethodDescriptorProto(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      name_ = "";
+      inputType_ = "";
+      outputType_ = "";
+      if (options_ != null) {
+        options_.Clear();
+      }
+      clientStreaming_ = false;
+      serverStreaming_ = false;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "name" field.</summary>
@@ -6246,6 +6470,41 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FileOptions Clone() {
       return new FileOptions(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      javaPackage_ = "";
+      javaOuterClassname_ = "";
+      javaMultipleFiles_ = false;
+      javaGenerateEqualsAndHash_ = false;
+      javaStringCheckUtf8_ = false;
+      optimizeFor_ = global::Google.Protobuf.Reflection.FileOptions.Types.OptimizeMode.Speed;
+      goPackage_ = "";
+      ccGenericServices_ = false;
+      javaGenericServices_ = false;
+      pyGenericServices_ = false;
+      deprecated_ = false;
+      ccEnableArenas_ = true;
+      objcClassPrefix_ = "";
+      csharpNamespace_ = "";
+      swiftPrefix_ = "";
+      phpClassPrefix_ = "";
+      phpNamespace_ = "";
+      phpMetadataNamespace_ = "";
+      rubyPackage_ = "";
+      if (features_ != null) {
+        features_.Clear();
+      }
+      uninterpretedOption_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "java_package" field.</summary>
@@ -7628,6 +7887,27 @@ namespace Google.Protobuf.Reflection {
       return new MessageOptions(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      messageSetWireFormat_ = false;
+      noStandardDescriptorAccessor_ = false;
+      deprecated_ = false;
+      mapEntry_ = false;
+      deprecatedLegacyJsonFieldConflicts_ = false;
+      if (features_ != null) {
+        features_.Clear();
+      }
+      uninterpretedOption_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "message_set_wire_format" field.</summary>
     public const int MessageSetWireFormatFieldNumber = 1;
     private readonly static bool MessageSetWireFormatDefaultValue = false;
@@ -8251,6 +8531,36 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FieldOptions Clone() {
       return new FieldOptions(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      ctype_ = global::Google.Protobuf.Reflection.FieldOptions.Types.CType.String;
+      packed_ = false;
+      jstype_ = global::Google.Protobuf.Reflection.FieldOptions.Types.JSType.JsNormal;
+      lazy_ = false;
+      unverifiedLazy_ = false;
+      deprecated_ = false;
+      weak_ = false;
+      debugRedact_ = false;
+      retention_ = global::Google.Protobuf.Reflection.FieldOptions.Types.OptionRetention.RetentionUnknown;
+      targets_.Clear();
+      editionDefaults_.Clear();
+      if (features_ != null) {
+        features_.Clear();
+      }
+      if (featureSupport_ != null) {
+        featureSupport_.Clear();
+      }
+      uninterpretedOption_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "ctype" field.</summary>
@@ -9230,6 +9540,17 @@ namespace Google.Protobuf.Reflection {
           return new EditionDefault(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          edition_ = global::Google.Protobuf.Reflection.Edition.Unknown;
+          value_ = "";
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "edition" field.</summary>
         public const int EditionFieldNumber = 3;
         private readonly static global::Google.Protobuf.Reflection.Edition EditionDefaultValue = global::Google.Protobuf.Reflection.Edition.Unknown;
@@ -9502,6 +9823,19 @@ namespace Google.Protobuf.Reflection {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public FeatureSupport Clone() {
           return new FeatureSupport(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          editionIntroduced_ = global::Google.Protobuf.Reflection.Edition.Unknown;
+          editionDeprecated_ = global::Google.Protobuf.Reflection.Edition.Unknown;
+          deprecationWarning_ = "";
+          editionRemoved_ = global::Google.Protobuf.Reflection.Edition.Unknown;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "edition_introduced" field.</summary>
@@ -9896,6 +10230,21 @@ namespace Google.Protobuf.Reflection {
       return new OneofOptions(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (features_ != null) {
+        features_.Clear();
+      }
+      uninterpretedOption_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "features" field.</summary>
     public const int FeaturesFieldNumber = 1;
     private global::Google.Protobuf.Reflection.FeatureSet features_;
@@ -10186,6 +10535,25 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public EnumOptions Clone() {
       return new EnumOptions(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      allowAlias_ = false;
+      deprecated_ = false;
+      deprecatedLegacyJsonFieldConflicts_ = false;
+      if (features_ != null) {
+        features_.Clear();
+      }
+      uninterpretedOption_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "allow_alias" field.</summary>
@@ -10654,6 +11022,27 @@ namespace Google.Protobuf.Reflection {
       return new EnumValueOptions(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      deprecated_ = false;
+      if (features_ != null) {
+        features_.Clear();
+      }
+      debugRedact_ = false;
+      if (featureSupport_ != null) {
+        featureSupport_.Clear();
+      }
+      uninterpretedOption_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "deprecated" field.</summary>
     public const int DeprecatedFieldNumber = 1;
     private readonly static bool DeprecatedDefaultValue = false;
@@ -11105,6 +11494,23 @@ namespace Google.Protobuf.Reflection {
       return new ServiceOptions(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      if (features_ != null) {
+        features_.Clear();
+      }
+      deprecated_ = false;
+      uninterpretedOption_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "features" field.</summary>
     public const int FeaturesFieldNumber = 34;
     private global::Google.Protobuf.Reflection.FeatureSet features_;
@@ -11451,6 +11857,24 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public MethodOptions Clone() {
       return new MethodOptions(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      deprecated_ = false;
+      idempotencyLevel_ = global::Google.Protobuf.Reflection.MethodOptions.Types.IdempotencyLevel.IdempotencyUnknown;
+      if (features_ != null) {
+        features_.Clear();
+      }
+      uninterpretedOption_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "deprecated" field.</summary>
@@ -11883,6 +12307,22 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public UninterpretedOption Clone() {
       return new UninterpretedOption(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      name_.Clear();
+      identifierValue_ = "";
+      positiveIntValue_ = 0UL;
+      negativeIntValue_ = 0L;
+      doubleValue_ = 0D;
+      stringValue_ = pb::ByteString.Empty;
+      aggregateValue_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "name" field.</summary>
@@ -12392,6 +12832,17 @@ namespace Google.Protobuf.Reflection {
           return new NamePart(this);
         }
 
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          namePart_ = "";
+          isExtension_ = false;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
         /// <summary>Field number for the "name_part" field.</summary>
         public const int NamePart_FieldNumber = 1;
         private readonly static string NamePart_DefaultValue = "";
@@ -12678,6 +13129,26 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FeatureSet Clone() {
       return new FeatureSet(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      fieldPresence_ = global::Google.Protobuf.Reflection.FeatureSet.Types.FieldPresence.Unknown;
+      enumType_ = global::Google.Protobuf.Reflection.FeatureSet.Types.EnumType.Unknown;
+      repeatedFieldEncoding_ = global::Google.Protobuf.Reflection.FeatureSet.Types.RepeatedFieldEncoding.Unknown;
+      utf8Validation_ = global::Google.Protobuf.Reflection.FeatureSet.Types.Utf8Validation.Unknown;
+      messageEncoding_ = global::Google.Protobuf.Reflection.FeatureSet.Types.MessageEncoding.Unknown;
+      jsonFormat_ = global::Google.Protobuf.Reflection.FeatureSet.Types.JsonFormat.Unknown;
+      enforceNamingStyle_ = global::Google.Protobuf.Reflection.FeatureSet.Types.EnforceNamingStyle.Unknown;
+      defaultSymbolVisibility_ = global::Google.Protobuf.Reflection.FeatureSet.Types.VisibilityFeature.Types.DefaultSymbolVisibility.Unknown;
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "field_presence" field.</summary>
@@ -13339,6 +13810,14 @@ namespace Google.Protobuf.Reflection {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
           return Equals(other as VisibilityFeature);
         }
@@ -13542,6 +14021,18 @@ namespace Google.Protobuf.Reflection {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FeatureSetDefaults Clone() {
       return new FeatureSetDefaults(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      _hasBits0 = 0;
+      defaults_.Clear();
+      minimumEdition_ = global::Google.Protobuf.Reflection.Edition.Unknown;
+      maximumEdition_ = global::Google.Protobuf.Reflection.Edition.Unknown;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "defaults" field.</summary>
@@ -13852,6 +14343,22 @@ namespace Google.Protobuf.Reflection {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public FeatureSetEditionDefault Clone() {
           return new FeatureSetEditionDefault(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          edition_ = global::Google.Protobuf.Reflection.Edition.Unknown;
+          if (overridableFeatures_ != null) {
+            overridableFeatures_.Clear();
+          }
+          if (fixedFeatures_ != null) {
+            fixedFeatures_.Clear();
+          }
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "edition" field.</summary>
@@ -14175,6 +14682,18 @@ namespace Google.Protobuf.Reflection {
       return new SourceCodeInfo(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      location_.Clear();
+      if (_extensions != null) {
+        _extensions.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "location" field.</summary>
     public const int LocationFieldNumber = 1;
     private static readonly pb::FieldCodec<global::Google.Protobuf.Reflection.SourceCodeInfo.Types.Location> _repeated_location_codec
@@ -14454,6 +14973,19 @@ namespace Google.Protobuf.Reflection {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public Location Clone() {
           return new Location(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          path_.Clear();
+          span_.Clear();
+          leadingComments_ = "";
+          trailingComments_ = "";
+          leadingDetachedComments_.Clear();
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "path" field.</summary>
@@ -14888,6 +15420,15 @@ namespace Google.Protobuf.Reflection {
       return new GeneratedCodeInfo(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      annotation_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "annotation" field.</summary>
     public const int AnnotationFieldNumber = 1;
     private static readonly pb::FieldCodec<global::Google.Protobuf.Reflection.GeneratedCodeInfo.Types.Annotation> _repeated_annotation_codec
@@ -15086,6 +15627,20 @@ namespace Google.Protobuf.Reflection {
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public Annotation Clone() {
           return new Annotation(this);
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void Clear() {
+          _hasBits0 = 0;
+          path_.Clear();
+          sourceFile_ = "";
+          begin_ = 0;
+          end_ = 0;
+          semantic_ = global::Google.Protobuf.Reflection.GeneratedCodeInfo.Types.Annotation.Types.Semantic.None;
+          if (_unknownFields != null) {
+            _unknownFields.Clear();
+          }
         }
 
         /// <summary>Field number for the "path" field.</summary>

--- a/csharp/src/Google.Protobuf/UnknownFieldSet.cs
+++ b/csharp/src/Google.Protobuf/UnknownFieldSet.cs
@@ -130,6 +130,17 @@ namespace Google.Protobuf
             return ret;
         }
 
+        /// <summary>
+        /// Clear this set
+        /// </summary>
+        public void Clear()
+        {
+            fields.Clear();
+
+            lastFieldNumber = 0;
+            lastField = null;
+        }
+
         // Optimization:  We keep around the last field that was
         // modified so that we can efficiently add to it multiple times in a
         // row (important when parsing an unknown repeated field).

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Any.pb.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Any.pb.cs
@@ -172,6 +172,16 @@ namespace Google.Protobuf.WellKnownTypes {
       return new Any(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      typeUrl_ = "";
+      value_ = pb::ByteString.Empty;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "type_url" field.</summary>
     public const int TypeUrlFieldNumber = 1;
     private string typeUrl_ = "";

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Api.pb.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Api.pb.cs
@@ -115,6 +115,23 @@ namespace Google.Protobuf.WellKnownTypes {
       return new Api(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      methods_.Clear();
+      options_.Clear();
+      version_ = "";
+      if (sourceContext_ != null) {
+        sourceContext_.Clear();
+      }
+      mixins_.Clear();
+      syntax_ = global::Google.Protobuf.WellKnownTypes.Syntax.Proto2;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private string name_ = "";
@@ -553,6 +570,21 @@ namespace Google.Protobuf.WellKnownTypes {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Method Clone() {
       return new Method(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      requestTypeUrl_ = "";
+      requestStreaming_ = false;
+      responseTypeUrl_ = "";
+      responseStreaming_ = false;
+      options_.Clear();
+      syntax_ = global::Google.Protobuf.WellKnownTypes.Syntax.Proto2;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "name" field.</summary>
@@ -1058,6 +1090,16 @@ namespace Google.Protobuf.WellKnownTypes {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Mixin Clone() {
       return new Mixin(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      root_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "name" field.</summary>

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Duration.pb.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Duration.pb.cs
@@ -146,6 +146,16 @@ namespace Google.Protobuf.WellKnownTypes {
       return new Duration(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      seconds_ = 0L;
+      nanos_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "seconds" field.</summary>
     public const int SecondsFieldNumber = 1;
     private long seconds_;

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Empty.pb.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Empty.pb.cs
@@ -94,6 +94,14 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
       return Equals(other as Empty);
     }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/FieldMask.pb.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/FieldMask.pb.cs
@@ -284,6 +284,15 @@ namespace Google.Protobuf.WellKnownTypes {
       return new FieldMask(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      paths_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "paths" field.</summary>
     public const int PathsFieldNumber = 1;
     private static readonly pb::FieldCodec<string> _repeated_paths_codec

--- a/csharp/src/Google.Protobuf/WellKnownTypes/SourceContext.pb.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/SourceContext.pb.cs
@@ -89,6 +89,15 @@ namespace Google.Protobuf.WellKnownTypes {
       return new SourceContext(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      fileName_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "file_name" field.</summary>
     public const int FileNameFieldNumber = 1;
     private string fileName_ = "";

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Struct.pb.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Struct.pb.cs
@@ -122,6 +122,15 @@ namespace Google.Protobuf.WellKnownTypes {
       return new Struct(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      fields_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "fields" field.</summary>
     public const int FieldsFieldNumber = 1;
     private static readonly pbc::MapField<string, global::Google.Protobuf.WellKnownTypes.Value>.Codec _map_fields_codec
@@ -338,6 +347,16 @@ namespace Google.Protobuf.WellKnownTypes {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Value Clone() {
       return new Value(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      kindCase_ = KindOneofCase.None;
+      kind_ = null;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "null_value" field.</summary>
@@ -853,6 +872,15 @@ namespace Google.Protobuf.WellKnownTypes {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public ListValue Clone() {
       return new ListValue(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      values_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "values" field.</summary>

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Timestamp.pb.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Timestamp.pb.cs
@@ -177,6 +177,16 @@ namespace Google.Protobuf.WellKnownTypes {
       return new Timestamp(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      seconds_ = 0L;
+      nanos_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "seconds" field.</summary>
     public const int SecondsFieldNumber = 1;
     private long seconds_;

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Type.pb.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Type.pb.cs
@@ -150,6 +150,23 @@ namespace Google.Protobuf.WellKnownTypes {
       return new Type(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      fields_.Clear();
+      oneofs_.Clear();
+      options_.Clear();
+      if (sourceContext_ != null) {
+        sourceContext_.Clear();
+      }
+      syntax_ = global::Google.Protobuf.WellKnownTypes.Syntax.Proto2;
+      edition_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private string name_ = "";
@@ -571,6 +588,24 @@ namespace Google.Protobuf.WellKnownTypes {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Field Clone() {
       return new Field(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      kind_ = global::Google.Protobuf.WellKnownTypes.Field.Types.Kind.TypeUnknown;
+      cardinality_ = global::Google.Protobuf.WellKnownTypes.Field.Types.Cardinality.Unknown;
+      number_ = 0;
+      name_ = "";
+      typeUrl_ = "";
+      oneofIndex_ = 0;
+      packed_ = false;
+      options_.Clear();
+      jsonName_ = "";
+      defaultValue_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "kind" field.</summary>
@@ -1236,6 +1271,22 @@ namespace Google.Protobuf.WellKnownTypes {
       return new Enum(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      enumvalue_.Clear();
+      options_.Clear();
+      if (sourceContext_ != null) {
+        sourceContext_.Clear();
+      }
+      syntax_ = global::Google.Protobuf.WellKnownTypes.Syntax.Proto2;
+      edition_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private string name_ = "";
@@ -1624,6 +1675,17 @@ namespace Google.Protobuf.WellKnownTypes {
       return new EnumValue(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      number_ = 0;
+      options_.Clear();
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "name" field.</summary>
     public const int NameFieldNumber = 1;
     private string name_ = "";
@@ -1895,6 +1957,18 @@ namespace Google.Protobuf.WellKnownTypes {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public Option Clone() {
       return new Option(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      name_ = "";
+      if (value_ != null) {
+        value_.Clear();
+      }
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "name" field.</summary>

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Wrappers.pb.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Wrappers.pb.cs
@@ -106,6 +106,15 @@ namespace Google.Protobuf.WellKnownTypes {
       return new DoubleValue(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = 0D;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "value" field.</summary>
     public const int ValueFieldNumber = 1;
     private double value_;
@@ -313,6 +322,15 @@ namespace Google.Protobuf.WellKnownTypes {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public FloatValue Clone() {
       return new FloatValue(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = 0F;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "value" field.</summary>
@@ -524,6 +542,15 @@ namespace Google.Protobuf.WellKnownTypes {
       return new Int64Value(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = 0L;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "value" field.</summary>
     public const int ValueFieldNumber = 1;
     private long value_;
@@ -731,6 +758,15 @@ namespace Google.Protobuf.WellKnownTypes {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public UInt64Value Clone() {
       return new UInt64Value(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = 0UL;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "value" field.</summary>
@@ -942,6 +978,15 @@ namespace Google.Protobuf.WellKnownTypes {
       return new Int32Value(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "value" field.</summary>
     public const int ValueFieldNumber = 1;
     private int value_;
@@ -1149,6 +1194,15 @@ namespace Google.Protobuf.WellKnownTypes {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public UInt32Value Clone() {
       return new UInt32Value(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = 0;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "value" field.</summary>
@@ -1360,6 +1414,15 @@ namespace Google.Protobuf.WellKnownTypes {
       return new BoolValue(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = false;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "value" field.</summary>
     public const int ValueFieldNumber = 1;
     private bool value_;
@@ -1569,6 +1632,15 @@ namespace Google.Protobuf.WellKnownTypes {
       return new StringValue(this);
     }
 
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = "";
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
+    }
+
     /// <summary>Field number for the "value" field.</summary>
     public const int ValueFieldNumber = 1;
     private string value_ = "";
@@ -1776,6 +1848,15 @@ namespace Google.Protobuf.WellKnownTypes {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public BytesValue Clone() {
       return new BytesValue(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void Clear() {
+      value_ = pb::ByteString.Empty;
+      if (_unknownFields != null) {
+        _unknownFields.Clear();
+      }
     }
 
     /// <summary>Field number for the "value" field.</summary>

--- a/src/google/protobuf/compiler/csharp/csharp_field_base.h
+++ b/src/google/protobuf/compiler/csharp/csharp_field_base.h
@@ -36,6 +36,7 @@ class FieldGeneratorBase : public SourceGeneratorBase {
   FieldGeneratorBase& operator=(const FieldGeneratorBase&) = delete;
 
   virtual void GenerateCloningCode(io::Printer* printer) = 0;
+  virtual void GenerateClearCode(io::Printer* printer) = 0;
   virtual void GenerateFreezingCode(io::Printer* printer);
   virtual void GenerateCodecCode(io::Printer* printer);
   virtual void GenerateExtensionCode(io::Printer* printer);

--- a/src/google/protobuf/compiler/csharp/csharp_map_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_map_field.cc
@@ -117,6 +117,11 @@ void MapFieldGenerator::GenerateCloningCode(io::Printer* printer) {
     "$name$_ = other.$name$_.Clone();\n");
 }
 
+void MapFieldGenerator::GenerateClearCode(io::Printer* printer) {
+  printer->Print(variables_,
+    "$name$_.Clear();\n");
+}
+
 void MapFieldGenerator::GenerateFreezingCode(io::Printer* printer) {
 }
 

--- a/src/google/protobuf/compiler/csharp/csharp_map_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_map_field.h
@@ -27,6 +27,7 @@ class MapFieldGenerator : public FieldGeneratorBase {
   MapFieldGenerator& operator=(const MapFieldGenerator&) = delete;
 
   void GenerateCloningCode(io::Printer* printer) override;
+  void GenerateClearCode(io::Printer* printer) override;
   void GenerateFreezingCode(io::Printer* printer) override;
   void GenerateMembers(io::Printer* printer) override;
   void GenerateMergingCode(io::Printer* printer) override;

--- a/src/google/protobuf/compiler/csharp/csharp_message.h
+++ b/src/google/protobuf/compiler/csharp/csharp_message.h
@@ -31,6 +31,7 @@ class MessageGenerator : public SourceGeneratorBase {
   MessageGenerator& operator=(const MessageGenerator&) = delete;
 
   void GenerateCloningCode(io::Printer* printer);
+  void GenerateClearCode(io::Printer* printer);
   void GenerateFreezingCode(io::Printer* printer);
   void GenerateFrameworkMethods(io::Printer* printer);
   void Generate(io::Printer* printer);

--- a/src/google/protobuf/compiler/csharp/csharp_message_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message_field.cc
@@ -162,6 +162,13 @@ void MessageFieldGenerator::GenerateCloningCode(io::Printer* printer) {
     "$name$_ = other.$has_property_check$ ? other.$name$_.Clone() : null;\n");
 }
 
+void MessageFieldGenerator::GenerateClearCode(io::Printer* printer) {
+  printer->Print(variables_,
+    "if ($name$_ != null) {\n"
+    "  $name$_.Clear();\n"
+    "}\n");
+}
+
 void MessageFieldGenerator::GenerateFreezingCode(io::Printer* printer) {
 }
 
@@ -258,6 +265,10 @@ void MessageOneofFieldGenerator::WriteToString(io::Printer* printer) {
 void MessageOneofFieldGenerator::GenerateCloningCode(io::Printer* printer) {
   printer->Print(variables_,
     "$property_name$ = other.$property_name$.Clone();\n");
+}
+
+void MessageOneofFieldGenerator::GenerateClearCode(io::Printer* printer) {
+  // No-Op: Message fields in oneofs are correctly cleared by clearing the oneof
 }
 
 }  // namespace csharp

--- a/src/google/protobuf/compiler/csharp/csharp_message_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_message_field.h
@@ -28,6 +28,7 @@ class MessageFieldGenerator : public FieldGeneratorBase {
 
   void GenerateCodecCode(io::Printer* printer) override;
   void GenerateCloningCode(io::Printer* printer) override;
+  void GenerateClearCode(io::Printer* printer) override;
   void GenerateFreezingCode(io::Printer* printer) override;
   void GenerateMembers(io::Printer* printer) override;
   void GenerateMergingCode(io::Printer* printer) override;
@@ -53,6 +54,7 @@ class MessageOneofFieldGenerator : public MessageFieldGenerator {
       delete;
 
   void GenerateCloningCode(io::Printer* printer) override;
+  void GenerateClearCode(io::Printer* printer) override;
   void GenerateMembers(io::Printer* printer) override;
   void GenerateMergingCode(io::Printer* printer) override;
   void WriteToString(io::Printer* printer) override;

--- a/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
@@ -232,6 +232,11 @@ void PrimitiveFieldGenerator::GenerateCloningCode(io::Printer* printer) {
     "$name$_ = other.$name$_;\n");
 }
 
+void PrimitiveFieldGenerator::GenerateClearCode(io::Printer* printer) {
+  printer->Print(variables_,
+    "$name$_ = $default_value$;\n");
+}
+
 void PrimitiveFieldGenerator::GenerateCodecCode(io::Printer* printer) {
   printer->Print(
     variables_,
@@ -322,6 +327,10 @@ void PrimitiveOneofFieldGenerator::GenerateParsingCode(io::Printer* printer) {
 void PrimitiveOneofFieldGenerator::GenerateCloningCode(io::Printer* printer) {
   printer->Print(variables_,
     "$property_name$ = other.$property_name$;\n");
+}
+
+void PrimitiveOneofFieldGenerator::GenerateClearCode(io::Printer* printer) {
+  // No-Op: Primitive fields in oneofs are correctly cleared by clearing the oneof
 }
 
 }  // namespace csharp

--- a/src/google/protobuf/compiler/csharp/csharp_primitive_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_primitive_field.h
@@ -30,6 +30,7 @@ class PrimitiveFieldGenerator : public FieldGeneratorBase {
 
   void GenerateCodecCode(io::Printer* printer) override;
   void GenerateCloningCode(io::Printer* printer) override;
+  void GenerateClearCode(io::Printer* printer) override;
   void GenerateMembers(io::Printer* printer) override;
   void GenerateMergingCode(io::Printer* printer) override;
   void GenerateParsingCode(io::Printer* printer) override;
@@ -57,6 +58,7 @@ class PrimitiveOneofFieldGenerator : public PrimitiveFieldGenerator {
       delete;
 
   void GenerateCloningCode(io::Printer* printer) override;
+  void GenerateClearCode(io::Printer* printer) override;
   void GenerateMembers(io::Printer* printer) override;
   void GenerateMergingCode(io::Printer* printer) override;
   void WriteToString(io::Printer* printer) override;

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc
@@ -106,6 +106,11 @@ void RepeatedEnumFieldGenerator::GenerateCloningCode(io::Printer* printer) {
     "$name$_ = other.$name$_.Clone();\n");
 }
 
+void RepeatedEnumFieldGenerator::GenerateClearCode(io::Printer* printer) {
+  printer->Print(variables_,
+    "$name$_.Clear();\n");
+}
+
 void RepeatedEnumFieldGenerator::GenerateExtensionCode(io::Printer* printer) {
   WritePropertyDocComment(printer, options(), descriptor_);
   AddDeprecatedFlag(printer);

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.h
@@ -30,6 +30,7 @@ class RepeatedEnumFieldGenerator : public FieldGeneratorBase {
       delete;
 
   void GenerateCloningCode(io::Printer* printer) override;
+  void GenerateClearCode(io::Printer* printer) override;
   void GenerateFreezingCode(io::Printer* printer) override;
   void GenerateMembers(io::Printer* printer) override;
   void GenerateMergingCode(io::Printer* printer) override;

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc
@@ -123,6 +123,11 @@ void RepeatedMessageFieldGenerator::GenerateCloningCode(io::Printer* printer) {
     "$name$_ = other.$name$_.Clone();\n");
 }
 
+void RepeatedMessageFieldGenerator::GenerateClearCode(io::Printer* printer) {
+  printer->Print(variables_,
+    "$name$_.Clear();\n");
+}
+
 void RepeatedMessageFieldGenerator::GenerateFreezingCode(io::Printer* printer) {
 }
 

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.h
@@ -30,6 +30,7 @@ class RepeatedMessageFieldGenerator : public FieldGeneratorBase {
       const RepeatedMessageFieldGenerator&) = delete;
 
   void GenerateCloningCode(io::Printer* printer) override;
+  void GenerateClearCode(io::Printer* printer) override;
   void GenerateFreezingCode(io::Printer* printer) override;
   void GenerateMembers(io::Printer* printer) override;
   void GenerateMergingCode(io::Printer* printer) override;

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc
@@ -104,6 +104,11 @@ void RepeatedPrimitiveFieldGenerator::GenerateCloningCode(io::Printer* printer) 
     "$name$_ = other.$name$_.Clone();\n");
 }
 
+void RepeatedPrimitiveFieldGenerator::GenerateClearCode(io::Printer* printer) {
+  printer->Print(variables_,
+    "$name$_.Clear();\n");
+}
+
 void RepeatedPrimitiveFieldGenerator::GenerateFreezingCode(io::Printer* printer) {
 }
 

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.h
@@ -26,6 +26,7 @@ class RepeatedPrimitiveFieldGenerator : public FieldGeneratorBase {
   RepeatedPrimitiveFieldGenerator& operator=(const RepeatedPrimitiveFieldGenerator&) = delete;
 
   void GenerateCloningCode(io::Printer* printer) override;
+  void GenerateClearCode(io::Printer* printer) override;
   void GenerateFreezingCode(io::Printer* printer) override;
   void GenerateMembers(io::Printer* printer) override;
   void GenerateMergingCode(io::Printer* printer) override;

--- a/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc
@@ -163,6 +163,11 @@ void WrapperFieldGenerator::GenerateCloningCode(io::Printer* printer) {
     "$property_name$ = other.$property_name$;\n");
 }
 
+void WrapperFieldGenerator::GenerateClearCode(io::Printer* printer) {
+  printer->Print(variables_,
+    "$name$_ = $default_value$;\n");
+}
+
 void WrapperFieldGenerator::GenerateCodecCode(io::Printer* printer) {
   if (is_value_type) {
     printer->Print(

--- a/src/google/protobuf/compiler/csharp/csharp_wrapper_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_wrapper_field.h
@@ -30,6 +30,7 @@ class WrapperFieldGenerator : public FieldGeneratorBase {
 
   void GenerateCodecCode(io::Printer* printer) override;
   void GenerateCloningCode(io::Printer* printer) override;
+  void GenerateClearCode(io::Printer* printer) override;
   void GenerateMembers(io::Printer* printer) override;
   void GenerateMergingCode(io::Printer* printer) override;
   void GenerateParsingCode(io::Printer* printer) override;


### PR DESCRIPTION
# Motivation
In C# game development or real-time bidding, object pooling is a common way to optimize. However, the C# runtime of Protobuf does not support Clear message. See issue: #18782.

This pull request add Clear method to IMessage.cs, makes Protobuf C# message can be reused.

# What's added or changed
* Protoc: csharp codegen add Clear() method, inspired of java clear() implementation.
* WellKnown protos: Regenerated by Protoc tools above.
* IMessage: interface add Clear() method, few old proto generated file or C# file was correct by hand.
* Tests: base unit tests are included.

If this pull request has any breaking changes or improvement, please let me know. And I will try my best to improve it.

Thanks for your time.