### PR TITLE
Handle conflicting macros for OpenBSD

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -751,7 +751,7 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
 #undef GID_MAX
 #endif  // defined(ANDROID) || defined(__ANDROID__)
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 // Inconvenient macro names from /usr/include/sys/param.h.
 #pragma push_macro("TRUE")
 #undef TRUE
@@ -762,7 +762,7 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
 #undef UID_MAX
 #pragma push_macro("GID_MAX")
 #undef GID_MAX
-#endif  // __FreeBSD__
+#endif  // defined(__FreeBSD__) || defined(__OpenBSD__)
 
 #if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
 // Don't let Objective-C Macros interfere with proto identifiers with the same

--- a/src/google/protobuf/port_undef.inc
+++ b/src/google/protobuf/port_undef.inc
@@ -156,12 +156,12 @@
 #pragma pop_macro("GID_MAX")
 #endif  // defined(ANDROID) || defined(__ANDROID__)
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #pragma pop_macro("TRUE")
 #pragma pop_macro("FALSE")
 #pragma pop_macro("UID_MAX")
 #pragma pop_macro("GID_MAX")
-#endif  // __FreeBSD__
+#endif  // defined(__FreeBSD__) || defined(__OpenBSD__)
 
 #if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
 #pragma pop_macro("DEBUG")


### PR DESCRIPTION
```
[ 54%] Building CXX object CMakeFiles/libtest_common.dir/google/protobuf/unittest_proto3_bad_macros.pb.cc.o
In file included from /home/brad/tmp/protobuf/build/google/protobuf/unittest_proto3_bad_macros.pb.cc:6:
/home/brad/tmp/protobuf/build/google/protobuf/unittest_proto3_bad_macros.pb.h:87:22: error: expected unqualified-id
   87 | inline constexpr GID GID_MAX =
      |                      ^
/usr/include/sys/limits.h:84:18: note: expanded from macro 'GID_MAX'
   84 | # define GID_MAX        UINT_MAX        /* max value for a gid_t */
      |                         ^
/usr/include/sys/limits.h:56:18: note: expanded from macro 'UINT_MAX'
   56 | #define UINT_MAX        0xffffffffU     /* max value for an unsigned int */
      |                         ^
In file included from /home/brad/tmp/protobuf/build/google/protobuf/unittest_proto3_bad_macros.pb.cc:6:
/home/brad/tmp/protobuf/build/google/protobuf/unittest_proto3_bad_macros.pb.h:122:22: error: expected unqualified-id
  122 | inline constexpr UID UID_MAX =
      |                      ^
/usr/include/sys/limits.h:83:18: note: expanded from macro 'UID_MAX'
   83 | # define UID_MAX        UINT_MAX        /* max value for a uid_t */
      |                         ^
/usr/include/sys/limits.h:56:18: note: expanded from macro 'UINT_MAX'
   56 | #define UINT_MAX        0xffffffffU     /* max value for an unsigned int */
      |                         ^
2 errors generated.
```