### PR TITLE
Avoid linker errors when compiling for AOT.

### DIFF
--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -711,7 +711,13 @@ namespace Google.Protobuf.Collections
             // 1. protobuf wire bytes is LittleEndian only
             // 2. validate that size of csharp element T is matching the size of protobuf wire size
             //    NOTE: cannot use bool with this span because csharp marshal it as 4 bytes
-            if (BitConverter.IsLittleEndian && (codec.FixedSize > 0 && Marshal.SizeOf(typeof(T)) == codec.FixedSize))
+            if (BitConverter.IsLittleEndian && (codec.FixedSize > 0 &&
+#if NETSTANDARD1_2_OR_GREATER || NET451_OR_GREATER || NET
+                Marshal.SizeOf<T>()
+#else
+                Marshal.SizeOf(typeof(T))
+#endif
+                == codec.FixedSize))
             {
                 handle = GCHandle.Alloc(array, GCHandleType.Pinned);
                 span = new Span<byte>(handle.AddrOfPinnedObject().ToPointer(), array.Length * codec.FixedSize);

--- a/csharp/src/Google.Protobuf/Reflection/FeatureSetDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FeatureSetDescriptor.cs
@@ -41,9 +41,12 @@ internal sealed partial class FeatureSetDescriptor
         var featureSetDefaults = FeatureSetDefaults.Parser.ParseFrom(Convert.FromBase64String(DefaultsBase64));
         var ret = new Dictionary<Edition, FeatureSetDescriptor>();
 
-        // Note: Enum.GetValues<TEnum> isn't available until .NET 5. It's not worth making this conditional
-        // based on that.
-        var supportedEditions = ((Edition[]) Enum.GetValues(typeof(Edition)))
+        var supportedEditions =
+#if NET5_0_OR_GREATER
+            Enum.GetValues<Edition>()
+#else
+            ((Edition[])Enum.GetValues(typeof(Edition)))
+#endif
             .OrderBy(x => x)
             .Where(e => e >= featureSetDefaults.MinimumEdition && e <= featureSetDefaults.MaximumEdition);
 


### PR DESCRIPTION
Using `Marshal.SizeOf(typeof(T))` or `Enum.GetValues(typeof(T))` can cause AOT builds to fail when including the Google.Protobuf NuGet package and using the tools from a recent enough .NET SDK (9.0.300 or possibly earlier).

Set `<TrimmerSingleWarn>false</TrimmerSingleWarn>` and `<TreatWarningsAsErrors>True</TreatWarningsAsErrors>` to see something like this:

```
/_/csharp/src/Google.Protobuf/Collections/RepeatedField.cs(714): AOT analysis error IL3050: Google.Protobuf.Collections.RepeatedField`1.TryGetArrayAsSpanPinnedUnsafe(FieldCodec`1<T>,Span`1<Byte>&,GCHandle&): Using member 'System.Runtime.InteropServices.Marshal.SizeOf(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. Marshalling code for the object might not be available. Use the SizeOf<T> overload instead. [/src/xxxx/xxxx.csproj]
/root/.nuget/packages/microsoft.dotnet.ilcompiler/9.0.5/build/Microsoft.NETCore.Native.targets(317,5): error MSB3073: The command ""/root/.nuget/packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/9.0.5/tools/ilc" @"obj/Release/net9.0/linux-x64/native/RootApp.HubServer.ilc.rsp"" exited with code -1. [/src/xxxx/xxxx.csproj]
```