### PR TITLE
Cherry-pick: Add missing `copts` attribute

### DIFF
--- a/src/google/protobuf/compiler/java/BUILD.bazel
+++ b/src/google/protobuf/compiler/java/BUILD.bazel
@@ -85,6 +85,7 @@ cc_library(
         "generator.h",
         "internal_helpers.h",
     ],
+    copts = COPTS,
     strip_include_prefix = "/src",
     visibility = [
         "//src/google/protobuf/compiler/java:__subpackages__",


### PR DESCRIPTION
This will add the `-Wno-sign-compare` flag and thereby silence warnings or errors about comparing integers of different signedness.

Fixes #21938.

PiperOrigin-RevId: 763894798