### PR TITLE
Cherry-pick: drop use of deprecated Python pkg_resources (#22442)

### DIFF
--- a/python/google/__init__.py
+++ b/python/google/__init__.py
@@ -1,4 +1,3 @@
-try:
-  __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-  __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
# Description
As of setuptools 81, pkg_resources.declare_namespace has been marked as deprecated (scheduled to be removed after 2025-11-30) so I remove it from init.py

# Environment:
a virtual machine of arch riscv64

# procedure
I got this problem when running a test that applied this package.
```
src/certbot_dns_google/_internal/tests/dns_google_test.py:9: in <module>
    from google.auth import exceptions as googleauth_exceptions
/usr/lib/python3.13/site-packages/google/__init__.py:2: in <module>
    __import__('pkg_resources').declare_namespace(__name__)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.13/site-packages/pkg_resources/__init__.py:98: in <module>
    warnings.warn(
E   UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```
[certbot-dns-google-4.1.1-1-riscv64-check.log](https://github.com/user-attachments/files/20976539/certbot-dns-google-4.1.1-1-riscv64-check.log)

COPYBARA_INTEGRATE_REVIEW=https://github.com/protocolbuffers/protobuf/pull/22442 from gyx47:patch-1 6aef5c9df150cce444910d224fe90b2a514c7868 PiperOrigin-RevId: 782041935