### PR TITLE
rules_python: 1.0.0 -> 1.1.0 (#22078)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -44,7 +44,7 @@ bazel_dep(name = "rules_jvm_external", version = "6.7")
 bazel_dep(name = "rules_kotlin", version = "1.9.6")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.1.0")
 
 # Pin to rules_proto to 7.1.0 to avoid toolchain incompatibilities when
 # --incompatible_enable_proto_toolchain_resolution=true in Bazel 7.

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -23,7 +23,7 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_java", version = "8.6.1")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.1.0")
 
 # For clang-cl configuration
 cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -141,9 +141,9 @@ def protobuf_deps():
     if not native.existing_rule("rules_python"):
         http_archive(
             name = "rules_python",
-            sha256 = "4f7e2aa1eb9aa722d96498f5ef514f426c1f55161c3c9ae628c857a7128ceb07",
-            strip_prefix = "rules_python-1.0.0",
-            url = "https://github.com/bazelbuild/rules_python/releases/download/1.0.0/rules_python-1.0.0.tar.gz",
+            sha256 = "9c6e26911a79fbf510a8f06d8eedb40f412023cf7fa6d1461def27116bff022c",
+            strip_prefix = "rules_python-1.1.0",
+            url = "https://github.com/bazelbuild/rules_python/releases/download/1.1.0/rules_python-1.1.0.tar.gz",
         )
 
     if not native.existing_rule("system_python"):


### PR DESCRIPTION
We here update the minimum required version of `rules_python` from 1.0.0 to 1.1.0 in order to enable using the new `direct_pyi_files` and `transitive_pyi_files` members of `PyInfo` in #21567.

Closes #22078.