### PR TITLE
refactor(protobuf): remove redundant typecast in Timestamps.normalizedTimestamp

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/Timestamps.java
+++ b/java/util/src/main/java/com/google/protobuf/util/Timestamps.java
@@ -478,12 +478,10 @@ public final class Timestamps {
     }
     if (nanos <= -NANOS_PER_SECOND || nanos >= NANOS_PER_SECOND) {
       seconds = addExact(seconds, nanos / NANOS_PER_SECOND);
-      nanos = (int) (nanos % NANOS_PER_SECOND);
+      nanos = nanos % NANOS_PER_SECOND;
     }
     if (nanos < 0) {
-      nanos =
-          (int)
-              (nanos + NANOS_PER_SECOND); // no overflow since nanos is negative (and we're adding)
+      nanos = nanos + NANOS_PER_SECOND; // no overflow since nanos is negative (and we're adding)
       seconds = subtractExact(seconds, 1);
     }
     Timestamp timestamp = Timestamp.newBuilder().setSeconds(seconds).setNanos(nanos).build();


### PR DESCRIPTION
Removed unnecessary typecast in the normalizedTimestamp method.

Modified: java/util/src/main/java/com/google/protobuf/util/Timestamps.java