### PR TITLE
Cherry-pick: Upgrade Clang on Windows test runs and work around MSVC error

### DIFF
--- a/.github/workflows/test_bazel.yml
+++ b/.github/workflows/test_bazel.yml
@@ -56,6 +56,12 @@ jobs:
         shell: bash
         run: echo "startup --output_user_root=C:/ --windows_enable_symlinks" >> .bazelrc
 
+      # TODO: b/426584168 - Remove this workaround after the GitHub runners are fixed
+      - name: Upgrade LLVM on Windows
+        if: ${{ runner.os == 'Windows' && (!matrix.continuous-only || inputs.continuous-run) }}
+        shell: bash
+        run: choco upgrade llvm
+
       - name: Configure Bazel version
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
         working-directory: examples

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -429,6 +429,11 @@ jobs:
         uses: protocolbuffers/protobuf-ci/checkout@v4
         with:
           ref: ${{ inputs.safe-checkout }}
+      # TODO: b/426584168 - Remove this workaround after the GitHub runners are fixed
+      - name: Upgrade LLVM on Windows
+        if: ${{ runner.os == 'Windows' && (!matrix.continuous-only || inputs.continuous-run) }}
+        shell: bash
+        run: choco upgrade llvm
       - name: Run tests
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
         uses: protocolbuffers/protobuf-ci/bazel@v4
@@ -496,6 +501,12 @@ jobs:
         with:
           arch: ${{ matrix.windows-arch || 'x64' }}
           vsversion: ${{ matrix.vsversion }}
+
+      # TODO: b/426584168 - Remove this workaround after the GitHub runners are fixed
+      - name: Upgrade LLVM on Windows
+        if: ${{ runner.os == 'Windows' && (!matrix.continuous-only || inputs.continuous-run) }}
+        shell: bash
+        run: choco upgrade llvm
 
       - name: Setup sccache
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -62,6 +62,11 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
+      # TODO: b/426584168 - Remove this workaround after the GitHub runners are fixed
+      - name: Upgrade LLVM
+        shell: bash
+        run: choco upgrade llvm
+
       - name: Run tests
         uses: protocolbuffers/protobuf-ci/bash@v4
         with:

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -87,6 +87,10 @@ jobs:
         uses: protocolbuffers/protobuf-ci/checkout@v4
         with:
           ref: ${{ inputs.safe-checkout }}
+      # TODO: b/426584168 - Remove this workaround after the GitHub runners are fixed
+      - name: Upgrade LLVM
+        shell: bash
+        run: choco upgrade llvm
       - name: Run tests
         uses: protocolbuffers/protobuf-ci/bazel@v4
         with:


### PR DESCRIPTION
Most of our Windows test runs are currently failing with an error message about the Clang version being too old. This seems to be an occasional [issue](https://github.com/actions/runner-images/issues/10001) with the GitHub Windows runners, and the suggested workaround is to use `choco` to upgrade LLVM. We should revert this change as soon as the GitHub runners are fixed.

PiperOrigin-RevId: 773825728