### PR TITLE
Fixed to prevent segmentation faults when iterating a message

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -400,10 +400,21 @@ static zend_object* Message_clone_obj(zend_object* object) {
  * Message_get_properties()
  *
  * Object handler for the get_properties event in PHP. This returns a HashTable
- * of our internal properties. We don't support this, so we return NULL.
+ * of our internal properties.
+ *
+ * Protobuf messages are not meant to be iterable, but we must return an empty
+ * HashTable instead of NULL to prevent segmentation faults when users attempt
+ * to iterate over a message with foreach().
+ *
+ * See: https://github.com/protocolbuffers/protobuf/issues/22173
  */
 static HashTable* Message_get_properties(zend_object* object) {
-  return NULL;  // We don't offer direct references to our properties.
+  // Ensure the standard properties table is initialized (even if empty)
+  // to prevent segmentation faults when users attempt foreach() iteration.
+  if (!object->properties) {
+    zend_std_get_properties(object);
+  }
+  return object->properties;
 }
 
 // C Functions from message.h. /////////////////////////////////////////////////

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -2063,4 +2063,25 @@ class GeneratedClassTest extends TestBase
         // test forwardslash on new line
         $this->assertContains("* /\n", $docComment);
     }
+
+    public function testForeachOnMessageDoesNotSegfault()
+    {
+        // Regression test for issue #22173
+        // https://github.com/protocolbuffers/protobuf/issues/22173
+        //
+        // Attempting to iterate a protobuf Message with foreach should not
+        // cause a segmentation fault. While messages are not meant to be
+        // iterable (they have fixed fields, not dynamic properties), we
+        // should handle this gracefully by returning an empty iteration
+        // rather than crashing.
+        $m = new TestMessage();
+        $m->setOptionalInt32(42);
+        $m->setOptionalString("test");
+
+        $count = 0;
+        foreach ($m as $key => $value) {
+        }
+
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
Hello! I have found a solution to the issue in #22173, so I would like you to review it.

## Problem

- Fixes #22173

When attempting to iterate over a protobuf `Message` object using PHP's `foreach` construct, a segmentation fault occurs. This happens because the `get_properties` object handler returns `NULL`, which causes the Zend engine to dereference a null pointer when attempting iteration.

```php
$msg = new \Example\ProtoMessage();
foreach ($msg as $key => $value) {  // Segmentation fault
    // ...
}
```

### Root Cause

The issue occurs in three object handlers:
- `Message_get_properties()` in `message.c`

All three handlers were returning `NULL` with the comment "We don't have/offer a properties table." While this is intentional (protobuf messages are not meant to be iterable), returning `NULL` causes the Zend engine to crash when PHP's foreach tries to use the result.

From the stack trace in #22173:
```
#0  ZEND_FE_RESET_R_SPEC_CV_HANDLER () at ./Zend/zend_hash.h:317
#1  zend_vm_call_opcode_handler (ex=ex@entry=0x7fe88d214020) at ./Zend/zend_vm_execute.h:68448
```

The crash happens at `zend_hash.h:317` where `zend_hash_num_elements(ht)` is called with a NULL pointer.

## Solution

Instead of returning `NULL`, we now ensure that a valid (but empty) `HashTable` is returned by calling `zend_std_get_properties()`. This is the standard Zend API function that:
1. Initializes `object->properties` if it doesn't exist
2. Returns an empty but valid `HashTable`
3. Prevents the segmentation fault while maintaining the expected behavior (no properties to iterate)

### Changes Made

1. **php/ext/google/protobuf/message.c**: Modified `Message_get_properties()` to call `zend_std_get_properties()` and return a valid HashTable
2. **php/tests/GeneratedClassTest.php**: Added regression test `testForeachOnMessageDoesNotSegfault()`

## Testing

### Manual Test
```php
<?php
require 'build/gen/GPBMetadata/Message.php';
require 'build/gen/Example/ProtoMessage.php';

echo "iterating generated php class ProtoMessage\n";

$proto_msg = new \Example\ProtoMessage();
foreach ($proto_msg as $key => $value) {
    assert(false);  // Should not iterate any elements
}
echo "SUCCESS: No segmentation fault\n";
```

**Before fix**: Segmentation fault
**After fix**: No crash, zero iterations (expected behavior)

### Unit Test
Added `testForeachOnMessageDoesNotSegfault()` in `GeneratedClassTest.php`:
- Creates a `TestMessage` with some fields set
- Attempts to iterate with foreach
- Verifies no segfault occurs

### Build and Test

```bash
composer install
composer test_c
```

## Expected Behavior

After this fix:
- ✅ No segmentation fault when using foreach on Message objects
- ✅ Foreach completes gracefully with zero iterations (messages are not meant to be iterable)
- ✅ All existing functionality remains unchanged
- ✅ RepeatedField and MapField continue to work correctly with their IteratorAggregate implementation

## Compatibility

- Tested on PHP 8.4.1 and PHP 8.5.0
- Uses standard Zend API (`zend_std_get_properties`) available in all PHP versions
- No breaking changes to existing code
- Backward compatible with all PHP versions that protobuf supports

## Related Issues

- Fixes #22173
- Related to #7319 (similar issue from 2020)
