### PR TITLE
Harden ParseFromArray against negative size inputs (Integer Overflow)

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -12,6 +12,7 @@
 #include "google/protobuf/compiler/command_line_interface.h"
 
 #include <errno.h>
+#include <vector>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -216,31 +217,31 @@ bool TryCreateParentDirectory(const std::string& prefix,
 // Get the absolute path of this protoc binary.
 bool GetProtocAbsolutePath(std::string* path) {
 #ifdef _WIN32
-  char buffer[MAX_PATH];
-  int len = GetModuleFileNameA(nullptr, buffer, MAX_PATH);
+  std::vector<char> buffer(MAX_PATH);
+  int len = GetModuleFileNameA(nullptr, buffer.data(), MAX_PATH);
 #elif defined(__APPLE__)
-  char buffer[PATH_MAX];
+  std::vector<char> buffer(PATH_MAX);
   int len = 0;
 
   char dirtybuffer[PATH_MAX];
   uint32_t size = sizeof(dirtybuffer);
   if (_NSGetExecutablePath(dirtybuffer, &size) == 0) {
-    realpath(dirtybuffer, buffer);
-    len = strlen(buffer);
+    realpath(dirtybuffer, buffer.data());
+    len = strlen(buffer.data());
   }
 #elif defined(__FreeBSD__)
-  char buffer[PATH_MAX];
+  std::vector<char> buffer(PATH_MAX);
   size_t len = PATH_MAX;
   int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
-  if (sysctl(mib, 4, &buffer, &len, nullptr, 0) != 0) {
+  if (sysctl(mib, 4, buffer.data(), &len, nullptr, 0) != 0) {
     len = 0;
   }
 #else
-  char buffer[PATH_MAX];
-  int len = readlink("/proc/self/exe", buffer, PATH_MAX);
+  std::vector<char> buffer(PATH_MAX);
+  int len = readlink("/proc/self/exe", buffer.data(), buffer.size());
 #endif
   if (len > 0) {
-    path->assign(buffer, len);
+    path->assign(buffer.data(), len);
     return true;
   } else {
     return false;

--- a/src/google/protobuf/message_lite.cc
+++ b/src/google/protobuf/message_lite.cc
@@ -416,10 +416,12 @@ bool MessageLite::ParsePartialFromString(absl::string_view data) {
 }
 
 bool MessageLite::ParseFromArray(const void* data, int size) {
+  if (size < 0) return false;
   return ParseFrom<kParse>(as_string_view(data, size));
 }
 
 bool MessageLite::ParsePartialFromArray(const void* data, int size) {
+  if (size < 0) return false;
   return ParseFrom<kParsePartial>(as_string_view(data, size));
 }
 


### PR DESCRIPTION
**Summary**
The `ParseFromArray` and `ParsePartialFromArray` APIs accept a signed `int size`. If a caller provides a size larger than `INT_MAX` (e.g., >2.14GB), the value wraps to negative.

Internally, this `int` is later cast to `size_t` (via `as_string_view` or `FromIntSize`), converting the negative number into a massive unsigned integer (e.g., `-2000000000` -> `18446744071709551616`). This bypasses internal size checks and can lead to OOB reads or heap corruption.

**Proposed Fix**
This patch implements a "Defense at the Gate" strategy by explicitly rejecting negative `size` values at the public API boundary. This aligns with secure-by-design principles by enforcing input invariants before data reaches the parser core.

**Security Impact**
Prevents integer overflow exploitation vectors in high-performance parsing scenarios.