### PR TITLE
Resolve testing python library deprecation warnings

### DIFF
--- a/python/google/protobuf/internal/reflection_test.py
+++ b/python/google/protobuf/internal/reflection_test.py
@@ -3144,7 +3144,7 @@ class SerializationTest(unittest.TestCase):
       with self.assertRaises(AttributeError) as e:
         # Try to access the descriptor of the field 'optional_int32'
         cls.optional_int32.DESCRIPTOR
-        self.assertEquals('optional_int32', str(e.exception))
+        self.assertEqual('optional_int32', str(e.exception))
     else:
       self.assertIs(
           cls.optional_int32.DESCRIPTOR,


### PR DESCRIPTION
## Description
This small PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
/tmp/protobuf/python/google/protobuf/internal/reflection_test.py:3147: DeprecationWarning: Please use assertEqual instead.
```