### PR TITLE
Experiment: Make rust/ a bazel module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ vendor/
 
 # Ignore the bazel symlinks
 /bazel-*
+/rust/bazel-*
 
 # ruby test output
 ruby/tests/basic_test_pb.rb

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -3,15 +3,16 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
-load("//bazel/toolchains:proto_lang_toolchain.bzl", "proto_lang_toolchain")
+load("@com_google_protobuf//bazel/toolchains:proto_lang_toolchain.bzl", "proto_lang_toolchain")
 
 licenses(["notice"])
 
 package_group(
     name = "protobuf_internal",
     packages = [
-        "//rust/...",
-        "//src/google/protobuf/...",
+        "//...",
+        # "@com_google_protobuf//src/google/protobuf/...",
+        'public',
     ],
 )
 
@@ -88,7 +89,7 @@ rust_library(
     srcs = PROTOBUF_SHARED + ["upb.rs"],
     crate_root = "shared.rs",
     proc_macro_deps = [
-        "//rust/protobuf_macros",
+        "//protobuf_macros",
         "@crate_index//:paste",
     ],
     rustc_flags = [
@@ -98,7 +99,7 @@ rust_library(
     visibility = [":protobuf_internal"],
     deps = [
         ":utf8",
-        "//rust/upb",
+        "//upb",
     ],
 )
 
@@ -135,7 +136,7 @@ rust_library(
     srcs = PROTOBUF_SHARED + ["cpp.rs"],
     crate_root = "shared.rs",
     proc_macro_deps = [
-        "//rust/protobuf_macros",
+        "//protobuf_macros",
         "@crate_index//:paste",
     ],
     rustc_flags = [
@@ -145,7 +146,7 @@ rust_library(
     visibility = [":protobuf_internal"],
     deps = [
         ":utf8",
-        "//rust/cpp_kernel:cpp_api",
+        "//cpp_kernel:cpp_api",
     ],
 )
 
@@ -177,8 +178,8 @@ rust_library(
     testonly = True,
     srcs = ["gtest_matchers.rs"],
     aliases = select({
-        ":use_upb_kernel": {"//rust:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers_impl"},
-        "//conditions:default": {"//rust:protobuf_gtest_matchers_cpp": "protobuf_gtest_matchers_impl"},
+        ":use_upb_kernel": {"//:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers_impl"},
+        "//conditions:default": {"//:protobuf_gtest_matchers_cpp": "protobuf_gtest_matchers_impl"},
     }),
     visibility = ["//visibility:public"],
     deps = select({
@@ -192,7 +193,7 @@ rust_library(
     testonly = True,
     srcs = ["gtest_matchers_impl.rs"],
     aliases = {
-        "//rust:protobuf_cpp": "protobuf",
+        "//:protobuf_cpp": "protobuf",
     },
     visibility = [":protobuf_internal"],
     deps = [
@@ -206,7 +207,7 @@ rust_library(
     testonly = True,
     srcs = ["gtest_matchers_impl.rs"],
     aliases = {
-        "//rust:protobuf_upb": "protobuf",
+        "//:protobuf_upb": "protobuf",
     },
     visibility = [":protobuf_internal"],
     deps = [
@@ -224,7 +225,7 @@ proto_lang_toolchain(
     name = "proto_rust_upb_toolchain",
     command_line = "--rust_out=$(OUT)",
     output_files = "multiple",
-    plugin = "//src/google/protobuf/compiler/rust:protoc-gen-rust",
+    plugin = "@com_google_protobuf//src/google/protobuf/compiler/rust:protoc-gen-rust",
     plugin_format_flag = "--plugin=protoc-gen-rust=%s",
     progress_message = "Generating Rust proto_library %{label}",
     runtime = ":protobuf_upb",
@@ -235,7 +236,7 @@ proto_lang_toolchain(
     name = "proto_rust_cpp_toolchain",
     command_line = "--rust_out=$(OUT)",
     output_files = "multiple",
-    plugin = "//src/google/protobuf/compiler/rust:protoc-gen-rust",
+    plugin = "@com_google_protobuf//src/google/protobuf/compiler/rust:protoc-gen-rust",
     plugin_format_flag = "--plugin=protoc-gen-rust=%s",
     progress_message = "Generating Rust proto_library %{label}",
     runtime = ":protobuf_cpp",
@@ -244,7 +245,7 @@ proto_lang_toolchain(
 
 package_group(
     name = "rust_proto_library_allowed_in_different_package",
-    packages = ["//rust/test"],  # for unittest proto_libraries
+    packages = ["//test"],  # for unittest proto_libraries
 )
 
 # This flag controls what kernel all Rust Protobufs are using in the current build.
@@ -262,28 +263,28 @@ config_setting(
     flag_values = {
         ":rust_proto_library_kernel": "upb",
     },
-    visibility = ["//:__subpackages__"],
+    visibility = ["@com_google_protobuf//:__subpackages__"],
 )
 
 pkg_files(
     name = "rust_protobuf_src",
     srcs = ALL_RUST_SRCS,
-    strip_prefix = strip_prefix.from_root("rust"),
+    strip_prefix = strip_prefix.from_root(""),
 )
 
 pkg_filegroup(
     name = "rust_protobuf_src_dir",
     srcs = [
         ":rust_protobuf_src",
-        "//rust/upb:src",
+        "//upb:src",
     ],
     prefix = "src",
-    visibility = ["//rust/release_crates:__subpackages__"],
+    visibility = ["//release_crates:__subpackages__"],
 )
 
 pkg_files(
     name = "amalgamated_upb",
-    srcs = ["//upb:gen_amalgamation"],
+    srcs = ["@com_google_protobuf//upb:gen_amalgamation"],
     strip_prefix = strip_prefix.from_root(""),
 )
 
@@ -291,13 +292,13 @@ pkg_filegroup(
     name = "rust_protobuf_libupb_src",
     srcs = [
         ":amalgamated_upb",
-        "//upb/cmake:upb_cmake_dist",
+        "@com_google_protobuf//upb/cmake:upb_cmake_dist",
     ],
     prefix = "libupb",
-    visibility = ["//rust/release_crates:__subpackages__"],
+    visibility = ["//release_crates:__subpackages__"],
 )
 
 alias(
     name = "release",
-    actual = "//rust/release_crates:workspace",
+    actual = "//release_crates:workspace",
 )

--- a/rust/MODULE.bazel
+++ b/rust/MODULE.bazel
@@ -1,0 +1,51 @@
+module(
+    name = "protobuf-rust",
+    version = "34.0-dev",
+)
+
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf")
+local_path_override(
+    module_name = "protobuf",
+    path = "../",
+)
+
+
+bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_pkg", version = "1.0.1")
+bazel_dep(name = "rules_rust", version = "0.63.0")
+bazel_dep(name = "rules_shell", version = "0.2.0")
+bazel_dep(name = "abseil-cpp", version = "20250512.1")
+
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust", dev_dependency = True)
+
+# As of October 2025, our minimum supported Rust version is 1.79. However, we
+# use 1.85.0 here so that we can get some test coverage with edition 2024.
+# Cargo and our Bazel WORKSPACE build are both still on edition 2021.
+rust.toolchain(
+    edition = "2024",
+    versions = ["1.85.0"],
+)
+
+crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate", dev_dependency = True)
+crate.spec(
+    package = "googletest",
+    version = ">0.0.0",
+)
+crate.spec(
+    package = "paste",
+    version = ">=1",
+)
+crate.spec(
+    package = "quote",
+    version = ">=1",
+)
+crate.spec(
+    package = "syn",
+    version = ">=2",
+)
+crate.from_specs()
+use_repo(crate, crate_index = "crates")
+
+
+bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True)

--- a/rust/bazel/aspects.bzl
+++ b/rust/bazel/aspects.bzl
@@ -9,11 +9,11 @@ load("@rules_rust//rust/private:providers.bzl", "CrateInfo", "DepInfo", "DepVari
 
 # buildifier: disable=bzl-visibility
 load("@rules_rust//rust/private:rustc.bzl", "rustc_compile_action")
-load("//bazel/common:proto_common.bzl", "proto_common")
-load("//bazel/common:proto_info.bzl", "ProtoInfo")
-load("//bazel/private:cc_proto_aspect.bzl", "cc_proto_aspect")
+load("@com_google_protobuf//bazel/common:proto_common.bzl", "proto_common")
+load("@com_google_protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
+load("@com_google_protobuf//bazel/private:cc_proto_aspect.bzl", "cc_proto_aspect")
 
-visibility(["//rust/...", "//third_party/crubit/rs_bindings_from_cc/..."])
+visibility(["//...", "//third_party/crubit/rs_bindings_from_cc/..."])
 
 CrateMappingInfo = provider(
     doc = "Struct mapping crate name to the .proto import paths",
@@ -38,9 +38,9 @@ def label_to_crate_name(ctx, label, toolchain):
 
 def proto_rust_toolchain_label(is_upb):
     if is_upb:
-        return "//rust:proto_rust_upb_toolchain"
+        return "//:proto_rust_upb_toolchain"
     else:
-        return "//rust:proto_rust_cpp_toolchain"
+        return "//:proto_rust_cpp_toolchain"
 
 def _register_crate_mapping_write_action(name, actions, crate_mappings):
     """Registers an action that generates a crate mapping for a proto_library.
@@ -420,9 +420,9 @@ def _make_proto_library_aspect(is_upb):
             ),
             "_cpp_thunks_deps": attr.label_list(
                 default = [
-                    Label("//rust/cpp_kernel:cpp_api"),
-                    Label("//src/google/protobuf"),
-                    Label("//src/google/protobuf:protobuf_lite"),
+                    Label("//cpp_kernel:cpp_api"),
+                    Label("@com_google_protobuf//src/google/protobuf"),
+                    Label("@com_google_protobuf//src/google/protobuf:protobuf_lite"),
                 ],
             ),
             "_error_format": attr.label(

--- a/rust/cpp_kernel/BUILD
+++ b/rust/cpp_kernel/BUILD
@@ -21,14 +21,14 @@ cc_library(
         "strings.h",
     ],
     visibility = [
-        "//rust:__subpackages__",
-        "//src/google/protobuf:__subpackages__",
+        "//:__subpackages__",
+        "@com_google_protobuf//src/google/protobuf:__subpackages__",
     ],
     deps = [
         ":rust_alloc_for_cpp_api",  # buildcleaner: keep
-        "//src/google/protobuf",
-        "//src/google/protobuf:protobuf_lite",
-        "//src/google/protobuf/io",
+        "@com_google_protobuf//src/google/protobuf",
+        "@com_google_protobuf//src/google/protobuf:protobuf_lite",
+        "@com_google_protobuf//src/google/protobuf/io",
         "@abseil-cpp//absl/functional:overload",
         "@abseil-cpp//absl/log:absl_check",
         "@abseil-cpp//absl/log:absl_log",
@@ -41,6 +41,6 @@ rust_library(
     name = "rust_alloc_for_cpp_api",
     srcs = ["rust_alloc_for_cpp_api.rs"],
     visibility = [
-        "//rust:__subpackages__",
+        "//:__subpackages__",
     ],
 )

--- a/rust/cpp_kernel/compare.cc
+++ b/rust/cpp_kernel/compare.cc
@@ -1,4 +1,4 @@
-#include "rust/cpp_kernel/compare.h"
+#include "cpp_kernel/compare.h"
 
 #include <string>
 

--- a/rust/cpp_kernel/debug.cc
+++ b/rust/cpp_kernel/debug.cc
@@ -1,9 +1,9 @@
-#include "rust/cpp_kernel/debug.h"
+#include "cpp_kernel/debug.h"
 
 #include <string>
 
 #include "google/protobuf/message_lite.h"
-#include "rust/cpp_kernel/strings.h"
+#include "cpp_kernel/strings.h"
 
 extern "C" {
 

--- a/rust/cpp_kernel/debug.h
+++ b/rust/cpp_kernel/debug.h
@@ -2,7 +2,7 @@
 #define GOOGLE_PROTOBUF_RUST_CPP_KERNEL_DEBUG_H__
 
 #include "google/protobuf/message_lite.h"
-#include "rust/cpp_kernel/strings.h"
+#include "cpp_kernel/strings.h"
 
 extern "C" {
 

--- a/rust/cpp_kernel/map.cc
+++ b/rust/cpp_kernel/map.cc
@@ -13,7 +13,7 @@
 #include "absl/strings/string_view.h"
 #include "google/protobuf/message.h"
 #include "google/protobuf/message_lite.h"
-#include "rust/cpp_kernel/strings.h"
+#include "cpp_kernel/strings.h"
 
 namespace google {
 namespace protobuf {

--- a/rust/cpp_kernel/message.cc
+++ b/rust/cpp_kernel/message.cc
@@ -1,8 +1,8 @@
 #include <limits>
 
 #include "google/protobuf/message_lite.h"
-#include "rust/cpp_kernel/serialized_data.h"
-#include "rust/cpp_kernel/strings.h"
+#include "cpp_kernel/serialized_data.h"
+#include "cpp_kernel/strings.h"
 
 extern "C" {
 

--- a/rust/cpp_kernel/repeated.cc
+++ b/rust/cpp_kernel/repeated.cc
@@ -8,7 +8,7 @@
 #include "google/protobuf/message_lite.h"
 #include "google/protobuf/repeated_field.h"
 #include "google/protobuf/repeated_ptr_field.h"
-#include "rust/cpp_kernel/strings.h"
+#include "cpp_kernel/strings.h"
 
 extern "C" {
 #define expose_repeated_field_methods(ty, rust_ty)                             \

--- a/rust/cpp_kernel/serialized_data.h
+++ b/rust/cpp_kernel/serialized_data.h
@@ -16,7 +16,7 @@
 #include "absl/log/absl_check.h"
 #include "absl/log/absl_log.h"
 #include "google/protobuf/message_lite.h"
-#include "rust/cpp_kernel/rust_alloc_for_cpp_api.h"
+#include "cpp_kernel/rust_alloc_for_cpp_api.h"
 
 namespace google {
 namespace protobuf {

--- a/rust/cpp_kernel/strings.cc
+++ b/rust/cpp_kernel/strings.cc
@@ -1,10 +1,10 @@
-#include "rust/cpp_kernel/strings.h"
+#include "cpp_kernel/strings.h"
 
 #include <cstring>
 #include <string>
 
 #include "absl/strings/string_view.h"
-#include "rust/cpp_kernel/rust_alloc_for_cpp_api.h"
+#include "cpp_kernel/rust_alloc_for_cpp_api.h"
 
 namespace google {
 namespace protobuf {

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -3,10 +3,10 @@
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_rust//rust:defs.bzl", "rust_common")
 load("@rules_rust//rust:rust_common.bzl", "CrateInfo", "DepInfo")
-load("//bazel/common:proto_common.bzl", "proto_common")
-load("//bazel/common:proto_info.bzl", "ProtoInfo")
+load("@com_google_protobuf//bazel/common:proto_common.bzl", "proto_common")
+load("@com_google_protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
 load(
-    "//rust/bazel:aspects.bzl",
+    "//bazel:aspects.bzl",
     "RustProtoInfo",
     "label_to_crate_name",
     "proto_rust_toolchain_label",
@@ -44,7 +44,7 @@ def rust_proto_library(name, deps, **args):
     native.alias(
         name = name + "_rust_proto",
         actual = select({
-            "//rust:use_upb_kernel": name + "_upb_rust_proto",
+            "//:use_upb_kernel": name + "_upb_rust_proto",
             "//conditions:default": name + "_cpp_rust_proto",
         }),
         **alias_args
@@ -53,14 +53,14 @@ def rust_proto_library(name, deps, **args):
     rust_upb_proto_library(
         name = name + "_upb_rust_proto",
         deps = deps,
-        visibility = ["//rust/test:__subpackages__"],
+        visibility = ["//test:__subpackages__"],
         **args
     )
 
     rust_cc_proto_library(
         name = name + "_cpp_rust_proto",
         deps = deps,
-        visibility = ["//rust/test:__subpackages__"],
+        visibility = ["//test:__subpackages__"],
         **args
     )
 

--- a/rust/protobuf_macros/BUILD
+++ b/rust/protobuf_macros/BUILD
@@ -14,7 +14,7 @@ rust_proc_macro(
     srcs = PROC_MACRO_SRCS,
     visibility = [
         "//devtools/rust/rust_analyzer/proc_macros:__pkg__",
-        "//rust:__subpackages__",
+        "//:__subpackages__",
     ],
     deps = [
         "@crate_index//:quote",
@@ -25,7 +25,7 @@ rust_proc_macro(
 pkg_files(
     name = "rust_protobuf_macros_src",
     srcs = PROC_MACRO_SRCS,
-    strip_prefix = strip_prefix.from_root("rust/protobuf_macros"),
+    strip_prefix = strip_prefix.from_root("protobuf_macros"),
 )
 
 pkg_filegroup(
@@ -34,5 +34,5 @@ pkg_filegroup(
         ":rust_protobuf_macros_src",
     ],
     prefix = "src",
-    visibility = ["//rust/release_crates:__subpackages__"],
+    visibility = ["//release_crates:__subpackages__"],
 )

--- a/rust/release_crates/BUILD
+++ b/rust/release_crates/BUILD
@@ -6,22 +6,22 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 pkg_files(
     name = "license",
-    srcs = ["//:LICENSE"],
-    visibility = ["//rust/release_crates:__subpackages__"],
+    srcs = ["@com_google_protobuf//:LICENSE"],
+    visibility = ["//release_crates:__subpackages__"],
 )
 
 pkg_tar(
     name = "workspace",
     srcs = [
         ":Cargo.toml",
-        "//rust/release_crates/protobuf:protobuf_crate",
-        "//rust/release_crates/protobuf_codegen:protobuf_codegen_crate",
-        "//rust/release_crates/protobuf_example:protobuf_example_crate",
-        "//rust/release_crates/protobuf_macros:protobuf_macros_crate",
-        "//rust/release_crates/protobuf_tests:protobuf_tests_crate",
-        "//rust/release_crates/protobuf_well_known_types:protobuf_well_known_types_crate",
+        "//release_crates/protobuf:protobuf_crate",
+        "//release_crates/protobuf_codegen:protobuf_codegen_crate",
+        "//release_crates/protobuf_example:protobuf_example_crate",
+        "//release_crates/protobuf_macros:protobuf_macros_crate",
+        "//release_crates/protobuf_tests:protobuf_tests_crate",
+        "//release_crates/protobuf_well_known_types:protobuf_well_known_types_crate",
     ],
-    visibility = ["//rust:__pkg__"],
+    visibility = ["//:__pkg__"],
 )
 
 # Run the cargo test with only a bundled linux-x86_64 protoc.
@@ -30,7 +30,7 @@ sh_binary(
     srcs = ["cargo_test.sh"],
     data = [
         ":workspace",
-        "//:protoc",
+        "@com_google_protobuf//:protoc",
     ],
     tags = ["manual"],
     deps = ["@bazel_tools//tools/bash/runfiles"],

--- a/rust/release_crates/protobuf/BUILD
+++ b/rust/release_crates/protobuf/BUILD
@@ -1,22 +1,22 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
-load("//rust/release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
+load("//release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
 
 pkg_filegroup(
     name = "protobuf_crate",
     srcs = [
         ":crate_root_files",
-        "//rust:rust_protobuf_libupb_src",
-        "//rust:rust_protobuf_src_dir",
-        "//rust/release_crates:license",
+        "//:rust_protobuf_libupb_src",
+        "//:rust_protobuf_src_dir",
+        "//release_crates:license",
     ],
     prefix = "protobuf",
-    visibility = ["//rust:__subpackages__"],
+    visibility = ["//:__subpackages__"],
 )
 
 pkg_files(
     name = "crate_root_files",
     srcs = [":srcs"],
-    strip_prefix = strip_prefix.from_root("rust/release_crates/protobuf"),
+    strip_prefix = strip_prefix.from_root("release_crates/protobuf"),
 )
 
 substitute_rust_release_version(

--- a/rust/release_crates/protobuf_codegen/BUILD
+++ b/rust/release_crates/protobuf_codegen/BUILD
@@ -1,21 +1,21 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
-load("//rust/release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
+load("//release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
 
 pkg_filegroup(
     name = "protobuf_codegen_crate",
     srcs = [
         ":protobuf_codegen_files",
-        "//rust/release_crates:license",
+        "//release_crates:license",
     ],
     prefix = "protobuf_codegen",
     tags = ["manual"],
-    visibility = ["//rust:__subpackages__"],
+    visibility = ["//:__subpackages__"],
 )
 
 pkg_files(
     name = "protobuf_codegen_files",
     srcs = [":srcs"],
-    strip_prefix = strip_prefix.from_root("rust/release_crates/protobuf_codegen"),
+    strip_prefix = strip_prefix.from_root("release_crates/protobuf_codegen"),
 )
 
 substitute_rust_release_version(

--- a/rust/release_crates/protobuf_example/BUILD
+++ b/rust/release_crates/protobuf_example/BUILD
@@ -1,20 +1,20 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
-load("//rust/release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
+load("//release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
 
 pkg_filegroup(
     name = "protobuf_example_crate",
     srcs = [
         ":protobuf_example_files",
-        "//rust/release_crates:license",
+        "//release_crates:license",
     ],
     prefix = "protobuf_example",
-    visibility = ["//rust:__subpackages__"],
+    visibility = ["//:__subpackages__"],
 )
 
 pkg_files(
     name = "protobuf_example_files",
     srcs = [":srcs"],
-    strip_prefix = strip_prefix.from_root("rust/release_crates/protobuf_example"),
+    strip_prefix = strip_prefix.from_root("release_crates/protobuf_example"),
 )
 
 substitute_rust_release_version(

--- a/rust/release_crates/protobuf_macros/BUILD
+++ b/rust/release_crates/protobuf_macros/BUILD
@@ -1,21 +1,21 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
-load("//rust/release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
+load("//release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
 
 pkg_filegroup(
     name = "protobuf_macros_crate",
     srcs = [
         ":crate_root_files",
-        "//rust/protobuf_macros:rust_protobuf_macros_src_dir",
-        "//rust/release_crates:license",
+        "//protobuf_macros:rust_protobuf_macros_src_dir",
+        "//release_crates:license",
     ],
     prefix = "protobuf_macros",
-    visibility = ["//rust:__subpackages__"],
+    visibility = ["//:__subpackages__"],
 )
 
 pkg_files(
     name = "crate_root_files",
     srcs = [":srcs"],
-    strip_prefix = strip_prefix.from_root("rust/release_crates/protobuf_macros"),
+    strip_prefix = strip_prefix.from_root("release_crates/protobuf_macros"),
 )
 
 substitute_rust_release_version(

--- a/rust/release_crates/protobuf_tests/BUILD
+++ b/rust/release_crates/protobuf_tests/BUILD
@@ -1,23 +1,23 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
-load("//rust/release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
+load("//release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
 
 pkg_filegroup(
     name = "protobuf_tests_crate",
     srcs = [
         ":crate_root_files",
-        "//rust/release_crates:license",
-        "//rust/test:google_protobuf_proto_srcs",
-        "//rust/test:test_proto_srcs",
-        "//rust/test/shared:test_srcs",
+        "//release_crates:license",
+        "//test:google_protobuf_proto_srcs",
+        "//test:test_proto_srcs",
+        "//test/shared:test_srcs",
     ],
     prefix = "protobuf_tests",
-    visibility = ["//rust:__subpackages__"],
+    visibility = ["//:__subpackages__"],
 )
 
 pkg_files(
     name = "crate_root_files",
     srcs = [":srcs"],
-    strip_prefix = strip_prefix.from_root("rust/release_crates/protobuf_tests"),
+    strip_prefix = strip_prefix.from_root("release_crates/protobuf_tests"),
 )
 
 substitute_rust_release_version(
@@ -32,5 +32,5 @@ filegroup(
         "build.rs",
         "tests/protos/mod.rs",
     ],
-    visibility = ["//rust:__subpackages__"],
+    visibility = ["//:__subpackages__"],
 )

--- a/rust/release_crates/protobuf_well_known_types/BUILD.bazel
+++ b/rust/release_crates/protobuf_well_known_types/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
-load("//rust/release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
+load("//release_crates:substitute_rust_release_version.bzl", "substitute_rust_release_version")
 
 pkg_filegroup(
     name = "protobuf_well_known_types_crate",
@@ -7,16 +7,16 @@ pkg_filegroup(
         ":crate_root_files",
         ":well_known_types",
         ":well_known_types_gencode",
-        "//rust/release_crates:license",
+        "//release_crates:license",
     ],
     prefix = "protobuf_well_known_types",
-    visibility = ["//rust:__subpackages__"],
+    visibility = ["//:__subpackages__"],
 )
 
 pkg_files(
     name = "crate_root_files",
     srcs = [":srcs"],
-    strip_prefix = strip_prefix.from_root("rust/release_crates/protobuf_well_known_types"),
+    strip_prefix = strip_prefix.from_root("release_crates/protobuf_well_known_types"),
 )
 
 substitute_rust_release_version(
@@ -27,19 +27,19 @@ substitute_rust_release_version(
 filegroup(
     name = "srcs",
     srcs = ["Cargo.toml"] + glob(["**/*"]),
-    visibility = ["//rust:__subpackages__"],
+    visibility = ["//:__subpackages__"],
 )
 
 pkg_files(
     name = "well_known_types",
-    srcs = ["//src/google/protobuf:well_known_type_protos"],
+    srcs = ["@com_google_protobuf//src/google/protobuf:well_known_type_protos"],
     prefix = "proto/google/protobuf",
 )
 
 genrule(
     name = "gen_well_known_types",
     srcs = [
-        "//src/google/protobuf:well_known_type_protos",
+        "@com_google_protobuf//src/google/protobuf:well_known_type_protos",
     ],
     outs = [
         "google/protobuf/any.u.pb.rs",
@@ -54,8 +54,8 @@ genrule(
         "google/protobuf/type.u.pb.rs",
         "google/protobuf/wrappers.u.pb.rs",
     ],
-    cmd = "echo $(SRCS) | sed 's?src/??g' | xargs $(location //:protoc) -I src --rust_out=$(@D) --rust_opt=experimental-codegen=enabled,kernel=upb",
-    tools = ["//:protoc"],
+    cmd = "echo $(SRCS) | sed 's?external/protobuf+/src/??g' | xargs $(location @com_google_protobuf//:protoc) -I external/protobuf+/src --rust_out=$(@D) --rust_opt=experimental-codegen=enabled,kernel=upb",
+    tools = ["@com_google_protobuf//:protoc"],
 )
 
 pkg_files(

--- a/rust/release_crates/substitute_rust_release_version.bzl
+++ b/rust/release_crates/substitute_rust_release_version.bzl
@@ -1,6 +1,6 @@
 """A rule to textually replace {{VERSION}} with the Rust release version in files."""
 
-load("//:protobuf_version.bzl", "PROTOBUF_RUST_VERSION")
+load("@com_google_protobuf//:protobuf_version.bzl", "PROTOBUF_RUST_VERSION")
 
 # Temporarily append a -release suffix to non-RC versions until we consider the
 # release stable. Since "release" lexicographically comes after "rc", Cargo

--- a/rust/test/BUILD
+++ b/rust/test/BUILD
@@ -5,15 +5,15 @@
 # https://developers.google.com/open-source/licenses/bsd
 
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
-load("//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load(
-    "//rust:defs.bzl",
+    "//:defs.bzl",
     "rust_cc_proto_library",
     "rust_upb_proto_library",
 )
 
 package(
-    default_visibility = ["//rust:__subpackages__"],
+    default_visibility = ["//:__subpackages__"],
 )
 
 pkg_files(
@@ -26,8 +26,8 @@ pkg_files(
 pkg_files(
     name = "google_protobuf_proto_srcs",
     srcs = [
-        "//src/google/protobuf:cpp_features_proto_srcs",
-        "//src/google/protobuf:descriptor_proto_srcs",
+        "@com_google_protobuf//src/google/protobuf:cpp_features_proto_srcs",
+        "@com_google_protobuf//src/google/protobuf:descriptor_proto_srcs",
     ],
     prefix = "proto",
     strip_prefix = strip_prefix.from_root("src"),
@@ -92,7 +92,7 @@ proto_library(
     name = "edition2023_proto",
     testonly = True,
     srcs = ["edition2023.proto"],
-    deps = ["//src/google/protobuf:cpp_features_proto"],
+    deps = ["@com_google_protobuf//src/google/protobuf:cpp_features_proto"],
 )
 
 rust_cc_proto_library(
@@ -466,5 +466,5 @@ rust_upb_proto_library(
 rust_upb_proto_library(
     name = "descriptor_upb_rust_proto",
     testonly = True,
-    deps = ["//src/google/protobuf:descriptor_proto"],
+    deps = ["@com_google_protobuf//src/google/protobuf:descriptor_proto"],
 )

--- a/rust/test/child.proto
+++ b/rust/test/child.proto
@@ -9,6 +9,6 @@ syntax = "proto2";
 
 package child_package;
 
-import public "rust/test/parent.proto";
+import public "test/parent.proto";
 
 message Child {}

--- a/rust/test/cpp/BUILD
+++ b/rust/test/cpp/BUILD
@@ -12,9 +12,9 @@
 #   `//rust:protobuf`.
 
 load("@rules_rust//rust:defs.bzl", "rust_test")
-load("//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load(
-    "//rust:defs.bzl",
+    "//:defs.bzl",
     "rust_cc_proto_library",
 )
 
@@ -49,7 +49,7 @@ rust_test(
     deps = [
         ":debug_cpp_rust_proto",
         ":optimize_for_lite_cpp_rust_proto",
-        "//rust:protobuf_cpp_export",
+        "//:protobuf_cpp_export",
         "@crate_index//:googletest",
     ],
 )

--- a/rust/test/cpp/interop/BUILD
+++ b/rust/test/cpp/interop/BUILD
@@ -2,10 +2,10 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rust//rust:defs.bzl", "rust_test")
-load("//bazel:cc_proto_library.bzl", "cc_proto_library")
-load("//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load(
-    "//rust:defs.bzl",
+    "//:defs.bzl",
     "rust_cc_proto_library",
 )
 
@@ -14,7 +14,7 @@ cc_library(
     srcs = ["test_utils.cc"],
     deps = [
         ":interop_test_cc_proto",
-        "//rust/cpp_kernel:cpp_api",
+        "//cpp_kernel:cpp_api",
         "@abseil-cpp//absl/log:absl_check",
         "@abseil-cpp//absl/strings",
     ],
@@ -26,7 +26,7 @@ rust_test(
     deps = [
         ":interop_test_cpp_rust_proto",
         ":test_utils",
-        "//rust:protobuf_cpp",
+        "//:protobuf_cpp",
         "@crate_index//:googletest",
     ],
 )

--- a/rust/test/cpp/interop/test_utils.cc
+++ b/rust/test/cpp/interop/test_utils.cc
@@ -10,9 +10,9 @@
 
 #include "absl/log/absl_check.h"
 #include "absl/strings/string_view.h"
-#include "rust/cpp_kernel/serialized_data.h"
-#include "rust/cpp_kernel/strings.h"
-#include "rust/test/cpp/interop/interop_test.pb.h"
+#include "cpp_kernel/serialized_data.h"
+#include "cpp_kernel/strings.h"
+#include "test/cpp/interop/interop_test.pb.h"
 
 using google::protobuf::rust::SerializedData;
 using google::protobuf::rust::SerializeMsg;

--- a/rust/test/fields_with_imported_types.proto
+++ b/rust/test/fields_with_imported_types.proto
@@ -9,7 +9,7 @@ syntax = "proto2";
 
 package main;
 
-import "rust/test/imported_types.proto";
+import "test/imported_types.proto";
 
 message MsgWithFieldsWithImportedTypes {
   optional imported_types.ImportedMessage imported_message_field = 1;

--- a/rust/test/import_public.proto
+++ b/rust/test/import_public.proto
@@ -9,4 +9,4 @@ syntax = "proto2";
 
 package import_public;
 
-import public "rust/test/import_public_primary_src.proto";
+import public "test/import_public_primary_src.proto";

--- a/rust/test/import_public2.proto
+++ b/rust/test/import_public2.proto
@@ -9,5 +9,5 @@ syntax = "proto2";
 
 package import_public;
 
-import public "rust/test/import_public_non_primary_src1.proto";
-import public "rust/test/import_public_non_primary_src2.proto";
+import public "test/import_public_non_primary_src1.proto";
+import public "test/import_public_non_primary_src2.proto";

--- a/rust/test/import_public_primary_src.proto
+++ b/rust/test/import_public_primary_src.proto
@@ -9,7 +9,7 @@ syntax = "proto2";
 
 package primary_src_testing_packages;
 
-import public "rust/test/import_public_grandparent.proto";
+import public "test/import_public_grandparent.proto";
 
 message PrimarySrcPubliclyImportedMsg {}
 

--- a/rust/test/map_unittest.proto
+++ b/rust/test/map_unittest.proto
@@ -9,7 +9,7 @@ syntax = "proto3";
 
 package rust_unittest;
 
-import "rust/test/unittest.proto";
+import "test/unittest.proto";
 
 option cc_enable_arenas = true;
 

--- a/rust/test/no_package.proto
+++ b/rust/test/no_package.proto
@@ -7,7 +7,7 @@
 
 syntax = "proto2";
 
-import public "rust/test/no_package_import.proto";
+import public "test/no_package_import.proto";
 
 message MsgWithoutPackage {}
 

--- a/rust/test/package.proto
+++ b/rust/test/package.proto
@@ -9,7 +9,7 @@ syntax = "proto2";
 
 package testing_packages;
 
-import public "rust/test/package_import.proto";
+import public "test/package_import.proto";
 
 message MsgWithPackage {}
 

--- a/rust/test/package_disabiguation2.proto
+++ b/rust/test/package_disabiguation2.proto
@@ -9,7 +9,7 @@ syntax = "proto2";
 
 package package2;
 
-import "rust/test/package_disabiguation1.proto";
+import "test/package_disabiguation1.proto";
 
 message YayConflict {
   optional .package1.YayConflict other_message = 1;

--- a/rust/test/rust_proto_library_unit_test/defs.bzl
+++ b/rust/test/rust_proto_library_unit_test/defs.bzl
@@ -1,7 +1,7 @@
 """Support for rust_proto_library_aspect unit-tests."""
 
 load(
-    "//rust/bazel:aspects.bzl",
+    "//bazel:aspects.bzl",
     "RustProtoInfo",
     "rust_cc_proto_library_aspect",
     "rust_upb_proto_library_aspect",

--- a/rust/test/rust_proto_library_unit_test/rust_proto_library_unit_test.bzl
+++ b/rust/test/rust_proto_library_unit_test/rust_proto_library_unit_test.bzl
@@ -1,9 +1,9 @@
 """This module contains unit tests for rust_proto_library and its aspect."""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("//bazel:proto_library.bzl", "proto_library")
-load("//rust:defs.bzl", "rust_cc_proto_library", "rust_upb_proto_library")
-load("//rust/bazel:aspects.bzl", "RustProtoInfo")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("//:defs.bzl", "rust_cc_proto_library", "rust_upb_proto_library")
+load("//bazel:aspects.bzl", "RustProtoInfo")
 load(":defs.bzl", "ActionsInfo", "attach_cc_aspect", "attach_upb_aspect")
 
 def _find_actions_with_mnemonic(actions, mnemonic):
@@ -30,14 +30,14 @@ def _check_crate_mapping(actions, target_name):
         ))
     expected_content = """grand_parent_proto
 2
-rust/test/rust_proto_library_unit_test/grandparent1.proto
-rust/test/rust_proto_library_unit_test/grandparent2.proto
+test/rust_proto_library_unit_test/grandparent1.proto
+test/rust_proto_library_unit_test/grandparent2.proto
 parent_proto
 1
-rust/test/rust_proto_library_unit_test/parent.proto
+test/rust_proto_library_unit_test/parent.proto
 parent2_proto
 1
-rust/test/rust_proto_library_unit_test/parent2.proto
+test/rust_proto_library_unit_test/parent2.proto
 """
     if crate_mapping_action.content != expected_content:
         fail("The crate mapping file content didn't match. Was: {}".format(

--- a/rust/test/shared/BUILD
+++ b/rust/test/shared/BUILD
@@ -32,19 +32,19 @@ pkg_files(
         ],
     ),
     prefix = "tests",
-    visibility = ["//rust:__subpackages__"],
+    visibility = ["//:__subpackages__"],
 )
 
 rust_test(
     name = "ctype_cord_upb_test",
     srcs = ["ctype_cord_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -53,12 +53,12 @@ rust_test(
     name = "ctype_cord_cpp_test",
     srcs = ["ctype_cord_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:unittest_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -67,13 +67,13 @@ rust_test(
     name = "child_parent_upb_test",
     srcs = ["child_parent_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:child_upb_rust_proto",
-        "//rust/test:parent_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:child_upb_rust_proto",
+        "//test:parent_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -82,13 +82,13 @@ rust_test(
     name = "child_parent_cpp_test",
     srcs = ["child_parent_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:child_cpp_rust_proto",
-        "//rust/test:parent_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:child_cpp_rust_proto",
+        "//test:parent_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -98,7 +98,7 @@ rust_test(
     srcs = ["edition2023_test.rs"],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust/test:edition2023_cpp_rust_proto",
+        "//test:edition2023_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -108,7 +108,7 @@ rust_test(
     srcs = ["edition2023_test.rs"],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust/test:edition2023_upb_rust_proto",
+        "//test:edition2023_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -117,13 +117,13 @@ rust_test(
     name = "enum_cpp_test",
     srcs = ["enum_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:enums_cpp_rust_proto",
-        "//rust/test:unittest_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:enums_cpp_rust_proto",
+        "//test:unittest_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -132,13 +132,13 @@ rust_test(
     name = "enum_upb_test",
     srcs = ["enum_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:enums_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:enums_upb_rust_proto",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -148,7 +148,7 @@ rust_test(
     srcs = ["import_public_test.rs"],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust/test:import_public_cpp_rust_proto",
+        "//test:import_public_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -158,7 +158,7 @@ rust_test(
     srcs = ["import_public_test.rs"],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust/test:import_public_upb_rust_proto",
+        "//test:import_public_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -168,9 +168,9 @@ rust_test(
     srcs = ["package_test.rs"],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust/test:dots_in_package_cpp_rust_proto",
-        "//rust/test:no_package_cpp_rust_proto",
-        "//rust/test:package_cpp_rust_proto",
+        "//test:dots_in_package_cpp_rust_proto",
+        "//test:no_package_cpp_rust_proto",
+        "//test:package_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -180,9 +180,9 @@ rust_test(
     srcs = ["package_test.rs"],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust/test:dots_in_package_upb_rust_proto",
-        "//rust/test:no_package_upb_rust_proto",
-        "//rust/test:package_upb_rust_proto",
+        "//test:dots_in_package_upb_rust_proto",
+        "//test:no_package_upb_rust_proto",
+        "//test:package_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -190,26 +190,26 @@ rust_test(
 rust_test(
     name = "package_disambiguation_cpp_test",
     srcs = ["package_disambiguation_test.rs"],
-    deps = ["//rust/test:package_disabiguation_cpp_rust_proto"],
+    deps = ["//test:package_disabiguation_cpp_rust_proto"],
 )
 
 rust_test(
     name = "package_disambiguation_upb_test",
     srcs = ["package_disambiguation_test.rs"],
-    deps = ["//rust/test:package_disabiguation_upb_rust_proto"],
+    deps = ["//test:package_disabiguation_upb_rust_proto"],
 )
 
 rust_test(
     name = "bad_names_cpp_test",
     srcs = ["bad_names_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:bad_names_cpp_rust_proto",
-        "//rust/test:unittest_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:bad_names_cpp_rust_proto",
+        "//test:unittest_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -218,13 +218,13 @@ rust_test(
     name = "bad_names_upb_test",
     srcs = ["bad_names_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:bad_names_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:bad_names_upb_rust_proto",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -234,7 +234,7 @@ rust_test(
     srcs = ["nested_types_test.rs"],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust/test:unittest_cpp_rust_proto",
+        "//test:unittest_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -244,7 +244,7 @@ rust_test(
     srcs = ["nested_types_test.rs"],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust/test:unittest_upb_rust_proto",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -253,16 +253,16 @@ rust_test(
     name = "accessors_cpp_test",
     srcs = ["accessors_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_cpp_rust_proto",
-        "//rust/test:unittest_import_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:unittest_cpp_rust_proto",
+        "//test:unittest_import_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -271,16 +271,16 @@ rust_test(
     name = "accessors_upb_test",
     srcs = ["accessors_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_import_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:unittest_import_upb_rust_proto",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -289,13 +289,13 @@ rust_test(
     name = "accessors_proto3_cpp_test",
     srcs = ["accessors_proto3_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_proto3_cpp_rust_proto",
-        "//rust/test:unittest_proto3_optional_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:unittest_proto3_cpp_rust_proto",
+        "//test:unittest_proto3_optional_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -304,13 +304,13 @@ rust_test(
     name = "accessors_proto3_upb_test",
     srcs = ["accessors_proto3_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_proto3_optional_upb_rust_proto",
-        "//rust/test:unittest_proto3_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:unittest_proto3_optional_upb_rust_proto",
+        "//test:unittest_proto3_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -319,17 +319,17 @@ rust_test(
     name = "serialization_upb_test",
     srcs = ["serialization_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_proto3_optional_upb_rust_proto",
-        "//rust/test:unittest_proto3_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:unittest_proto3_optional_upb_rust_proto",
+        "//test:unittest_proto3_upb_rust_proto",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -338,17 +338,17 @@ rust_test(
     name = "serialization_cpp_test",
     srcs = ["serialization_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_cpp_rust_proto",
-        "//rust/test:unittest_proto3_cpp_rust_proto",
-        "//rust/test:unittest_proto3_optional_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:unittest_cpp_rust_proto",
+        "//test:unittest_proto3_cpp_rust_proto",
+        "//test:unittest_proto3_optional_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -357,13 +357,13 @@ rust_test(
     name = "simple_nested_cpp_test",
     srcs = ["simple_nested_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:map_unittest_cpp_rust_proto",
-        "//rust/test:nested_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:map_unittest_cpp_rust_proto",
+        "//test:nested_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -372,13 +372,13 @@ rust_test(
     name = "simple_nested_upb_test",
     srcs = ["simple_nested_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:map_unittest_upb_rust_proto",
-        "//rust/test:nested_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:map_unittest_upb_rust_proto",
+        "//test:nested_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -387,15 +387,15 @@ rust_test(
     name = "accessors_repeated_cpp_test",
     srcs = ["accessors_repeated_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:unittest_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -404,15 +404,15 @@ rust_test(
     name = "accessors_repeated_upb_test",
     srcs = ["accessors_repeated_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -421,17 +421,17 @@ rust_test(
     name = "accessors_map_cpp_test",
     srcs = ["accessors_map_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:enums_cpp_rust_proto",
-        "//rust/test:map_unittest_cpp_rust_proto",
-        "//rust/test:unittest_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:enums_cpp_rust_proto",
+        "//test:map_unittest_cpp_rust_proto",
+        "//test:unittest_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -440,17 +440,17 @@ rust_test(
     name = "accessors_map_upb_test",
     srcs = ["accessors_map_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:enums_upb_rust_proto",
-        "//rust/test:map_unittest_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:enums_upb_rust_proto",
+        "//test:map_unittest_upb_rust_proto",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -460,9 +460,9 @@ rust_test(
     srcs = ["fields_with_imported_types_test.rs"],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:fields_with_imported_types_cpp_rust_proto",
-        "//rust/test:imported_types_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:fields_with_imported_types_cpp_rust_proto",
+        "//test:imported_types_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -472,9 +472,9 @@ rust_test(
     srcs = ["fields_with_imported_types_test.rs"],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:fields_with_imported_types_upb_rust_proto",
-        "//rust/test:imported_types_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:fields_with_imported_types_upb_rust_proto",
+        "//test:imported_types_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -483,12 +483,12 @@ rust_test(
     name = "message_copy_merge_cpp_test",
     srcs = ["message_copy_merge_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp": "protobuf",
+        "//:protobuf_cpp": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp",
-        "//rust/test:unittest_cpp_rust_proto",
+        "//:protobuf_cpp",
+        "//test:unittest_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -497,12 +497,12 @@ rust_test(
     name = "message_copy_merge_upb_test",
     srcs = ["message_copy_merge_test.rs"],
     aliases = {
-        "//rust:protobuf_upb": "protobuf",
+        "//:protobuf_upb": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -511,13 +511,13 @@ rust_test(
     name = "proto_macro_cpp_test",
     srcs = ["proto_macro_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp": "protobuf",
+        "//:protobuf_cpp": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp",
-        "//rust/test:map_unittest_cpp_rust_proto",
-        "//rust/test:unittest_cpp_rust_proto",
+        "//:protobuf_cpp",
+        "//test:map_unittest_cpp_rust_proto",
+        "//test:unittest_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -526,15 +526,15 @@ rust_test(
     name = "proto_macro_upb_test",
     srcs = ["proto_macro_test.rs"],
     aliases = {
-        "//rust:protobuf_upb": "protobuf",
-        "//rust:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers",
+        "//:protobuf_upb": "protobuf",
+        "//:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_gtest_matchers_upb",
-        "//rust:protobuf_upb",
-        "//rust/test:map_unittest_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_gtest_matchers_upb",
+        "//:protobuf_upb",
+        "//test:map_unittest_upb_rust_proto",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -543,19 +543,19 @@ rust_test(
     name = "gtest_matchers_cpp_test",
     srcs = ["gtest_matchers_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp": "protobuf",
-        "//rust:protobuf_gtest_matchers_cpp": "protobuf_gtest_matchers",
+        "//:protobuf_cpp": "protobuf",
+        "//:protobuf_gtest_matchers_cpp": "protobuf_gtest_matchers",
     },
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp",
-        "//rust:protobuf_gtest_matchers_cpp",
-        "//rust/test:unittest_cpp_rust_proto",
-        "//rust/test:unittest_proto3_cpp_rust_proto",
-        "//rust/test:unittest_proto3_optional_cpp_rust_proto",
+        "//:protobuf_cpp",
+        "//:protobuf_gtest_matchers_cpp",
+        "//test:unittest_cpp_rust_proto",
+        "//test:unittest_proto3_cpp_rust_proto",
+        "//test:unittest_proto3_optional_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -564,19 +564,19 @@ rust_test(
     name = "gtest_matchers_upb_test",
     srcs = ["gtest_matchers_test.rs"],
     aliases = {
-        "//rust:protobuf_upb": "protobuf",
-        "//rust:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers",
+        "//:protobuf_upb": "protobuf",
+        "//:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers",
     },
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_gtest_matchers_upb",
-        "//rust:protobuf_upb",
-        "//rust/test:unittest_proto3_optional_upb_rust_proto",
-        "//rust/test:unittest_proto3_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_gtest_matchers_upb",
+        "//:protobuf_upb",
+        "//test:unittest_proto3_optional_upb_rust_proto",
+        "//test:unittest_proto3_upb_rust_proto",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -585,11 +585,11 @@ rust_test(
     name = "no_internal_access_test_cpp",
     srcs = ["no_internal_access_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
+        "//:protobuf_cpp_export",
         "@crate_index//:googletest",
     ],
 )
@@ -598,11 +598,11 @@ rust_test(
     name = "no_internal_access_test_upb",
     srcs = ["no_internal_access_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
+        "//:protobuf_upb_export",
         "@crate_index//:googletest",
     ],
 )
@@ -611,12 +611,12 @@ rust_test(
     name = "threading_test_cpp",
     srcs = ["threading_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_cpp_export",
-        "//rust/test:unittest_cpp_rust_proto",
+        "//:protobuf_cpp_export",
+        "//test:unittest_cpp_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -625,12 +625,12 @@ rust_test(
     name = "threading_test_upb",
     srcs = ["threading_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     rustc_flags = ["--cfg=bzl"],
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )

--- a/rust/test/shared/utf8/BUILD
+++ b/rust/test/shared/utf8/BUILD
@@ -1,8 +1,8 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_rust//rust:defs.bzl", "rust_test")
-load("//bazel:cc_proto_library.bzl", "cc_proto_library")
-load("//bazel:proto_library.bzl", "proto_library")
-load("//rust:defs.bzl", "rust_cc_proto_library", "rust_upb_proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("//:defs.bzl", "rust_cc_proto_library", "rust_upb_proto_library")
 
 licenses(["notice"])
 
@@ -10,13 +10,13 @@ rust_test(
     name = "utf8_cpp_test",
     srcs = ["utf8_test.rs"],
     aliases = {
-        "//rust:protobuf_cpp_export": "protobuf",
+        "//:protobuf_cpp_export": "protobuf",
     },
     deps = [
         ":feature_verify_cpp_rust_proto",
         ":no_features_proto2_cpp_rust_proto",
         ":no_features_proto3_cpp_rust_proto",
-        "//rust:protobuf_cpp_export",
+        "//:protobuf_cpp_export",
         "@crate_index//:googletest",
     ],
 )
@@ -25,13 +25,13 @@ rust_test(
     name = "utf8_upb_test",
     srcs = ["utf8_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     deps = [
         ":feature_verify_upb_rust_proto",
         ":no_features_proto2_upb_rust_proto",
         ":no_features_proto3_upb_rust_proto",
-        "//rust:protobuf_upb_export",
+        "//:protobuf_upb_export",
         "@crate_index//:googletest",
     ],
 )

--- a/rust/test/shared/utf8/utf8_test.cc
+++ b/rust/test/shared/utf8/utf8_test.cc
@@ -3,9 +3,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/strings/string_view.h"
-#include "rust/test/shared/utf8/feature_verify.pb.h"
-#include "rust/test/shared/utf8/no_features_proto2.pb.h"
-#include "rust/test/shared/utf8/no_features_proto3.pb.h"
+#include "test/shared/utf8/feature_verify.pb.h"
+#include "test/shared/utf8/no_features_proto2.pb.h"
+#include "test/shared/utf8/no_features_proto3.pb.h"
 
 namespace {
 

--- a/rust/test/srcsless_library_test_parent.proto
+++ b/rust/test/srcsless_library_test_parent.proto
@@ -5,7 +5,7 @@ package srcsless_library_test;
 // The purpose of this proto is for a test where a proto_library target that has
 // no srcs (an "alias library") can be used in the middle between this parent
 // target and this imported file.
-import "rust/test/srcsless_library_test_child.proto";
+import "test/srcsless_library_test_child.proto";
 
 option java_multiple_files = true;
 

--- a/rust/test/unittest.proto
+++ b/rust/test/unittest.proto
@@ -17,7 +17,7 @@ edition = "2023";
 
 package rust_unittest;
 
-import "rust/test/unittest_import.proto";
+import "test/unittest_import.proto";
 
 option features = { enum_type : CLOSED, repeated_field_encoding : EXPANDED, utf8_validation : NONE };
 option cc_enable_arenas = true;

--- a/rust/test/unittest_proto3.proto
+++ b/rust/test/unittest_proto3.proto
@@ -9,7 +9,7 @@ syntax = "proto3";
 
 package rust_proto3_unittest;
 
-import "rust/test/unittest_import.proto";
+import "test/unittest_import.proto";
 
 option optimize_for = SPEED;
 

--- a/rust/test/upb/BUILD
+++ b/rust/test/upb/BUILD
@@ -19,7 +19,7 @@
 
 load("@rules_rust//rust:defs.bzl", "rust_test")
 
-package(default_applicable_licenses = ["//:license"])
+package(default_applicable_licenses = ["@com_google_protobuf//:license"])
 
 licenses(["notice"])
 
@@ -28,11 +28,11 @@ rust_test(
     name = "string_ctypes_test_upb_test",
     srcs = ["string_ctypes_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_proto3_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:unittest_proto3_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -43,9 +43,9 @@ rust_test(
     name = "debug_string_test",
     srcs = ["debug_string_test.rs"],
     deps = [
-        "//rust:protobuf_upb",
-        "//rust/test:map_unittest_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb",
+        "//test:map_unittest_upb_rust_proto",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -54,11 +54,11 @@ rust_test(
     name = "thread_local_arena_test",
     srcs = ["thread_local_arena_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -67,11 +67,11 @@ rust_test(
     name = "entity_type_test",
     srcs = ["entity_type_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )
@@ -80,12 +80,12 @@ rust_test(
     name = "generated_descriptors_test",
     srcs = ["generated_descriptors_test.rs"],
     aliases = {
-        "//rust:protobuf_upb_export": "protobuf",
+        "//:protobuf_upb_export": "protobuf",
     },
     deps = [
-        "//rust:protobuf_upb_export",
-        "//rust/test:descriptor_upb_rust_proto",
-        "//rust/test:unittest_upb_rust_proto",
+        "//:protobuf_upb_export",
+        "//test:descriptor_upb_rust_proto",
+        "//test:unittest_upb_rust_proto",
         "@crate_index//:googletest",
     ],
 )

--- a/rust/test/upb/generated_descriptors_test.rs
+++ b/rust/test/upb/generated_descriptors_test.rs
@@ -12,28 +12,28 @@ use protobuf::prelude::*;
 #[gtest]
 fn test_generated_descriptors() {
     let descriptor = FileDescriptorProto::parse(
-            unittest_rust_proto::__unstable::RUST_TEST_UNITTEST_DESCRIPTOR_INFO
+            unittest_rust_proto::__unstable::TEST_UNITTEST_DESCRIPTOR_INFO
             .descriptor,
     )
     .unwrap();
-    expect_that!(descriptor.name().to_str().unwrap(), ends_with("rust/test/unittest.proto"));
+    expect_that!(descriptor.name().to_str().unwrap(), ends_with("test/unittest.proto"));
     assert_that!(descriptor.dependency().len(), eq(1));
     expect_that!(
         descriptor.dependency().get(0).unwrap().to_str().unwrap(),
-        ends_with("rust/test/unittest_import.proto")
+        ends_with("test/unittest_import.proto")
     );
 
     assert_that!(
-            unittest_rust_proto::__unstable::RUST_TEST_UNITTEST_DESCRIPTOR_INFO
+            unittest_rust_proto::__unstable::TEST_UNITTEST_DESCRIPTOR_INFO
             .deps
             .len(),
         eq(1)
     );
     let dep = FileDescriptorProto::parse(
-            unittest_rust_proto::__unstable::RUST_TEST_UNITTEST_DESCRIPTOR_INFO
+            unittest_rust_proto::__unstable::TEST_UNITTEST_DESCRIPTOR_INFO
             .deps[0]
             .descriptor,
     )
     .unwrap();
-    expect_that!(dep.name().to_str().unwrap(), ends_with("rust/test/unittest_import.proto"));
+    expect_that!(dep.name().to_str().unwrap(), ends_with("test/unittest_import.proto"));
 }

--- a/rust/upb/BUILD
+++ b/rust/upb/BUILD
@@ -7,7 +7,7 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
-package(default_applicable_licenses = ["//:license"])
+package(default_applicable_licenses = ["@com_google_protobuf//:license"])
 
 rust_library(
     name = "upb",
@@ -25,11 +25,11 @@ rust_library(
     ],
     rustc_flags = ["--cfg=bzl"],
     visibility = [
-        "//rust:__subpackages__",
-        "//src/google/protobuf:__subpackages__",
+        "//:__subpackages__",
+        "@com_google_protobuf//src/google/protobuf:__subpackages__",
     ],
     deps = [
-        "//rust/upb/sys",
+        "//upb/sys",
     ],
 )
 
@@ -45,12 +45,12 @@ rust_test(
 pkg_files(
     name = "src",
     srcs = glob(["*"]) + [
-        "//rust/upb/sys:srcs",
+        "//upb/sys:srcs",
     ],
     prefix = "upb",
-    strip_prefix = strip_prefix.from_root("rust/upb"),
+    strip_prefix = strip_prefix.from_root("upb"),
     visibility = [
-        "//rust:__subpackages__",
-        "//src/google/protobuf:__subpackages__",
+        "//:__subpackages__",
+        "@com_google_protobuf//src/google/protobuf:__subpackages__",
     ],
 )

--- a/rust/upb/sys/BUILD
+++ b/rust/upb/sys/BUILD
@@ -8,7 +8,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
-package(default_applicable_licenses = ["//:license"])
+package(default_applicable_licenses = ["@com_google_protobuf//:license"])
 
 rust_library(
     name = "sys",
@@ -35,7 +35,7 @@ rust_library(
         "wire/wire.rs",
     ],
     rustc_flags = ["--cfg=bzl"],
-    visibility = ["//rust/upb:__subpackages__"],
+    visibility = ["//upb:__subpackages__"],
     deps = [":upb_c_api"],
 )
 
@@ -51,21 +51,21 @@ cc_library(
     name = "upb_c_api",
     srcs = ["upb_api.c"],
     deps = [
-        "//upb/mem",
-        "//upb/message",
-        "//upb/message:compare",
-        "//upb/message:copy",
-        "//upb/mini_descriptor",
-        "//upb/mini_table",
-        "//upb/text:debug",
+        "@com_google_protobuf//upb/mem",
+        "@com_google_protobuf//upb/message",
+        "@com_google_protobuf//upb/message:compare",
+        "@com_google_protobuf//upb/message:copy",
+        "@com_google_protobuf//upb/mini_descriptor",
+        "@com_google_protobuf//upb/mini_table",
+        "@com_google_protobuf//upb/text:debug",
     ],
 )
 
 pkg_files(
     name = "srcs",
     srcs = glob(["**/*"]),
-    strip_prefix = strip_prefix.from_root("rust/upb"),
+    strip_prefix = strip_prefix.from_root("upb"),
     visibility = [
-        "//rust/upb:__subpackages__",
+        "//upb:__subpackages__",
     ],
 )

--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -314,11 +314,7 @@ proto_library(
     name = "descriptor_proto",
     srcs = ["descriptor.proto"],
     strip_import_prefix = "/src",
-    visibility = [
-        "//:__pkg__",
-        "//pkg:__pkg__",
-        "//rust/test:__pkg__",
-    ],
+    visibility = ["//visibility:public"],
 )
 
 upb_c_proto_library(
@@ -343,7 +339,7 @@ proto_library(
     name = "cpp_features_proto",
     srcs = ["cpp_features.proto"],
     strip_import_prefix = "/src",
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [":descriptor_proto"],
 )
 
@@ -697,9 +693,7 @@ cc_library(
     }),
     linkopts = LINK_OPTS,
     strip_include_prefix = "/src",
-    visibility = [
-        "//:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     # In Bazel 6.0+, these will be `interface_deps`:
     deps = [
         ":arena",
@@ -802,9 +796,7 @@ cc_library(
     copts = COPTS,
     linkopts = LINK_OPTS,
     strip_include_prefix = "/src",
-    visibility = [
-        "//:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         ":internal_visibility",
         ":micro_string",
@@ -987,19 +979,19 @@ filegroup(
         "type.proto",
         "wrappers.proto",
     ],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "descriptor_proto_srcs",
     srcs = ["descriptor.proto"],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "cpp_features_proto_srcs",
     srcs = ["cpp_features.proto"],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/src/google/protobuf/compiler/rust/BUILD.bazel
+++ b/src/google/protobuf/compiler/rust/BUILD.bazel
@@ -21,7 +21,7 @@ load(
 cc_binary(
     name = "protoc-gen-rust",
     srcs = ["main.cc"],
-    visibility = ["//rust:__pkg__"],
+    visibility = ["//visibility:public"],
     deps = [
         ":rust",
         "//src/google/protobuf/compiler:plugin",

--- a/src/google/protobuf/compiler/rust/generator.cc
+++ b/src/google/protobuf/compiler/rust/generator.cc
@@ -273,8 +273,8 @@ bool RustGenerator::Generate(const FileDescriptor* file,
 #include "google/protobuf/map.h"
 #include "google/protobuf/repeated_field.h"
 #include "google/protobuf/repeated_ptr_field.h"
-#include "rust/cpp_kernel/serialized_data.h"
-#include "rust/cpp_kernel/strings.h"
+#include "cpp_kernel/serialized_data.h"
+#include "cpp_kernel/strings.h"
         )cc");
   }
 

--- a/upb/BUILD
+++ b/upb/BUILD
@@ -159,7 +159,7 @@ upb_amalgamation(
         "//upb/wire:writer",
     ],
     strip_import_prefix = ["src"],
-    visibility = ["//rust:__pkg__"],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/upb/cmake/BUILD.bazel
+++ b/upb/cmake/BUILD.bazel
@@ -54,5 +54,5 @@ pkg_files(
         "//upb/wire:source_files",
     ],
     strip_prefix = strip_prefix.from_root(""),
-    visibility = ["//rust:__pkg__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
`bazel test //...` passes under the `rust` directory