### PR TITLE
Use ACLE __crc32cd intrinsic on Arm

### DIFF
--- a/src/google/protobuf/port.h
+++ b/src/google/protobuf/port.h
@@ -23,6 +23,10 @@
 #include <type_traits>
 #include <typeinfo>
 
+#if defined(__ARM_FEATURE_CRC32)
+#include <arm_acle.h>
+#endif
+
 #include "absl/base/optimization.h"
 
 
@@ -802,9 +806,7 @@ inline uint32_t Crc32(uint32_t crc, uint64_t v) {
 #elif defined(__ARM_FEATURE_CRC32)
 
 constexpr bool HasCrc32() { return true; }
-inline uint32_t Crc32(uint32_t crc, uint64_t v) {
-  return __builtin_arm_crc32cd(crc, v);
-}
+inline uint32_t Crc32(uint32_t crc, uint64_t v) { return __crc32cd(crc, v); }
 
 #else
 


### PR DESCRIPTION
Switch from __builtin_arm_crc32cd to __crc32cd so code compiles on both AArch32 and AArch64 when CRC32 is available.

Before this change, users of the `google/prototobuf/port.h` header on AArch64 Linux error out with

    /home/linuxbrew/.linuxbrew/include/google/protobuf/port.h: In function ‘uint32_t google::protobuf::internal::Crc32(uint32_t, uint64_t)’: /home/linuxbrew/.linuxbrew/include/google/protobuf/port.h:798:10: error: ‘__builtin_arm_crc32cd’ was not declared in this scope; did you mean ‘__builtin_aarch64_crc32cx’?
      798 |   return __builtin_arm_crc32cd(crc, v);
          |          ^~~~~~~~~~~~~~~~~~~~~
          |          __builtin_aarch64_crc32cx
    gmake[2]: *** [CMakeFiles/test.dir/build.make:79: CMakeFiles/test.dir/test.cpp.o] Error 1
    gmake[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/test.dir/all] Error 2
    gmake: *** [Makefile:91: all] Error 2