### PR TITLE
Disable python tests on windows

### DIFF
--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: "upb-bazel-windows"
-          bazel: test --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 //upb/... //upb_generator/... //python/...
+          bazel: test --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 //upb/... //upb_generator/...
           version: 6.4.0
           exclude-targets: -//python:conformance_test -//upb/reflection:def_builder_test
 


### PR DESCRIPTION
These were never supported (due to issues in system_python), and always fell back to the incompatible system_python path anyway.  For some reason our mechanism for skipping these builds seems to have failed on the source_wheels genrule.  Disabling them entirely is easy and doesn't actually reduce coverage at all