### PR TITLE
Add rules_jvm_external 6.7 to protobuf_deps.bzl

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -155,9 +155,9 @@ def protobuf_deps():
     if not native.existing_rule("rules_jvm_external"):
         http_archive(
             name = "rules_jvm_external",
-            strip_prefix = "rules_jvm_external-6.3",
-            sha256 = "c18a69d784bcd851be95897ca0eca0b57dc86bb02e62402f15736df44160eb02",
-            url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/6.3/rules_jvm_external-6.3.tar.gz",
+            strip_prefix = "rules_jvm_external-6.7",
+            sha256 = "a1e351607f04fed296ba33c4977d3fe2a615ed50df7896676b67aac993c53c18",
+            url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/6.7/rules_jvm_external-6.7.tar.gz",
         )
 
     if not native.existing_rule("rules_pkg"):


### PR DESCRIPTION
Commit 73401b0 updated bazel-contrib/rules_jvm_external to 6.5 in `MODULE.bazel` for v31.0, but missed it in `//:protobuf_deps.bzl`. This caused `WORKSPACE` builds to break under Bazel 8.2.1 with `rules_java` 8.12.0 and `--incompatible_autoload_externally=`:

- https://github.com/protocolbuffers/protobuf/pull/19129#issuecomment-2968934424

Confirmed that this change fixes the breakage when building the following target in bazel-contrib/rules_scala:

```
USE_BAZEL_VERSION=8.2.1 bazel build \
  --noenable_bzlmod --enable_workspace \
  --incompatible_autoload_externally= \
  //test/proto/custom_generator:failing_scala_proto_deps_toolchain_def
```