### PR TITLE
java: clarify aliasing contract for bytes accessors

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -397,9 +397,9 @@ public abstract class CodedInputStream {
   /**
    * Read a {@code bytes} field value from the stream.
    *
-   * <p>The returned {@link ByteBuffer} may reference (alias) the underlying input buffer for
-   * decoders that are backed by an on-heap {@code byte[]} whose contents will not be overwritten or
-   * reused for the lifetime of the returned view, and when aliasing is enabled.
+   * <p>If aliasing is enabled, the returned {@link ByteBuffer} may reference (alias) the underlying
+   * input buffer for decoders that are backed by an on-heap {@code byte[]} whose contents will not
+   * be overwritten or reused for the lifetime of the returned view.
    *
    * <p>Safety contract: Callers should treat the returned buffer as read-only and should not rely
    * on its contents remaining valid after the input advances. If you need a stable, read-only view,


### PR DESCRIPTION
This PR clarifies the aliasing / lifetime contract for CodedInputStream’s bytes accessors.

Changes (docs-only):
- Document that `readBytes()` may alias the underlying input buffer when `enableAliasing(true)` is enabled and supported.
- Document that `readByteBuffer()` may alias the underlying input buffer when aliasing is enabled and the decoder is backed by an on-heap `byte[]` whose contents are not overwritten/reused for the lifetime of the returned view.
- Expand `enableAliasing(boolean)` Javadoc to:
  - describe the performance motivation (avoid copies)
  - spell out the buffer lifetime / mutation / reuse hazards
  - note that some decoder implementations may ignore the setting (e.g., stream-backed decoders that refill/reuse internal buffers, or direct-backed decoders without a stable on-heap `byte[]`)
  - recommend callers treat returned `ByteBuffers` as read-only and consider calling `asReadOnlyBuffer()` immediately when safety-by-default is desired.

No runtime behavior changes and no test changes.