### PR TITLE
Drop windows-2019 runners from CI

### DIFF
--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -466,17 +466,6 @@ jobs:
               -Dprotobuf_BUILD_EXAMPLES=ON
             vsversion: '2022'
             cache-prefix: windows-2022-cmake
-          - name: Windows CMake 2019
-            os: windows-2019
-            flags: >-
-              -G Ninja -Dprotobuf_WITH_ZLIB=OFF -Dprotobuf_BUILD_CONFORMANCE=OFF
-              -Dprotobuf_BUILD_SHARED_LIBS=OFF
-              -Dprotobuf_BUILD_EXAMPLES=ON
-            vsversion: '2019'
-            cache-prefix: windows-2019-cmake
-            # windows-2019 has python3.7 installed, which is incompatible with the latest gcloud
-            python-version: '3.9'
-            continuous-only: true
           - name: Windows CMake 32-bit
             os: windows-2022
             flags: >-
@@ -518,17 +507,6 @@ jobs:
         with:
           arch: ${{ matrix.windows-arch || 'x64' }}
           vsversion: ${{ matrix.vsversion }}
-
-      # Workaround for incompatibility between gcloud and windows-2019 runners.
-      - name: Install Python
-        if: ${{ matrix.python-version && (!matrix.continuous-only || inputs.continuous-run) }}
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Use custom python for gcloud
-        if: ${{ matrix.python-version  && (!matrix.continuous-only || inputs.continuous-run) }}
-        run: echo "CLOUDSDK_PYTHON=${Python3_ROOT_DIR}\\python3" >> $GITHUB_ENV
-        shell: bash
 
       - name: Setup sccache
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -50,7 +50,7 @@ jobs:
 
   windows:
     name: Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout pending changes
         uses: protocolbuffers/protobuf-ci/checkout@v4
@@ -61,15 +61,6 @@ jobs:
         uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
         with:
           dotnet-version: '6.0.x'
-
-      # Workaround for incompatibility between gcloud and windows-2019 runners.
-      - name: Install Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
-        with:
-          python-version: '3.9'
-      - name: Use custom python for gcloud
-        run: echo "CLOUDSDK_PYTHON=${Python3_ROOT_DIR}\\python3" >> $GITHUB_ENV
-        shell: bash
 
       - name: Run tests
         uses: protocolbuffers/protobuf-ci/bash@v4

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -193,16 +193,16 @@ jobs:
           - { os: macos-13, python-version: "3.13", architecture: x64, type: 'source', continuous-only: true }
 
           # Windows uses the full API up until Python 3.10.
-          - { os: windows-2019, python-version: "3.9", architecture: x86, type: 'binary', continuous-only: true }
-          - { os: windows-2019, python-version: "3.10", architecture: x86, type: 'binary', continuous-only: true }
-          - { os: windows-2019, python-version: "3.11", architecture: x86, type: 'binary', continuous-only: true }
-          - { os: windows-2019, python-version: "3.12", architecture: x86, type: 'binary', continuous-only: true }
-          - { os: windows-2019, python-version: "3.13", architecture: x86, type: 'binary', continuous-only: true }
-          - { os: windows-2019, python-version: "3.9", architecture: x64, type: 'binary' }
-          - { os: windows-2019, python-version: "3.10", architecture: x64, type: 'binary', continuous-only: true }
-          - { os: windows-2019, python-version: "3.11", architecture: x64, type: 'binary', continuous-only: true }
-          - { os: windows-2019, python-version: "3.12", architecture: x64, type: 'binary', continuous-only: true }
-          - { os: windows-2019, python-version: "3.13", architecture: x64, type: 'binary' }
+          - { os: windows-2022, python-version: "3.9", architecture: x86, type: 'binary', continuous-only: true }
+          - { os: windows-2022, python-version: "3.10", architecture: x86, type: 'binary', continuous-only: true }
+          - { os: windows-2022, python-version: "3.11", architecture: x86, type: 'binary', continuous-only: true }
+          - { os: windows-2022, python-version: "3.12", architecture: x86, type: 'binary', continuous-only: true }
+          - { os: windows-2022, python-version: "3.13", architecture: x86, type: 'binary', continuous-only: true }
+          - { os: windows-2022, python-version: "3.9", architecture: x64, type: 'binary' }
+          - { os: windows-2022, python-version: "3.10", architecture: x64, type: 'binary', continuous-only: true }
+          - { os: windows-2022, python-version: "3.11", architecture: x64, type: 'binary', continuous-only: true }
+          - { os: windows-2022, python-version: "3.12", architecture: x64, type: 'binary', continuous-only: true }
+          - { os: windows-2022, python-version: "3.13", architecture: x64, type: 'binary' }
     name: ${{ matrix.continuous-only && inputs.continuous-prefix || '' }} Test Wheels Python ${{ matrix.python-version }} ${{ matrix.os }} ${{ matrix.architecture }} ${{ matrix.type }}
     needs: build_wheels
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
#test-continuous

PiperOrigin-RevId: 769765346