### PR TITLE
Resolve different signedness warning

### DIFF
--- a/src/google/protobuf/compiler/java/internal_helpers.cc
+++ b/src/google/protobuf/compiler/java/internal_helpers.cc
@@ -177,7 +177,7 @@ void GenerateLarge(
         }},
        {"aliases",
         [&] {
-          for (int i = 0; i < (int)aliases.size(); i++) {
+          for (size_t i = 0; i < aliases.size(); i++) {
             WriteEnumValueDocComment(printer, aliases[i].first,
                                      context->options());
             printer->Emit({{"name", aliases[i].first->name()},

--- a/src/google/protobuf/compiler/java/internal_helpers.cc
+++ b/src/google/protobuf/compiler/java/internal_helpers.cc
@@ -177,7 +177,7 @@ void GenerateLarge(
         }},
        {"aliases",
         [&] {
-          for (int i = 0; i < aliases.size(); i++) {
+          for (int i = 0; i < (int)aliases.size(); i++) {
             WriteEnumValueDocComment(printer, aliases[i].first,
                                      context->options());
             printer->Emit({{"name", aliases[i].first->name()},


### PR DESCRIPTION
The size() by default returns an unsigned integer datatype. In other places in this code a C cast style is used. Follow the same resolution, and cast the unsigned integer type to signed integer.