### PR TITLE
fix proto_lang_toolchain_rule.bzl typo

### DIFF
--- a/bazel/private/proto_lang_toolchain_rule.bzl
+++ b/bazel/private/proto_lang_toolchain_rule.bzl
@@ -71,7 +71,7 @@ consult their documentation.
 tune your Java compiler.
 
 <p>There's no compiler. The proto-compiler is taken from the proto_library rule we attach to. It is
-passed as a command-line flag to Blaze.
+passed as a command-line flag to Bazel.
 Several features require a proto-compiler to be invoked on the proto_library rule itself.
 It's beneficial to enforce the compiler that LANG_proto_library uses is the same as the one
 <code>proto_library</code> does.


### PR DESCRIPTION
Fix a typo in the documentation:
https://bazel.build/reference/be/protocol-buffer

"The proto-compiler is taken from the proto_library rule we attach to. It is passed as a command-line flag to `Blaze`."
Blaze -> Bazel