### PR TITLE
Improve exception message in get_field() for unknown properties

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -94,7 +94,8 @@ static const upb_FieldDef* get_field(Message* msg, zend_string* member) {
       m, ZSTR_VAL(member), ZSTR_LEN(member));
 
   if (!f) {
-    zend_throw_exception_ex(NULL, 0, "No such property %s.",
+    zend_throw_exception_ex(NULL, 0, "No such property %s on %s.",
+                            ZSTR_VAL(member),
                             ZSTR_VAL(msg->desc->class_entry->name));
   }
 

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -41,6 +41,14 @@ class GeneratedClassTest extends TestBase
         $this->assertSame(1, $m->getOptionalInt32());
     }
 
+    public function testUnknownPropertyErrorIncludesPropertyAndClass()
+    {
+        $m = new TestMessage();
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No such property does_not_exist on Foo\\TestMessage');
+        $m->does_not_exist;
+    }
+
     #########################################################
     # Test int32 field.
     #########################################################


### PR DESCRIPTION
Improves the exception message when a property doesn't exist. Previously, it only mentioned the class name, without actually explaining what property does not exist. I've added a simple test to cover this