### PR TITLE
fix(php): phpstan errors on repeated field

### DIFF
--- a/php/src/Google/Protobuf/Internal/RepeatedField.php
+++ b/php/src/Google/Protobuf/Internal/RepeatedField.php
@@ -7,7 +7,7 @@ if (false) {
      * This class is deprecated. Use Google\Protobuf\RepeatedField instead.
      * @deprecated
      */
-    class RepeatedField {}
+    class RepeatedField extends \Google\Protobuf\RepeatedField {}
 }
 class_exists(\Google\Protobuf\RepeatedField::class);
 @trigger_error('Google\Protobuf\Internal\RepeatedField is deprecated and will be removed in the next major release. Use Google\Protobuf\RepeatedField instead', E_USER_DEPRECATED);


### PR DESCRIPTION
Should fix https://github.com/googleapis/google-cloud-php/issues/8372 (phpstan typehinting issues) by having the old `RepeatedField` class extend the new one.