### PR TITLE
Remove redundant `break`

### DIFF
--- a/python/google/protobuf/pyext/descriptor.cc
+++ b/python/google/protobuf/pyext/descriptor.cc
@@ -916,7 +916,6 @@ static PyObject* GetDefaultValue(PyBaseDescriptor* self, void* closure) {
     }
     case FieldDescriptor::CPPTYPE_MESSAGE: {
       Py_RETURN_NONE;
-      break;
     }
     default:
       PyErr_Format(PyExc_NotImplementedError, "default value for %s",


### PR DESCRIPTION
`Py_RETURN_NONE` returns, so the `break` is unreachable.

Identified with `-Wunreachable-code-break` in LLVM.