### PR TITLE
fix(php): Correct uint32 type mapping to use UInt32 instead of Int32

### DIFF
--- a/php/ext/google/protobuf/convert.c
+++ b/php/ext/google/protobuf/convert.c
@@ -148,7 +148,7 @@ upb_CType pbphp_dtype_to_type(upb_FieldType type) {
     CASE(Enum, Enum);
     CASE(Int32, Int32);
     CASE(Int64, Int64);
-    CASE(UInt32, Int32);
+    CASE(UInt32, UInt32);
     CASE(UInt64, UInt64);
     CASE(SInt32, Int32);
     CASE(SInt64, Int64);

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -269,6 +269,43 @@ class GeneratedClassTest extends TestBase
         $this->assertSame(MIN_INT32, $m->getOptionalUint32());
     }
 
+    public function testUint32ArrayConstructor()
+    {
+        $m1 = new TestMessage(['optional_uint32' => 2147483648]);
+        $this->assertSame(MIN_INT32, $m1->getOptionalUint32());
+
+        $m2 = new TestMessage(['optional_uint32' => MAX_UINT32]);
+        $this->assertSame(-1, $m2->getOptionalUint32());
+    }
+
+    public function testRepeatedUint32Boundaries()
+    {
+        $m = new TestMessage();
+        $rf = $m->getRepeatedUint32();
+
+        $rf[] = 0;
+        $rf[] = MAX_INT32;
+        $rf[] = 2147483648;
+        $rf[] = MAX_UINT32;
+
+        $this->assertSame(0, $rf[0]);
+        $this->assertSame(MAX_INT32, $rf[1]);
+        $this->assertSame(MIN_INT32, $rf[2]);
+        $this->assertSame(-1, $rf[3]);
+    }
+
+    public function testMapUint32Uint32Boundaries()
+    {
+        $m = new TestMessage();
+        $map = $m->getMapUint32Uint32();
+
+        $map[1] = 0;
+        $map[MAX_UINT32] = MAX_UINT32;
+
+        $this->assertSame(0, $map[1]);
+        $this->assertSame(-1, $map[MAX_UINT32]);
+    }
+
     #########################################################
     # Test int64 field.
     #########################################################


### PR DESCRIPTION
This fixes the PHP extension's mapping for `uint32`, which was incorrectly using `Int32`. I've also added a couple of small tests to cover edge cases in `RepeatedField` and `MapField`