### PR TITLE
Fix an endian problem in upb that caused protoc plugins to crash on big endian platforms

### DIFF
--- a/upb/wire/decode.c
+++ b/upb/wire/decode.c
@@ -359,6 +359,7 @@ static const char* _upb_Decoder_DecodeEnumPacked(
       _upb_Decoder_AddEnumValueToUnknown(d, msg, field, &elem);
       continue;
     }
+    _upb_Decoder_MungeInt32(&elem);
     if (_upb_Decoder_Reserve(d, arr, 1)) {
       out = UPB_PTR_AT(upb_Array_MutableDataPtr(arr),
                        arr->UPB_PRIVATE(size) * 4, void);


### PR DESCRIPTION
The protobuf build started failing on big endian platforms (I'm using s390x) starting with v33.0. The cmake build would fail when running `protoc` to compile test files. The errors looked like:

```bash
gmake[2]: *** [CMakeFiles/upb-test.dir/build.make:85: google/protobuf/any.upb.h] Error 1
--upb_out: protoc-gen-upb: Plugin killed by signal 11.
```

I did a git bisect and the crash started with commit c36f728a3e4352d887f82d53dda330972b27dbf7. The fix is to add a `_upb_Decoder_MungeInt32(val)` call on the closed enum value so it can be decoded properly later.

I think this might fix https://github.com/protocolbuffers/protobuf/issues/24103 but I'm not able to test it.