### PR TITLE
Remove fast-path check for non-clang compilers in MessageCreator.

### DIFF
--- a/src/google/protobuf/message_lite.h
+++ b/src/google/protobuf/message_lite.h
@@ -1188,7 +1188,7 @@ inline void AssertDownCast(const MessageLite& from, const MessageLite& to) {
 }
 
 template <typename MessageLite>
-PROTOBUF_ALWAYS_INLINE MessageLite* MessageCreator::PlacementNew(
+PROTOBUF_ALWAYS_INLINE inline MessageLite* MessageCreator::PlacementNew(
     const MessageLite* prototype_for_func,
     const MessageLite* prototype_for_copy, void* mem, Arena* arena) const {
   ABSL_DCHECK_EQ(reinterpret_cast<uintptr_t>(mem) % alignment_, 0u);
@@ -1290,7 +1290,7 @@ PROTOBUF_ALWAYS_INLINE MessageLite* MessageCreator::PlacementNew(
 }
 
 template <typename MessageLite>
-PROTOBUF_ALWAYS_INLINE MessageLite* MessageCreator::New(
+PROTOBUF_ALWAYS_INLINE inline MessageLite* MessageCreator::New(
     const MessageLite* prototype_for_func,
     const MessageLite* prototype_for_copy, Arena* arena) const {
   return PlacementNew(prototype_for_func, prototype_for_copy,

--- a/src/google/protobuf/message_lite.h
+++ b/src/google/protobuf/message_lite.h
@@ -119,11 +119,11 @@ class MessageCreator {
         func_(func) {}
 
   // Template for testing.
-  template <bool test_call = false, typename MessageLite>
+  template <typename MessageLite>
   MessageLite* New(const MessageLite* prototype_for_func,
                    const MessageLite* prototype_for_copy, Arena* arena) const;
 
-  template <bool test_call = false, typename MessageLite>
+  template <typename MessageLite>
   MessageLite* PlacementNew(const MessageLite* prototype_for_func,
                             const MessageLite* prototype_for_copy, void* mem,
                             Arena* arena) const;
@@ -1187,19 +1187,15 @@ inline void AssertDownCast(const MessageLite& from, const MessageLite& to) {
       << "Cannot downcast " << from.GetTypeName() << " to " << to.GetTypeName();
 }
 
-template <bool test_call, typename MessageLite>
-PROTOBUF_ALWAYS_INLINE inline MessageLite* MessageCreator::PlacementNew(
+template <typename MessageLite>
+PROTOBUF_ALWAYS_INLINE MessageLite* MessageCreator::PlacementNew(
     const MessageLite* prototype_for_func,
     const MessageLite* prototype_for_copy, void* mem, Arena* arena) const {
   ABSL_DCHECK_EQ(reinterpret_cast<uintptr_t>(mem) % alignment_, 0u);
   const Tag as_tag = tag();
-  // When the feature is not enabled we skip the `as_tag` check since it is
-  // unnecessary. Except for testing, where we want to test the copy logic even
-  // when we can't use it for real messages.
-  constexpr bool kMustBeFunc = !test_call && !internal::EnableCustomNew();
   static_assert(kFunc < 0 && !(kZeroInit < 0) && !(kMemcpy < 0),
                 "Only kFunc must be the only negative value");
-  if (ABSL_PREDICT_FALSE(kMustBeFunc || as_tag < 0)) {
+  if (ABSL_PREDICT_FALSE(static_cast<int8_t>(as_tag) < 0)) {
     PROTOBUF_DEBUG_COUNTER("MessageCreator.Func").Inc();
     return static_cast<MessageLite*>(func_(prototype_for_func, mem, arena));
   }
@@ -1293,15 +1289,15 @@ PROTOBUF_ALWAYS_INLINE inline MessageLite* MessageCreator::PlacementNew(
   return Launder(reinterpret_cast<MessageLite*>(mem));
 }
 
-template <bool test_call, typename MessageLite>
-PROTOBUF_ALWAYS_INLINE inline MessageLite* MessageCreator::New(
+template <typename MessageLite>
+PROTOBUF_ALWAYS_INLINE MessageLite* MessageCreator::New(
     const MessageLite* prototype_for_func,
     const MessageLite* prototype_for_copy, Arena* arena) const {
-  return PlacementNew<test_call>(prototype_for_func, prototype_for_copy,
-                                 arena != nullptr
-                                     ? arena->AllocateAligned(allocation_size_)
-                                     : ::operator new(allocation_size_),
-                                 arena);
+  return PlacementNew(prototype_for_func, prototype_for_copy,
+                      arena != nullptr
+                          ? arena->AllocateAligned(allocation_size_)
+                          : ::operator new(allocation_size_),
+                      arena);
 }
 
 }  // namespace internal

--- a/src/google/protobuf/port.h
+++ b/src/google/protobuf/port.h
@@ -384,19 +384,16 @@ constexpr T* Launder(T* p) {
 }
 
 #if defined(PROTOBUF_CUSTOM_VTABLE)
-constexpr bool EnableCustomNew() { return true; }
 template <typename T>
 constexpr bool EnableCustomNewFor() {
   return true;
 }
 #elif ABSL_HAVE_BUILTIN(__is_bitwise_cloneable)
-constexpr bool EnableCustomNew() { return true; }
 template <typename T>
 constexpr bool EnableCustomNewFor() {
   return __is_bitwise_cloneable(T);
 }
 #else
-constexpr bool EnableCustomNew() { return false; }
 template <typename T>
 constexpr bool EnableCustomNewFor() {
   return false;


### PR DESCRIPTION
This check can lead to issues if the translation units are compiled with different compilers.

PiperOrigin-RevId: 755012244