### PR TITLE
Add another typescript protobuf plugin to the docs

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -123,6 +123,7 @@ These are projects we know about implementing Protocol Buffers for other program
 *   Solidity: https://github.com/celer-network/pb3-gen-sol
 *   Swift: https://github.com/alexeyxo/protobuf-swift
 *   Swift: https://github.com/apple/swift-protobuf/
+*   Typescript: https://github.com/improbable-eng/ts-protoc-gen
 *   Typescript: https://github.com/thesayyn/protoc-gen-ts
 *   Typescript: https://github.com/pbkit/pbkit
 *   Vala: https://launchpad.net/protobuf-vala


### PR DESCRIPTION
This one has a slight name collision with one already on this list, and I think it's easier to notice that if both are listed.

https://github.com/improbable-eng/ts-protoc-gen seems to have more stars than the one that was previously listed here, https://github.com/thesayyn/protoc-gen-ts.