### PR TITLE
Fix inaccurate JSON parsing error offset

### DIFF
--- a/src/google/protobuf/json/internal/lexer.h
+++ b/src/google/protobuf/json/internal/lexer.h
@@ -198,6 +198,8 @@ class JsonLexer {
     JsonLocation loc = json_loc_;
     auto taken = stream_.Take(len);
     RETURN_IF_ERROR(taken.status());
+    json_loc_.offset += len;
+    json_loc_.col += len;
     return LocationWith<MaybeOwnedString>{*std::move(taken), loc};
   }
 
@@ -206,6 +208,9 @@ class JsonLexer {
     JsonLocation loc = json_loc_;
     auto taken = stream_.TakeWhile(std::move(p));
     RETURN_IF_ERROR(taken.status());
+    size_t len = taken->AsView().size();
+    json_loc_.offset += len;
+    json_loc_.col += len;
     return LocationWith<MaybeOwnedString>{*std::move(taken), loc};
   }
 


### PR DESCRIPTION
### Summary

Corrects JSON byte‑offset tracking in `google::protobuf::json_internal::JsonLexer` so error messages point to the exact offending character.

---

### Problem

* `JsonLexer` keeps an `json_loc_.offset` counter that is advanced in `Advance()`.
* Helper functions `Take()` and `TakeWhile()` also consume input, but they never touch `json_loc_.offset`.
* If a syntax error is detected at any point after `Take()` or `TakeWhile()` have consumed bytes—for instance, anywhere following a numeric literal—the reported offset lags behind by exactly the number of bytes those helpers read.

```jsonc
// Input
{"a":123,"b":"foo"}

// Old message, points to 'b'
INVALID_ARGUMENT: invalid JSON in SomeMessage @ b: uint32, near 1:11 (offset 10): invalid number: 'foo'

// New message, points to '"' (the starting quote of "foo")
INVALID_ARGUMENT: invalid JSON in SomeMessage @ b: uint32, near 1:14 (offset 13): invalid number: 'foo'
```

---

### Fix

* Add the same counter increment to both `Take()` and `TakeWhile()`.
* No public API or behavior changes beyond more accurate error locations.