### PR TITLE
Fix `IsOkAndHolds` in `extension_test.cc` to point to the one in `absl/status/status_matchers.h`

### DIFF
--- a/hpb_generator/tests/BUILD
+++ b/hpb_generator/tests/BUILD
@@ -189,6 +189,7 @@ cc_test(
         "//hpb:requires",
         "//hpb/backend/upb:interop",
         "//upb/mem",
+        "@abseil-cpp//absl/status:status_matchers",
         "@abseil-cpp//absl/strings:string_view",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/hpb_generator/tests/extension_test.cc
+++ b/hpb_generator/tests/extension_test.cc
@@ -13,6 +13,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/strings/string_view.h"
+#include "absl/status/status_matchers.h"
 #include "hpb_generator/tests/child_model.hpb.h"
 #include "hpb_generator/tests/test_extension.hpb.h"
 #include "hpb_generator/tests/test_model.hpb.h"
@@ -43,7 +44,7 @@ using ::hpb_unittest::someotherpackage::protos::string_trigraph_ext;
 using ::hpb_unittest::someotherpackage::protos::uint32_ext;
 using ::hpb_unittest::someotherpackage::protos::uint64_ext;
 
-using ::testing::status::IsOkAndHolds;
+using ::absl_testing::IsOkAndHolds;
 
 TEST(CppGeneratedCode, HasExtension) {
   TestModel model;


### PR DESCRIPTION
Without this PR `IsOkAndHolds` is not declared.