### PR TITLE
fix(php): use count instead of ->count() to avoid bug in c-extension

### DIFF
--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -130,6 +130,34 @@ class GeneratedClassTest extends TestBase
         $this->assertEquals(0, $deprecationCount);
     }
 
+    public function testDeprecatedFieldSetterThrowsWarning()
+    {
+        // temporarily change error handler to capture the deprecated errors
+        $deprecationCount = 0;
+        set_error_handler(function ($errno, $errstr) use (&$deprecationCount) {
+            if (false !== strpos($errstr, ' is deprecated.')) {
+                $deprecationCount++;
+            }
+        }, E_USER_DEPRECATED);
+
+        // does not throw warning
+        $message = new TestMessage();
+        $message->setDeprecatedInt32(1);
+        $message->setDeprecatedOptionalInt32(1);
+        $message->setDeprecatedInt32ValueUnwrapped(1); // wrapped field
+        $message->setDeprecatedInt32Value(new \Google\Protobuf\Int32Value(['value' => 1])); // wrapped field
+        $message->setDeprecatedOneofInt32(1); // oneof field
+        $message->setDeprecatedRepeatedInt32([1]); // repeated field
+        $message->setDeprecatedMapInt32Int32([1 => 1]); // map field
+        $message->setDeprecatedAny(new \Google\Protobuf\Any(['type_url' => 'foo', 'value' => 'bar'])); // any field
+        $message->setDeprecatedMessage(new TestMessage()); // message field
+        $message->setDeprecatedEnum(1); // enum field
+
+        restore_error_handler();
+
+        $this->assertEquals(9, $deprecationCount);
+    }
+
     public function testDeprecatedFieldGetterThrowsWarningWithValue()
     {
         $message = new TestMessage([

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -148,7 +148,7 @@ class GeneratedClassTest extends TestBase
 
         restore_error_handler();
 
-        $this->assertEquals(2, $deprecationCount);
+        $this->assertEquals(0, $deprecationCount);
     }
 
     public function testDeprecatedFieldGetterThrowsWarningWithValue()

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -119,7 +119,6 @@ class GeneratedClassTest extends TestBase
         $message->getDeprecatedInt32Value(); // wrapped field
         $message->getDeprecatedOneofInt32(); // oneof field
         $message->getDeprecatedOneof(); // oneof field
-        $message->setDeprecatedRepeatedInt32([1]); // repeated field
         $message->getDeprecatedRepeatedInt32(); // repeated field
         $message->getDeprecatedMapInt32Int32(); // map field
         $message->getDeprecatedAny(); // any field

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -119,6 +119,7 @@ class GeneratedClassTest extends TestBase
         $message->getDeprecatedInt32Value(); // wrapped field
         $message->getDeprecatedOneofInt32(); // oneof field
         $message->getDeprecatedOneof(); // oneof field
+        $message->setDeprecatedRepeatedInt32([1]); // repeated field
         $message->getDeprecatedRepeatedInt32(); // repeated field
         $message->getDeprecatedMapInt32Int32(); // map field
         $message->getDeprecatedAny(); // any field
@@ -130,7 +131,7 @@ class GeneratedClassTest extends TestBase
         $this->assertEquals(0, $deprecationCount);
     }
 
-    public function testDeprecatedFieldSetterThrowsWarning()
+    public function testDeprecatedFieldSetterDoesNotThrowWarningForRepeatedAndMapFieldsWithEmptyArrays()
     {
         // temporarily change error handler to capture the deprecated errors
         $deprecationCount = 0;
@@ -140,22 +141,15 @@ class GeneratedClassTest extends TestBase
             }
         }, E_USER_DEPRECATED);
 
-        // does not throw warning
+
+        // This behavior exists because otherwise the deprecation is thrown on serializeToJsonString
         $message = new TestMessage();
-        $message->setDeprecatedInt32(1);
-        $message->setDeprecatedOptionalInt32(1);
-        $message->setDeprecatedInt32ValueUnwrapped(1); // wrapped field
-        $message->setDeprecatedInt32Value(new \Google\Protobuf\Int32Value(['value' => 1])); // wrapped field
-        $message->setDeprecatedOneofInt32(1); // oneof field
-        $message->setDeprecatedRepeatedInt32([1]); // repeated field
-        $message->setDeprecatedMapInt32Int32([1 => 1]); // map field
-        $message->setDeprecatedAny(new \Google\Protobuf\Any(['type_url' => 'foo', 'value' => 'bar'])); // any field
-        $message->setDeprecatedMessage(new TestMessage()); // message field
-        $message->setDeprecatedEnum(1); // enum field
+        $message->setDeprecatedRepeatedInt32([]); // repeated field
+        $message->setDeprecatedMapInt32Int32([]); // map field
 
         restore_error_handler();
 
-        $this->assertEquals(9, $deprecationCount);
+        $this->assertEquals(2, $deprecationCount);
     }
 
     public function testDeprecatedFieldGetterThrowsWarningWithValue()

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -221,7 +221,7 @@ std::string DefaultForField(const FieldDescriptor* field) {
 
 std::string DeprecatedConditionalForField(const FieldDescriptor* field) {
   if (field->is_repeated()) {
-    return absl::StrCat("count(", field->name(), ") !== 0");
+    return absl::StrCat("count($this->", field->name(), ") !== 0");
   }
   if (field->real_containing_oneof() != nullptr) {
     return absl::StrCat("$this->hasOneof(", field->number(), ")");

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -221,7 +221,7 @@ std::string DefaultForField(const FieldDescriptor* field) {
 
 std::string DeprecatedConditionalForField(const FieldDescriptor* field) {
   if (field->is_repeated()) {
-    return absl::StrCat("$this->", field->name(), "->count() !== 0");
+    return absl::StrCat("count(", field->name(), ") !== 0");
   }
   if (field->real_containing_oneof() != nullptr) {
     return absl::StrCat("$this->hasOneof(", field->number(), ")");
@@ -749,7 +749,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
 
   if (field->options().deprecated() &&
       (field->is_map() || field->is_repeated())) {
-    printer->Print("if ($arr->count() !== 0) {\n    ^deprecation_trigger^}\n",
+    printer->Print("if (count($arr) !== 0) {\n    ^deprecation_trigger^}\n",
                    "deprecation_trigger", deprecation_trigger);
   }
 


### PR DESCRIPTION
see https://github.com/protocolbuffers/protobuf/issues/21812

Calling `setX($val)` on a deprecated repeated field or map when the php extension is enabled results in a PHP error:

```
PHP Error: Call to a member function count() on array
```

This is because the c-extension seems to have different behavior than the PHP native library - the return type of `GPBUtil::checkRepeatedField` is of type `RepeatedField` in the native library, but in the extension it is `array`.

This should be fixed in the PHP extension as well, but this PR only fixes the issue in the gencode.