### PR TITLE
Update raw_ptr_test.cc

### DIFF
--- a/src/google/protobuf/raw_ptr_test.cc
+++ b/src/google/protobuf/raw_ptr_test.cc
@@ -44,7 +44,11 @@ TEST(RawPtr, Basic) {
 }
 
 TEST(RawPtr, Constexpr) {
+#ifdef __windows__
   constexpr RawPtr<Obj> raw(kZeroBuffer);
+#else
+  constexpr RawPtr<Obj> raw;
+#endif
   EXPECT_EQ(raw->i, 0);
   EXPECT_EQ((*raw).i, 0);
   EXPECT_EQ(static_cast<void*>(&raw->i), kZeroBuffer);


### PR DESCRIPTION
error: constexpr variable 'raw' must be initialized by a constant expression
[build]    47 |   constexpr RawPtr<Obj> raw;
[build]       |                         ^~~
[build] 1 error generated.