### PR TITLE
Bug fix: Fully qualify `absl` and `std` namespace lookups in generated Protobuf code.

### DIFF
--- a/hpb_generator/gen_accessors.cc
+++ b/hpb_generator/gen_accessors.cc
@@ -567,16 +567,16 @@ void WriteMapAccessorDefinitions(const google::protobuf::Descriptor* desc,
          {"converted_key_name", converted_key_name},
          {"upb_field_name", upbc_name}},
         R"cc(
-          absl::StatusOr<$const_val$> $class_name$::get_$field_name$(
+          ::absl::StatusOr<$const_val$> $class_name$::get_$field_name$(
               $const_key$ key) {
             upb_StringView value;
             $optional_conversion_code$bool success =
                 $upb_msg_name$_$upb_field_name$_get(msg_, $converted_key_name$,
                                                     &value);
             if (success) {
-              return absl::string_view(value.data, value.size);
+              return ::absl::string_view(value.data, value.size);
             }
-            return absl::NotFoundError("");
+            return ::absl::NotFoundError("");
           }
         )cc");
     ctx.Emit(
@@ -621,7 +621,7 @@ void WriteMapAccessorDefinitions(const google::protobuf::Descriptor* desc,
          {"converted_key_name", converted_key_name},
          {"upb_field_name", upbc_name}},
         R"cc(
-          absl::StatusOr<$const_val$> $class_name$::get_$field_name$(
+          ::absl::StatusOr<$const_val$> $class_name$::get_$field_name$(
               $const_key$ key) {
             $const_val$ value;
             $optional_conversion_code$bool success =
@@ -630,7 +630,7 @@ void WriteMapAccessorDefinitions(const google::protobuf::Descriptor* desc,
             if (success) {
               return value;
             }
-            return absl::NotFoundError("");
+            return ::absl::NotFoundError("");
           }
         )cc");
     ctx.Emit(

--- a/hpb_generator/names.cc
+++ b/hpb_generator/names.cc
@@ -70,7 +70,7 @@ std::string CppTypeInternal(const google::protobuf::FieldDescriptor* field, bool
     case google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
       return "uint64_t";
     case google::protobuf::FieldDescriptor::CPPTYPE_STRING:
-      return "absl::string_view";
+      return "::absl::string_view";
     default:
       ABSL_LOG(FATAL) << "Unexpected type: " << field->cpp_type();
   }

--- a/src/google/protobuf/compiler/cpp/field_generators/cord_field.cc
+++ b/src/google/protobuf/compiler/cpp/field_generators/cord_field.cc
@@ -144,8 +144,8 @@ void CordFieldGenerator::GeneratePrivateMembers(io::Printer* printer) const {
   if (!field_->default_value_string().empty()) {
     format(
         "struct _default_$name$_func_ {\n"
-        "  constexpr absl::string_view operator()() const {\n"
-        "    return absl::string_view($default$, $default_length$);\n"
+        "  constexpr ::absl::string_view operator()() const {\n"
+        "    return ::absl::string_view($default$, $default_length$);\n"
         "  }\n"
         "};\n");
   }
@@ -319,8 +319,8 @@ void CordOneofFieldGenerator::GenerateStaticMembers(
   if (!field_->default_value_string().empty()) {
     format(
         "struct _default_$name$_func_ {\n"
-        "  constexpr absl::string_view operator()() const {\n"
-        "    return absl::string_view($default$, $default_length$);\n"
+        "  constexpr ::absl::string_view operator()() const {\n"
+        "    return ::absl::string_view($default$, $default_length$);\n"
         "  }\n"
         "};"
         "static const ::absl::Cord $default_variable_name$;\n");

--- a/src/google/protobuf/compiler/cpp/helpers.cc
+++ b/src/google/protobuf/compiler/cpp/helpers.cc
@@ -948,11 +948,11 @@ std::string DefaultValue(const Options& options, const FieldDescriptor* field) {
     case FieldDescriptor::CPPTYPE_DOUBLE: {
       double value = field->default_value_double();
       if (value == std::numeric_limits<double>::infinity()) {
-        return "std::numeric_limits<double>::infinity()";
+        return "::std::numeric_limits<double>::infinity()";
       } else if (value == -std::numeric_limits<double>::infinity()) {
-        return "-std::numeric_limits<double>::infinity()";
+        return "-::std::numeric_limits<double>::infinity()";
       } else if (value != value) {
-        return "std::numeric_limits<double>::quiet_NaN()";
+        return "::std::numeric_limits<double>::quiet_NaN()";
       } else {
         return io::SimpleDtoa(value);
       }
@@ -960,11 +960,11 @@ std::string DefaultValue(const Options& options, const FieldDescriptor* field) {
     case FieldDescriptor::CPPTYPE_FLOAT: {
       float value = field->default_value_float();
       if (value == std::numeric_limits<float>::infinity()) {
-        return "std::numeric_limits<float>::infinity()";
+        return "::std::numeric_limits<float>::infinity()";
       } else if (value == -std::numeric_limits<float>::infinity()) {
-        return "-std::numeric_limits<float>::infinity()";
+        return "-::std::numeric_limits<float>::infinity()";
       } else if (value != value) {
-        return "std::numeric_limits<float>::quiet_NaN()";
+        return "::std::numeric_limits<float>::quiet_NaN()";
       } else {
         std::string float_value = io::SimpleFtoa(value);
         // If floating point value contains a period (.) or an exponent


### PR DESCRIPTION
PiperOrigin-RevId: 860194958