### PR TITLE
Update github major version tags to be formatted v<MAJOR>.<MINOR>.<MI…

### DIFF
--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.12.0'
 
   s.source = { :git => 'https://github.com/protocolbuffers/protobuf.git',
-               :tag => "v#{s.version}" }
+               :tag => "v#{s.version}-objectivec" }
 
   s.source_files = 'objectivec/*.{h,m,swift}'
   # The following would cause duplicate symbol definitions. GPBProtocolBuffers is expected to be


### PR DESCRIPTION
…CRO>-<language> for clarity

Updates Protobuf.podspec for objective-c cocoapods to point at the new tag, removes obsolete cpp tag (Protobuf-C++.podspec was removed in 30.x), and removes the rust tag (seems unused, https://crates.io/crates/protobuf/4.31.1-release actually references protoc version)

Follow-up PR to backport Protobuf.podspec changes to 31.x

Fixes https://github.com/protocolbuffers/protobuf/issues/22205

PiperOrigin-RevId: 774847783