### PR TITLE
update platforms with musttail support

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -236,7 +236,8 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
 #endif
 #if ABSL_HAVE_CPP_ATTRIBUTE(clang::musttail) && !defined(__arm__) &&  \
     !defined(_ARCH_PPC) && !defined(__wasm__) &&                      \
-    !(defined(_MSC_VER) && defined(_M_IX86)) && !defined(__i386__)
+    !(defined(_MSC_VER) && defined(_M_IX86)) && !defined(__i386__) && \
+    !defined(__s390x__)
 // Compilation fails on ARM32: b/195943306
 // Compilation fails on powerpc64le: b/187985113
 // Compilation fails on X86 Windows:


### PR DESCRIPTION
GCC 15 gained the support for the musttail attribute, but similar to clang the attribute isn't supported on all targets. Add IBM Z (aka s390x) to the list of skipped platforms.