### PR TITLE
Make `ExtensionNotFoundError` function signature from defintion in `hpb/status.cc` conform to its signature from declaration in `hpb/status.h`

### DIFF
--- a/hpb/status.cc
+++ b/hpb/status.cc
@@ -20,7 +20,7 @@ absl::Status MessageAllocationError(SourceLocation loc) {
                       "Upb message allocation error");
 }
 
-absl::Status ExtensionNotFoundError(int ext_number, SourceLocation loc) {
+absl::Status ExtensionNotFoundError(uint32_t ext_number, SourceLocation loc) {
   return absl::Status(absl::StatusCode::kUnknown,
                       absl::StrFormat("Extension %d not found", ext_number));
 }


### PR DESCRIPTION
The function signatures were different, and thus incompatible, so the `ExtensionNotFoundError` declared in the header file was never defined.