### PR TITLE
Give `hpb_generator` visibility into `//upb:fasttable_enabled_setting`

### DIFF
--- a/upb/BUILD
+++ b/upb/BUILD
@@ -52,6 +52,7 @@ config_setting(
         "//python:__pkg__",
         "//upb:__subpackages__",
         "//upb_generator:__subpackages__",
+        "//hpb_generator:__subpackages__",
     ],
 )
 


### PR DESCRIPTION
`//hpb_generator:generator` depends on `//upb:fasttable_enabled_setting`