### PR TITLE
fix(php): remove "provide" from composer.json

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -8,9 +8,6 @@
   "require": {
     "php": ">=8.1.0"
   },
-  "provide": {
-    "ext-protobuf": "*"
-  },
   "require-dev": {
     "phpunit/phpunit": ">=5.0.0 <8.5.27"
   },

--- a/php/composer.json.dist
+++ b/php/composer.json.dist
@@ -8,9 +8,6 @@
   "require": {
     "php": ">=8.1.0"
   },
-  "provide": {
-    "ext-protobuf": "*"
-  },
   "require-dev": {
     "phpunit/phpunit": ">=5.0.0 <8.5.27"
   },

--- a/php/tests/ComposerJsonTest.php
+++ b/php/tests/ComposerJsonTest.php
@@ -11,7 +11,11 @@ class ComposerJsonTest extends TestBase
         $composerJsonDist = json_decode(file_get_contents(__DIR__ . '/../composer.json.dist'), true);
 
         // We don't want the subrepo to have "scripts" or "config"
-        unset($composerJson['scripts'], $composerJson['config'], $composerJson['autoload-dev']);
+        unset(
+            $composerJson['scripts'],
+            $composerJson['config'],
+            $composerJson['autoload-dev']
+        );
 
         $this->assertEquals($composerJson, $composerJsonDist);
     }


### PR DESCRIPTION
fixes https://github.com/protocolbuffers/protobuf/issues/23236

see https://github.com/protocolbuffers/protobuf/issues/23236#issuecomment-3254793639

TLDR: `provide` is for virtual packages, and we are setting this to `ext-protobuf: *`, which is not virtual. As a result its conflicting with our latest versions of GAX