### PR TITLE
Add option for PHP to emit default values for JSON.

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -773,6 +773,9 @@ PHP_METHOD(Message, serializeToJsonString) {
     if (Z_LVAL_P(flags) & PRESERVE_PROTO_FIELD_NAMES) {
       options |= upb_JsonEncode_UseProtoNames;
     }
+    if (Z_LVAL_P(flags) & EMIT_DEFAULTS) {
+      options |= upb_JsonEncode_EmitDefaults;
+    }
   }
 
   upb_Status_Clear(&status);

--- a/php/ext/google/protobuf/print_options.c
+++ b/php/ext/google/protobuf/print_options.c
@@ -24,4 +24,7 @@ void PrintOptions_ModuleInit() {
   zend_declare_class_constant_long(options_ce, "ALWAYS_PRINT_ENUMS_AS_INTS",
                                    sizeof("ALWAYS_PRINT_ENUMS_AS_INTS") - 1,
                                    ALWAYS_PRINT_ENUMS_AS_INTS);
+  zend_declare_class_constant_long(options_ce, "EMIT_DEFAULTS",
+                                   sizeof("EMIT_DEFAULTS") - 1,
+                                   EMIT_DEFAULTS);
 }

--- a/php/ext/google/protobuf/print_options.h
+++ b/php/ext/google/protobuf/print_options.h
@@ -10,6 +10,7 @@
 
 #define PRESERVE_PROTO_FIELD_NAMES (1 << 0)
 #define ALWAYS_PRINT_ENUMS_AS_INTS (1 << 1)
+#define EMIT_DEFAULTS (1 << 2)
 
 // Registers the PHP PrintOptions class.
 void PrintOptions_ModuleInit();

--- a/php/src/Google/Protobuf/PrintOptions.php
+++ b/php/src/Google/Protobuf/PrintOptions.php
@@ -13,4 +13,5 @@ class PrintOptions
 {
     const PRESERVE_PROTO_FIELD_NAMES = 1 << 0;
     const ALWAYS_PRINT_ENUMS_AS_INTS = 1 << 1;
+    const EMIT_DEFAULTS = 1 << 2;
 }

--- a/php/tests/EncodeDecodeTest.php
+++ b/php/tests/EncodeDecodeTest.php
@@ -1707,4 +1707,239 @@ class EncodeDecodeTest extends TestBase
             [false, '{"oneofEnum":"ONE"}'],
         ];
     }
+
+    public function testEmitDefaultsInt32()
+    {
+        $m = new TestMessage();
+        // Without EMIT_DEFAULTS, default values should not be included
+        $this->assertSame("{}", $m->serializeToJsonString());
+
+        // With EMIT_DEFAULTS, default values should be included
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"optionalInt32":0', $json);
+        $this->assertStringContainsString('"optionalUint32":0', $json);
+        $this->assertStringContainsString('"optionalSint32":0', $json);
+    }
+
+    public function testEmitDefaultsInt64()
+    {
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"optionalInt64":"0"', $json);
+        $this->assertStringContainsString('"optionalUint64":"0"', $json);
+        $this->assertStringContainsString('"optionalSint64":"0"', $json);
+    }
+
+    public function testEmitDefaultsFloat()
+    {
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"optionalFloat":0', $json);
+        $this->assertStringContainsString('"optionalDouble":0', $json);
+    }
+
+    public function testEmitDefaultsBool()
+    {
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"optionalBool":false', $json);
+    }
+
+    public function testEmitDefaultsString()
+    {
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"optionalString":""', $json);
+        $this->assertStringContainsString('"optionalBytes":""', $json);
+    }
+
+    public function testEmitDefaultsEnum()
+    {
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"optionalEnum":"ZERO"', $json);
+    }
+
+    public function testEmitDefaultsMessage()
+    {
+        $m = new TestMessage();
+        // Messages are not included even with EMIT_DEFAULTS when they are null
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertThat($json, $this->logicalNot($this->stringContains('"optionalMessage"')));
+    }
+
+    public function testEmitDefaultsRepeatedFields()
+    {
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+
+        // Empty repeated fields should be included as [] with EMIT_DEFAULTS
+        $this->assertStringContainsString('"repeatedInt32":[]', $json);
+        $this->assertStringContainsString('"repeatedString":[]', $json);
+
+        // Non-empty repeated fields are always included
+        $m->setRepeatedInt32([1, 2, 3]);
+        $json2 = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"repeatedInt32":[1,2,3]', $json2);
+    }
+
+    public function testEmitDefaultsMaps()
+    {
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+
+        // Empty maps should be included as {} with EMIT_DEFAULTS
+        $this->assertStringContainsString('"mapInt32Int32":{}', $json);
+        $this->assertStringContainsString('"mapStringString":{}', $json);
+
+        // Non-empty maps are always included
+        $m->getMapInt32Int32()[1] = 100;
+        $json2 = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"mapInt32Int32":{"1":100}', $json2);
+    }
+
+    public function testEmitDefaultsWithNonDefaultValues()
+    {
+        $m = new TestMessage();
+        $m->setOptionalInt32(42);
+        $m->setOptionalString("test");
+
+        // Non-default values should always be included
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"optionalInt32":42', $json);
+        $this->assertStringContainsString('"optionalString":"test"', $json);
+
+        // Default values should also be included
+        $this->assertStringContainsString('"optionalBool":false', $json);
+        $this->assertStringContainsString('"optionalDouble":0', $json);
+    }
+
+    public function testEmitDefaultsWithPreserveProtoFieldNames()
+    {
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(
+            PrintOptions::EMIT_DEFAULTS | PrintOptions::PRESERVE_PROTO_FIELD_NAMES
+        );
+
+        // Should use proto field names (with underscores)
+        $this->assertStringContainsString('"optional_int32":0', $json);
+        $this->assertStringContainsString('"optional_string":""', $json);
+        $this->assertStringContainsString('"optional_bool":false', $json);
+    }
+
+    public function testEmitDefaultsWithAlwaysPrintEnumsAsInts()
+    {
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(
+            PrintOptions::EMIT_DEFAULTS | PrintOptions::ALWAYS_PRINT_ENUMS_AS_INTS
+        );
+
+        // Enum should be printed as integer
+        $this->assertStringContainsString('"optionalEnum":0', $json);
+    }
+
+    public function testEmitDefaultsAllFlags()
+    {
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(
+            PrintOptions::EMIT_DEFAULTS | 
+            PrintOptions::PRESERVE_PROTO_FIELD_NAMES | 
+            PrintOptions::ALWAYS_PRINT_ENUMS_AS_INTS
+        );
+
+        // Should have all three flag behaviors
+        $this->assertStringContainsString('"optional_int32":0', $json);
+        $this->assertStringContainsString('"optional_enum":0', $json);
+        $this->assertStringContainsString('"optional_bool":false', $json);
+    }
+
+    public function testEmitDefaultsDoesNotAffectParsing()
+    {
+        // Create a message with default values using EMIT_DEFAULTS
+        $m1 = new TestMessage();
+        $json = $m1->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+
+        // Parse it back
+        $m2 = new TestMessage();
+        $m2->mergeFromJsonString($json);
+
+        // All fields should have default values
+        $this->assertSame(0, $m2->getOptionalInt32());
+        $this->assertSame(false, $m2->getOptionalBool());
+        $this->assertSame('', $m2->getOptionalString());
+        $this->assertSame(TestEnum::ZERO, $m2->getOptionalEnum());
+    }
+
+    public function testEmitDefaultsWithSetThenClearedField()
+    {
+        $m = new TestMessage();
+        $m->setOptionalInt32(42);
+        $m->setOptionalInt32(0);  // Set back to default
+
+        // Without EMIT_DEFAULTS, should not be in JSON
+        $json1 = $m->serializeToJsonString();
+        $this->assertSame("{}", $json1);
+
+        // With EMIT_DEFAULTS, should be in JSON
+        $json2 = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"optionalInt32":0', $json2);
+    }
+
+    public function testEmitDefaultsTrueOptionalFieldsWithHazzer()
+    {
+        // True optional fields (proto3 optional) should not be included
+        // even with EMIT_DEFAULTS if they haven't been set
+        $m = new TestMessage();
+        $json = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+
+        // Regular optional (implicit presence) should be included
+        $this->assertStringContainsString('"optionalInt32":0', $json);
+
+        // True optional (explicit presence) should NOT be included if not set
+        $this->assertThat($json, $this->logicalNot($this->stringContains('"trueOptionalInt32"')));
+
+        // But if we set the true optional field, it should be included
+        $m->setTrueOptionalInt32(0);
+        $json2 = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertStringContainsString('"trueOptionalInt32":0', $json2);
+    }
+
+    public function testEmitDefaultsWellKnownTypes()
+    {
+        // Test with wrapper types
+        $m = new Int32Value();
+
+        // Without setting value
+        $json1 = $m->serializeToJsonString();
+        $this->assertSame("0", $json1);
+
+        // With EMIT_DEFAULTS (should behave the same for wrapper types)
+        $json2 = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertSame("0", $json2);
+    }
+
+    public function testEmitDefaultsStructAndListValue()
+    {
+        // Test with ListValue
+        $m = new ListValue();
+
+        // Empty ListValue
+        $json1 = $m->serializeToJsonString();
+        $this->assertSame("[]", $json1);
+
+        // With EMIT_DEFAULTS
+        $json2 = $m->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertSame("[]", $json2);
+
+        // Test with Struct
+        $s = new Struct();
+
+        // Empty Struct
+        $json3 = $s->serializeToJsonString();
+        $this->assertSame("{}", $json3);
+
+        // With EMIT_DEFAULTS
+        $json4 = $s->serializeToJsonString(PrintOptions::EMIT_DEFAULTS);
+        $this->assertSame("{}", $json4);
+    }
 }


### PR DESCRIPTION
This is a reopening of https://github.com/protocolbuffers/protobuf/issues/6035, where it was requested that someone contribute a PR. I chose the option name `EMIT_DEFAULTS` to match the ruby client and existing upd option. I tried to be relatively comprehensive with the tests, but let me know if there's anything stylistically or logically you want changed.

Locally the tests run happily:
```
php % git rev-parse HEAD 

7cb3b2d9f60bdffce69c01143ca15c46d2eaa900
php % php -dextension=ext/google/protobuf/modules/protobuf.so -d error_reporting="E_ALL & ~E_DEPRECATED" vendor/bin/phpunit --bootstrap tests/force_c_ext.php tests/EncodeDecodeTest.php
PHPUnit 8.5.26 #StandWithUkraine

...............................................................  63 / 147 ( 42%)
............................................................... 126 / 147 ( 85%)
.....................                                           147 / 147 (100%)

Time: 49 ms, Memory: 6.00 MB

OK (147 tests, 1150 assertions)
```