### PR TITLE
chore(php): fix chr() deprecation in CodedOutputStream.php

### DIFF
--- a/php/src/Google/Protobuf/Internal/CodedOutputStream.php
+++ b/php/src/Google/Protobuf/Internal/CodedOutputStream.php
@@ -98,7 +98,7 @@ class CodedOutputStream
         }
 
         while (($low >= 0x80 || $low < 0) || $high != 0) {
-            $buffer[$current] = chr($low | 0x80);
+            $buffer[$current] = chr(($low | 0x80) & 0xFF);
             $value = ($value >> 7) & ~(0x7F << ((PHP_INT_SIZE << 3) - 7));
             $carry = ($high & 0x7F) << ((PHP_INT_SIZE << 3) - 7);
             $high = ($high >> 7) & ~(0x7F << ((PHP_INT_SIZE << 3) - 7));


### PR DESCRIPTION
Fix a line in `CodedOutputStream` to get rid of [a new deprecation in PHP 8.5](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.standard):
```
PHP Deprecated:  chr(): Providing a value not in-between 0 and 255 is deprecated, this is because a byte value must be in the [0, 255] interval. The value used will be constrained using % 256
```