### PR TITLE
Make CI cover compilation with Abseil of Debian "trixie" (current stable) — related to #24399

### DIFF
--- a/.github/workflows/abseil_debian_trixie.Dockerfile
+++ b/.github/workflows/abseil_debian_trixie.Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:trixie
+
+RUN apt-get update \
+        && \
+    apt-get install --no-install-recommends -y -V \
+            build-essential \
+            ca-certificates \
+            cmake \
+            git \
+            libabsl-dev \
+            make
+
+ADD . ./
+
+RUN cmake . \
+        && \
+    { make -j$(nproc) || make VERBOSE=1 ; }

--- a/.github/workflows/abseil_debian_trixie.yml
+++ b/.github/workflows/abseil_debian_trixie.yml
@@ -1,0 +1,30 @@
+name: Cover compilation with Abseil of Debian "trixie"
+
+on:
+  push:
+  # to all branches
+
+  schedule:
+    # Run Tuesdays at 19:00 UTC (i.e. 04:00 pacific time, i.e. UTC-8)
+    - cron: 0 19 * * 2
+
+  # manual
+  workflow_dispatch:
+
+# Drop permissions to minimum for security
+permissions:
+  contents: read
+
+jobs:
+  abseil-debian-trixie:
+    name: Cover compilation with Abseil of Debian "trixie"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Protobuf"
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          persist-credentials: false
+
+      - name: "Compile with Abseil of Debian \"trixie\" using Docker"
+        run: |-
+          docker build -f .github/workflows/abseil_debian_trixie.Dockerfile .


### PR DESCRIPTION
.. so that breaking support for it cannot go unnoticed in the future. Currently [trixie is at Abseil version 20240722.0-4](https://packages.debian.org/trixie/libabsl-dev).

Follow-up to pull request #24507, related to #24399

CC @mkruskal-google

