### PR TITLE
feat: `--<lang>_prefix` cli option

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2461,6 +2461,25 @@ CommandLineInterface::InterpretArgument(const std::string& name,
       return PARSE_ARGUMENT_FAIL;
     }
     fatal_warnings_ = true;
+  } else if (name == "--plugin-command-prefix") {
+    if (plugin_prefix_.empty()) {
+      std::cerr << "This compiler does not support plugins." << std::endl;
+      return PARSE_ARGUMENT_FAIL;
+    }
+    if (!plugin_command_prefix_.empty()) {
+      std::cerr << name << " may only be passed once." << std::endl;
+      return PARSE_ARGUMENT_FAIL;
+    }
+    if (value.empty()) {
+      std::cerr << name << " requires a non-empty value." << std::endl;
+      return PARSE_ARGUMENT_FAIL;
+    }
+    plugin_command_prefix_ =
+        absl::StrSplit(value, absl::ByAnyChar(" \t"), absl::SkipWhitespace());
+    if (plugin_command_prefix_.empty()) {
+      std::cerr << name << " requires a non-empty value." << std::endl;
+      return PARSE_ARGUMENT_FAIL;
+    }
   } else if (name == "--plugin") {
     if (plugin_prefix_.empty()) {
       std::cerr << "This compiler does not support plugins." << std::endl;
@@ -2717,7 +2736,11 @@ Parse PROTO_FILES and generate output based on the options given:
                               Additionally, EXECUTABLE may be of the form
                               NAME=PATH, in which case the given plugin name
                               is mapped to the given executable even if
-                              the executable's own name differs.)";
+                              the executable's own name differs.
+  --plugin-command-prefix=COMMAND
+                              Runs plugins via COMMAND. protoc executes
+                              "COMMAND <plugin>" instead of invoking the
+                              plugin binary directly.)";
   }
 
   for (const auto& kv : generators_by_flag_name_) {
@@ -3073,10 +3096,24 @@ bool CommandLineInterface::GeneratePluginOutput(
   // Invoke the plugin.
   Subprocess subprocess;
 
-  if (plugins_.count(plugin_name) > 0) {
-    subprocess.Start(plugins_[plugin_name], Subprocess::EXACT_NAME);
+  const auto plugin_it = plugins_.find(plugin_name);
+  const bool has_registered_path = plugin_it != plugins_.end();
+  const std::string executable =
+      has_registered_path ? plugin_it->second : plugin_name;
+
+  if (plugin_command_prefix_.empty()) {
+    subprocess.Start(executable,
+                     has_registered_path ? Subprocess::EXACT_NAME
+                                         : Subprocess::SEARCH_PATH);
   } else {
-    subprocess.Start(plugin_name, Subprocess::SEARCH_PATH);
+    // When a prefix is provided, we always execute the prefix first and pass the
+    // plugin executable as an argument. If a custom path was registered, we pass
+    // that path so the prefix does not need to search for the binary.
+    std::vector<std::string> args(plugin_command_prefix_.begin() + 1,
+                                  plugin_command_prefix_.end());
+    args.push_back(executable);
+    subprocess.Start(plugin_command_prefix_.front(), Subprocess::SEARCH_PATH,
+                     args);
   }
 
   std::string communicate_error;

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2737,10 +2737,11 @@ Parse PROTO_FILES and generate output based on the options given:
   --<lang>_prefix=COMMAND     Runs the plugin used by --<lang>_out via
                               COMMAND. protoc executes "COMMAND <plugin>"
                               instead of invoking the plugin binary directly.
-                              The value is split into argv tokens on
-                              whitespace; tokens containing spaces or quotes
-                              are not supported. Use a wrapper script for
-                              more complex invocations.)";
+                              COMMAND's first token is resolved via the
+                              search path (PATH). The value is split into
+                              argv tokens on whitespace; quotes are not
+                              supported. Use a wrapper script for more
+                              complex invocations.)";
   }
 
   for (const auto& kv : generators_by_flag_name_) {

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2736,7 +2736,11 @@ Parse PROTO_FILES and generate output based on the options given:
   --plugin-command-prefix=COMMAND
                               Runs plugins via COMMAND. protoc executes
                               "COMMAND <plugin>" instead of invoking the
-                              plugin binary directly.)";
+                              plugin binary directly. The value is split
+                              into argv tokens on whitespace; tokens
+                              containing spaces or quotes are not
+                              supported. Use a wrapper script for more
+                              complex invocations.)";
   }
 
   for (const auto& kv : generators_by_flag_name_) {

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2470,10 +2470,6 @@ CommandLineInterface::InterpretArgument(const std::string& name,
       std::cerr << name << " may only be passed once." << std::endl;
       return PARSE_ARGUMENT_FAIL;
     }
-    if (value.empty()) {
-      std::cerr << name << " requires a non-empty value." << std::endl;
-      return PARSE_ARGUMENT_FAIL;
-    }
     plugin_command_prefix_ =
         absl::StrSplit(value, absl::ByAnyChar(" \t"), absl::SkipWhitespace());
     if (plugin_command_prefix_.empty()) {

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -300,10 +300,12 @@ void AddDefaultProtoPaths(
 
 std::string PluginName(absl::string_view plugin_prefix,
                        absl::string_view directive) {
-  // Assuming the directive starts with "--" and ends with "_out" or "_opt",
-  // strip the "--" and "_out/_opt" and add the plugin prefix.
+  // Assuming the directive starts with "--" and ends with one of "_out",
+  // "_opt", or "_prefix", strip the "--" and the trailing "_..." segment and
+  // add the plugin prefix.
+  size_t suffix_start = directive.find_last_of('_');
   return absl::StrCat(plugin_prefix, "gen-",
-                      directive.substr(2, directive.size() - 6));
+                      directive.substr(2, suffix_start - 2));
 }
 
 bool GetBootstrapParam(const std::string& parameter) {
@@ -2461,21 +2463,6 @@ CommandLineInterface::InterpretArgument(const std::string& name,
       return PARSE_ARGUMENT_FAIL;
     }
     fatal_warnings_ = true;
-  } else if (name == "--plugin-command-prefix") {
-    if (plugin_prefix_.empty()) {
-      std::cerr << "This compiler does not support plugins." << std::endl;
-      return PARSE_ARGUMENT_FAIL;
-    }
-    if (!plugin_command_prefix_.empty()) {
-      std::cerr << name << " may only be passed once." << std::endl;
-      return PARSE_ARGUMENT_FAIL;
-    }
-    plugin_command_prefix_ =
-        absl::StrSplit(value, absl::ByAnyChar(" \t"), absl::SkipWhitespace());
-    if (plugin_command_prefix_.empty()) {
-      std::cerr << name << " requires a non-empty value." << std::endl;
-      return PARSE_ARGUMENT_FAIL;
-    }
   } else if (name == "--plugin") {
     if (plugin_prefix_.empty()) {
       std::cerr << "This compiler does not support plugins." << std::endl;
@@ -2601,6 +2588,20 @@ CommandLineInterface::InterpretArgument(const std::string& name,
           parameters->append(",");
         }
         parameters->append(value);
+      } else if (absl::StartsWith(name, "--") && absl::EndsWith(name, "_prefix")) {
+        std::string plugin_name = PluginName(plugin_prefix_, name);
+        if (plugin_command_prefixes_.find(plugin_name) !=
+            plugin_command_prefixes_.end()) {
+          std::cerr << name << " may only be passed once." << std::endl;
+          return PARSE_ARGUMENT_FAIL;
+        }
+        std::vector<std::string> tokens = absl::StrSplit(
+            value, absl::ByAnyChar(" \t"), absl::SkipWhitespace());
+        if (tokens.empty()) {
+          std::cerr << name << " requires a non-empty value." << std::endl;
+          return PARSE_ARGUMENT_FAIL;
+        }
+        plugin_command_prefixes_[plugin_name] = std::move(tokens);
       } else {
         std::cerr << "Unknown flag: " << name << std::endl;
         return PARSE_ARGUMENT_FAIL;
@@ -2733,14 +2734,13 @@ Parse PROTO_FILES and generate output based on the options given:
                               NAME=PATH, in which case the given plugin name
                               is mapped to the given executable even if
                               the executable's own name differs.
-  --plugin-command-prefix=COMMAND
-                              Runs plugins via COMMAND. protoc executes
-                              "COMMAND <plugin>" instead of invoking the
-                              plugin binary directly. The value is split
-                              into argv tokens on whitespace; tokens
-                              containing spaces or quotes are not
-                              supported. Use a wrapper script for more
-                              complex invocations.)";
+  --<lang>_prefix=COMMAND     Runs the plugin used by --<lang>_out via
+                              COMMAND. protoc executes "COMMAND <plugin>"
+                              instead of invoking the plugin binary directly.
+                              The value is split into argv tokens on
+                              whitespace; tokens containing spaces or quotes
+                              are not supported. Use a wrapper script for
+                              more complex invocations.)";
   }
 
   for (const auto& kv : generators_by_flag_name_) {
@@ -3101,7 +3101,8 @@ bool CommandLineInterface::GeneratePluginOutput(
   const std::string executable =
       has_registered_path ? plugin_it->second : plugin_name;
 
-  if (plugin_command_prefix_.empty()) {
+  const auto prefix_it = plugin_command_prefixes_.find(plugin_name);
+  if (prefix_it == plugin_command_prefixes_.end()) {
     subprocess.Start(executable,
                      has_registered_path ? Subprocess::EXACT_NAME
                                          : Subprocess::SEARCH_PATH);
@@ -3109,11 +3110,11 @@ bool CommandLineInterface::GeneratePluginOutput(
     // When a prefix is provided, we always execute the prefix first and pass the
     // plugin executable as an argument. If a custom path was registered, we pass
     // that path so the prefix does not need to search for the binary.
-    std::vector<std::string> args(plugin_command_prefix_.begin() + 1,
-                                  plugin_command_prefix_.end());
+    const std::vector<std::string>& prefix_tokens = prefix_it->second;
+    std::vector<std::string> args(prefix_tokens.begin() + 1,
+                                  prefix_tokens.end());
     args.push_back(executable);
-    subprocess.Start(plugin_command_prefix_.front(), Subprocess::SEARCH_PATH,
-                     args);
+    subprocess.Start(prefix_tokens.front(), Subprocess::SEARCH_PATH, args);
   }
 
   std::string communicate_error;

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -2595,6 +2595,13 @@ CommandLineInterface::InterpretArgument(const std::string& name,
           std::cerr << name << " may only be passed once." << std::endl;
           return PARSE_ARGUMENT_FAIL;
         }
+        if (value.find_first_of("\"'") != std::string::npos) {
+          std::cerr << name
+                    << ": quotes are not supported in the value. Use a "
+                       "wrapper script for more complex invocations."
+                    << std::endl;
+          return PARSE_ARGUMENT_FAIL;
+        }
         std::vector<std::string> tokens = absl::StrSplit(
             value, absl::ByAnyChar(" \t"), absl::SkipWhitespace());
         if (tokens.empty()) {

--- a/src/google/protobuf/compiler/command_line_interface.h
+++ b/src/google/protobuf/compiler/command_line_interface.h
@@ -393,6 +393,8 @@ class PROTOC_EXPORT CommandLineInterface {
 
   // See AllowPlugins().  If this is empty, plugins aren't allowed.
   std::string plugin_prefix_;
+  // Optional prefix command used to invoke plugins.
+  std::vector<std::string> plugin_command_prefix_;
 
   // Maps specific plugin names to files.  When executing a plugin, this map
   // is searched first to find the plugin executable.  If not found here, the

--- a/src/google/protobuf/compiler/command_line_interface.h
+++ b/src/google/protobuf/compiler/command_line_interface.h
@@ -393,8 +393,11 @@ class PROTOC_EXPORT CommandLineInterface {
 
   // See AllowPlugins().  If this is empty, plugins aren't allowed.
   std::string plugin_prefix_;
-  // Optional prefix command used to invoke plugins.
-  std::vector<std::string> plugin_command_prefix_;
+  // Optional per-plugin prefix command used to invoke a plugin. Populated from
+  // --<lang>_prefix. The key is the resolved plugin name (e.g.
+  // "protoc-gen-foo"), the value is the prefix command split into argv tokens.
+  absl::flat_hash_map<std::string, std::vector<std::string>>
+      plugin_command_prefixes_;
 
   // Maps specific plugin names to files.  When executing a plugin, this map
   // is searched first to find the plugin executable.  If not found here, the

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -601,7 +601,7 @@ TEST_F(CommandLineInterfaceTest, PluginPrefixInvokesWrapper) {
   ASSERT_EQ(0, chmod(wrapper_path.c_str(), 0777));
 #endif
 
-  Run(absl::StrCat("protocol_compiler --plugin-command-prefix=", wrapper_path,
+  Run(absl::StrCat("protocol_compiler --plug_prefix=", wrapper_path,
                    " --plug_out=$tmpdir --proto_path=$tmpdir foo.proto"));
 
   ExpectNoErrors();

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -609,6 +609,108 @@ TEST_F(CommandLineInterfaceTest, PluginPrefixInvokesWrapper) {
   ExpectFileContentContainsSubstring("wrapper_invoked.txt", "wrapped");
 }
 
+#ifndef _WIN32
+TEST_F(CommandLineInterfaceTest, PluginPrefixForwardsArguments) {
+  CreateTempFile("foo.proto",
+                 "syntax = \"proto2\";\n"
+                 "message Foo {}\n");
+
+  // Wrapper records every argv element on its own line, then shifts past the
+  // two wrapper-specific args (--foo, --bar=baz) and execs the remaining
+  // tail (the plugin path appended by protoc).
+  CreateTempFile("plugin_wrapper.sh",
+                 "#!/bin/sh\n"
+                 "for arg in \"$@\"; do\n"
+                 "  printf '%s\\n' \"$arg\" >> \"$tmpdir/wrapper_argv.txt\"\n"
+                 "done\n"
+                 "shift 2\n"
+                 "exec \"$@\"\n");
+  const std::string wrapper_path =
+      absl::StrCat(temp_directory(), "/plugin_wrapper.sh");
+  ASSERT_EQ(0, chmod(wrapper_path.c_str(), 0777));
+
+  // Pass the prefix value as a single argv element so the embedded spaces
+  // form multiple tokens (Run() splits on whitespace; RunWithArgs does not).
+  RunWithArgs({
+      "protocol_compiler",
+      absl::StrCat("--plug_prefix=", wrapper_path, " --foo --bar=baz"),
+      "--plug_out=$tmpdir",
+      "--proto_path=$tmpdir",
+      "foo.proto",
+  });
+
+  ExpectNoErrors();
+  ExpectGenerated("test_plugin", "", "foo.proto", "Foo");
+  ExpectFileContentContainsSubstring("wrapper_argv.txt", "--foo");
+  ExpectFileContentContainsSubstring("wrapper_argv.txt", "--bar=baz");
+}
+
+TEST_F(CommandLineInterfaceTest, PluginPrefixFromSearchPath) {
+  CreateTempFile("foo.proto",
+                 "syntax = \"proto2\";\n"
+                 "message Foo {}\n");
+
+  const std::string wrapper_basename = "plugin_wrapper_searchpath.sh";
+  CreateTempFile(wrapper_basename,
+                 "#!/bin/sh\n"
+                 "echo wrapped > \"$tmpdir/wrapper_invoked.txt\"\n"
+                 "exec \"$@\"\n");
+  const std::string wrapper_path =
+      absl::StrCat(temp_directory(), "/", wrapper_basename);
+  ASSERT_EQ(0, chmod(wrapper_path.c_str(), 0777));
+
+  // Prepend the temp directory to PATH so the wrapper can be located by
+  // basename only (Subprocess uses execvp / SEARCH_PATH for the prefix).
+  const char* old_path_cstr = getenv("PATH");
+  const std::string old_path = old_path_cstr ? old_path_cstr : "";
+  setenv("PATH", absl::StrCat(temp_directory(), ":", old_path).c_str(), 1);
+
+  Run(absl::StrCat("protocol_compiler --plug_prefix=", wrapper_basename,
+                   " --plug_out=$tmpdir --proto_path=$tmpdir foo.proto"));
+
+  setenv("PATH", old_path.c_str(), 1);
+
+  ExpectNoErrors();
+  ExpectGenerated("test_plugin", "", "foo.proto", "Foo");
+  ExpectFileContentContainsSubstring("wrapper_invoked.txt", "wrapped");
+}
+#endif  // !_WIN32
+
+TEST_F(CommandLineInterfaceTest, PluginPrefixRejectsEmptyValue) {
+  CreateTempFile("foo.proto",
+                 "syntax = \"proto2\";\n"
+                 "message Foo {}\n");
+
+  Run("protocol_compiler --plug_prefix= "
+      "--plug_out=$tmpdir --proto_path=$tmpdir foo.proto");
+
+  ExpectErrorSubstring("--plug_prefix");
+  ExpectErrorSubstring("non-empty value");
+}
+
+TEST_F(CommandLineInterfaceTest, PluginPrefixRejectsDuplicate) {
+  CreateTempFile("foo.proto",
+                 "syntax = \"proto2\";\n"
+                 "message Foo {}\n");
+
+  Run("protocol_compiler --plug_prefix=foo --plug_prefix=bar "
+      "--plug_out=$tmpdir --proto_path=$tmpdir foo.proto");
+
+  ExpectErrorSubstring("--plug_prefix");
+  ExpectErrorSubstring("only be passed once");
+}
+
+TEST_F(CommandLineInterfaceTest, PluginPrefixMissingExecutable) {
+  CreateTempFile("foo.proto",
+                 "syntax = \"proto2\";\n"
+                 "message Foo {}\n");
+
+  Run("protocol_compiler --plug_prefix=/nonexistent/path/to/wrapper "
+      "--plug_out=$tmpdir --proto_path=$tmpdir foo.proto");
+
+  ExpectErrorSubstring("Plugin failed");
+}
+
 TEST_F(CommandLineInterfaceTest, GeneratorAndPlugin_DescriptorSetIn) {
   // Invoke a generator and a plugin at the same time.
 

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -644,37 +644,57 @@ TEST_F(CommandLineInterfaceTest, PluginPrefixForwardsArguments) {
   ExpectFileContentContainsSubstring("wrapper_argv.txt", "--foo");
   ExpectFileContentContainsSubstring("wrapper_argv.txt", "--bar=baz");
 }
+#endif  // !_WIN32
 
 TEST_F(CommandLineInterfaceTest, PluginPrefixFromSearchPath) {
   CreateTempFile("foo.proto",
                  "syntax = \"proto2\";\n"
                  "message Foo {}\n");
 
+#ifdef _WIN32
+  const std::string wrapper_basename = "plugin_wrapper_searchpath.bat";
+  CreateTempFile(wrapper_basename,
+                 "@echo off\r\n"
+                 "echo wrapped > \"%~dp0wrapper_invoked.txt\"\r\n"
+                 "\"%~1\"\r\n"
+                 "exit /b %errorlevel%\r\n");
+  const char path_separator = ';';
+#else
   const std::string wrapper_basename = "plugin_wrapper_searchpath.sh";
   CreateTempFile(wrapper_basename,
                  "#!/bin/sh\n"
                  "echo wrapped > \"$tmpdir/wrapper_invoked.txt\"\n"
                  "exec \"$@\"\n");
-  const std::string wrapper_path =
-      absl::StrCat(temp_directory(), "/", wrapper_basename);
-  ASSERT_EQ(0, chmod(wrapper_path.c_str(), 0777));
+  ASSERT_EQ(0, chmod(absl::StrCat(temp_directory(), "/", wrapper_basename).c_str(),
+                     0777));
+  const char path_separator = ':';
+#endif
 
   // Prepend the temp directory to PATH so the wrapper can be located by
   // basename only (Subprocess uses execvp / SEARCH_PATH for the prefix).
   const char* old_path_cstr = getenv("PATH");
   const std::string old_path = old_path_cstr ? old_path_cstr : "";
-  setenv("PATH", absl::StrCat(temp_directory(), ":", old_path).c_str(), 1);
+  const std::string new_path =
+      absl::StrCat(temp_directory(), std::string(1, path_separator), old_path);
+#ifdef _WIN32
+  _putenv_s("PATH", new_path.c_str());
+#else
+  setenv("PATH", new_path.c_str(), 1);
+#endif
 
   Run(absl::StrCat("protocol_compiler --plug_prefix=", wrapper_basename,
                    " --plug_out=$tmpdir --proto_path=$tmpdir foo.proto"));
 
+#ifdef _WIN32
+  _putenv_s("PATH", old_path.c_str());
+#else
   setenv("PATH", old_path.c_str(), 1);
+#endif
 
   ExpectNoErrors();
   ExpectGenerated("test_plugin", "", "foo.proto", "Foo");
   ExpectFileContentContainsSubstring("wrapper_invoked.txt", "wrapped");
 }
-#endif  // !_WIN32
 
 TEST_F(CommandLineInterfaceTest, PluginPrefixRejectsEmptyValue) {
   CreateTempFile("foo.proto",

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -609,25 +609,33 @@ TEST_F(CommandLineInterfaceTest, PluginPrefixInvokesWrapper) {
   ExpectFileContentContainsSubstring("wrapper_invoked.txt", "wrapped");
 }
 
-#ifndef _WIN32
 TEST_F(CommandLineInterfaceTest, PluginPrefixForwardsArguments) {
   CreateTempFile("foo.proto",
                  "syntax = \"proto2\";\n"
                  "message Foo {}\n");
 
-  // Wrapper records every argv element on its own line, then shifts past the
-  // two wrapper-specific args (--foo, --bar=baz) and execs the remaining
-  // tail (the plugin path appended by protoc).
-  CreateTempFile("plugin_wrapper.sh",
+  // Wrapper records the two prefix-supplied args, then invokes the plugin
+  // (the third and final argv element appended by protoc).
+  std::string wrapper_path;
+#ifdef _WIN32
+  CreateTempFile("plugin_wrapper_args.bat",
+                 "@echo off\r\n"
+                 "echo %~1>>\"%~dp0wrapper_argv.txt\"\r\n"
+                 "echo %~2>>\"%~dp0wrapper_argv.txt\"\r\n"
+                 "\"%~3\"\r\n"
+                 "exit /b %errorlevel%\r\n");
+  wrapper_path = absl::StrCat(temp_directory(), "/plugin_wrapper_args.bat");
+#else
+  CreateTempFile("plugin_wrapper_args.sh",
                  "#!/bin/sh\n"
                  "for arg in \"$@\"; do\n"
                  "  printf '%s\\n' \"$arg\" >> \"$tmpdir/wrapper_argv.txt\"\n"
                  "done\n"
                  "shift 2\n"
                  "exec \"$@\"\n");
-  const std::string wrapper_path =
-      absl::StrCat(temp_directory(), "/plugin_wrapper.sh");
+  wrapper_path = absl::StrCat(temp_directory(), "/plugin_wrapper_args.sh");
   ASSERT_EQ(0, chmod(wrapper_path.c_str(), 0777));
+#endif
 
   // Pass the prefix value as a single argv element so the embedded spaces
   // form multiple tokens (Run() splits on whitespace; RunWithArgs does not).
@@ -644,7 +652,6 @@ TEST_F(CommandLineInterfaceTest, PluginPrefixForwardsArguments) {
   ExpectFileContentContainsSubstring("wrapper_argv.txt", "--foo");
   ExpectFileContentContainsSubstring("wrapper_argv.txt", "--bar=baz");
 }
-#endif  // !_WIN32
 
 TEST_F(CommandLineInterfaceTest, PluginPrefixFromSearchPath) {
   CreateTempFile("foo.proto",

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -727,6 +727,23 @@ TEST_F(CommandLineInterfaceTest, PluginPrefixRejectsDuplicate) {
   ExpectErrorSubstring("only be passed once");
 }
 
+TEST_F(CommandLineInterfaceTest, PluginPrefixRejectsQuotes) {
+  CreateTempFile("foo.proto",
+                 "syntax = \"proto2\";\n"
+                 "message Foo {}\n");
+
+  RunWithArgs({
+      "protocol_compiler",
+      "--plug_prefix=\"my cmd\"",
+      "--plug_out=$tmpdir",
+      "--proto_path=$tmpdir",
+      "foo.proto",
+  });
+
+  ExpectErrorSubstring("--plug_prefix");
+  ExpectErrorSubstring("quotes are not supported");
+}
+
 TEST_F(CommandLineInterfaceTest, PluginPrefixMissingExecutable) {
   CreateTempFile("foo.proto",
                  "syntax = \"proto2\";\n"

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -624,19 +624,29 @@ TEST_F(CommandLineInterfaceTest, PluginPrefixForwardsArguments) {
   // protoc) to invoke.
   CreateTempFile("plugin_wrapper_args.bat",
                  "@echo off\r\n"
+                 // %* is the raw, untokenized arg tail; %~dp0 is the script's
+                 // own dir, so the record lands where the test can read it.
                  "echo %*>>\"%~dp0wrapper_argv.txt\"\r\n"
+                 // Start clean before recovering the plugin path.
                  "set \"plugin=\"\r\n"
+                 // Loop leaves %%A holding the last token: the plugin path
+                 // protoc appended (positional %1/%2 are unreliable here).
                  "for %%A in (%*) do set \"plugin=%%A\"\r\n"
+                 // Run the plugin
                  "\"%plugin%\"\r\n"
                  "exit /b %errorlevel%\r\n");
   wrapper_path = absl::StrCat(temp_directory(), "/plugin_wrapper_args.bat");
 #else
   CreateTempFile("plugin_wrapper_args.sh",
                  "#!/bin/sh\n"
+                 // Record every argument (prefix tokens + appended plugin
+                 // path), one per line, where the test can read it.
                  "for arg in \"$@\"; do\n"
                  "  printf '%s\\n' \"$arg\" >> \"$tmpdir/wrapper_argv.txt\"\n"
                  "done\n"
+                 // Drop the two prefix tokens; what remains is the plugin path.
                  "shift 2\n"
+                 // Exec the plugin
                  "exec \"$@\"\n");
   wrapper_path = absl::StrCat(temp_directory(), "/plugin_wrapper_args.sh");
   ASSERT_EQ(0, chmod(wrapper_path.c_str(), 0777));

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -614,15 +614,20 @@ TEST_F(CommandLineInterfaceTest, PluginPrefixForwardsArguments) {
                  "syntax = \"proto2\";\n"
                  "message Foo {}\n");
 
-  // Wrapper records the two prefix-supplied args, then invokes the plugin
-  // (the third and final argv element appended by protoc).
+  // Wrapper records the prefix-supplied args, then invokes the plugin
+  // (the final argv element appended by protoc).
   std::string wrapper_path;
 #ifdef _WIN32
+  // Batch %1/%2/... tokenize on '=' (and ',' ';'), which would split
+  // "--bar=baz" into two parameters. Record the raw, un-split argument tail
+  // via %* instead, and take the last token (the plugin path appended by
+  // protoc) to invoke.
   CreateTempFile("plugin_wrapper_args.bat",
                  "@echo off\r\n"
-                 "echo %~1>>\"%~dp0wrapper_argv.txt\"\r\n"
-                 "echo %~2>>\"%~dp0wrapper_argv.txt\"\r\n"
-                 "\"%~3\"\r\n"
+                 "echo %*>>\"%~dp0wrapper_argv.txt\"\r\n"
+                 "set \"plugin=\"\r\n"
+                 "for %%A in (%*) do set \"plugin=%%A\"\r\n"
+                 "\"%plugin%\"\r\n"
                  "exit /b %errorlevel%\r\n");
   wrapper_path = absl::StrCat(temp_directory(), "/plugin_wrapper_args.bat");
 #else

--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -25,7 +25,6 @@
 #include "absl/log/absl_log.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/substitute.h"
 #include "google/protobuf/io/io_win32.h"
@@ -99,55 +98,26 @@ void Subprocess::Start(const std::string& program, SearchMode search_mode,
     ABSL_LOG(FATAL) << "GetStdHandle: " << Win32ErrorMessage(GetLastError());
   }
 
-  // CreateProcessW takes a single command-line string, so we need to quote any
-  // argument that contains spaces, tabs, quotes, or backslashes before quotes.
-  // This is a minimal implementation that mirrors the basic CommandLineToArgvW
-  // expectations for our usage: protoc plugin names and optional wrappers.
-  auto quote_for_windows = [](absl::string_view arg) {
-    bool needs_quotes = arg.empty();
-    for (char ch : arg) {
-      if (ch == ' ' || ch == '\t' || ch == '"') {
-        needs_quotes = true;
-        break;
-      }
-    }
-    if (!needs_quotes) {
-      return std::string(arg);
-    }
-    std::string quoted;
-    quoted.reserve(arg.size() + 2);
-    quoted.push_back('"');
-    for (char ch : arg) {
-      if (ch == '"' || ch == '\\') {
-        quoted.push_back('\\');
-      }
-      quoted.push_back(ch);
-    }
-    quoted.push_back('"');
-    return quoted;
-  };
-
-  std::vector<std::string> argv;
-  argv.reserve(args.size() + 1);
-  argv.push_back(program);
-  argv.insert(argv.end(), args.begin(), args.end());
-
-  std::string joined = absl::StrJoin(
-      argv, " ", [&quote_for_windows](std::string* out, const std::string& arg) {
-        out->append(quote_for_windows(arg));
-      });
-
-  std::string command_line = joined;
-  if (search_mode == SEARCH_PATH) {
-    // SEARCH_PATH needs cmd.exe so .bat/.cmd files on PATH are picked up.
-    command_line = absl::StrCat("cmd.exe /c ", quote_for_windows(joined));
-  }
-
   // get wide string version of program as the path may contain non-ascii characters
   std::wstring wprogram;
   if (!io::win32::strings::utf8_to_wcs(program.c_str(), &wprogram)) {
     ABSL_LOG(FATAL) << "utf8_to_wcs: " << Win32ErrorMessage(GetLastError());
   }
+
+  // Join program and args into a single command-line string, as CreateProcessW expects it.
+  // We do not perform any quoting — callers are responsible for any
+  // escaping their tokens require to round-trip through the child's parser.
+  std::vector<std::string> argv;
+  argv.reserve(args.size() + 1);
+  argv.push_back(program);
+  argv.insert(argv.end(), args.begin(), args.end());
+  std::string joined = absl::StrJoin(argv, " ");
+
+  // Invoking cmd.exe allows for '.bat' files from the path as well as '.exe'.
+  std::string command_line =
+      search_mode == SEARCH_PATH
+          ? absl::StrCat("cmd.exe /c \"", joined, "\"")
+          : joined;
 
   // get wide string version of command line as the path may contain non-ascii characters
   std::wstring wcommand_line;
@@ -159,12 +129,15 @@ void Subprocess::Start(const std::string& program, SearchMode search_mode,
   // parameter.
   wchar_t *wcommand_line_copy = _wcsdup(wcommand_line.c_str());
 
-  // Create the process.
+  // Create the process. With EXACT_NAME and no args we pass lpCommandLine=NULL
+  // so behavior is driven solely by lpApplicationName, matching the original
+  // `--plugin` semantics on Windows.
   PROCESS_INFORMATION process_info;
 
   if (CreateProcessW(
           (search_mode == SEARCH_PATH) ? nullptr : wprogram.c_str(),
-          wcommand_line_copy,
+          (search_mode == SEARCH_PATH || !args.empty()) ? wcommand_line_copy
+                                                        : nullptr,
           nullptr,  // process security attributes
           nullptr,  // thread security attributes
           TRUE,     // inherit handles?

--- a/src/google/protobuf/compiler/subprocess.h
+++ b/src/google/protobuf/compiler/subprocess.h
@@ -20,7 +20,9 @@
 #include <unistd.h>
 #endif  // !_WIN32
 #include <string>
+#include <vector>
 
+#include "absl/types/span.h"
 #include "google/protobuf/port.h"
 
 // Must be included last.
@@ -44,9 +46,9 @@ class PROTOC_EXPORT Subprocess {
     EXACT_NAME    // Program is an exact file name; don't use the PATH.
   };
 
-  // Start the subprocess.  Currently we don't provide a way to specify
-  // arguments as protoc plugins don't have any.
-  void Start(const std::string& program, SearchMode search_mode);
+  // Start the subprocess with optional arguments.
+  void Start(const std::string& program, SearchMode search_mode,
+             absl::Span<const std::string> args = {});
 
   // Serialize the input message and pipe it to the subprocess's stdin, then
   // close the pipe.  Meanwhile, read from the subprocess's stdout and parse


### PR DESCRIPTION
Closes https://github.com/protocolbuffers/protobuf/issues/23509

# Description

- Add per-plugin `--<lang>_prefix=COMMAND` flag to `protoc`, allowing a plugin to be invoked through a user-supplied command wrapper.
- `<lang>` matches the plugin used by `--<lang>_out`, so different plugins can use different wrappers in a single invocation.
- protoc executes `COMMAND <plugin>`; COMMAND's first token is resolved via the search path (PATH), the value is tokenized on whitespace into argv, and quotes are rejected at parse time. Use a wrapper script for more complex invocations.
- Wrapper still honours custom plugin paths set with `--plugin`.
- Cross-platform tests (POSIX shell scripts; Windows `.bat`) cover happy-path invocation, argument forwarding, PATH-based resolution, missing executable, duplicate flags, empty values, and quote rejection.

# Naming

Earlier revisions of this PR used a single global `--plugin-command-prefix` flag. Per https://github.com/protocolbuffers/protobuf/issues/23509#issuecomment-3478221497, this PR now uses per-plugin `--<lang>_prefix` to match the existing `--<lang>_out` / `--<lang>_opt` convention.

# Testing

I've tested this in https://github.com/status-im/status-go with this command in `messaging/layers/encryption/`:
```
protoc --go_prefix="go tool" --go_out=. ./messaging/layers/encryption/protocol_message.proto
```