### PR TITLE
Eliminate bzlmod warnings.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,7 +29,7 @@ single_version_override(
 #endif // PROTO2_OPENSOURCE
 # protoc dependencies
 bazel_dep(name = "abseil-cpp", version = "20250512.1")
-bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 #ifndef PROTO2_OPENSOURCE
 # LINT.ThenChange(//depot/google3/third_party/protobuf/compiler/notices.h)
@@ -37,7 +37,7 @@ bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 
 # other dependencies
 bazel_dep(name = "bazel_features", version = "1.33.0", repo_name = "proto_bazel_features")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "jsoncpp", version = "1.9.6")
 bazel_dep(name = "rules_java", version = "8.6.1")
 bazel_dep(name = "rules_jvm_external", version = "6.7")
@@ -80,7 +80,7 @@ single_version_override(
     version = "0.17.3",
 )
 
-bazel_dep(name = "rules_shell", version = "0.2.0")
+bazel_dep(name = "rules_shell", version = "0.3.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 
 # Ruby toolchains
@@ -276,7 +276,7 @@ protobuf_maven_dev.install(
 )
 use_repo(protobuf_maven_dev, "protobuf_maven_dev")
 
-bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True)
+bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)
 bazel_dep(name = "rules_buf", version = "0.3.0", dev_dependency = True)
 bazel_dep(name = "rules_testing", version = "0.9.0", dev_dependency = True)
 bazel_dep(


### PR DESCRIPTION
When building protoc, several bzlmod warnings were displayed that newer versions of rules_cc, bazel_skylib, googletest, and rules_shell were selected.