### PR TITLE
fix(php): allow json-encoding of numbers in field masks

### DIFF
--- a/php/ext/google/protobuf/php-upb.c
+++ b/php/ext/google/protobuf/php-upb.c
@@ -6329,10 +6329,11 @@ static void jsonenc_fieldpath(jsonenc* e, upb_StringView path) {
     if (ch >= 'A' && ch <= 'Z') {
       jsonenc_err(e, "Field mask element may not have upper-case letter.");
     } else if (ch == '_') {
-      if (ptr == end - 1 || *(ptr + 1) < 'a' || *(ptr + 1) > 'z') {
+      if (ptr == end - 1 || !(islower(*(ptr+1)) || isdigit(*(ptr+1)))) {
         jsonenc_err(e, "Underscore must be followed by a lowercase letter.");
       }
-      ch = *++ptr - 32;
+      ch = *++ptr;
+      if (islower(ch)) ch -= 32;
     }
 
     jsonenc_putbytes(e, &ch, 1);


### PR DESCRIPTION
Addresses https://github.com/protocolbuffers/protobuf/issues/25786

Ensures that the protobuf c-extension for PHP behaves the same as the native library when serializing fields with numbers to JSON.

```php
$fieldMask = new Google\Protobuf\FieldMask();
$fieldMask->setPaths(['custom_label_0']);

// Previous: `Uncaught Exception: Error occurred during JSON serialization`
// With this fix: `string(14) ""customLabel0""`
var_dump($fieldMask->serializeToJsonString()); 
```