### PR TITLE
Fix BoolKeys test to use integer-to-bool cast

### DIFF
--- a/upb/hash/test.cc
+++ b/upb/hash/test.cc
@@ -336,7 +336,7 @@ TEST(IntTableTest, BoolKeys) {
   // First element.
   EXPECT_TRUE(upb_inttable_next(&t, &key, &val, &iter));
   bool key_bool;
-  memcpy(&key_bool, &key, sizeof(key_bool));
+  key_bool = static_cast<bool>(key);
   EXPECT_EQ(key_bool, false);
   EXPECT_EQ(upb_inttable_iter_key(&t, iter), false);
   EXPECT_EQ(val.val, true);
@@ -345,7 +345,7 @@ TEST(IntTableTest, BoolKeys) {
 
   // Second element.
   EXPECT_TRUE(upb_inttable_next(&t, &key, &val, &iter));
-  memcpy(&key_bool, &key, sizeof(key_bool));
+  key_bool = static_cast<bool>(key);
   EXPECT_EQ(key_bool, true);
   EXPECT_EQ(upb_inttable_iter_key(&t, iter), true);
   EXPECT_EQ(val.val, false);


### PR DESCRIPTION
This PR has been raised to resolve the following test case failure **`//upb/hash:test`** occurred in s390x:
**`Error:`**
```
upb/hash/test.cc:349: Failure
Expected equality of these values:
 key_bool
  Which is: false
 true

[ FAILED ] IntTableTest.BoolKeys (0 ms)
```

**`Solution:`**
- The use of memcpy() copied byte from an integer key into a bool, which fails on big endian systems. 
- Replacing it with an explicit static type cast conversion from integer to bool worked on both little and big endian systems
`key_bool = static_cast<bool>(key);`