### PR TITLE
Cherry-pick Rust fix to 31.x

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -30,7 +30,7 @@ jobs:
 
           # Override cases with custom images
           - config: { name: Cargo }
-            image: "us-docker.pkg.dev/protobuf-build/containers/release/linux/rust:8.0.1-1.74.0-b77fdae6d4771789dfc66a56bf8d806354e8011a"
+            image: "us-docker.pkg.dev/protobuf-build/containers/release/linux/rust:8.0.1-1.79.0-d271543f317955b5732ce19b2be672a195e96508"
             bazel_cmd: "run"
             targets: "//rust/release_crates:cargo_test"
 

--- a/rust/release_crates/protobuf/Cargo-template.toml
+++ b/rust/release_crates/protobuf/Cargo-template.toml
@@ -11,7 +11,7 @@ version = "{VERSION}"
 edition = "2021"  # The Rust edition (not to be confused with Protobuf Edition).
 links = "upb"
 license = "BSD-3-Clause"
-rust-version = "1.74"
+rust-version = "1.79"
 description = "Protocol Buffers - Google's data interchange format"
 
 [lib]

--- a/rust/release_crates/protobuf/build.rs
+++ b/rust/release_crates/protobuf/build.rs
@@ -19,7 +19,9 @@ fn main() {
         .file("libupb/third_party/utf8_range/utf8_range.c")
         .define("UPB_BUILD_API", Some("1"))
         .compile("libupb");
-    let path = std::path::Path::new("libupb");
-    println!("cargo:include={}", path.canonicalize().unwrap().display());
+
+    let path = std::path::absolute("libupb").expect("Failed to get full path to libupb");
+
+    println!("cargo:include={}", path.display());
     println!("cargo:version={}", VERSION);
 }

--- a/rust/release_crates/protobuf_codegen/Cargo-template.toml
+++ b/rust/release_crates/protobuf_codegen/Cargo-template.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 version = "{VERSION}"
 description = "Code generator for Rust Protocol Buffers bindings"
 license = "BSD-3-Clause"
-rust-version = "1.74"
+rust-version = "1.79"
 
 
 [dependencies]

--- a/rust/release_crates/protobuf_macros/Cargo-template.toml
+++ b/rust/release_crates/protobuf_macros/Cargo-template.toml
@@ -10,7 +10,7 @@ name = "protobuf-macros"
 version = "{VERSION}"
 edition = "2021"  # The Rust edition (not to be confused with Protobuf Edition).
 license = "BSD-3-Clause"
-rust-version = "1.74"
+rust-version = "1.79"
 description = "Protobuf proc macro implementation (internal)"
 
 [lib]


### PR DESCRIPTION
This cherry-picks the fix for #21590 to 31.x, including upgrading our minimum supported Rust version to 1.79.