### PR TITLE
Use generic Marshal.SizeOf when possible (#21964)

### DIFF
--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -711,7 +711,13 @@ namespace Google.Protobuf.Collections
             // 1. protobuf wire bytes is LittleEndian only
             // 2. validate that size of csharp element T is matching the size of protobuf wire size
             //    NOTE: cannot use bool with this span because csharp marshal it as 4 bytes
-            if (BitConverter.IsLittleEndian && (codec.FixedSize > 0 && Marshal.SizeOf(typeof(T)) == codec.FixedSize))
+            if (BitConverter.IsLittleEndian && (codec.FixedSize > 0 &&
+#if GOOGLE_PROTOBUF_SUPPORT_GENERIC_SIZEOF
+            Marshal.SizeOf<T>()
+#else
+            Marshal.SizeOf(typeof(T))
+#endif
+             == codec.FixedSize))
             {
                 handle = GCHandle.Alloc(array, GCHandleType.Pinned);
                 span = new Span<byte>(handle.AddrOfPinnedObject().ToPointer(), array.Length * codec.FixedSize);

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -25,15 +25,15 @@
     <IsTrimmable>true</IsTrimmable>
     <!-- Disable warnings about AOT and trimming features on older targets, e.g. netstandard2.0.
          For now, continue to apply these features to these targets because some packages don't have a target that supports them -->
-    <NoWarn>$(NoWarn);NETSDK1195;NETSDK1210</NoWarn>	  
+    <NoWarn>$(NoWarn);NETSDK1195;NETSDK1210</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);GOOGLE_PROTOBUF_SUPPORT_FAST_STRING</DefineConstants>
+    <DefineConstants>$(DefineConstants);GOOGLE_PROTOBUF_SUPPORT_FAST_STRING;GOOGLE_PROTOBUF_SUPPORT_GENERIC_SIZEOF</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net50' ">
-    <DefineConstants>$(DefineConstants);GOOGLE_PROTOBUF_SUPPORT_FAST_STRING;GOOGLE_PROTOBUF_SIMD</DefineConstants>
+    <DefineConstants>$(DefineConstants);GOOGLE_PROTOBUF_SUPPORT_FAST_STRING;GOOGLE_PROTOBUF_SUPPORT_GENERIC_SIZEOF;GOOGLE_PROTOBUF_SIMD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
85507b98a603bfee2ee0685f7825e5e903e1716a introduced a new call to Marshal.Sizeof(Type). This call is not AOT compatible, which is a regression as prior versions were AOT compatible, even if not directly supported.

This conditionally uses the generic version of Marshal.SizeOf, which is AOT compatible to fix the issue.

Closes #21824

Closes #21964

COPYBARA_INTEGRATE_REVIEW=https://github.com/protocolbuffers/protobuf/pull/21964 from ThadHouse:genericsizeof a12294e624a0b6dda8cedc7ac73516e4cada7c6d PiperOrigin-RevId: 818694739

Cherry-pick of b9fc8a3