### PR TITLE
Restore ABI compatibility for extension methods which was previously (knowingly) broken with 4.x: https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -949,14 +949,58 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
     /** Check if a singular extension is present. */
     <T> boolean hasExtension(ExtensionLite<? extends MessageT, T> extension);
 
+    /**
+     * hasExtension() overload for {@link Extension} instances. Since {@link Extension} is a subtype
+     * of {@link ExtensionLite}, this is redundant for source-compatibility, but exists here to
+     * maintain ABI compatibility with .class files which dispatch to a method of the concrete type.
+     */
+    default <T> boolean hasExtension(Extension<? extends MessageT, T> extension) {
+      return hasExtension((ExtensionLite<? extends MessageT, T>) extension);
+    }
+
+    /** Overload to maintain ABI compatibility. See {@link #hasExtension(ExtensionLite)}. */
+    default <T> boolean hasExtension(GeneratedExtension<? extends MessageT, T> extension) {
+      return hasExtension((ExtensionLite<? extends MessageT, T>) extension);
+    }
+
     /** Get the number of elements in a repeated extension. */
     <T> int getExtensionCount(ExtensionLite<? extends MessageT, List<T>> extension);
+
+    /** Overload to maintain ABI compatibility. See {@link #getExtensionCount(ExtensionLite)}. */
+    default <T> int getExtensionCount(Extension<? extends MessageT, List<T>> extension) {
+      return getExtensionCount((ExtensionLite<? extends MessageT, List<T>>) extension);
+    }
+
+    /** Overload to maintain ABI compatibility. See {@link #getExtensionCount(ExtensionLite)}. */
+    default <T> int getExtensionCount(GeneratedExtension<MessageT, List<T>> extension) {
+      return getExtensionCount((ExtensionLite<? extends MessageT, List<T>>) extension);
+    }
 
     /** Get the value of an extension. */
     <T> T getExtension(ExtensionLite<? extends MessageT, T> extension);
 
+    /** Overload to maintain ABI compatibility. See {@link #getExtension(ExtensionLite)}. */
+    default <T> T getExtension(Extension<? extends MessageT, T> extension) {
+      return getExtension((ExtensionLite<? extends MessageT, T>) extension);
+    }
+
+    /** Overload to maintain ABI compatibility. See {@link #getExtension(ExtensionLite)}. */
+    default <T> T getExtension(GeneratedExtension<MessageT, T> extension) {
+      return getExtension((ExtensionLite<? extends MessageT, T>) extension);
+    }
+
     /** Get one element of a repeated extension. */
     <T> T getExtension(ExtensionLite<? extends MessageT, List<T>> extension, int index);
+
+    /** Overload to maintain ABI compatibility. See {@link #getExtension(ExtensionLite)}. */
+    default <T> T getExtension(Extension<? extends MessageT, List<T>> extension, int index) {
+      return getExtension((ExtensionLite<? extends MessageT, List<T>>) extension, index);
+    }
+
+    /** Overload to maintain ABI compatibility. See {@link #getExtension(ExtensionLite)}. */
+    default <T> T getExtension(GeneratedExtension<MessageT, List<T>> extension, int index) {
+      return getExtension((ExtensionLite<? extends MessageT, List<T>>) extension, index);
+    }
   }
 
   /**
@@ -1436,6 +1480,12 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
           extension.singularFromReflectionType(extensions.getRepeatedField(descriptor, index));
     }
 
+    /** Overload to maintain ABI compatibility. See {@link #setExtension(ExtensionLite, Object)}. */
+    public final <T> BuilderT setExtension(
+        final Extension<? extends MessageT, T> extension, final T value) {
+      return setExtension((ExtensionLite<? extends MessageT, T>) extension, value);
+    }
+
     /** Set the value of an extension. */
     public final <T> BuilderT setExtension(
         final ExtensionLite<? extends MessageT, T> extensionLite, final T value) {
@@ -1447,6 +1497,15 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
       extensions.setField(descriptor, extension.toReflectionType(value));
       onChanged();
       return (BuilderT) this;
+    }
+
+    /**
+     * Overload to maintain ABI compatibility. See {@link #setExtension(ExtensionLite, int,
+     * Object)}.
+     */
+    public final <T> BuilderT setExtension(
+        final Extension<? extends MessageT, List<T>> extension, final int index, final T value) {
+      return setExtension((ExtensionLite<? extends MessageT, List<T>>) extension, index, value);
     }
 
     /** Set the value of one element of a repeated extension. */
@@ -1464,6 +1523,12 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
       return (BuilderT) this;
     }
 
+    /** Overload to maintain ABI compatibility. See {@link #addExtension(ExtensionLite, Object)}. */
+    public final <T> BuilderT addExtension(
+        final Extension<? extends MessageT, List<T>> extension, final T value) {
+      return addExtension((ExtensionLite<? extends MessageT, List<T>>) extension, value);
+    }
+
     /** Append a value to a repeated extension. */
     public final <T> BuilderT addExtension(
         final ExtensionLite<? extends MessageT, List<T>> extensionLite, final T value) {
@@ -1475,6 +1540,11 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
       extensions.addRepeatedField(descriptor, extension.singularToReflectionType(value));
       onChanged();
       return (BuilderT) this;
+    }
+
+    /** Overload to maintain ABI compatibility. See {@link #clearExtension(ExtensionLite)}. */
+    public final <T> BuilderT clearExtension(final Extension<? extends MessageT, T> extension) {
+      return clearExtension((ExtensionLite<? extends MessageT, T>) extension);
     }
 
     /** Clear an extension. */

--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -327,41 +327,6 @@ public abstract class GeneratedMessageV3
   public interface ExtendableMessageOrBuilder<MessageT extends ExtendableMessage<MessageT>>
       extends GeneratedMessage.ExtendableMessageOrBuilder<GeneratedMessageV3> {
 
-    /* Removed from GeneratedMessage.ExtendableMessageOrBuilder in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    <T> boolean hasExtension(GeneratedExtension<MessageT, T> extension);
-
-    /* Removed from GeneratedMessage.ExtendableMessageOrBuilder in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    <T> int getExtensionCount(GeneratedExtension<MessageT, List<T>> extension);
-
-    /* Removed from GeneratedMessage.ExtendableMessageOrBuilder in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    <T> T getExtension(GeneratedExtension<MessageT, T> extension);
-
-    /* Removed from GeneratedMessage.ExtendableMessageOrBuilder in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    <T> T getExtension(GeneratedExtension<MessageT, List<T>> extension, int index);
   }
 
   /**
@@ -386,55 +351,6 @@ public abstract class GeneratedMessageV3
     @Deprecated
     protected ExtendableMessage(ExtendableBuilder<MessageT, ?> builder) {
       super(builder);
-    }
-
-    /* Removed from GeneratedMessage.ExtendableMessage in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    @Override
-    public final <T> boolean hasExtension(final GeneratedExtension<MessageT, T> extension) {
-      return hasExtension((ExtensionLite<MessageT, T>) extension);
-    }
-
-    /* Removed from GeneratedMessage.ExtendableMessage in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    @Override
-    public final <T> int getExtensionCount(final GeneratedExtension<MessageT, List<T>> extension) {
-      return getExtensionCount((ExtensionLite<MessageT, List<T>>) extension);
-    }
-
-    /* Removed from GeneratedMessage.ExtendableMessage in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    @Override
-    public final <T> T getExtension(final GeneratedExtension<MessageT, T> extension) {
-      return getExtension((ExtensionLite<MessageT, T>) extension);
-    }
-
-    /* Removed from GeneratedMessage.ExtendableMessage in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    @Override
-    public final <T> T getExtension(
-        final GeneratedExtension<MessageT, List<T>> extension, final int index) {
-      return getExtension((ExtensionLite<MessageT, List<T>>) extension, index);
     }
 
     /* Overrides abstract GeneratedMessage.ExtendableMessage.internalGetFieldAccessorTable().
@@ -514,55 +430,6 @@ public abstract class GeneratedMessageV3
     @Deprecated
     protected ExtendableBuilder(BuilderParent parent) {
       super(parent);
-    }
-
-    /* Removed from GeneratedMessage.ExtendableBuilder in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    @Override
-    public final <T> boolean hasExtension(final GeneratedExtension<MessageT, T> extension) {
-      return hasExtension((ExtensionLite<MessageT, T>) extension);
-    }
-
-    /* Removed from GeneratedMessage.ExtendableBuilder in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    @Override
-    public final <T> int getExtensionCount(final GeneratedExtension<MessageT, List<T>> extension) {
-      return getExtensionCount((ExtensionLite<MessageT, List<T>>) extension);
-    }
-
-    /* Removed from GeneratedMessage.ExtendableBuilder in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    @Override
-    public final <T> T getExtension(final GeneratedExtension<MessageT, T> extension) {
-      return getExtension((ExtensionLite<MessageT, T>) extension);
-    }
-
-    /* Removed from GeneratedMessage.ExtendableBuilder in
-     * https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8
-     *
-     * @deprecated This method is deprecated, and slated for removal in the next Java breaking
-     * change (5.x). Users should update gencode to >= 4.26.x which no longer overrides this method.
-     */
-    @Deprecated
-    @Override
-    public final <T> T getExtension(
-        final GeneratedExtension<MessageT, List<T>> extension, final int index) {
-      return getExtension((ExtensionLite<MessageT, List<T>>) extension, index);
     }
 
     /* Removed from GeneratedMessage.ExtendableBuilder in


### PR DESCRIPTION
…(knowingly) broken with 4.x: https://github.com/protocolbuffers/protobuf/commit/94a2a448518403341b8aa71335ab1123fbdcccd8

Having overloads of the subtypes is unnecessary for source compatibility (where javac will resolve the type to the base type method), but removal of them an ABI break if .class files compiled against PBJ 3.x are used with PBJ 4.x.

PiperOrigin-RevId: 805035553