### PR TITLE
Cherry-pick: Automated rollback of commit c256302461b4223ddec008d6ecb05fc0e3b7ce01.

### DIFF
--- a/.github/workflows/test_bazel.yml
+++ b/.github/workflows/test_bazel.yml
@@ -56,12 +56,6 @@ jobs:
         shell: bash
         run: echo "startup --output_user_root=C:/ --windows_enable_symlinks" >> .bazelrc
 
-      # TODO: b/426584168 - Remove this workaround after the GitHub runners are fixed
-      - name: Upgrade LLVM on Windows
-        if: ${{ runner.os == 'Windows' && (!matrix.continuous-only || inputs.continuous-run) }}
-        shell: bash
-        run: choco upgrade llvm
-
       - name: Configure Bazel version
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
         working-directory: examples

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -429,11 +429,6 @@ jobs:
         uses: protocolbuffers/protobuf-ci/checkout@v4
         with:
           ref: ${{ inputs.safe-checkout }}
-      # TODO: b/426584168 - Remove this workaround after the GitHub runners are fixed
-      - name: Upgrade LLVM on Windows
-        if: ${{ runner.os == 'Windows' && (!matrix.continuous-only || inputs.continuous-run) }}
-        shell: bash
-        run: choco upgrade llvm
       - name: Run tests
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
         uses: protocolbuffers/protobuf-ci/bazel@v4
@@ -501,12 +496,6 @@ jobs:
         with:
           arch: ${{ matrix.windows-arch || 'x64' }}
           vsversion: ${{ matrix.vsversion }}
-
-      # TODO: b/426584168 - Remove this workaround after the GitHub runners are fixed
-      - name: Upgrade LLVM on Windows
-        if: ${{ runner.os == 'Windows' && (!matrix.continuous-only || inputs.continuous-run) }}
-        shell: bash
-        run: choco upgrade llvm
 
       - name: Setup sccache
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -62,11 +62,6 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
-      # TODO: b/426584168 - Remove this workaround after the GitHub runners are fixed
-      - name: Upgrade LLVM
-        shell: bash
-        run: choco upgrade llvm
-
       - name: Run tests
         uses: protocolbuffers/protobuf-ci/bash@v4
         with:

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -87,10 +87,6 @@ jobs:
         uses: protocolbuffers/protobuf-ci/checkout@v4
         with:
           ref: ${{ inputs.safe-checkout }}
-      # TODO: b/426584168 - Remove this workaround after the GitHub runners are fixed
-      - name: Upgrade LLVM
-        shell: bash
-        run: choco upgrade llvm
       - name: Run tests
         uses: protocolbuffers/protobuf-ci/bazel@v4
         with:


### PR DESCRIPTION
We can roll back this workaround now that the Windows GitHub runner has been fixed.

PiperOrigin-RevId: 781236113