### PR TITLE
Fix thread safety issues when sharing `Message` objects across threads

### DIFF
--- a/python/python_api.h
+++ b/python/python_api.h
@@ -38,4 +38,14 @@ PyAPI_FUNC(const char*)
     PyUnicode_AsUTF8AndSize(PyObject* unicode, Py_ssize_t* size);
 #endif
 
+// Py_BEGIN_CRITICAL_SECTION and Py_END_CRITICAL_SECTION were added in 3.13
+// mostly for use under the free-threaded build. We're defining the macro here
+// for use with the stable ABI and older Pythons.
+#if defined(Py_LIMITED_API) || PY_VERSION_HEX < 0x030D00B3
+#  define Py_BEGIN_CRITICAL_SECTION(op) {
+#  define Py_END_CRITICAL_SECTION() }
+#  define Py_BEGIN_CRITICAL_SECTION2(a, b) {
+#  define Py_END_CRITICAL_SECTION2() }
+#endif
+
 #endif  // PYUPB_PYTHON_H__


### PR DESCRIPTION
Because `Message` objects may be shared across threads, we need to lock when accessing its internal fiels as well as the `upb` backend.

Here, I'm using `Py_BEGIN_CRITICAL_SECTION` to use the per-object mutex to lock the message when using it.