### PR TITLE
Cherry-pick: Rust: remove `DEP_UPB_VERSION` check in codegen crate

### DIFF
--- a/rust/release_crates/protobuf/build.rs
+++ b/rust/release_crates/protobuf/build.rs
@@ -19,9 +19,4 @@ fn main() {
         .file("libupb/third_party/utf8_range/utf8_range.c")
         .define("UPB_BUILD_API", Some("1"))
         .compile("libupb");
-
-    let path = std::path::absolute("libupb").expect("Failed to get full path to libupb");
-
-    println!("cargo:include={}", path.display());
-    println!("cargo:version={}", VERSION);
 }

--- a/rust/release_crates/protobuf_codegen/src/lib.rs
+++ b/rust/release_crates/protobuf_codegen/src/lib.rs
@@ -131,14 +131,6 @@ impl CodeGen {
     }
 
     pub fn generate_and_compile(&self) -> Result<(), String> {
-        let upb_version = std::env::var("DEP_UPB_VERSION").expect("DEP_UPB_VERSION should have been set, make sure that the Protobuf crate is a dependency");
-        if VERSION != upb_version {
-            panic!(
-                "protobuf-codegen version {} does not match protobuf version {}.",
-                VERSION, upb_version
-            );
-        }
-
         let mut version_cmd = std::process::Command::new("protoc");
         let output = version_cmd.arg("--version").output().map_err(|e| {
             format!("failed to run protoc --version: {} {}", e, missing_protoc_error_message())


### PR DESCRIPTION
This check was meant to enforce that the version of the protobuf crate exactly matches the version of the codegen crate, but this is not strictly necessary. Tonic would also like to re-export our crate from the `tonic-protobuf` crate, and the `DEP_UPB_VERSION` check is causing problems with that since the environment variable is set only for crates that directly depend on the `protobuf` crate (see
[discussion](https://github.com/hyperium/tonic/pull/2320#discussion_r2228822853)).

While I was at it I also removed the code in the protobuf build script that sets the `DEP_UPB_INCLUDE` variable, which is unnecessary now that we no longer generate any C code which would need to know where to find upb's headers.

PiperOrigin-RevId: 786760264