### PR TITLE
Remove direct dependency on rules_apple

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,13 +13,6 @@ module(
 # https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
 # Thus the highest version in their module graph is resolved.
 
-# These dependencies must be declared before the other rules dependencies.
-# Workaround rules_apple having a default dependency on rules_swift 2.4.0, which in turn has a
-# hard dependency on the presence of swiftc.exe on Windows.
-bazel_dep(name = "rules_swift", version = "3.0.2", repo_name = "build_bazel_rules_swift")
-
-# TODO: Can rules_apple be removed, and thus allow rules_swift to be removed?
-bazel_dep(name = "rules_apple", version = "4.0.0", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "apple_support", version = "1.15.1", repo_name = "build_bazel_apple_support")
 
 # Keep apple_support on 1.15.1 for now to avoid this issue:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,10 +114,6 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
 
-load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-
-apple_rules_dependencies()
-
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
 
 apple_support_dependencies()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -10,8 +10,6 @@ if(${CMAKE_VERSION} VERSION_GREATER 3.16 OR ${CMAKE_VERSION} VERSION_EQUAL 3.16)
   include_guard()
 endif()
 
-set(rules_swift-version "3.0.2")
-set(rules_apple-version "4.0.0")
 set(apple_support-version "1.15.1")
 set(abseil-cpp-version "20250512.1")
 set(rules_cc-version "0.0.17")

--- a/protobuf_deps.bzl
+++ b/protobuf_deps.bzl
@@ -171,23 +171,6 @@ def protobuf_deps():
             sha256 = "d20c951960ed77cb7b341c2a59488534e494d5ad1d30c4818c736d57772a9fef",
         )
 
-    # Workaround rules_apple having a default dependency on rules_swift 2.4.0, which in turn has a
-    # hard dependency on the presence of swiftc.exe on Windows.
-    if not native.existing_rule("build_bazel_rules_swift"):
-        http_archive(
-            name = "build_bazel_rules_swift",
-            sha256 = "b17bdad10f3996cffc1ae3634e426d5280848cdb25ae5351f39357599938f5c6",
-            url = "https://github.com/bazelbuild/rules_swift/releases/download/3.0.2/rules_swift.3.0.2.tar.gz",
-        )
-
-    # TODO: Can rules_apple be removed, and thus allow rules_swift to be removed?
-    if not native.existing_rule("build_bazel_rules_apple"):
-        http_archive(
-            name = "build_bazel_rules_apple",
-            sha256 = "70b0fb2aec1055c978109199bf58ccb5008aba8e242f3305194045c271ca3cae",
-            url = "https://github.com/bazelbuild/rules_apple/releases/download/4.0.0/rules_apple.4.0.0.tar.gz",
-        )
-
     if not native.existing_rule("build_bazel_apple_support"):
         http_archive(
             name = "build_bazel_apple_support",

--- a/ruby/ext/google/protobuf_c/BUILD.bazel
+++ b/ruby/ext/google/protobuf_c/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_apple//apple:apple_binary.bzl", "apple_binary")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("//upb/cmake:build_defs.bzl", "staleness_test")
@@ -111,30 +111,26 @@ cc_library(
     alwayslink = 1,
 )
 
-apple_binary(
+cc_binary(
     name = "ffi_bundle",
-    binary_type = "loadable_bundle",
     linkopts = [
-        "-undefined,dynamic_lookup",
-        "-multiply_defined,suppress",
+        "-Wl,-undefined,dynamic_lookup",
+        "-Wl,-multiply_defined,suppress",
+        "-Wl,-bundle",
     ],
-    minimum_os_version = "12.0",
-    platform_type = "macos",
     tags = ["manual"],
     deps = [
         ":protobuf_c_ffi",
     ],
 )
 
-apple_binary(
+cc_binary(
     name = "bundle",
-    binary_type = "loadable_bundle",
     linkopts = [
-        "-undefined,dynamic_lookup",
-        "-multiply_defined,suppress",
+        "-Wl,-undefined,dynamic_lookup",
+        "-Wl,-multiply_defined,suppress",
+        "-Wl,-bundle",
     ],
-    minimum_os_version = "12.0",
-    platform_type = "macos",
     tags = ["manual"],
     deps = [
         ":protobuf_c",


### PR DESCRIPTION
This was only used for 2 apple_binary targets that we can replace with
cc_binary. There is a difference here that previously these binary
targets would transitively set the macOS version being targeted via a
transition, this is no longer the case and now that setting is inherited
from the including project's config instead. If unset it uses the host
OS version which isn't ideal.
