### PR TITLE
fix(strtod): use size_t instead of int for strlen() result #1

### DIFF
--- a/upb/lex/strtod.c
+++ b/upb/lex/strtod.c
@@ -68,7 +68,7 @@ double _upb_NoLocaleStrtod(const char *str, char **endptr) {
     // Update endptr to point at the right location.
     if (endptr != NULL) {
       // size_diff is non-zero if the localized radix has multiple bytes.
-      int size_diff = strlen(localized) - strlen(str);
+      size_t size_diff = (size_t)strlen(localized) - (size_t)strlen(str);
       *endptr = (char *)str + (localized_endptr - &localized[0] - size_diff);
     }
   }


### PR DESCRIPTION
`strlen()` returns `size_t`, but the code was storing its value in an `int`.

Why this is important:
- `strlen()` can return values larger than `INT_MAX`, which may lead to 
  truncation or undefined behavior.
- Using the wrong type makes the code non-compliant with C standards and 
  triggers MISRA / static analysis warnings.
- This could potentially break parsing in edge cases with very long strings.

The fix:
- Changed `int size_diff` to `size_t size_diff` when computing 
  `strlen(localized) - strlen(str)`.

Additional note:
`size_diff` is only used to account for cases where the localized radix 
character occupies multiple bytes (e.g., in exotic locales).  
Since localization replaces '.' with a longer symbol at most, `localized` 
is guaranteed to be at least as long as `str`.  
This means the difference cannot be negative, so `size_t` is safe and 
semantically correct (see the original comment in the code).