### PR TITLE
Convert list to string for COMMENT argument

### DIFF
--- a/cmake/protobuf-generate.cmake
+++ b/cmake/protobuf-generate.cmake
@@ -140,10 +140,12 @@ function(protobuf_generate)
 
     set(_comment "Running ${protobuf_generate_LANGUAGE} protocol buffer compiler on ${_proto}")
     if(protobuf_generate_PROTOC_OPTIONS)
-      set(_comment "${_comment}, protoc-options: ${protobuf_generate_PROTOC_OPTIONS}")
+      string(REPLACE ";" " " _protoc_options_str "${protobuf_generate_PROTOC_OPTIONS}")
+      set(_comment "${_comment}, protoc-options: ${_protoc_options_str}")
     endif()
     if(_plugin_options)
-      set(_comment "${_comment}, plugin-options: ${_plugin_options}")
+      string(REPLACE ";" " " _plugin_options_str "${_plugin_options}")
+      set(_comment "${_comment}, plugin-options: ${_plugin_options_str}")
     endif()
 
     add_custom_command(


### PR DESCRIPTION
The issue occurs because CMake expects a single string for the COMMENT argument, but when a list is passed, it tries to expand the list into multiple arguments. To resolve this convert lists to strings using string(REPLACE ...) to join list items into a single string.

```
CMake Warning (dev) at <path>/protobuf-generate.cmake:150 (add_custom_command):
  COMMENT requires exactly one argument, but multiple values or COMMENT
  keywords have been given.
```