### PR TITLE
Give `hpb_generator` tests visibility into `//hpb/backend/upb:interop`

### DIFF
--- a/hpb/backend/upb/BUILD
+++ b/hpb/backend/upb/BUILD
@@ -37,6 +37,7 @@ cc_library(
     hdrs = ["interop.h"],
     visibility = [
         "//hpb:__subpackages__",
+        "//hpb_generator/tests:__pkg__",
         "//src/google/protobuf/compiler:__subpackages__",
     ],
     deps = [


### PR DESCRIPTION
The tests depend on interop, so they fail to build without visibility.