### PR TITLE
add missing `field_mask` upb proto targets to `src/google/protobuf/BUILD.bazel`

### DIFF
--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -123,6 +123,16 @@ cc_proto_library(
     deps = [":field_mask_proto"],
 )
 
+upb_c_proto_library(
+    name = "field_mask_upb_proto",
+    deps = [":field_mask_proto"],
+)
+
+upb_proto_reflection_library(
+    name = "field_mask_upb_reflection_proto",
+    deps = [":field_mask_proto"],
+)
+
 proto_library(
     name = "source_context_proto",
     srcs = ["source_context.proto"],


### PR DESCRIPTION
These targets are specified in the `BUILD.bazel` file in the root directory, but strangely did not exist.