### PR TITLE
Faster datetime parsing

### DIFF
--- a/python/google/protobuf/internal/well_known_types.py
+++ b/python/google/protobuf/internal/well_known_types.py
@@ -26,7 +26,6 @@ from google.protobuf.internal import field_mask
 
 FieldMask = field_mask.FieldMask
 
-_TIMESTAMPFORMAT = '%Y-%m-%dT%H:%M:%S'
 _NANOS_PER_SECOND = 1000000000
 _NANOS_PER_MILLISECOND = 1000000
 _NANOS_PER_MICROSECOND = 1000
@@ -145,7 +144,7 @@ class Timestamp(object):
           "time data '{0}' does not match format '%Y-%m-%dT%H:%M:%S', "
           "lowercase 't' is not accepted".format(second_value)
       )
-    date_object = datetime.datetime.strptime(second_value, _TIMESTAMPFORMAT)
+    date_object = datetime.datetime.fromisoformat(second_value)
     td = date_object - datetime.datetime(1970, 1, 1)
     seconds = td.seconds + td.days * _SECONDS_PER_DAY
     if len(nano_value) > 9:


### PR DESCRIPTION
We observed that replacing `date_object = datetime.datetime.strptime(second_value, _TIMESTAMPFORMAT)` with `date_object = datetime.datetime.fromisoformat(second_value)` cuts the total loading time by about 50% (we parse many jsons and it is a significant savings for us).

This change seems like it should be transparent since `_TIMESTAMPFORMAT` is practically the same as ISO format. 

A possible behavioral difference I can think of is `fromisoformat` would accept fractional/decimal seconds but I am not sure if `_TIMESTAMPFORMAT` would do so. If it doesn't, the code can be amended with a `td.seconds == int(td.seconds)` check if needed.

Would you be interested in this change?