### PR TITLE
Ignore files for doc

### DIFF
--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -13,3 +13,4 @@ ext/google/protobuf_c/third_party/utf8_range/utf8_range_sse.inc
 ext/google/protobuf_c/third_party/utf8_range/utf8_range_neon.inc
 ext/google/protobuf_c/third_party/utf8_range/LICENSE
 lib/google/protobuf/*_pb.rb
+lib/stubs/*.rb


### PR DESCRIPTION
Currently, when I run the rake task, I get diffs under `lib/stubs/`. Those files are for the doc that was added by #21212.

```
$ git status
HEAD detached at upstream/main
  (use "git add <file>..." to include in what will be committed)
        lib/stubs/abstract_message.rb
        lib/stubs/descriptor.rb
        lib/stubs/descriptor_pool.rb
        lib/stubs/enum.rb
        lib/stubs/enum_descriptor.rb
        lib/stubs/field_descriptor.rb
        lib/stubs/file_descriptor.rb
        lib/stubs/map.rb
        lib/stubs/method_descriptor.rb
        lib/stubs/oneof_descriptor.rb
        lib/stubs/repeated_field.rb
        lib/stubs/service_descriptor.rb
nothing added to commit but untracked files present (use "git add" to track)
```

I assume those files are not needed to commit to the repository. So I updated settings to ignore those.