### PR TITLE
[Cherrypick] Restore Protobuf Java extension modifiers in gencode 

### DIFF
--- a/src/google/protobuf/compiler/java/full/message_builder.cc
+++ b/src/google/protobuf/compiler/java/full/message_builder.cc
@@ -393,6 +393,37 @@ void MessageBuilderGenerator::GenerateCommonBuilderMethods(
 
   GenerateBuildPartial(printer);
 
+  // We include these methods only in open source to maintain long term ABI
+  // compatibility, and there should be no need to include them in Google3.
+  if (context_->options().opensource_runtime &&
+      descriptor_->extension_range_count() > 0) {
+    printer->Print(
+        "public <Type> Builder setExtension(\n"
+        "    com.google.protobuf.GeneratedMessage.GeneratedExtension<\n"
+        "        $classname$, Type> extension,\n"
+        "    Type value) {\n"
+        "  return super.setExtension(extension, value);\n"
+        "}\n"
+        "public <Type> Builder setExtension(\n"
+        "    com.google.protobuf.GeneratedMessage.GeneratedExtension<\n"
+        "        $classname$, java.util.List<Type>> extension,\n"
+        "    int index, Type value) {\n"
+        "  return super.setExtension(extension, index, value);\n"
+        "}\n"
+        "public <Type> Builder addExtension(\n"
+        "    com.google.protobuf.GeneratedMessage.GeneratedExtension<\n"
+        "        $classname$, java.util.List<Type>> extension,\n"
+        "    Type value) {\n"
+        "  return super.addExtension(extension, value);\n"
+        "}\n"
+        "public <Type> Builder clearExtension(\n"
+        "    com.google.protobuf.GeneratedMessage.GeneratedExtension<\n"
+        "        $classname$, Type> extension) {\n"
+        "  return super.clearExtension(extension);\n"
+        "}\n",
+        "classname", name_resolver_->GetImmutableClassName(descriptor_));
+  }
+
   // -----------------------------------------------------------------
 
   if (context_->HasGeneratedMethods(descriptor_)) {


### PR DESCRIPTION
that were previously removed in https://github.com/protocolbuffers/protobuf/commit/7bff169d32710b143951ec6ce2c4ea9a56e2ad24

PiperOrigin-RevId: 805013144