### PR TITLE
[numpy] Fix breakage in users of Python protobufs under NumPy 2.3rc1.

### DIFF
--- a/python/convert.c
+++ b/python/convert.c
@@ -208,6 +208,35 @@ bool PyUpb_IsNumpyNdarray(PyObject* obj, const upb_FieldDef* f) {
   return is_ndarray;
 }
 
+bool PyUpb_IsNumpyBoolScalar(PyObject* obj) {
+  PyObject* type_module_obj =
+      PyObject_GetAttrString((PyObject*)Py_TYPE(obj), "__module__");
+  bool is_numpy = !strcmp(PyUpb_GetStrData(type_module_obj), "numpy");
+  Py_DECREF(type_module_obj);
+  if (!is_numpy) {
+    return false;
+  }
+
+  PyObject* type_name_obj =
+      PyObject_GetAttrString((PyObject*)Py_TYPE(obj), "__name__");
+  bool is_bool = !strcmp(PyUpb_GetStrData(type_name_obj), "bool");
+  Py_DECREF(type_name_obj);
+  if (!is_bool) {
+    return false;
+  }
+  return true;
+}
+
+static bool PyUpb_GetBool(PyObject* obj, const upb_FieldDef* f, bool* val) {
+  if (PyUpb_IsNumpyNdarray(obj, f)) return false;
+  if (PyUpb_IsNumpyBoolScalar(obj)) {
+    *val = PyObject_IsTrue(obj);
+    return !PyErr_Occurred();
+  }
+  *val = PyLong_AsLong(obj);
+  return !PyErr_Occurred();
+}
+
 bool PyUpb_PyToUpb(PyObject* obj, const upb_FieldDef* f, upb_MessageValue* val,
                    upb_Arena* arena) {
   switch (upb_FieldDef_CType(f)) {
@@ -230,9 +259,7 @@ bool PyUpb_PyToUpb(PyObject* obj, const upb_FieldDef* f, upb_MessageValue* val,
       val->double_val = PyFloat_AsDouble(obj);
       return !PyErr_Occurred();
     case kUpb_CType_Bool:
-      if (PyUpb_IsNumpyNdarray(obj, f)) return false;
-      val->bool_val = PyLong_AsLong(obj);
-      return !PyErr_Occurred();
+      return PyUpb_GetBool(obj, f, &val->bool_val);
     case kUpb_CType_Bytes: {
       char* ptr;
       Py_ssize_t size;

--- a/python/google/protobuf/internal/type_checkers.py
+++ b/python/google/protobuf/internal/type_checkers.py
@@ -113,12 +113,21 @@ class BoolValueChecker(object):
   """Type checker used for bool fields."""
 
   def CheckValue(self, proposed_value):
-    if not hasattr(proposed_value, '__index__') or (
-        type(proposed_value).__module__ == 'numpy' and
+    if not hasattr(proposed_value, '__index__'):
+      # Under NumPy 2.3, numpy.bool does not have an __index__ method.
+      if (type(proposed_value).__module__ == 'numpy' and
+          type(proposed_value).__name__ == 'bool'):
+        return bool(proposed_value)
+      message = ('%.1024r has type %s, but expected one of: %s' %
+                 (proposed_value, type(proposed_value), (bool, int)))
+      raise TypeError(message)
+
+    if (type(proposed_value).__module__ == 'numpy' and
         type(proposed_value).__name__ == 'ndarray'):
       message = ('%.1024r has type %s, but expected one of: %s' %
                  (proposed_value, type(proposed_value), (bool, int)))
       raise TypeError(message)
+
     return bool(proposed_value)
 
   def DefaultValue(self):


### PR DESCRIPTION
As of NumPy 2.3.0rc1, numpy.bool scalars can no longer be interpreted as index values (https://github.com/numpy/numpy/releases/tag/v2.3.0rc1). This causes protobuf no longer to accept a np.bool scalar as a legal value for a boolean field.

We have two options:
a) either we can change protobuf so that it continues to accept NumPy boolean scalars (this change), or b) decide that protobuf should reject NumPy boolean scalars and that users must update their code to cast to a Python bool explicitly.

I have no strong opinion as to which, but option (a) seems less disruptive.

No test updates are needed: the existing tests fail under NumPy 2.3.

PiperOrigin-RevId: 766629310