### PR TITLE
Fixed edge cases in PyiGenerator when using reserved keywords

### DIFF
--- a/src/google/protobuf/compiler/python/helpers.cc
+++ b/src/google/protobuf/compiler/python/helpers.cc
@@ -72,6 +72,14 @@ std::string ResolveKeyword(absl::string_view name) {
   return std::string(name);
 }
 
+// Escapes Python keywords for use as plain identifiers by appending an underscore.
+std::string EscapeKeyword(absl::string_view name) {
+  if (IsPythonKeyword(name)) {
+    return absl::StrCat(name, "_");
+  }
+  return std::string(name);
+}
+
 std::string GetFileName(const FileDescriptor* file_des,
                         absl::string_view suffix) {
   std::string module_name = ModuleName(file_des->name());

--- a/src/google/protobuf/compiler/python/helpers.h
+++ b/src/google/protobuf/compiler/python/helpers.h
@@ -25,6 +25,7 @@ std::string StrippedModuleName(absl::string_view filename);
 bool ContainsPythonKeyword(absl::string_view module_name);
 bool IsPythonKeyword(absl::string_view name);
 std::string ResolveKeyword(absl::string_view name);
+std::string EscapeKeyword(absl::string_view name);
 std::string GetFileName(const FileDescriptor* file_des,
                         absl::string_view suffix);
 bool HasGenericServices(const FileDescriptor* file);


### PR DESCRIPTION
This fixes syntax errors when mypy or the IDE tries to parse the generated pyi files. Also added some unit-tests with examples.

There are probably more edge cases to fix, but these are the ones I encountered and managed to find reviewing the generator code.

Example proto, generated with by running : `/protoc --pyi_out=./python_out --python_out=./python_out ./test.proto` 

```proto3
# test.proto

syntax = "proto3";

package return;


enum class {
    None = 0;
    True = 1;
    False = 2;
}

message lambda {
    message nonlocal {
        oneof break {
            int32 int_value = 1;
            string string_value = 2;
        }
    }

    enum def {
        None = 0;
        True = 1;
        False = 2;
    }

    class foo = 1;
    nonlocal bar = 2;
    def baz = 3;
}
```

Before the fix  - invalid syntax:

```python3
import other_pb2 as _other_pb2
from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
from google.protobuf import descriptor as _descriptor
from google.protobuf import message as _message
from collections.abc import Mapping as _Mapping
from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union

DESCRIPTOR: _descriptor.FileDescriptor

class class(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
    __slots__ = ()
    None: _ClassVar[globals()['class']]
    True: _ClassVar[globals()['class']]
    False: _ClassVar[globals()['class']]
None: globals()['class']
True: globals()['class']
False: globals()['class']

class lambda(_message.Message):
    __slots__ = ("foo", "bar", "baz", "t")
    class def(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
        __slots__ = ()
        None: _ClassVar[getattr(globals()['lambda'], 'def')]
        True: _ClassVar[getattr(globals()['lambda'], 'def')]
        False: _ClassVar[getattr(globals()['lambda'], 'def')]
    None: getattr(globals()['lambda'], 'def')
    True: getattr(globals()['lambda'], 'def')
    False: getattr(globals()['lambda'], 'def')
    class nonlocal(_message.Message):
        __slots__ = ("int_value", "string_value")
        INT_VALUE_FIELD_NUMBER: _ClassVar[int]
        STRING_VALUE_FIELD_NUMBER: _ClassVar[int]
        int_value: int
        string_value: str
        def __init__(self, int_value: _Optional[int] = ..., string_value: _Optional[str] = ...) -> None: ...
    FOO_FIELD_NUMBER: _ClassVar[int]
    BAR_FIELD_NUMBER: _ClassVar[int]
    BAZ_FIELD_NUMBER: _ClassVar[int]
    T_FIELD_NUMBER: _ClassVar[int]
    foo: globals()['class']
    bar: getattr(globals()['lambda'], 'nonlocal')
    baz: getattr(globals()['lambda'], 'def')
    t: _other_pb2.globals()['try']
    def __init__(self, foo: _Optional[_Union[globals()['class'], str]] = ..., bar: _Optional[_Union[getattr(globals()['lambda'], 'nonlocal'), _Mapping]] = ..., baz: _Optional[_Union[getattr(globals()['lambda'], 'def'), str]] = ..., t: _Optional[_Union[_other_pb2.globals()['try'], _Mapping]] = ...) -> None: ...

```

After the fix:
```python3
import other_pb2 as _other_pb2
from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
from google.protobuf import descriptor as _descriptor
from google.protobuf import message as _message
from collections.abc import Mapping as _Mapping
from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union

DESCRIPTOR: _descriptor.FileDescriptor

class class_(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
    __slots__ = ()
    None_: _ClassVar[class_]
    True_: _ClassVar[class_]
    False_: _ClassVar[class_]
None_: class_
True_: class_
False_: class_

class lambda_(_message.Message):
    __slots__ = ("foo", "bar", "baz", "t")
    class def_(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
        __slots__ = ()
        None_: _ClassVar[lambda_.def_]
        True_: _ClassVar[lambda_.def_]
        False_: _ClassVar[lambda_.def_]
    None_: lambda_.def_
    True_: lambda_.def_
    False_: lambda_.def_
    class nonlocal_(_message.Message):
        __slots__ = ("int_value", "string_value")
        INT_VALUE_FIELD_NUMBER: _ClassVar[int]
        STRING_VALUE_FIELD_NUMBER: _ClassVar[int]
        int_value: int
        string_value: str
        def __init__(self, int_value: _Optional[int] = ..., string_value: _Optional[str] = ...) -> None: ...
    FOO_FIELD_NUMBER: _ClassVar[int]
    BAR_FIELD_NUMBER: _ClassVar[int]
    BAZ_FIELD_NUMBER: _ClassVar[int]
    T_FIELD_NUMBER: _ClassVar[int]
    foo: class_
    bar: lambda_.nonlocal_
    baz: lambda_.def_
    t: _other_pb2.try_
    def __init__(self, foo: _Optional[_Union[class_, str]] = ..., bar: _Optional[_Union[lambda_.nonlocal_, _Mapping]] = ..., baz: _Optional[_Union[lambda_.def_, str]] = ..., t: _Optional[_Union[_other_pb2.try_, _Mapping]] = ...) -> None: ...
```