### PR TITLE
Rename maven install back to `maven` in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -177,6 +177,7 @@ crate.spec(
 crate.from_specs()
 use_repo(crate, crate_index = "crates")
 
+# Keep this list minimal; these dependencies will be part of the common `maven` install and could affect end-user projects.
 PROTOBUF_MAVEN_ARTIFACTS = [
     "com.google.code.findbugs:jsr305:3.0.2",
     "com.google.code.gson:gson:2.8.9",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -187,7 +187,6 @@ PROTOBUF_MAVEN_ARTIFACTS = [
 
 protobuf_maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 protobuf_maven.install(
-    name = "protobuf_maven",
     artifacts = PROTOBUF_MAVEN_ARTIFACTS,
     lock_file = "//:maven_install.json",
     repositories = [
@@ -195,7 +194,9 @@ protobuf_maven.install(
         "https://repo.maven.apache.org/maven2",
     ],
 )
-use_repo(protobuf_maven, "protobuf_maven")
+# Use the default "maven" namespace because protobuf java targets are exposed to users
+# See https://github.com/protocolbuffers/protobuf/issues/21177
+use_repo(protobuf_maven, protobuf_maven="maven")
 
 # Temporarily pin transitive dependency for https://github.com/bazelbuild/bazel/issues/24426
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
@@ -203,7 +204,6 @@ bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
 # Development dependencies
 protobuf_maven_dev = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
 protobuf_maven_dev.install(
-    name = "protobuf_maven_dev",
     artifacts = PROTOBUF_MAVEN_ARTIFACTS + [
         "com.google.caliper:caliper:1.0-beta-3",
         "com.google.guava:guava-testlib:32.0.1-jre",
@@ -220,7 +220,7 @@ protobuf_maven_dev.install(
         "https://repo.maven.apache.org/maven2",
     ],
 )
-use_repo(protobuf_maven_dev, "protobuf_maven_dev")
+use_repo(protobuf_maven_dev, protobuf_maven_dev="maven")
 
 bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True)
 bazel_dep(name = "rules_buf", version = "0.3.0", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -186,8 +186,8 @@ PROTOBUF_MAVEN_ARTIFACTS = [
     "com.google.guava:guava:32.0.1-jre",
 ]
 
-protobuf_maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
-protobuf_maven.install(
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.install(
     artifacts = PROTOBUF_MAVEN_ARTIFACTS,
     lock_file = "//:maven_install.json",
     repositories = [
@@ -197,7 +197,7 @@ protobuf_maven.install(
 )
 # Use the default "maven" namespace because protobuf java targets are exposed to users
 # See https://github.com/protocolbuffers/protobuf/issues/21177
-use_repo(protobuf_maven, protobuf_maven="maven")
+use_repo(maven, "maven")
 
 # Temporarily pin transitive dependency for https://github.com/bazelbuild/bazel/issues/24426
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -205,6 +205,7 @@ bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
 # Development dependencies
 protobuf_maven_dev = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
 protobuf_maven_dev.install(
+    name = "protobuf_maven_dev",
     artifacts = PROTOBUF_MAVEN_ARTIFACTS + [
         "com.google.caliper:caliper:1.0-beta-3",
         "com.google.guava:guava-testlib:32.0.1-jre",
@@ -221,7 +222,7 @@ protobuf_maven_dev.install(
         "https://repo.maven.apache.org/maven2",
     ],
 )
-use_repo(protobuf_maven_dev, protobuf_maven_dev="maven")
+use_repo(protobuf_maven_dev, "protobuf_maven_dev")
 
 bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True)
 bazel_dep(name = "rules_buf", version = "0.3.0", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -65,7 +65,7 @@ rules_jvm_external_setup()
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
-    name = "protobuf_maven",
+    name = "maven",
     artifacts = PROTOBUF_MAVEN_ARTIFACTS,
     # For updating instructions, see:
     # https://github.com/bazelbuild/rules_jvm_external#updating-maven_installjson
@@ -76,7 +76,7 @@ maven_install(
     ],
 )
 
-load("@protobuf_maven//:defs.bzl", "pinned_maven_install")
+load("@maven//:defs.bzl", "pinned_maven_install")
 
 pinned_maven_install()
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -76,7 +76,7 @@ rules_jvm_external_setup()
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
-    name = "protobuf_maven",
+    name = "maven",
     artifacts = PROTOBUF_MAVEN_ARTIFACTS,
     repositories = [
         "https://repo1.maven.org/maven2",

--- a/java/util/BUILD.bazel
+++ b/java/util/BUILD.bazel
@@ -14,11 +14,11 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//java/core",
-        "@protobuf_maven//:com_google_code_findbugs_jsr305",
-        "@protobuf_maven//:com_google_code_gson_gson",
-        "@protobuf_maven//:com_google_errorprone_error_prone_annotations",
-        "@protobuf_maven//:com_google_guava_guava",
-        "@protobuf_maven//:com_google_j2objc_j2objc_annotations",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_code_gson_gson",
+        "@maven//:com_google_errorprone_error_prone_annotations",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_j2objc_j2objc_annotations",
     ],
 )
 
@@ -34,11 +34,11 @@ protobuf_versioned_java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//java/core",
-        "@protobuf_maven//:com_google_code_findbugs_jsr305",
-        "@protobuf_maven//:com_google_code_gson_gson",
-        "@protobuf_maven//:com_google_errorprone_error_prone_annotations",
-        "@protobuf_maven//:com_google_guava_guava",
-        "@protobuf_maven//:com_google_j2objc_j2objc_annotations",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_code_gson_gson",
+        "@maven//:com_google_errorprone_error_prone_annotations",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_j2objc_j2objc_annotations",
     ],
 )
 


### PR DESCRIPTION
Fixes https://github.com/protocolbuffers/protobuf/issues/21177

This PR essentially reverts https://github.com/protocolbuffers/protobuf/pull/18641, which claimed

> Since protobuf is not contributing to user's JARs

This is not true since targets like `@com_google_protobuf//:protobuf_java` are meant to be consumed by other projects, therefore protobuf should not use a private maven install namespace. Otherwise, it leads to duplicated maven jars and classpath conflicts. See https://github.com/protocolbuffers/protobuf/issues/21177 and https://github.com/bazel-contrib/rules_jvm_external/issues/916#issuecomment-3045506487

The original warning message caused by multiple modules contributing to `maven` can be suppressed with https://github.com/bazel-contrib/rules_jvm_external/pull/1393, which will be available in rules_jvm_external 6.8.