### PR TITLE
chore: show a validation action

### DIFF
--- a/bazel/private/BUILD
+++ b/bazel/private/BUILD
@@ -1,5 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":native_bool_flag.bzl", "native_bool_flag")
+load(":protoc_authenticity.bzl", "protoc_authenticity")
+
+protoc_authenticity(
+    name = "authenticity_check",
+    visibility = ["//visibility:public"],
+)
 
 package(default_applicable_licenses = ["//:license"])
 

--- a/bazel/private/proto_library_rule.bzl
+++ b/bazel/private/proto_library_rule.bzl
@@ -113,6 +113,7 @@ def _proto_library_impl(ctx):
             default_runfiles = ctx.runfiles(),  # empty
             data_runfiles = data_runfiles,
         ),
+        OutputGroupInfo(_validation = depset([ctx.attr._authenticity_check[OutputGroupInfo]._validation])),
     ]
 
 def _process_srcs(ctx, srcs, import_prefix, strip_import_prefix):
@@ -374,6 +375,9 @@ lang_proto_library that is not in one of the listed packages.""",
 List of files containing extension declarations. This attribute is only allowed
 for use with MessageSet.
 """,
+        ),
+        "_authenticity_check": attr.label(
+            default = "//bazel/private:authenticity_check",
         ),
         # buildifier: disable=attr-license (calling attr.license())
         "licenses": attr.license() if hasattr(attr, "license") else attr.string_list(),

--- a/bazel/private/protoc_authenticity.bzl
+++ b/bazel/private/protoc_authenticity.bzl
@@ -1,0 +1,42 @@
+"Checks that the protoc binary is authentic and not spoofed by a malicious actor"
+load("//bazel/common:proto_common.bzl", "proto_common")
+load("toolchain_helpers.bzl", "toolchains")
+
+def _protoc_authenticity_impl(ctx):
+    if proto_common.INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION:
+        toolchain = ctx.toolchains[toolchains.PROTO_TOOLCHAIN]
+        if not toolchain:
+            fail("Protocol compiler toolchain could not be resolved.")
+        proto_lang_toolchain_info = toolchain.proto
+    else:
+        proto_lang_toolchain_info = proto_common.ProtoLangToolchainInfo(
+            out_replacement_format_flag = "--descriptor_set_out=%s",
+            output_files = "single",
+            mnemonic = "GenProtoDescriptorSet",
+            progress_message = "Generating Descriptor Set proto_library %{label}",
+            proto_compiler = ctx.executable._proto_compiler,
+            protoc_opts = ctx.fragments.proto.experimental_protoc_opts,
+            plugin = None,
+        )
+    validation_output = ctx.actions.declare_file("validation_output.txt")
+    
+    ctx.actions.run_shell(
+        outputs = [validation_output],
+        tools = [proto_lang_toolchain_info.proto_compiler],
+        command = proto_lang_toolchain_info.proto_compiler.path + " --version ; echo 'protoc came from an untrusted source, we do not support this. To suppress this warning run with --norun_validations'; false".format(),
+    )
+    return [OutputGroupInfo(_validation = depset([validation_output]))]
+
+protoc_authenticity = rule(
+    implementation = _protoc_authenticity_impl,
+    fragments = ["proto"],
+    attrs = toolchains.if_legacy_toolchain({
+        "_proto_compiler": attr.label(
+            cfg = "exec",
+            executable = True,
+            allow_files = True,
+            default = "//src/google/protobuf/compiler:protoc_minimal",
+        ),
+    }),
+    toolchains = toolchains.use_toolchain(toolchains.PROTO_TOOLCHAIN),
+)

--- a/bazel/proto_library.bzl
+++ b/bazel/proto_library.bzl
@@ -16,8 +16,8 @@ def proto_library(**kwattrs):
         fail("Protobuf proto_library is not compatible with Bazel 6.")
 
     # Only use Starlark rules when they are removed from Bazel.
-    if not hasattr(native, "proto_library"):
-        _proto_library(**kwattrs)
-    else:
-        # On older Bazel versions keep using native rules, so that mismatch in ProtoInfo doesn't happen
-        native.proto_library(**kwattrs)  # buildifier: disable=native-proto
+    # if not hasattr(native, "proto_library"):
+    _proto_library(**kwattrs)
+    # else:
+    #     # On older Bazel versions keep using native rules, so that mismatch in ProtoInfo doesn't happen
+    #     native.proto_library(**kwattrs)  # buildifier: disable=native-proto


### PR DESCRIPTION
Rough sketch of a way to check whether protoc is an "authentic" release from the protobuf team.

We create a single validation action, and then forward the validation output group through proto_library to ensure all users should hit it.

Next steps to make it real:
- instead of just checking `protoc --version` and then failing, we should checksum protoc and verify against the expected hash


demo:

```
alexeagle@aspect-build protobuf % USE_BAZEL_VERSION=8.x bazel build rust/test:parent_proto --norun_validations
INFO: Analyzed target //rust/test:parent_proto (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //rust/test:parent_proto up-to-date:
  bazel-bin/rust/test/parent_proto-descriptor-set.proto.bin
INFO: Elapsed time: 0.210s, Critical Path: 0.00s
INFO: 1 process: 1 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
alexeagle@aspect-build protobuf % USE_BAZEL_VERSION=8.x bazel build rust/test:parent_proto                    
INFO: Analyzed target //rust/test:parent_proto (0 packages loaded, 0 targets configured).
ERROR: /Users/alexeagle/Projects/protobuf/bazel/private/BUILD:5:20: Action bazel/private/validation_output.txt failed: (Exit 1): bash failed: error executing Action command (from target //bazel/private:authenticity_check) /bin/bash -c ... (remaining 1 argument skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
libprotoc 33.0-dev
protoc came from an untrusted source, we do not support this. To suppress this warning run with --norun_validations
Target //rust/test:parent_proto failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.136s, Critical Path: 0.02s
INFO: 2 processes: 1 action cache hit, 2 internal.
```