### PR TITLE
chore(php): fix php 8.5 deprecations 33.x

### DIFF
--- a/php/src/Google/Protobuf/Internal/CodedOutputStream.php
+++ b/php/src/Google/Protobuf/Internal/CodedOutputStream.php
@@ -98,7 +98,7 @@ class CodedOutputStream
         }
 
         while (($low >= 0x80 || $low < 0) || $high != 0) {
-            $buffer[$current] = chr($low | 0x80);
+            $buffer[$current] = chr(($low | 0x80) & 0xFF);
             $value = ($value >> 7) & ~(0x7F << ((PHP_INT_SIZE << 3) - 7));
             $carry = ($high & 0x7F) << ((PHP_INT_SIZE << 3) - 7);
             $high = ($high >> 7) & ~(0x7F << ((PHP_INT_SIZE << 3) - 7));

--- a/php/src/Google/Protobuf/Internal/Descriptor.php
+++ b/php/src/Google/Protobuf/Internal/Descriptor.php
@@ -54,7 +54,7 @@ class Descriptor
     public function addField($field)
     {
         $this->field[$field->getNumber()] = $field;
-        $this->json_to_field[$field->getJsonName()] = $field;
+        $this->json_to_field[$field->getJsonName() ?? ''] = $field;
         $this->name_to_field[$field->getName()] = $field;
         $this->index_to_field[] = $field;
     }

--- a/php/src/Google/Protobuf/Internal/DescriptorPool.php
+++ b/php/src/Google/Protobuf/Internal/DescriptorPool.php
@@ -75,8 +75,8 @@ class DescriptorPool
         $this->unique_descs[$descriptor->getFullName()] =
             $descriptor;
         $this->class_to_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getLegacyClass()] = $descriptor;
-        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass()] = $descriptor;
+        $this->class_to_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
+        $this->class_to_desc[$descriptor->getPreviouslyUnreservedClass() ?? ''] = $descriptor;
         foreach ($descriptor->getNestedType() as $nested_type) {
             $this->addDescriptor($nested_type);
         }
@@ -90,7 +90,7 @@ class DescriptorPool
         $this->proto_to_class[$descriptor->getFullName()] =
             $descriptor->getClass();
         $this->class_to_enum_desc[$descriptor->getClass()] = $descriptor;
-        $this->class_to_enum_desc[$descriptor->getLegacyClass()] = $descriptor;
+        $this->class_to_enum_desc[$descriptor->getLegacyClass() ?? ''] = $descriptor;
     }
 
     public function getDescriptorByClassName($klass)


### PR DESCRIPTION
Submitting compatibility fixes for PHP 8.5 which were made to the main branch in https://github.com/protocolbuffers/protobuf/pull/24668 and https://github.com/protocolbuffers/protobuf/pull/24666 for the 33.x branch

These fixes are important for maintaining compatibility with 33.x for PHP 8.5

See also https://github.com/protocolbuffers/protobuf/pull/24666#issuecomment-3770112606 and https://github.com/googleapis/gax-php/pull/644