### PR TITLE
Expose NestedInFileClass naming helpers for Java immutable.

### DIFF
--- a/src/google/protobuf/compiler/java/full/message.cc
+++ b/src/google/protobuf/compiler/java/full/message.cc
@@ -37,6 +37,7 @@
 #include "google/protobuf/compiler/java/full/message_builder.h"
 #include "google/protobuf/compiler/java/message_serialization.h"
 #include "google/protobuf/compiler/java/name_resolver.h"
+#include "google/protobuf/compiler/java/names.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/descriptor.pb.h"
 #include "google/protobuf/io/coded_stream.h"
@@ -104,7 +105,7 @@ void ImmutableMessageGenerator::GenerateStaticVariables(
   if (descriptor_->containing_type() != nullptr) {
     vars["parent"] = UniqueFileScopeIdentifier(descriptor_->containing_type());
   }
-  if (NestedInFileClass(*descriptor_, /* immutable = */ true)) {
+  if (NestedInFileClass(*descriptor_)) {
     vars["private"] = "private ";
   } else {
     // We can only make these package-private since the classes that use them
@@ -179,7 +180,7 @@ void ImmutableMessageGenerator::GenerateFieldAccessorTable(
     io::Printer* printer, int* bytecode_estimate) {
   absl::flat_hash_map<absl::string_view, std::string> vars;
   vars["identifier"] = UniqueFileScopeIdentifier(descriptor_);
-  if (NestedInFileClass(*descriptor_, /* immutable = */ true)) {
+  if (NestedInFileClass(*descriptor_)) {
     vars["private"] = "private ";
   } else {
     // We can only make these package-private since the classes that use them

--- a/src/google/protobuf/compiler/java/helpers.cc
+++ b/src/google/protobuf/compiler/java/helpers.cc
@@ -927,29 +927,12 @@ const FieldDescriptor* MapValueField(const FieldDescriptor* descriptor) {
 
 namespace {
 
-// Gets the value of `nest_in_file_class` feature and returns whether the
-// generated class should be nested in the generated proto file Java class.
-template <typename Descriptor>
-inline bool NestInFileClass(const Descriptor& descriptor) {
-  auto nest_in_file_class =
-      JavaGenerator::GetResolvedSourceFeatureExtension(descriptor, pb::java)
-          .nest_in_file_class();
-  ABSL_CHECK(
-      nest_in_file_class !=
-      pb::JavaFeatures::NestInFileClassFeature::NEST_IN_FILE_CLASS_UNKNOWN);
-
-  if (nest_in_file_class == pb::JavaFeatures::NestInFileClassFeature::LEGACY) {
-    return !descriptor.file()->options().java_multiple_files();
-  }
-  return nest_in_file_class == pb::JavaFeatures::NestInFileClassFeature::YES;
-}
-
 // Returns whether the type should be nested in the file class for the given
 // descriptor, depending on different Protobuf Java API versions.
 template <typename Descriptor>
 bool NestInFileClass(const Descriptor& descriptor, bool immutable) {
   (void)immutable;
-  return NestInFileClass(descriptor);
+  return NestedInFileClass(descriptor);
 }
 
 template <typename Descriptor>

--- a/src/google/protobuf/compiler/java/names.h
+++ b/src/google/protobuf/compiler/java/names.h
@@ -187,6 +187,27 @@ PROTOC_EXPORT std::string KotlinExtensionsClassName(
     const Descriptor* descriptor);
 
 
+// Requires:
+//   descriptor != NULL
+// Returns:
+//   True if the generated message class should be nested in the generated proto
+//   file Java class.
+PROTOC_EXPORT bool NestedInFileClass(const Descriptor& message);
+
+// Requires:
+//   descriptor != NULL
+// Returns:
+//   True if the generated enum class should be nested in the generated proto
+//   file Java class.
+PROTOC_EXPORT bool NestedInFileClass(const EnumDescriptor& enm);
+
+// Requires:
+//   descriptor != NULL
+// Returns:
+//   True if the generated service class should be nested in the generated proto
+//   file Java class.
+PROTOC_EXPORT bool NestedInFileClass(const ServiceDescriptor& service);
+
 }  // namespace java
 }  // namespace compiler
 }  // namespace protobuf


### PR DESCRIPTION
This matches our GeneratorNames APIs, and it's become clear that this information is necessary for certain classes of code-generators to be able to predict where our generated code will end up.

PiperOrigin-RevId: 829216363

Cherry-pick of 0c48552