### PR TITLE
Add recursion guards for the following nested messages:

### DIFF
--- a/python/google/protobuf/internal/message_set_extensions.proto
+++ b/python/google/protobuf/internal/message_set_extensions.proto
@@ -26,6 +26,7 @@ message TestMessageSetExtension1 {
     optional TestMessageSetExtension1 message_set_extension = 98418603;
   }
   optional int32 i = 15;
+  optional TestMessageSet sub_msg = 16;
 }
 
 message TestMessageSetExtension2 {

--- a/python/google/protobuf/internal/more_messages.proto
+++ b/python/google/protobuf/internal/more_messages.proto
@@ -67,6 +67,12 @@ message ExtendClass {
   }
 }
 
+message TestRecursiveMapMessage {
+  optional TestRecursiveMapMessage a = 1;
+  optional int32 i = 2;
+  map<int32, TestRecursiveMapMessage> map_field = 3;
+}
+
 message TestFullKeyword {
   optional google.protobuf.internal.OutOfOrderFields field1 = 1;
   optional google.protobuf.internal.class field2 = 2;

--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -1241,7 +1241,9 @@ def _AddMergeFromStringMethod(message_descriptor, cls):
           tag_bytes, (None, None)
       )
       if field_decoder:
-        pos = field_decoder(buffer, new_pos, end, self, field_dict)
+        pos = field_decoder(
+            buffer, new_pos, end, self, field_dict, current_depth
+        )
         continue
       field_des, is_packed = fields_by_tag.get(tag_bytes, (None, None))
       if field_des is None:

--- a/upb/wire/decode.c
+++ b/upb/wire/decode.c
@@ -648,9 +648,13 @@ static void upb_Decoder_AddKnownMessageSetItem(
   upb_Message* submsg = _upb_Decoder_NewSubMessage2(
       d, ext->ext->UPB_PRIVATE(sub).UPB_PRIVATE(submsg),
       &ext->ext->UPB_PRIVATE(field), submsgp);
+  // upb_Decode_LimitDepth() takes uint32_t, d->depth - 1 can not be negative.
+  if (d->depth <= 1) {
+    upb_ErrorHandler_ThrowError(&d->err, kUpb_DecodeStatus_MaxDepthExceeded);
+  }
   upb_DecodeStatus status = upb_Decode(
       data, size, submsg, upb_MiniTableExtension_GetSubMessage(item_mt),
-      d->extreg, d->options, &d->arena);
+      d->extreg, upb_Decode_LimitDepth(d->options, d->depth - 1), &d->arena);
   if (status != kUpb_DecodeStatus_Ok) {
     upb_ErrorHandler_ThrowError(&d->err, status);
   }


### PR DESCRIPTION
- map field for pure Python
- message_set_extension for Pure Python
- message_set_extension for UPB Python https://github.com/protocolbuffers/protobuf/issues/25335

PiperOrigin-RevId: 868863633