### PR TITLE
Update Ruby 4.0 test Docker image and enable continuous tests.

### DIFF
--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -37,8 +37,8 @@ jobs:
           - { name: Ruby 3.4, ruby: ruby-3.4.1, continuous-only: true }
           # TODO: Remove the image property in the two entries below and update the configuration
           # used by all the images the next time there is an update to the Dockerfile
-          - { name: Ruby 4.0, ruby: ruby-4.0.0, ffi: NATIVE, image: 'us-docker.pkg.dev/protobuf-build/containers/test/linux/ruby:8.0.1-ruby-4.0.0-1a1642a7cba0a7fa4c226c2d047ed5fbe6ca5451' }
-          - { name: Ruby 4.0, ruby: ruby-4.0.0, ffi: FFI, image: 'us-docker.pkg.dev/protobuf-build/containers/test/linux/ruby:8.0.1-ruby-4.0.0-1a1642a7cba0a7fa4c226c2d047ed5fbe6ca5451' }
+          - { name: Ruby 4.0, ruby: ruby-4.0.0, ffi: NATIVE, image: 'us-docker.pkg.dev/protobuf-build/containers/test/linux/ruby:8.0.1-ruby-4.0.0-f1c24ed6acfbf6ec709b0de2f702209c9d3ac659' }
+          - { name: Ruby 4.0, ruby: ruby-4.0.0, ffi: FFI, image: 'us-docker.pkg.dev/protobuf-build/containers/test/linux/ruby:8.0.1-ruby-4.0.0-f1c24ed6acfbf6ec709b0de2f702209c9d3ac659' }
           - { name: JRuby 9.4, ruby: jruby-9.4.9.0, ffi: NATIVE }
           - { name: JRuby 9.4, ruby: jruby-9.4.9.0, ffi: FFI }
 
@@ -189,14 +189,9 @@ jobs:
           - { name: Ruby 3.1, ruby: ruby-3.1.6, ffi: FFI }
           - { name: Ruby 3.2, ruby: ruby-3.2.6, continuous-only: true}
           - { name: Ruby 3.3, ruby: ruby-3.3.6, continuous-only: true}
-          # TODO: After https://github.com/ruby/rubygems/issues/9244 is resolved,
-          # Replace these two test configurations:
-          - { name: Ruby 3.4, ruby: ruby-3.4.1, ffi: NATIVE }
-          - { name: Ruby 3.4, ruby: ruby-3.4.1, ffi: FFI, continuous-only: true }
-          # With these three test configurations:
-          # - { name: Ruby 3.4, ruby: ruby-3.4.1, continuous-only: true }
-          # - { name: Ruby 4.0, ruby: ruby-4.0.0, ffi: NATIVE, image: 'us-docker.pkg.dev/protobuf-build/containers/test/linux/ruby:8.0.1-ruby-4.0.0-1a1642a7cba0a7fa4c226c2d047ed5fbe6ca5451' }
-          # - { name: Ruby 4.0, ruby: ruby-4.0.0, ffi: FFI, image: 'us-docker.pkg.dev/protobuf-build/containers/test/linux/ruby:8.0.1-ruby-4.0.0-1a1642a7cba0a7fa4c226c2d047ed5fbe6ca5451' }
+          - { name: Ruby 3.4, ruby: ruby-3.4.1, continuous-only: true }
+          - { name: Ruby 4.0, ruby: ruby-4.0.0, ffi: NATIVE, image: 'us-docker.pkg.dev/protobuf-build/containers/test/linux/ruby:8.0.1-ruby-4.0.0-f1c24ed6acfbf6ec709b0de2f702209c9d3ac659' }
+          - { name: Ruby 4.0, ruby: ruby-4.0.0, ffi: FFI, image: 'us-docker.pkg.dev/protobuf-build/containers/test/linux/ruby:8.0.1-ruby-4.0.0-f1c24ed6acfbf6ec709b0de2f702209c9d3ac659' }
           - { name: JRuby 9.4, ruby: jruby-9.4.9.0, ffi: NATIVE }
           - { name: JRuby 9.4, ruby: jruby-9.4.9.0, ffi: FFI, continuous-only: true }
     name: ${{ matrix.continuous-only && inputs.continuous-prefix || '' }} Install ${{ matrix.name }}${{ matrix.ffi == 'FFI' && ' FFI' || '' }}


### PR DESCRIPTION
This docker image includes ruby gems v4.0.5, which includes https://github.com/ruby/rubygems/pull/9245 that fixes building multiple native extensions.

PiperOrigin-RevId: 863399053