### PR TITLE
Remove reference to nonexistent `wrap_memcpy`

### DIFF
--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     s.files     += ["lib/google/protobuf_java.jar"] +
       Dir.glob('ext/**/*').reject do |file|
         File.basename(file) =~ /^((convert|defs|map|repeated_field)\.[ch]|
-                                   BUILD\.bazel|extconf\.rb|wrap_memcpy\.c)$/x
+                                   BUILD\.bazel|extconf\.rb)$/x
       end
     s.extensions = ["ext/google/protobuf_c/Rakefile"]
     s.add_dependency "ffi", "~>1"

--- a/ruby/lib/google/tasks/ffi.rake
+++ b/ruby/lib/google/tasks/ffi.rake
@@ -12,7 +12,7 @@ def configure_common_compile_task(task)
   task.add_define 'NDEBUG'
   task.cflags << "-std=gnu99 -O3"
   [
-    :convert, :defs, :map, :message, :protobuf, :repeated_field, :wrap_memcpy
+    :convert, :defs, :map, :message, :protobuf, :repeated_field
   ].each { |file| task.exclude << "/#{file}.c" }
   task.ext_dir = src_dir
   task.source_dirs = [src_dir]


### PR DESCRIPTION
`wrap_memcpy.c` was removed by 4ba97331411293082632039c670c2af82a9f0415.