### PR TITLE
fix(release): update path of protoc integrity

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -9,7 +9,7 @@ TAG=$1
 PREFIX="protobuf-${TAG:1}"
 ARCHIVE="$PREFIX.bazel.tar.gz"
 ARCHIVE_TMP=$(mktemp)
-INTEGRITY_FILE=${PREFIX}/bazel/private/prebuilt_tool_integrity.bzl
+INTEGRITY_FILE=${PREFIX}/bazel/private/oss/toolchains/prebuilt/tool_integrity.bzl
 
 # NB: configuration for 'git archive' is in /.gitattributes
 git archive --format=tar --prefix=${PREFIX}/ ${TAG} > $ARCHIVE_TMP


### PR DESCRIPTION
This gets replaced during release.

broken by https://github.com/protocolbuffers/protobuf/pull/25541