### PR TITLE
Fix `system_python` for `MODULE.bazel`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -136,9 +136,11 @@ python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 ]
 
 python.defaults(python_version = SUPPORTED_PYTHON_VERSIONS[-1])
-use_repo(
-    python,
-    system_python = "python_{}".format(SUPPORTED_PYTHON_VERSIONS[-1].replace(".", "_")),
+system_python = use_repo_rule("//python/dist:system_python.bzl", "system_python")
+
+system_python(
+    name = "system_python",
+    minimum_python_version = SUPPORTED_PYTHON_VERSIONS[0],
 )
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)


### PR DESCRIPTION
Addresses #18750.

The call to `system_python`, which this PR replaces, did not create a `system_python` that conforms at all to the expectations of its callees.

Modeled after the `system_python` in the `WORKSPACE` file.