### PR TITLE
Update python edition default maximum edition to 2024

### DIFF
--- a/python/build_targets.bzl
+++ b/python/build_targets.bzl
@@ -177,7 +177,7 @@ def build_targets(name):
     compile_edition_defaults(
         name = "python_edition_defaults",
         srcs = ["//:descriptor_proto"],
-        maximum_edition = "2023",
+        maximum_edition = "2024",
         minimum_edition = "PROTO2",
     )
 


### PR DESCRIPTION
PiperOrigin-RevId: 789423971

Cherry-pick of 5ccfc19a5b9acb2f61870c79acf09fb66644fb8d