### PR TITLE
Fix a typo in ruby ffi backend

### DIFF
--- a/ruby/lib/google/protobuf/ffi/message.rb
+++ b/ruby/lib/google/protobuf/ffi/message.rb
@@ -254,7 +254,7 @@ module Google
             decoding_options = 0
             unless options.is_a? Hash
               if options.respond_to? :to_h
-                options options.to_h
+                options = options.to_h
               else
                 #TODO can this error message be improve to include what was received?
                 raise ArgumentError.new "Expected hash arguments"


### PR DESCRIPTION
Fix a typo that would cause crash when converting hash-like object to hash. 