### PR TITLE
Add fast path for continuous repeated packed 1-byte varint parsing on the Aarch64 architecture with SVE enabled

### DIFF
--- a/src/google/protobuf/generated_message_tctable_impl.h
+++ b/src/google/protobuf/generated_message_tctable_impl.h
@@ -991,6 +991,8 @@ class PROTOBUF_EXPORT TcParser final {
   PROTOBUF_CC static inline const char* RepeatedVarint(PROTOBUF_TC_PARAM_DECL);
   template <typename FieldType, typename TagType, bool zigzag = false>
   PROTOBUF_CC static inline const char* PackedVarint(PROTOBUF_TC_PARAM_DECL);
+  template <typename FieldType, typename TagType>
+  PROTOBUF_CC static inline const char* PackedVarintRaw(PROTOBUF_TC_PARAM_DECL);
 
   // Helper for ints > 127:
   template <typename FieldType, typename TagType, bool zigzag = false>

--- a/src/google/protobuf/generated_message_tctable_lite.cc
+++ b/src/google/protobuf/generated_message_tctable_lite.cc
@@ -1231,27 +1231,36 @@ PROTOBUF_ALWAYS_INLINE const char* TcParser::PackedVarint(
   });
 }
 
+template<typename FieldType, typename TagType>
+PROTOBUF_ALWAYS_INLINE const char* TcParser::PackedVarintRaw(PROTOBUF_TC_PARAM_DECL) {
+  if (ABSL_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+    PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+  }
+  ptr += sizeof(TagType);
+  // Since ctx->ReadPackedVarint does not use TailCall or Return, sync any
+  // pending hasbits now:
+  SyncHasbits(msg, hasbits, table);
+  auto& field = RefAt<RepeatedField<FieldType>>(msg, data.offset());
+  return ctx->ReadPackedVarintRaw(ptr, field);
+}
+
 PROTOBUF_NOINLINE const char* TcParser::FastV8P1(PROTOBUF_TC_PARAM_DECL) {
-  PROTOBUF_MUSTTAIL return PackedVarint<bool, uint8_t>(PROTOBUF_TC_PARAM_PASS);
+  PROTOBUF_MUSTTAIL return PackedVarintRaw<uint8_t, uint8_t>(PROTOBUF_TC_PARAM_PASS);
 }
 PROTOBUF_NOINLINE const char* TcParser::FastV8P2(PROTOBUF_TC_PARAM_DECL) {
-  PROTOBUF_MUSTTAIL return PackedVarint<bool, uint16_t>(PROTOBUF_TC_PARAM_PASS);
+  PROTOBUF_MUSTTAIL return PackedVarintRaw<uint8_t, uint16_t>(PROTOBUF_TC_PARAM_PASS);
 }
 PROTOBUF_NOINLINE const char* TcParser::FastV32P1(PROTOBUF_TC_PARAM_DECL) {
-  PROTOBUF_MUSTTAIL return PackedVarint<uint32_t, uint8_t>(
-      PROTOBUF_TC_PARAM_PASS);
+  PROTOBUF_MUSTTAIL return PackedVarintRaw<uint32_t, uint8_t>(PROTOBUF_TC_PARAM_PASS);
 }
 PROTOBUF_NOINLINE const char* TcParser::FastV32P2(PROTOBUF_TC_PARAM_DECL) {
-  PROTOBUF_MUSTTAIL return PackedVarint<uint32_t, uint16_t>(
-      PROTOBUF_TC_PARAM_PASS);
+  PROTOBUF_MUSTTAIL return PackedVarintRaw<uint32_t, uint16_t>(PROTOBUF_TC_PARAM_PASS);
 }
 PROTOBUF_NOINLINE const char* TcParser::FastV64P1(PROTOBUF_TC_PARAM_DECL) {
-  PROTOBUF_MUSTTAIL return PackedVarint<uint64_t, uint8_t>(
-      PROTOBUF_TC_PARAM_PASS);
+  PROTOBUF_MUSTTAIL return PackedVarintRaw<uint64_t, uint8_t>(PROTOBUF_TC_PARAM_PASS);
 }
 PROTOBUF_NOINLINE const char* TcParser::FastV64P2(PROTOBUF_TC_PARAM_DECL) {
-  PROTOBUF_MUSTTAIL return PackedVarint<uint64_t, uint16_t>(
-      PROTOBUF_TC_PARAM_PASS);
+  PROTOBUF_MUSTTAIL return PackedVarintRaw<uint64_t, uint16_t>(PROTOBUF_TC_PARAM_PASS);
 }
 
 PROTOBUF_NOINLINE const char* TcParser::FastZ32P1(PROTOBUF_TC_PARAM_DECL) {

--- a/src/google/protobuf/parse_context.cc
+++ b/src/google/protobuf/parse_context.cc
@@ -503,6 +503,18 @@ void WriteLengthDelimited(uint32_t num, absl::string_view val, std::string* s) {
   s->append(val.data(), val.size());
 }
 
+std::pair<const char*, uint8_t> VarintParseSlow8(const char* p,
+                                                   uint32_t res) {
+  // Accept >1 bytes
+  for (std::uint32_t i = 1; i < 10; i++) {
+    uint32_t byte = static_cast<uint8_t>(p[i]);
+    if (ABSL_PREDICT_TRUE(byte < 128)) {
+      return {p + i + 1, res};
+    }
+  }
+  return {nullptr, 0};
+}
+
 std::pair<const char*, uint32_t> VarintParseSlow32(const char* p,
                                                    uint32_t res) {
   for (std::uint32_t i = 1; i < 5; i++) {


### PR DESCRIPTION
This PR intends to improve the performance of parsing a continuous
stream of small-sized varints (especially 1 byte) in a repeated
packed varint field using SVE intrinsics under Aarch64. This affects the code for parsing repeated packed bools, (u)int32s and (u)int64s. 

## Benchmark

A benchmark is written to test this scenario:
[bench_repeated_varint.cpp](https://github.com/user-attachments/files/22236865/bench_repeated_varint.cpp)

Proto files used: [protos.zip](https://github.com/user-attachments/files/22238678/protos.zip) (they are just simple varint lists)

The benchmark result is attached, tested on an SVE machine (no SVE2) with 128-bit wide registers:
* [bench_il_upstream_j_3.txt](https://github.com/user-attachments/files/22238565/bench_il_upstream_j_3.txt): Original (upstream), using SVE `-march=armv8-a+sve`
* [bench_il_j_3.txt](https://github.com/user-attachments/files/22238563/bench_il_j_3.txt): Patched, without using SVE `-march=armv8-a`
* [bench_il_sj_3.txt](https://github.com/user-attachments/files/22238564/bench_il_sj_3.txt): Patched, using SVE `-march=armv8-a+sve`

It can be seen that 1-byte integer parsing is now nearly 20 times faster, without much performance regression on other sized integers.

You can also observe a performance improvement on large sized varints. This is because of the manual inlining + [here](https://github.com/protocolbuffers/protobuf/commit/37d71fc72a859c0c8e9b2926fe02d578364906c0#diff-3e71d99d9ff7f49b02bb8672f993518add47d1880294e68d7e1d9e3dceda26ddR1398) where I use `T` instead of `uint64_t` (I don't really know why this wasn't there in the first place, wouldn't that prevent specialization for `uint32_t` methods?)

The official benchmark is also tested, although no significant changes are observed:

* [bench_official_after_nosve.txt](https://github.com/user-attachments/files/22238578/bench_official_after_nosve.txt): With this PR, `-march=armv8-a`
* [bench_official_after_sve.txt](https://github.com/user-attachments/files/22238580/bench_official_after_sve.txt): With this PR, `-march=armv8-a+sve`
* [bench_official_before_sve.txt](https://github.com/user-attachments/files/22238581/bench_official_before_sve.txt): Without this PR, `-march=armv8-a+sve`

## Design
The motivation behind is that many repeated varint arrays contains just single-byte or up to double-byte varints (sensor data, DLRMs, #10646, [this post](https://mcyoung.xyz/2025/07/16/hyperpb/#fn:rep-benches)). In this case, we may have better chance of getting a continuous stream of single-byte varints. When this happens, we can use SVE to bulk-copy all of them into the output list. 

To support bulk-adding, it is not enough to modify just `ReadPackedVarintArray`, as it takes a function that is only capable of adding a single value. Thus, a new method `ReadPackedVarintArrayRaw` is introduced, which takes a `RepeatedField<T>` instead, and is basically the same as `ReadPackedVarintArray` except all `add()` calls are replaced by `RepeatedField<T>::Add`s. Similarly, `EpsCopyInputStream::ReadPackedVarintRaw` and `TcParser::PackedVarintRaw` are introduced in order to use this path.

For `ReadPackedVarintArrayRaw`, whenever a parser sees a value $<128$, it starts the continuous 1-byte varint discovery process. The parser loads as many bytes as possible before boundary, and break on the first value that is greater than $128$. The values before that are all written out to our target `rep`.

For repeated bools, this is as simple as just storing them. For repeated (u)int32s, we store them interleaved with 3 other zeroed vectors, which essentially zero-extends those values and write everything out. For (u)int64s there are no `svst8`, so we have to split them in half, extend all values to 16-bit, then store interleaved with other 3 zeroed 16-bit registers (so zero-extending to 64-bit).