### PR TITLE
Hold a per-object mutex when modifying PyUpb_WeakMaps

### DIFF
--- a/python/python_api.h
+++ b/python/python_api.h
@@ -38,4 +38,12 @@ PyAPI_FUNC(const char*)
     PyUnicode_AsUTF8AndSize(PyObject* unicode, Py_ssize_t* size);
 #endif
 
+// Py_BEGIN_CRITICAL_SECTION and Py_END_CRITICAL_SECTION were added in 3.13
+// mostly for use under the free-threaded build. We're defining the macro here
+// for use with the stable ABI and older Pythons.
+#if defined(Py_LIMITED_API) || PY_VERSION_HEX < 0x030D00B3
+#  define Py_BEGIN_CRITICAL_SECTION(op) {
+#  define Py_END_CRITICAL_SECTION() }
+#endif
+
 #endif  // PYUPB_PYTHON_H__


### PR DESCRIPTION
Because `upb_inttable` is not thread-safe, we need to hold a per-object mutex when calling into those APIs. This makes sure that's true, while also adding a very thin compatibility layer in `python/python_api.h`, so we don't have to wrap all the usages of the `Py_BEGIN_CRITICAL_SECTION` APIs in `#ifdef`s.