### PR TITLE
Fix pkg-config dependency resolution performance (#24610)

### DIFF
--- a/cmake/protobuf-lite.pc.cmake
+++ b/cmake/protobuf-lite.pc.cmake
@@ -6,7 +6,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: Protocol Buffers
 Description: Google's Data Interchange Format
 Version: @protobuf_VERSION@
-Requires: @_protobuf_PC_REQUIRES@
+Requires: @_protobuf_lite_PC_REQUIRES@
 Libs: -L${libdir} -lprotobuf-lite @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir} @_protobuf_PC_CFLAGS@
 Conflicts: protobuf


### PR DESCRIPTION
Turns out listing all 36 abseil deps in the .pc files was a bad idea. pkg-config goes nuts trying to resolve them on systems without memoization (we're talking 15+ min hangs).
Now we only list the abseil packages that actually show up in public headers. Way fewer deps, way faster resolution.

Fixes #24610