### PR TITLE
Switch the pre22 warning to use CopyOnWriteArraySet.

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -30,13 +30,13 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.logging.Logger;
 
 /**
@@ -416,8 +416,7 @@ public abstract class GeneratedMessage extends AbstractMessage implements Serial
           + " security vulnerability:"
           + " https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-h4h5-3hr4-j3g2";
 
-  protected static final Set<String> loggedPre22TypeNames =
-      Collections.synchronizedSet(new HashSet<String>());
+  protected static final Set<String> loggedPre22TypeNames = new CopyOnWriteArraySet<String>();
 
   static void warnPre22Gencode(Class<?> messageClass) {
     if (System.getProperty(PRE22_GENCODE_SILENCE_PROPERTY) != null) {


### PR DESCRIPTION
This data structure is better for cases where writes are rare and reads common. When this warning path is it, the writes only occur exactly once per CVE-affected type, and reads occur once per every parse of those types.

Broadly people sensitive by this performance concern should really regen their gencode, but this should help take the edge off of people who first upgrade to 4.x and then look to incrementally regen any ancient gencode.

Fixes https://github.com/protocolbuffers/protobuf/issues/23963

PiperOrigin-RevId: 819238880

Cherry-pick of c131253