### PR TITLE
Fix expected parse failures that may fail for the wrong reasons

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -49,28 +49,42 @@ While we plan to model all our supported languages more completely in Bazel,
 today some of them are a bit tricky to run.  Below is a list of the commands
 (and prerequisites) to run each language's conformance tests.
 
+C#:
+
+    $ which dotnet || echo "You must have dotnet installed!"
+    $ bazel test //csharp:conformance_test \
+        --action_env=DOTNET_CLI_TELEMETRY_OPTOUT=1 --test_env=DOTNET_CLI_HOME=~ \
+        --action_env=DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+
 Java:
 
     $ bazel test //java/core:conformance_test //java/lite:conformance_test
+
+Objective-C (Mac only):
+
+    $ bazel test //objectivec:conformance_test --macos_minimum_os=11.0
+
+PHP:
+
+    $ bazel test //php:conformance_test
+
+PHP (C):
+
+    $ which gcc     || echo "gcc is required!"
+    $ which libtool || echo "libtool is required!"
+    $ which make    || echo "make is required!"
+    $ which pear    || echo "pear is required! It might require a development version of PHP such as a php-dev package"
+    $ which pecl    || echo "pecl is required! It might require a development version of PHP such as a php-dev package"
+    $ which phpize  || echo "phpize is required! It might require a development version of PHP such as a php-dev package"
+    $ bazel test //php:conformance_test_c
 
 Python:
 
     $ bazel test //python:conformance_test
 
-Python C++:
+Python (C++):
 
     $ bazel test //python:conformance_test_cpp --define=use_fast_cpp_protos=true
-
-C#:
-
-    $ `which dotnet || echo "You must have dotnet installed!"
-    $ `bazel test //csharp:conformance_test \
-        --action_env=DOTNET_CLI_TELEMETRY_OPTOUT=1 --test_env=DOTNET_CLI_HOME=~ \
-        --action_env=DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
-
-Objective-C (Mac only):
-
-    $ `bazel test //objectivec:conformance_test --macos_minimum_os=11.0`
 
 Ruby:
 
@@ -78,7 +92,7 @@ Ruby:
     $ bazel test //ruby:conformance_test --define=ruby_platform=c \
         --action_env=PATH --action_env=GEM_PATH --action_env=GEM_HOME
 
-JRuby:
+Ruby (JRuby):
 
     $ [[ $(ruby --version) == "jruby"* ]] || echo "Switch to Java Ruby!"
     $ bazel test //ruby:conformance_test_jruby --define=ruby_platform=java \

--- a/conformance/bazel_conformance_test_runner.sh
+++ b/conformance/bazel_conformance_test_runner.sh
@@ -63,4 +63,6 @@ if [ -n "$MAXIMUM_EDITION" ]; then
   args+=(--maximum_edition $MAXIMUM_EDITION)
 fi
 
+args+=(--output_dir $(realpath $(mktemp -d)))
+
 $conformance_test_runner "${args[@]}" $conformance_testee

--- a/conformance/binary_json_conformance_suite.cc
+++ b/conformance/binary_json_conformance_suite.cc
@@ -2289,17 +2289,17 @@ void BinaryAndJsonConformanceSuiteImpl<
   // Duplicated field names are not allowed.
   ExpectParseFailureForJson("FieldNameDuplicate", RECOMMENDED,
                             R"({
-        "optionalNestedMessage": {a: 1},
+        "optionalNestedMessage": {\"a\": 1},
         "optionalNestedMessage": {}
       })");
   ExpectParseFailureForJson("FieldNameDuplicateDifferentCasing1", RECOMMENDED,
                             R"({
-        "optional_nested_message": {a: 1},
+        "optional_nested_message": {\"a\": 1},
         "optionalNestedMessage": {}
       })");
   ExpectParseFailureForJson("FieldNameDuplicateDifferentCasing2", RECOMMENDED,
                             R"({
-        "optionalNestedMessage": {a: 1},
+        "optionalNestedMessage": {\"a\": 1},
         "optional_nested_message": {}
       })");
   // Serializers should use lowerCamelCase by default.
@@ -2652,7 +2652,7 @@ void BinaryAndJsonConformanceSuiteImpl<
   ExpectParseFailureForJson("DoubleFieldTooSmall", REQUIRED,
                             R"({"optionalDouble": -1.89769e+308})");
   ExpectParseFailureForJson("DoubleFieldTooLarge", REQUIRED,
-                            R"({"optionalDouble": +1.89769e+308})");
+                            R"({"optionalDouble": 1.89769e+308})");
 
   // Parsers should reject empty string values.
   ExpectParseFailureForJson("DoubleFieldEmptyString", REQUIRED,

--- a/conformance/binary_json_conformance_suite.cc
+++ b/conformance/binary_json_conformance_suite.cc
@@ -2289,17 +2289,17 @@ void BinaryAndJsonConformanceSuiteImpl<
   // Duplicated field names are not allowed.
   ExpectParseFailureForJson("FieldNameDuplicate", RECOMMENDED,
                             R"({
-        "optionalNestedMessage": {\"a\": 1},
+        "optionalNestedMessage": {"a": 1},
         "optionalNestedMessage": {}
       })");
   ExpectParseFailureForJson("FieldNameDuplicateDifferentCasing1", RECOMMENDED,
                             R"({
-        "optional_nested_message": {\"a\": 1},
+        "optional_nested_message": {"a": 1},
         "optionalNestedMessage": {}
       })");
   ExpectParseFailureForJson("FieldNameDuplicateDifferentCasing2", RECOMMENDED,
                             R"({
-        "optionalNestedMessage": {\"a\": 1},
+        "optionalNestedMessage": {"a": 1},
         "optional_nested_message": {}
       })");
   // Serializers should use lowerCamelCase by default.

--- a/conformance/conformance_test.cc
+++ b/conformance/conformance_test.cc
@@ -685,8 +685,8 @@ bool ConformanceTestSuite::RunSuite(ConformanceTestRunner* runner,
               "didn't match any actual test name.  Remove them from the "
               "failure list by running from the root of your workspace:\n"
               "  bazel run "
-              "//google/protobuf/conformance:update_failure_list -- ",
-              failure_list_filename_, " --remove ", output_dir_,
+              "//conformance:update_failure_list -- $(realpath ",
+              failure_list_filename_, ") --remove ", output_dir_,
               "unmatched.txt"),
           output_dir_, &output_)) {
     ok = false;
@@ -700,8 +700,8 @@ bool ConformanceTestSuite::RunSuite(ConformanceTestRunner* runner,
               "failure messages do not match.  Remove their match from the "
               "failure list by running from the root of your workspace:\n"
               "  bazel run ",
-              "//google/protobuf/conformance:update_failure_list -- ",
-              failure_list_filename_, " --remove ", output_dir_,
+              "//conformance:update_failure_list -- $(realpath ",
+              failure_list_filename_, ") --remove ", output_dir_,
               "expected_failure_messages.txt"),
           output_dir_, &output_)) {
     ok = false;
@@ -715,8 +715,8 @@ bool ConformanceTestSuite::RunSuite(ConformanceTestRunner* runner,
               " Remove their match from the failure list by "
               "running from the root of your workspace:\n"
               "  bazel run "
-              "//google/protobuf/conformance:update_failure_list -- ",
-              failure_list_filename_, " --remove ", output_dir_,
+              "//conformance:update_failure_list -- $(realpath ",
+              failure_list_filename_, ") --remove ", output_dir_,
               "succeeding_tests.txt"),
           output_dir_, &output_)) {
     ok = false;
@@ -730,7 +730,7 @@ bool ConformanceTestSuite::RunSuite(ConformanceTestRunner* runner,
               "Remove them from the failure list by running from the root of "
               "your workspace:\n"
               "  bazel run "
-              "//google/protobuf/conformance:update_failure_list -- %s "
+              "//conformance:update_failure_list -- $(realpath %s) "
               "--remove %sexceeded_max_matches.txt",
               kMaximumWildcardExpansions, failure_list_filename_, output_dir_),
           output_dir_, &output_)) {
@@ -747,8 +747,8 @@ bool ConformanceTestSuite::RunSuite(ConformanceTestRunner* runner,
               "suite can succeed.  Add them to the failure list by "
               "running from the root of your workspace:\n"
               "  bazel run "
-              "//google/protobuf/conformance:update_failure_list -- ",
-              failure_list_filename_, " --add ", output_dir_,
+              "//conformance:update_failure_list -- $(realpath ",
+              failure_list_filename_, ") --add ", output_dir_,
               "unexpected_failure_messages.txt"),
           output_dir_, &output_)) {
     ok = false;
@@ -762,8 +762,8 @@ bool ConformanceTestSuite::RunSuite(ConformanceTestRunner* runner,
               "suite can succeed.  Add them to the failure list by "
               "running from the root of your workspace:\n"
               "  bazel run "
-              "//google/protobuf/conformance:update_failure_list -- ",
-              failure_list_filename_, " --add ", output_dir_,
+              "//conformance:update_failure_list -- $(realpath ",
+              failure_list_filename_, ") --add ", output_dir_,
               "failing_tests.txt"),
           output_dir_, &output_)) {
     ok = false;

--- a/conformance/failure_list_csharp.txt
+++ b/conformance/failure_list_csharp.txt
@@ -1,8 +1,20 @@
+Recommended.Editions_Proto2.JsonInput.FieldNameDuplicate                                                           # Should have failed to parse, but didn't.
+Recommended.Editions_Proto2.JsonInput.FieldNameDuplicateDifferentCasing1                                           # Should have failed to parse, but didn't.
+Recommended.Editions_Proto2.JsonInput.FieldNameDuplicateDifferentCasing2                                           # Should have failed to parse, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicate                                                           # Should have failed to parse, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicateDifferentCasing1                                           # Should have failed to parse, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicateDifferentCasing2                                           # Should have failed to parse, but didn't.
+Recommended.Proto2.JsonInput.FieldNameDuplicate                                                                    # Should have failed to parse, but didn't.
+Recommended.Proto2.JsonInput.FieldNameDuplicateDifferentCasing1                                                    # Should have failed to parse, but didn't.
+Recommended.Proto2.JsonInput.FieldNameDuplicateDifferentCasing2                                                    # Should have failed to parse, but didn't.
 Recommended.Proto2.JsonInput.FieldNameExtension.Validator
 Recommended.Proto2.JsonInput.BytesFieldBase64Url.JsonOutput
 Recommended.Proto2.JsonInput.BytesFieldBase64Url.ProtobufOutput
 Recommended.Proto3.JsonInput.BytesFieldBase64Url.JsonOutput
 Recommended.Proto3.JsonInput.BytesFieldBase64Url.ProtobufOutput
+Recommended.Proto3.JsonInput.FieldNameDuplicate                                                                    # Should have failed to parse, but didn't.
+Recommended.Proto3.JsonInput.FieldNameDuplicateDifferentCasing1                                                    # Should have failed to parse, but didn't.
+Recommended.Proto3.JsonInput.FieldNameDuplicateDifferentCasing2                                                    # Should have failed to parse, but didn't.
 Required.Proto2.JsonInput.OneofFieldNullFirst.JsonOutput
 Required.Proto2.JsonInput.OneofFieldNullFirst.ProtobufOutput
 Required.Proto2.JsonInput.OneofFieldNullSecond.JsonOutput

--- a/conformance/failure_list_php.txt
+++ b/conformance/failure_list_php.txt
@@ -5,8 +5,14 @@ Recommended.*.JsonInput.BytesFieldBase64Url.JsonOutput
 Recommended.*.JsonInput.BytesFieldBase64Url.ProtobufOutput
 Recommended.*.JsonInput.FieldMaskInvalidCharacter
 Recommended.*.ProtobufInput.ValidDataOneofBinary.MESSAGE.Merge.ProtobufOutput
-Recommended.*.ValueRejectInfNumberValue.JsonOutput # Should have failed to serialize, but didn't.
-Recommended.*.ValueRejectNanNumberValue.JsonOutput # Should have failed to serialize, but didn't.
+Recommended.*.ValueRejectInfNumberValue.JsonOutput                                                                 # Should have failed to serialize, but didn't.
+Recommended.*.ValueRejectNanNumberValue.JsonOutput                                                                 # Should have failed to serialize, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicate                                                           # Should have failed to parse, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicateDifferentCasing1                                           # Should have failed to parse, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicateDifferentCasing2                                           # Should have failed to parse, but didn't.
+Recommended.Proto3.JsonInput.FieldNameDuplicate                                                                    # Should have failed to parse, but didn't.
+Recommended.Proto3.JsonInput.FieldNameDuplicateDifferentCasing1                                                    # Should have failed to parse, but didn't.
+Recommended.Proto3.JsonInput.FieldNameDuplicateDifferentCasing2                                                    # Should have failed to parse, but didn't.
 Required.*.JsonInput.DoubleFieldTooSmall
 Required.*.JsonInput.DurationNegativeNanos.JsonOutput
 Required.*.JsonInput.DurationNegativeNanos.ProtobufOutput
@@ -30,6 +36,8 @@ Required.*.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput
 Required.*.ProtobufInput.ValidDataRepeated.FLOAT.PackedInput.JsonOutput
 Required.*.ProtobufInput.ValidDataRepeated.FLOAT.UnpackedInput.JsonOutput
 Required.*.ProtobufInput.ValidDataScalar.FLOAT[2].JsonOutput
-Required.*.JsonInput.Int32FieldQuotedExponentialValue.*     # Failed to parse input or produce output.
+Required.*.JsonInput.Int32FieldQuotedExponentialValue.*                                                            # Failed to parse input or produce output.
 Required.*.JsonInput.AnyWithNoType.*
-Required.*.JsonInput.TimestampWithMissingColonInOffset # Should have failed to parse, but didn't.
+Required.*.JsonInput.TimestampWithMissingColonInOffset                                                             # Should have failed to parse, but didn't.
+Required.Editions_Proto3.JsonInput.DoubleFieldTooLarge                                                             # Should have failed to parse, but didn't.
+Required.Proto3.JsonInput.DoubleFieldTooLarge                                                                      # Should have failed to parse, but didn't.

--- a/conformance/failure_list_php_c.txt
+++ b/conformance/failure_list_php_c.txt
@@ -1,5 +1,11 @@
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicate                                                           # Should have failed to parse, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicateDifferentCasing1                                           # Should have failed to parse, but didn't.
+Recommended.Editions_Proto3.JsonInput.FieldNameDuplicateDifferentCasing2                                           # Should have failed to parse, but didn't.
 Recommended.Proto2.JsonInput.FieldNameExtension.Validator
-Required.*.JsonInput.Int32FieldQuotedExponentialValue.*     # Failed to parse input or produce output.
+Recommended.Proto3.JsonInput.FieldNameDuplicate                                                                    # Should have failed to parse, but didn't.
+Recommended.Proto3.JsonInput.FieldNameDuplicateDifferentCasing1                                                    # Should have failed to parse, but didn't.
+Recommended.Proto3.JsonInput.FieldNameDuplicateDifferentCasing2                                                    # Should have failed to parse, but didn't.
+Required.*.JsonInput.Int32FieldQuotedExponentialValue.*                                                            # Failed to parse input or produce output.
 Required.Proto2.JsonInput.BoolFieldFalse.JsonOutput
 Required.Proto2.JsonInput.BoolFieldFalse.ProtobufOutput
 Required.Proto2.JsonInput.EnumField.JsonOutput

--- a/php/README.md
+++ b/php/README.md
@@ -25,11 +25,12 @@ PHP versions will change over time, see
 #### Prerequirements
 
 To install the c extension, the following tools are needed:
+* gcc
 * libtool
 * make
-* gcc
 * pear
 * pecl
+* phpize
 
 On Ubuntu, you can install them with:
 ```


### PR DESCRIPTION
These expected JSON parse failures will currently fail for reasons _other_ than the tested behavior.

Note that I'm being a little cute here by fixing the tests that [now apparently contradict the spec](https://github.com/protocolbuffers/protocolbuffers.github.io/commit/c18c8a72de22b99eaf536eb1f961371510159714#diff-98c94e5ab37db71fd002eff0d9cb2cfae9b0058ea00b412b466312ad819029d7). I happen to think the spec is misguided and these tests are better behavior, but I _expect_ the tests will end up being updated to match the spec.