### PR TITLE
Fix #24083

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -932,7 +932,7 @@ public class JsonFormat {
     /** Prints google.protobuf.FieldMask */
     private void printFieldMask(MessageOrBuilder message) throws IOException {
       FieldMask value = FieldMask.parseFrom(toByteString(message));
-      generator.print("\"" + FieldMaskUtil.toJsonString(value) + "\"");
+      generator.print(gson.toJson(FieldMaskUtil.toJsonString(value)));
     }
 
     /** Prints google.protobuf.Struct */

--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -948,6 +948,17 @@ public class JsonFormatTest {
   }
 
   @Test
+  public void testFieldMaskEscapesQuotes() throws Exception {
+    TestFieldMask message =
+        TestFieldMask.newBuilder()
+            .setFieldMaskValue(FieldMaskUtil.fromString("foo\"bar,baz\\,foo_bar.baz"))
+            .build();
+
+    assertThat(toJsonString(message))
+        .isEqualTo("{\n  \"fieldMaskValue\": \"foo\\\"bar,baz\\\\,fooBar.baz\"\n}");
+  }
+
+  @Test
   public void testStruct() throws Exception {
     // Build a struct with all possible values.
     TestStruct.Builder builder = TestStruct.newBuilder();


### PR DESCRIPTION
Wrapping the toJsonString result in gson.toJson() as we do with regular strings