### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/clear_caches.yml
+++ b/.github/workflows/clear_caches.yml
@@ -23,7 +23,7 @@ jobs:
       actions: write # permission is required to delete caches
       contents: read
     steps:
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: ${{ github.workspace }}/${{ steps.output.outputs.repository-cache }}
           key: repository-cache-${{ github.ref_name }}-${{ runner.os }}-reset-${{ github.sha }}

--- a/.github/workflows/janitor.yml
+++ b/.github/workflows/janitor.yml
@@ -36,7 +36,7 @@ jobs:
       issues: write # allow the action to comment on, add labels to, and close issues
       pull-requests: write # allow the action to comment on, add labels to, and close PRs
     steps:
-      - uses: actions/stale@b69b346013879cedbf50c69f572cd85439a41936
+      - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d  # v10.1.1
         with:
           stale-issue-message: >
             We triage inactive PRs and issues in order to make it easier to find
@@ -78,7 +78,7 @@ jobs:
           days-before-stale: 90
           days-before-close: 14
           operations-per-run: 100
-      - uses: actions/stale@b69b346013879cedbf50c69f572cd85439a41936
+      - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d  # v10.1.1
         with:
           # Have any reply on a 'wait for user action' issue or PR to readd 'untriaged' label. This
           # uses the same action as our actual stale issue management, but sets

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
 
@@ -47,7 +47,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/staleness_refresh.yml
+++ b/.github/workflows/staleness_refresh.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false   # Don't cancel all jobs if one fails.
 
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           # Note: this token has an expiration date, so if the workflow starts
           # failing then you may need to generate a fresh token.

--- a/.github/workflows/test_bazel.yml
+++ b/.github/workflows/test_bazel.yml
@@ -49,7 +49,7 @@ jobs:
       # opaque errors about coursier (see
       # https://github.com/bazel-contrib/rules_jvm_external/issues/1337).
       - name: Pin to Java 11
-        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
         with:
           distribution: 'temurin'

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -258,7 +258,7 @@ jobs:
           cat manifest/all.txt | grep -E '^lib/' | grep -vE '\.[0-9]+\.[0-9]+\.[0-9]+$' | sed 's:^lib/::g' > manifest/lib.txt
 
       - name: Upload install manifest
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
         with:
           name: installed_files_${{ matrix.type }}
@@ -287,7 +287,7 @@ jobs:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Download manifest
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #4.1.8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: installed_files_${{ matrix.build }}
           path: ${{ matrix.build }}

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+        uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309  # v5.1.0
         with:
           dotnet-version: '6.0.x'
 

--- a/.github/workflows/test_php_ext.yml
+++ b/.github/workflows/test_php_ext.yml
@@ -43,7 +43,7 @@ jobs:
             bazel build //php:release $BAZEL_FLAGS;
             cp bazel-bin/php/protobuf-*.tgz .
 
-      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: protobuf-php-release
           path: protobuf-*.tgz
@@ -60,7 +60,7 @@ jobs:
     name: ${{ matrix.continuous-only && inputs.continuous-prefix || '' }} Build ${{ matrix.version }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #4.1.8
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
         with:
           name: protobuf-php-release

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -96,7 +96,7 @@ jobs:
           ref: ${{ inputs.safe-checkout }}
 
       - name: Pin Python version
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f #v5.1.1
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.version }}
           cache: pip

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -62,7 +62,7 @@ jobs:
 # e.g. https://github.com/actions/upload-artifact/issues/569
 #      - name: Archive log artifacts
 #        if: ${{ matrix.presubmit || inputs.test-type == 'continuous' }}
-#        uses: actions/upload-artifact@v4
+#        uses: actions/upload-artifact@v6
 #        with:
 #          name: test-logs-${{ matrix.ruby }}_${{ matrix.ffi || 'NATIVE' }}
 #          path: logs

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           ref: ${{ inputs.safe-checkout }}
       - name: Setup Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.12
           cache: pip
@@ -123,11 +123,11 @@ jobs:
           bazel: build --crosstool_top=//toolchain:clang_suite --//toolchain:release=true --symlink_prefix=/ -c dbg --incompatible_enable_cc_toolchain_resolution=false //python/dist //python/dist:test_wheel //python/dist:source_wheel
       - name: Move Wheels
         run: mkdir wheels && find _build/out \( -name 'protobuf*.whl' -o -name 'protobuf-*.tar.gz' \) -exec mv '{}' wheels ';'
-      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: python-wheels
           path: wheels/
-      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: requirements
           # Tests shouldn't have access to the whole upb repo, upload the one file we need
@@ -172,18 +172,18 @@ jobs:
     steps:
       - name: Download Wheels
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 #6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: python-wheels
           path: wheels
       - name: Download Requirements
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 #6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: requirements
           path: requirements
       - name: Setup Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
         with:
           python-version: ${{ matrix.python-version }}
@@ -238,14 +238,14 @@ jobs:
     if: ${{ github.event_name != 'pull_request_target' }}
     steps:
       - name: Download Wheels
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 #6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: python-wheels
           path: wheels
       - name: Delete Binary Wheels
         run: find wheels -type f | grep -v none-any | xargs rm
       - name: Setup Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Python venv
@@ -255,7 +255,7 @@ jobs:
           source env/bin/activate
           echo "VIRTUAL ENV:" $VIRTUAL_ENV
       - name: Download Requirements
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 #6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: requirements
           path: requirements
@@ -295,7 +295,7 @@ jobs:
           ref: ${{ inputs.safe-checkout }}
       - name: Download Wheels
         if: ${{ inputs.continuous-run }}
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 #6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: python-wheels
           path: wheels
@@ -304,7 +304,7 @@ jobs:
         run: find wheels -type f | grep -v none-any | xargs rm
       - name: Setup Python
         if: ${{ inputs.continuous-run }}
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.14
       - name: Setup Python venv
@@ -316,7 +316,7 @@ jobs:
           echo "VIRTUAL ENV:" $VIRTUAL_ENV
       - name: Download Requirements
         if: ${{ inputs.continuous-run }}
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 #6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: requirements
           path: requirements

--- a/.github/workflows/update_php_repo.yml
+++ b/.github/workflows/update_php_repo.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout protobuf-php
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           repository: protocolbuffers/protobuf-php
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Clone protobuf
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           path: protobuf
       - name: Configure Git Bot


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`1bd1e32`](https://github.com/actions/cache/commit/1bd1e32a3bdc45362d1e726936510720a7c30a57) | [`8b402f5`](https://github.com/actions/cache/commit/8b402f58fbc84540c8b491a91e594a4576fec3d7) | [Release](https://github.com/actions/cache/releases/tag/v5) | clear_caches.yml |
| `actions/checkout` | [`8ade135`](https://github.com/actions/checkout/commit/8ade135a41bc03ea155e62e844d188df1ea18608) | [`8e8c483`](https://github.com/actions/checkout/commit/8e8c483db84b4bee98b60c0593521ed34d9990e8) | [Release](https://github.com/actions/checkout/releases/tag/v6) | scorecard.yml, staleness_refresh.yml, update_php_repo.yml |
| `actions/download-artifact` | [`018cc2c`](https://github.com/actions/download-artifact/commit/018cc2cf5baa6db3ef3c5f8a56943fffe632ef53), [`fa0a91b`](https://github.com/actions/download-artifact/commit/fa0a91b85d4f404e444e00e005971372dc801d16) | [`37930b1`](https://github.com/actions/download-artifact/commit/37930b1c2abaa49bbe596cd826c3c89aef350131) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | test_cpp.yml, test_php_ext.yml, test_upb.yml |
| `actions/setup-dotnet` | [`3447fd6`](https://github.com/actions/setup-dotnet/commit/3447fd6a9f9e57506b15f895c5b76d3b197dc7c2) | [`baa11fb`](https://github.com/actions/setup-dotnet/commit/baa11fbfe1d6520db94683bd5c7a3818018e4309) | [Release](https://github.com/actions/setup-dotnet/releases/tag/v5) | test_csharp.yml |
| `actions/setup-java` | [`3a4f6e1`](https://github.com/actions/setup-java/commit/3a4f6e1af504cf6a31855fa899c6aa5355ba6c12) | [`be666c2`](https://github.com/actions/setup-java/commit/be666c2fcd27ec809703dec50e508c2fdc7f6654) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | test_bazel.yml |
| `actions/setup-python` | [`39cd149`](https://github.com/actions/setup-python/commit/39cd14951b08e74b54015e9e001cdefcf80e669f), [`e797f83`](https://github.com/actions/setup-python/commit/e797f83bcb11b83ae66e0230d6156d7c80228e7c) | [`a309ff8`](https://github.com/actions/setup-python/commit/a309ff8b426b58ec0e2a45f0f869d46889d02405) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | test_python.yml, test_upb.yml |
| `actions/stale` | [`b69b346`](https://github.com/actions/stale/commit/b69b346013879cedbf50c69f572cd85439a41936) | [`9971854`](https://github.com/actions/stale/commit/997185467fa4f803885201cee163a9f38240193d) | [Release](https://github.com/actions/stale/releases/tag/v10) | janitor.yml |
| `actions/upload-artifact` | [`5076954`](https://github.com/actions/upload-artifact/commit/50769540e7f4bd5e21e526ee35c689e35e0d6874), [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`b7c566a`](https://github.com/actions/upload-artifact/commit/b7c566a772e6b6bfb58ed0dc250532a479d7789f) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | scorecard.yml, test_cpp.yml, test_php_ext.yml, test_ruby.yml, test_upb.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
