### PR TITLE
drop-deprecated-pkg-resources-declare

### DIFF
--- a/python/google/__init__.py
+++ b/python/google/__init__.py
@@ -1,4 +1,2 @@
-try:
-  __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-  __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+#drop-pkg-resources-declare
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
# discription
As of setuptools 81, pkg_resources.declare_namespace has been marked as deprecated (scheduled to be removed after 2025-11-30) so I remove it from init.py

# Environment: 
a virtual machine of arch riscv64

# procedure
I got this problem when running a test that applied this package.
```
src/certbot_dns_google/_internal/tests/dns_google_test.py:9: in <module>
    from google.auth import exceptions as googleauth_exceptions
/usr/lib/python3.13/site-packages/google/__init__.py:2: in <module>
    __import__('pkg_resources').declare_namespace(__name__)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.13/site-packages/pkg_resources/__init__.py:98: in <module>
    warnings.warn(
E   UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```
[certbot-dns-google-4.1.1-1-riscv64-check.log](https://github.com/user-attachments/files/20976539/certbot-dns-google-4.1.1-1-riscv64-check.log)
