### PR TITLE
include sha256 in rules_proto http_archive

### DIFF
--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -60,6 +60,7 @@ def protobuf_deps():
     if not native.existing_rule("rules_proto"):
         http_archive(
             name = "rules_proto",
+            sha256 = "14a225870ab4e91869652cfd69ef2028277fc1dc4910d65d353b62d6e0ae21f4",
             strip_prefix = "rules_proto-7.1.0",
             url = "https://github.com/bazelbuild/rules_proto/releases/download/7.1.0/rules_proto-7.1.0.tar.gz",
         )


### PR DESCRIPTION
DEBUG messages about integrity were showing up in builds because we were previously forgetting to check that the contents of the rules_proto http_archive were what we we expected them to be.