### PR TITLE
refactor(bazel): publish a separate .tar.gz

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "**leave this alone**",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{VERSION}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{VERSION}.bazel.tar.gz"
 }

--- a/.github/workflows/release_bazel_module.yaml
+++ b/.github/workflows/release_bazel_module.yaml
@@ -18,7 +18,7 @@ jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.3
     with:
-      release_files: protobuf-*.tar.gz
+      release_files: protobuf-*.bazel.tar.gz
       prerelease: false
       tag_name: ${{ inputs.tag_name }}
       # The release was already created by Google-internal mechanism,

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -7,7 +7,7 @@ set -o errexit -o nounset -o pipefail
 # https://github.com/bazel-contrib/.github/blob/v7.2.3/.github/workflows/release_ruleset.yaml#L104
 TAG=$1
 PREFIX="protobuf-${TAG:1}"
-ARCHIVE="$PREFIX.tar.gz"
+ARCHIVE="$PREFIX.bazel.tar.gz"
 ARCHIVE_TMP=$(mktemp)
 INTEGRITY_FILE=${PREFIX}/bazel/private/prebuilt_tool_integrity.bzl
 


### PR DESCRIPTION
Avoids mutating the protobuf tar.gz file that's created prior to the Bazel Central Registry publishing step.