### PR TITLE
bazel: add missing rules_cc loads (#23584)

### DIFF
--- a/lua/BUILD.bazel
+++ b/lua/BUILD.bazel
@@ -5,6 +5,9 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//bazel:proto_library.bzl", "proto_library")
 load(
     "//lua:lua_proto_library.bzl",

--- a/pkg/test/BUILD.bazel
+++ b/pkg/test/BUILD.bazel
@@ -1,5 +1,6 @@
 # Tests for CMake file list generation
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//pkg:build_systems.bzl", "gen_file_lists")
 load("//pkg:cc_dist_library.bzl", "cc_dist_library")

--- a/ruby/ext/google/protobuf_c/BUILD.bazel
+++ b/ruby/ext/google/protobuf_c/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_apple//apple:apple_binary.bzl", "apple_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("//upb/cmake:build_defs.bzl", "staleness_test")
 

--- a/ruby/lib/google/BUILD.bazel
+++ b/ruby/lib/google/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_java//java:java_binary.bzl", "java_binary")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_ruby//ruby:defs.bzl", "rb_library")

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -1,5 +1,6 @@
 """This file implements rust_proto_library."""
 
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_rust//rust:defs.bzl", "rust_common")
 load("@rules_rust//rust:rust_common.bzl", "CrateInfo", "DepInfo")
 load("//bazel/common:proto_common.bzl", "proto_common")

--- a/src/google/protobuf/compiler/cpp/BUILD.bazel
+++ b/src/google/protobuf/compiler/cpp/BUILD.bazel
@@ -2,6 +2,7 @@
 # Protocol Buffers Compiler - C++ code generator
 ################################################################################
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("//bazel:cc_proto_library.bzl", "cc_proto_library")

--- a/src/google/protobuf/compiler/java/full/BUILD.bazel
+++ b/src/google/protobuf/compiler/java/full/BUILD.bazel
@@ -1,6 +1,7 @@
 # We use abbreviated target names in this directory to work around:
 #     https://github.com/bazelbuild/bazel/issues/18683
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//build_defs:cpp_opts.bzl", "COPTS")
 
 cc_library(

--- a/src/google/protobuf/compiler/java/lite/BUILD.bazel
+++ b/src/google/protobuf/compiler/java/lite/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//build_defs:cpp_opts.bzl", "COPTS")
 
 cc_library(

--- a/src/google/protobuf/compiler/kotlin/BUILD.bazel
+++ b/src/google/protobuf/compiler/kotlin/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//build_defs:cpp_opts.bzl", "COPTS")
 
 cc_library(

--- a/src/google/protobuf/compiler/php/BUILD.bazel
+++ b/src/google/protobuf/compiler/php/BUILD.bazel
@@ -2,6 +2,7 @@
 # Protocol Buffers Compiler - PHP code generator
 ################################################################################
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("//build_defs:cpp_opts.bzl", "COPTS")

--- a/src/google/protobuf/compiler/rust/BUILD.bazel
+++ b/src/google/protobuf/compiler/rust/BUILD.bazel
@@ -9,6 +9,8 @@
 # Protocol Buffers Compiler - Rust code generator
 ################################################################################
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//build_defs:cpp_opts.bzl", "COPTS")
 load(

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc/toolchains:cc_toolchain.bzl", "cc_toolchain")
+load("@rules_cc//cc/toolchains:cc_toolchain_suite.bzl", "cc_toolchain_suite")
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
This is required for use with bazel after this commit https://github.com/bazelbuild/bazel/commit/71ca0ed111ff3d842a0d23bc3a46bd2e6745491d

Many files have these already

Closes #23584

COPYBARA_INTEGRATE_REVIEW=https://github.com/protocolbuffers/protobuf/pull/23584 from keith:ks/bazel-add-missing-rules_cc-loads 733a0ccf6f53f469352b19440a1d152eccea6bec PiperOrigin-RevId: 817836399