### PR TITLE
feat: introduce version constraints for proto toolchain

### DIFF
--- a/bazel/private/prebuilt_tool_integrity.bzl
+++ b/bazel/private/prebuilt_tool_integrity.bzl
@@ -19,3 +19,17 @@ _TEST_SHAS["protoc-33.0-win64.zip"] = "3742cd49c8b6bd78b6760540367eb0ff62fa70a10
 
 RELEASE_VERSION = _TEST_VERSION
 RELEASED_BINARY_INTEGRITY = _TEST_SHAS
+
+def _parse_version(version):
+    """Parse version string like 'v33.0' or 'v33.0.1' into (major, minor, patch) tuple."""
+    stripped = version.removeprefix("v")
+    parts = stripped.split(".")
+    major = parts[0] if len(parts) > 0 else "0"
+    minor = parts[1] if len(parts) > 1 else "0"
+    patch = parts[2] if len(parts) > 2 else "0"
+    return (major, minor, patch)
+
+_PARSED_VERSION = _parse_version(RELEASE_VERSION)
+RELEASE_MAJOR = _PARSED_VERSION[0]
+RELEASE_MINOR = _PARSED_VERSION[1]
+RELEASE_PATCH = _PARSED_VERSION[2]

--- a/bazel/private/proto_library_rule.bzl
+++ b/bazel/private/proto_library_rule.bzl
@@ -14,6 +14,7 @@ load("@proto_bazel_features//:features.bzl", "bazel_features")
 load("//bazel/common:proto_common.bzl", "proto_common")
 load("//bazel/common:proto_info.bzl", "ProtoInfo")
 load("//bazel/private:toolchain_helpers.bzl", "toolchains")
+load("//bazel/private/toolchains/version:version_transition.bzl", "protoc_version_transition")
 
 DIRECT_DEPS_FLAG_TEMPLATE = (
     "--direct_dependencies_violation_msg=" +
@@ -267,6 +268,7 @@ _extra_doc = ""
 
 proto_library = rule(
     implementation = _proto_library_impl,
+    cfg = protoc_version_transition,
     # TODO: proto_common docs are missing
     # TODO: ProtoInfo link doesn't work and docs are missing
     doc = """

--- a/bazel/private/toolchains/prebuilt/BUILD.bazel
+++ b/bazel/private/toolchains/prebuilt/BUILD.bazel
@@ -11,8 +11,13 @@ load(":protoc_authenticity.bzl", "protoc_authenticity")
     toolchain(
         name = "{}_toolchain".format(platform.replace("-", "_")),
         exec_compatible_with = meta["compatible_with"],
-        # Toolchain resolution will only permit this toolchain if the config_setting for prefer_prebuilt_protoc is true,
-        target_settings = ["@com_google_protobuf//bazel/toolchains:prefer_prebuilt_protoc.flag_set"],
+        # Toolchain resolution will only permit this toolchain if:
+        # 1. prefer_prebuilt_protoc flag is true
+        # 2. The requested version matches via semver (major, major.minor, or exact)
+        target_settings = [
+            "@com_google_protobuf//bazel/toolchains:prefer_prebuilt_protoc.flag_set",
+            "@com_google_protobuf//bazel/private/toolchains/version:semver_match",
+        ],
         # Bazel does not follow this attribute during analysis, so the referenced repo
         # will only be fetched if this toolchain is selected.
         toolchain = "@prebuilt_protoc.{}//:prebuilt_protoc_toolchain".format(platform.replace("-", "_")),

--- a/bazel/private/toolchains/version/BUILD.bazel
+++ b/bazel/private/toolchains/version/BUILD.bazel
@@ -1,0 +1,77 @@
+"""Internal version settings and config settings for semver toolchain matching."""
+
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "string_setting")
+load("//bazel/private:prebuilt_tool_integrity.bzl", "RELEASE_MAJOR", "RELEASE_MINOR", "RELEASE_PATCH")
+
+package(default_visibility = ["//bazel/private:__subpackages__"])
+
+# Internal settings (set by transition, not by users directly)
+string_setting(
+    name = "protoc_major",
+    build_setting_default = RELEASE_MAJOR,
+)
+
+string_setting(
+    name = "protoc_minor",
+    build_setting_default = RELEASE_MINOR,
+)
+
+string_setting(
+    name = "protoc_patch",
+    build_setting_default = RELEASE_PATCH,
+)
+
+# Config settings for version component matching
+config_setting(
+    name = "has_major",
+    flag_values = {":protoc_major": RELEASE_MAJOR},
+)
+
+config_setting(
+    name = "has_minor",
+    flag_values = {":protoc_minor": RELEASE_MINOR},
+)
+
+config_setting(
+    name = "has_patch",
+    flag_values = {":protoc_patch": RELEASE_PATCH},
+)
+
+# Combined matching groups
+selects.config_setting_group(
+    name = "match_major",
+    match_all = [":has_major"],
+)
+
+selects.config_setting_group(
+    name = "match_major_minor",
+    match_all = [
+        ":has_major",
+        ":has_minor",
+    ],
+)
+
+selects.config_setting_group(
+    name = "match_exact",
+    match_all = [
+        ":has_major",
+        ":has_minor",
+        ":has_patch",
+    ],
+)
+
+# Semver range: toolchain matches if ANY of these are satisfied
+# This allows a toolchain to be selected when the user requests:
+# - Just the major version (e.g., "33")
+# - Major.minor (e.g., "33.0")
+# - Exact version (e.g., "33.0.0")
+selects.config_setting_group(
+    name = "semver_match",
+    match_any = [
+        ":match_major",
+        ":match_major_minor",
+        ":match_exact",
+    ],
+    visibility = ["//bazel/private/toolchains/prebuilt:__pkg__"],
+)

--- a/bazel/private/toolchains/version/version_transition.bzl
+++ b/bazel/private/toolchains/version/version_transition.bzl
@@ -1,0 +1,49 @@
+"""Version transition that parses the single user flag into internal components."""
+
+load("//bazel/private:prebuilt_tool_integrity.bzl", "RELEASE_MAJOR", "RELEASE_MINOR", "RELEASE_PATCH")
+
+def _parse_version(version_str):
+    """Parse '33' or '33.0' or '33.0.0' into (major, minor, patch).
+
+    Args:
+        version_str: The version string to parse. Can be:
+            - Empty string: use RELEASE_VERSION defaults
+            - "33": major version only
+            - "33.0": major.minor
+            - "33.0.0": exact version
+
+    Returns:
+        A tuple of (major, minor, patch) strings.
+    """
+    if not version_str:
+        # Empty means use the release version
+        return (RELEASE_MAJOR, RELEASE_MINOR, RELEASE_PATCH)
+
+    parts = version_str.split(".")
+    major = parts[0] if len(parts) > 0 else RELEASE_MAJOR
+
+    # If user only specifies major (e.g., "33"), minor and patch are empty
+    # This allows match_major to succeed while match_major_minor fails
+    minor = parts[1] if len(parts) > 1 else ""
+    patch = parts[2] if len(parts) > 2 else ""
+    return (major, minor, patch)
+
+def _protoc_version_transition_impl(settings, attr):
+    user_version = settings["@com_google_protobuf//bazel/toolchains:protoc_version"]
+    major, minor, patch = _parse_version(user_version)
+
+    return {
+        "@com_google_protobuf//bazel/private/toolchains/version:protoc_major": major,
+        "@com_google_protobuf//bazel/private/toolchains/version:protoc_minor": minor,
+        "@com_google_protobuf//bazel/private/toolchains/version:protoc_patch": patch,
+    }
+
+protoc_version_transition = transition(
+    implementation = _protoc_version_transition_impl,
+    inputs = ["@com_google_protobuf//bazel/toolchains:protoc_version"],
+    outputs = [
+        "@com_google_protobuf//bazel/private/toolchains/version:protoc_major",
+        "@com_google_protobuf//bazel/private/toolchains/version:protoc_minor",
+        "@com_google_protobuf//bazel/private/toolchains/version:protoc_patch",
+    ],
+)

--- a/bazel/toolchains/BUILD
+++ b/bazel/toolchains/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_setting")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -66,4 +66,13 @@ config_setting(
     name = "allow_nonstandard_protoc.flag_set",
     flag_values = {":allow_nonstandard_protoc": "true"},
     visibility = ["//bazel/private/toolchains/prebuilt:__pkg__"],
+)
+
+# User-facing version flag for semver toolchain matching.
+# Users can set this to request a specific protoc version (e.g., "33", "33.0", or "33.0.0").
+# Empty value means use the default RELEASE_VERSION.
+string_setting(
+    name = "protoc_version",
+    build_setting_default = "",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This feature adds semver range matching for prebuilt protoc toolchains. The internal protoc_major, protoc_minor, and protoc_patch settings default to RELEASE_VERSION (e.g., 33.0.0). Downstream projects can apply their own transitions to request a specific version range. Toolchains match if the requested version aligns at any granularity—so a v33.0.0 toolchain matches requests for 33, 33.0, or 33.0.0, enabling the protobuf cross-version runtime guarantee.

Continuation of https://github.com/protocolbuffers/protobuf/pull/24115