### PR TITLE
chore(php): prevent PHP 8.5 null array key deprecation

### DIFF
--- a/php/src/Google/Protobuf/Internal/Descriptor.php
+++ b/php/src/Google/Protobuf/Internal/Descriptor.php
@@ -54,7 +54,7 @@ class Descriptor
     public function addField($field)
     {
         $this->field[$field->getNumber()] = $field;
-        $this->json_to_field[$field->getJsonName()] = $field;
+        $this->json_to_field[$field->getJsonName() ?? ''] = $field;
         $this->name_to_field[$field->getName()] = $field;
         $this->index_to_field[] = $field;
     }

--- a/php/src/Google/Protobuf/Internal/DescriptorPool.php
+++ b/php/src/Google/Protobuf/Internal/DescriptorPool.php
@@ -75,8 +75,8 @@ class DescriptorPool
         $this->unique_descs[$descriptor->getFullName()] =
             $descriptor;
         $this->class_to_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getLegacyClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass()] = $descriptor;
+        $this->class_to_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
+        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass() ?? ''] = $descriptor;
         foreach ($descriptor->getNestedType() as $nested_type) {
             $this->addDescriptor($nested_type);
         }
@@ -90,7 +90,7 @@ class DescriptorPool
         $this->proto_to_class[$descriptor->getFullName()] =
             $descriptor->getClass();
         $this->class_to_enum_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_enum_desc[$descriptor->getLegacyClass()] = $descriptor;
+        $this->class_to_enum_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
     }
 
     public function getDescriptorByClassName($klass)


### PR DESCRIPTION
[Using null as an array offset](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.using-null-as-an-array-offset) is now deprecated PHP 8.5. The changes in this PR will fix the following:

```
PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in php/src/Google/Protobuf/Internal/Descriptor.php on line 57
PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in php/src/Google/Protobuf/Internal/DescriptorPool.php on line 78
PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in php/src/Google/Protobuf/Internal/DescriptorPool.php on line 79
PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in php/src/Google/Protobuf/Internal/DescriptorPool.php on line 93
```