### PR TITLE
fix(php): Fix double to bool casting (use Z_DVAL_P: -0.0 -> false)

### DIFF
--- a/php/ext/google/protobuf/convert.c
+++ b/php/ext/google/protobuf/convert.c
@@ -291,7 +291,7 @@ static bool to_bool(zval* from, bool* to) {
       *to = (Z_LVAL_P(from) != 0);
       return true;
     case IS_DOUBLE:
-      *to = (Z_LVAL_P(from) != 0);
+      *to = (Z_DVAL_P(from) != 0.0);
       return true;
     case IS_STRING:
       if (Z_STRLEN_P(from) == 0 ||

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -497,6 +497,47 @@ class GeneratedClassTest extends TestBase
         $this->assertSame(false, $m->getOptionalBool());
     }
 
+    public function testBoolFromDoubleArrayConstructor()
+    {
+        $m = new TestMessage(['optional_bool' => -0.0]);
+        $this->assertFalse($m->getOptionalBool());
+
+        $m = new TestMessage(['optional_bool' => 0.0]);
+        $this->assertFalse($m->getOptionalBool());
+
+        $m = new TestMessage(['optional_bool' => 1.5]);
+        $this->assertTrue($m->getOptionalBool());
+
+        $m = new TestMessage(['optional_bool' => NAN]);
+        $this->assertTrue($m->getOptionalBool());
+
+        $m = new TestMessage(['optional_bool' => INF]);
+        $this->assertTrue($m->getOptionalBool());
+
+        $m = new TestMessage(['optional_bool' => -INF]);
+        $this->assertTrue($m->getOptionalBool());
+    }
+
+    public function testRepeatedBoolFromDouble()
+    {
+        $m  = new TestMessage();
+        $rf = $m->getRepeatedBool();
+
+        $rf[] = -0.0;
+        $rf[] = 0.0;
+        $rf[] = 1.5;
+        $rf[] = NAN;
+        $rf[] = INF;
+        $rf[] = -INF;
+
+        $this->assertFalse($rf[0]);
+        $this->assertFalse($rf[1]);
+        $this->assertTrue($rf[2]);
+        $this->assertTrue($rf[3]);
+        $this->assertTrue($rf[4]);
+        $this->assertTrue($rf[5]);
+    }
+
     #########################################################
     # Test string field.
     #########################################################


### PR DESCRIPTION
Updates the `IS_DOUBLE` branch to use `Z_DVAL_P(from)` instead of `Z_LVAL_P(from)`. The old code was reading from the integer slot, which isn’t defined for doubles and could return garbage.

The new logic follows PHP's own casting rules: 0.0 and -0.0 are `false`, everything else (1.5, INF, -INF, NAN) is `true`.

Added a PHPT test that fails with the old code but passes with this change.

No API changes, just correctness and consistency with PHP itself.