### PR TITLE
Fix SkipLastField : WireFormat.WireType.Varint should be handled up t…

### DIFF
--- a/csharp/src/Google.Protobuf/ParsingPrimitivesMessages.cs
+++ b/csharp/src/Google.Protobuf/ParsingPrimitivesMessages.cs
@@ -48,7 +48,7 @@ namespace Google.Protobuf
                     ParsingPrimitives.SkipRawBytes(ref buffer, ref state, length);
                     break;
                 case WireFormat.WireType.Varint:
-                    ParsingPrimitives.ParseRawVarint32(ref buffer, ref state);
+                    ParsingPrimitives.ParseRawVarint64(ref buffer, ref state);
                     break;
             }
         }


### PR DESCRIPTION
…o 64-bit values.

Replaces ParseRawVarint32 with ParseRawVarint64 when handling the Varint wire type in ParsingPrimitivesMessages. This ensures correct parsing of 64-bit varints.