### PR TITLE
feat(proctoc): Adds support for building protoc on the RISC-V platform and provides protoc prebuilt binaries

### DIFF
--- a/protoc-artifacts/build-protoc.sh
+++ b/protoc-artifacts/build-protoc.sh
@@ -93,6 +93,8 @@ checkArch ()
         assertEq $format "elf64-x86-64" $LINENO
       elif [[ "$ARCH" == aarch_64 ]]; then
         assertEq $format "elf64-little" $LINENO
+      elif [[ "$ARCH" == riscv64 ]]; then
+         assertEq $format "elf64-littleriscv" $LINENO
       elif [[ "$ARCH" == s390_64 ]]; then
 	if [[ $host_machine == s390x ]];then
 	  assertEq $format "elf64-s390" $LINENO
@@ -162,6 +164,9 @@ checkDependencies ()
     elif [[ "$ARCH" == aarch_64 ]]; then
       dump_cmd='objdump -p '"$1"' | grep NEEDED'
       white_list="libpthread\.so\.0\|libm\.so\.6\|libc\.so\.6\|ld-linux-aarch64\.so\.1"
+    elif [[ "$ARCH" == riscv64 ]]; then
+      dump_cmd='objdump -p '"$1"' | grep NEEDED'
+      white_list="libatomic\.so\.1\|libm\.so\.6\|libc\.so\.6\|ld-linux-riscv64-lp64d\.so\.1"
     fi
   elif [[ "$OS" == osx ]]; then
     dump_cmd='otool -L '"$1"' | fgrep dylib'
@@ -223,6 +228,8 @@ elif [[ "$(uname)" == Linux* ]]; then
       CXXFLAGS="$CXXFLAGS -m32"
     elif [[ "$ARCH" == aarch_64 ]]; then
       CONFIGURE_ARGS="$CONFIGURE_ARGS --host=aarch64-linux-gnu"
+    elif [[ "$ARCH" == riscv64 ]]; then
+      CONFIGURE_ARGS="$CONFIGURE_ARGS --host=riscv64-openEuler-linux-g++"   
     elif [[ "$ARCH" == ppcle_64 ]]; then
       CXXFLAGS="$CXXFLAGS -m64"
       CONFIGURE_ARGS="$CONFIGURE_ARGS --host=powerpc64le-linux-gnu"


### PR DESCRIPTION
**Summary**

This PR adds support for building protoc (Protocol Buffers Compiler) on the RISC-V platform and provides protoc prebuilt binaries, addressing the lack of official RISC-V support and prebuilts for protoc.

**Changes**
1. Updated build scripts to detect and recognize riscv64 as a supported target platform.
2. Extended architecture-specific logic in protoc-artifacts/build-protoc.sh to include the riscv64 architecture, enabling proper compilation for RISC-V.
3. Ensured all newly added code paths are conditionally compiled—this modification does not impact existing supported architectures (e.g., x86_64, ARM).

**Motivation**

RISC-V is an open, rapidly evolving CPU architecture with growing adoption. Prior to this PR:
- protoc lacked official build support for RISC-V, leading to compilation failures when attempting to build natively or cross-compile for the platform.
- No protoc prebuilt binaries for RISC-V exist in Maven Central Repository (https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/), which blocked direct use of protoc prebuilts for Maven-based projects (e.g., Hadoop, Spark, and related plugins) on RISC-V.
This PR resolves both gaps to unblock RISC-V adoption for protoc-dependent projects.

**Testing**

1. Successfully built protoc natively on a Sophgo SG2042 RISC-V CPU running Linux.
2. Used the RISC-V-built protoc to compile Hadoop and Spark on riscv64—both projects built successfully.

**Related Issue**

- Addresses: [protoc does not support RISC-V architecture #17798](https://github.com/protocolbuffers/protobuf/issues/17798)

**Additional Notes**

protoc prebuilt binaries:https://github.com/zhanchangbao-sanechips/protobuf/tree/support-riscv/protoc-3.21.12-linux-riscv64.exe