### PR TITLE
Replace the usage of cc_info.debug_context with _debug_context

### DIFF
--- a/bazel/private/cc_proto_support.bzl
+++ b/bazel/private/cc_proto_support.bzl
@@ -132,7 +132,11 @@ def cc_proto_compile_and_link(ctx, deps, sources, headers, disallow_dynamic_libr
     if bazel_features.cc.protobuf_on_allowlist:
         debug_context = cc_common.merge_debug_context(
             [cc_common.create_debug_context(compilation_outputs)] +
-            [dep[CcInfo].debug_context() for dep in deps if CcInfo in dep],
+            [
+                dep[CcInfo]._debug_context if hasattr(dep[CcInfo], "_debug_context") else dep[CcInfo].debug_context()
+                for dep in deps
+                if CcInfo in dep
+            ],
         )
         temps = compilation_outputs.temps()
 


### PR DESCRIPTION
This reduces the regression that would've been caused by direct Starlarkification.

PiperOrigin-RevId: 788799519