### PR TITLE
Fix silent failure of `rb_test` rules to run test (#21733)

### DIFF
--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
@@ -1089,7 +1089,17 @@ public class RubyMessage extends RubyObject {
         }
         break;
       case MESSAGE:
-        val = ((RubyMessage) value).build(context, depth + 1, recursionLimit);
+        RubyMessage msg;
+        if (value instanceof RubyHash) {
+          RubyClass typeClass =
+              (RubyClass)
+                  ((RubyDescriptor) getDescriptorForField(context, fieldDescriptor))
+                      .msgclass(context);
+          msg = (RubyMessage) typeClass.newInstance(context, value);
+        } else {
+          msg = (RubyMessage) value;
+        }
+        val = msg.build(context, depth + 1, recursionLimit);
         break;
       case ENUM:
         EnumDescriptor enumDescriptor = fieldDescriptor.getEnumType();

--- a/ruby/tests/BUILD.bazel
+++ b/ruby/tests/BUILD.bazel
@@ -19,6 +19,10 @@ internal_ruby_proto_library(
 rb_test(
     name = "implementation",
     srcs = ["implementation.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/implementation.rb",
+    ],
     deps = [
         "//ruby:protobuf",
         "@protobuf_bundle",
@@ -28,6 +32,10 @@ rb_test(
 rb_test(
     name = "basic",
     srcs = ["basic.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/basic.rb",
+    ],
     deps = [
         ":common_tests",
         ":test_ruby_protos",
@@ -39,6 +47,10 @@ rb_test(
 rb_test(
     name = "basic_proto2",
     srcs = ["basic_proto2.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/basic_proto2.rb",
+    ],
     deps = [
         ":common_tests",
         ":test_ruby_protos",
@@ -50,6 +62,10 @@ rb_test(
 rb_test(
     name = "encode_decode_test",
     srcs = ["encode_decode_test.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/encode_decode_test.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -60,6 +76,10 @@ rb_test(
 rb_test(
     name = "gc_test",
     srcs = ["gc_test.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/gc_test.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -70,6 +90,10 @@ rb_test(
 rb_test(
     name = "generated_code_test",
     srcs = ["generated_code_test.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/generated_code_test.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -80,6 +104,10 @@ rb_test(
 rb_test(
     name = "multi_level_nesting_test",
     srcs = ["multi_level_nesting_test.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/multi_level_nesting_test.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -90,6 +118,10 @@ rb_test(
 rb_test(
     name = "object_cache_test",
     srcs = ["object_cache_test.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/object_cache_test.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -100,6 +132,10 @@ rb_test(
 rb_test(
     name = "repeated_field_test",
     srcs = ["repeated_field_test.rb"],
+    args = [
+        "-Iruby/lib:ruby:ruby/tests",
+        "ruby/tests/repeated_field_test.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -110,6 +146,10 @@ rb_test(
 rb_test(
     name = "ruby_version",
     srcs = ["ruby_version.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/ruby_version.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -120,6 +160,10 @@ rb_test(
 rb_test(
     name = "stress",
     srcs = ["stress.rb"],
+    args = [
+        "-Iruby/lib:ruby:ruby/tests",
+        "ruby/tests/stress.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -130,6 +174,10 @@ rb_test(
 rb_test(
     name = "type_errors",
     srcs = ["type_errors.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/type_errors.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -140,6 +188,10 @@ rb_test(
 rb_test(
     name = "utf8",
     srcs = ["utf8.rb"],
+    args = [
+        "-Iruby/lib:ruby:ruby/tests",
+        "ruby/tests/utf8.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -150,6 +202,10 @@ rb_test(
 rb_test(
     name = "well_known_types_test",
     srcs = ["well_known_types_test.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/well_known_types_test.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -160,6 +216,10 @@ rb_test(
 rb_test(
     name = "service_test",
     srcs = ["service_test.rb"],
+    args = [
+        "-Iruby/lib:ruby:ruby/tests",
+        "ruby/tests/service_test.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",
@@ -170,6 +230,10 @@ rb_test(
 rb_test(
     name = "memory_test",
     srcs = ["memory_test.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/memory_test.rb",
+    ],
     deps = [
         ":test_ruby_protos",
         "//ruby:protobuf",


### PR DESCRIPTION
Additional details discussed in https://github.com/bazel-contrib/rules_ruby/issues/233 and https://github.com/bazel-contrib/rules_ruby/issues/223

Restoring tests revealed latent bug in JRuby's `RubyMessage#convert` that was exposed by the introduction `test_to_hash` while tests were not running; fix included.

Closes #21733

COPYBARA_INTEGRATE_REVIEW=https://github.com/protocolbuffers/protobuf/pull/21733 from protocolbuffers:fix_rb_test 3f8418f2f4471d78b980b658ca04d534e2ce9dc6 PiperOrigin-RevId: 758470283