### PR TITLE
avoid using deprecated `@bazel_tools//src/conditions:host_windows` (#23119)

### DIFF
--- a/python/build_targets.bzl
+++ b/python/build_targets.bzl
@@ -17,7 +17,7 @@ load("//build_defs:arch_tests.bzl", "aarch64_test", "x86_64_test")
 load("//build_defs:cpp_opts.bzl", "COPTS")
 load("//conformance:defs.bzl", "conformance_test")
 load("//editions:defaults.bzl", "compile_edition_defaults", "embed_edition_defaults")
-load(":internal.bzl", "internal_copy_files", "internal_py_test")
+load(":internal.bzl", "internal_copy_files", "internal_is_windows", "internal_py_test")
 
 def build_targets(name):
     """
@@ -61,6 +61,12 @@ def build_targets(name):
             "//editions:__pkg__",
             "//upb:__subpackages__",
         ],
+    )
+
+    # Visibility needs to be public per https://github.com/bazelbuild/bazel-skylib/pull/584
+    internal_is_windows(
+        name = "is_windows",
+        visibility = ["//visibility:public"],
     )
 
     internal_copy_files(

--- a/python/internal.bzl
+++ b/python/internal.bzl
@@ -4,6 +4,22 @@ Internal helpers for building the Python protobuf runtime.
 
 load("@rules_python//python:py_test.bzl", "py_test")
 
+# Adapted from https://github.com/bazelbuild/bazel-skylib/blob/main/rules/private/copy_common.bzl#L47
+InternalOsInfo = provider(
+    doc = "Information about the target platform's OS.",
+    fields = ["is_windows"],
+)
+
+# Adapted from https://github.com/bazelbuild/bazel-skylib/blob/main/rules/private/copy_common.bzl#L52
+internal_is_windows = rule(
+    implementation = lambda ctx: InternalOsInfo(
+        is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]),
+    ),
+    attrs = {
+        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
+    },
+)
+
 def _remove_cross_repo_path(path):
     components = path.split("/")
     if components[0] == "..":
@@ -24,7 +40,9 @@ def _internal_copy_files_impl(ctx):
         dest = ctx.actions.declare_file(short_path[len(strip_prefix):])
         src_dests.append([src, dest])
 
-    if ctx.attr.is_windows:
+    # Windows check adapted from
+    # https://github.com/bazelbuild/bazel-skylib/blob/main/rules/private/copy_file_private.bzl#L71C10-L71C54
+    if ctx.attr._exec_is_windows[InternalOsInfo].is_windows:
         bat_file = ctx.actions.declare_file(ctx.label.name + "_copy.bat")
         ctx.actions.write(
             output = bat_file,
@@ -83,7 +101,13 @@ This rule implements file copying, including a compatibility mode for Windows.
     attrs = {
         "srcs": attr.label_list(allow_files = True, providers = [DefaultInfo]),
         "strip_prefix": attr.string(),
-        "is_windows": attr.bool(),
+        # Adapted from https://github.com/bazelbuild/bazel-skylib/blob/main/rules/private/copy_file_private.bzl#L91C1-L96C7
+        "_exec_is_windows": attr.label(
+            default = ":is_windows",
+            # The exec transition must match the exec group of the actions, which in
+            # this case is the default exec group.
+            cfg = "exec",
+        ),
     },
 )
 
@@ -113,10 +137,6 @@ def internal_copy_files(name, srcs, strip_prefix, **kwargs):
         name = name,
         srcs = srcs,
         strip_prefix = strip_prefix,
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
         **kwargs
     )
 


### PR DESCRIPTION
We here imitate the current practice in bazel-skylib to avoid depending on `@bazel_tools//src/conditions:host_windows`, which is deprecated as of Bazel 8.3.0.

#test-continuous

Closes #23116

Closes #23119
