### PR TITLE
Cherry-pick "Raise warnings for float_precision from python json_format. Raise warnings for float_format/double_format from python text_format."

### DIFF
--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -26,6 +26,7 @@ import json
 import math
 from operator import methodcaller
 import re
+import warnings
 
 from google.protobuf import descriptor
 from google.protobuf import message_factory
@@ -191,6 +192,11 @@ class _Printer(object):
     self.use_integers_for_enums = use_integers_for_enums
     self.descriptor_pool = descriptor_pool
     if float_precision:
+      warnings.warn(
+          'float_precision option is deprecated for json_format. '
+          'This will turn into error in 7.34.0, please remove it '
+          'before that.'
+      )
       self.float_format = '.{}g'.format(float_precision)
     else:
       self.float_format = None

--- a/python/google/protobuf/text_format.py
+++ b/python/google/protobuf/text_format.py
@@ -25,6 +25,7 @@ import encodings.unicode_escape  # pylint: disable=unused-import
 import io
 import math
 import re
+import warnings
 
 from google.protobuf.internal import decoder
 from google.protobuf.internal import type_checkers
@@ -416,6 +417,10 @@ class _Printer(object):
     self.use_index_order = use_index_order
     self.float_format = float_format
     if double_format is not None:
+      warnings.warn(
+          'double_format is deprecated for text_format. This will '
+          'turn into error in 7.34.0, please remove it before that.'
+      )
       self.double_format = double_format
     else:
       self.double_format = float_format
@@ -652,6 +657,11 @@ class _Printer(object):
         out.write('false')
     elif field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_FLOAT:
       if self.float_format is not None:
+        warnings.warn(
+            'float_format is deprecated for text_format. This '
+            'will turn into error in 7.34.0, please remove it '
+            'before that.'
+        )
         out.write('{1:{0}}'.format(self.float_format, value))
       else:
         if math.isnan(value):


### PR DESCRIPTION
Cherry pick https://github.com/anandolee/protobuf/commit/4659cd700643b5544416cfaa4f925f939b8a967f
Those will turn into error in 34.0 release.

PiperOrigin-RevId: 791826874