### PR TITLE
Update github major version tags to be formatted v<MAJOR>.<MINOR>.<MI…

### DIFF
--- a/Protobuf-C++.podspec
+++ b/Protobuf-C++.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.12.0'
 
   s.source = { :git => 'https://github.com/google/protobuf.git',
-               :tag => "v#{s.version}" }
+               :tag => "v#{s.version}-cpp" }
 
   s.source_files = 'src/google/protobuf/*.{h,cc,inc}',
                    'src/google/protobuf/stubs/*.{h,cc}',

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.12.0'
 
   s.source = { :git => 'https://github.com/protocolbuffers/protobuf.git',
-               :tag => "v#{s.version}" }
+               :tag => "v#{s.version}-objectivec" }
 
   s.source_files = 'objectivec/*.{h,m}',
                    'objectivec/google/protobuf/Any.pbobjc.h',


### PR DESCRIPTION
…CRO>- for clarity

Updates Protobuf.podspec for objective-c cocoapods Protobuf-C++.podspec for cpp cocoapods to point at the new tags.

Follow-up PR to backport Protobuf.podspec changes to 25.x

Fixes https://github.com/protocolbuffers/protobuf/issues/22205

PiperOrigin-RevId: 774847783