### PR TITLE
Add recursion depth limits for Any-of-Any nesting in TextFormat

### DIFF
--- a/src/google/protobuf/BUILD.bazel
+++ b/src/google/protobuf/BUILD.bazel
@@ -2404,6 +2404,7 @@ cc_test(
     deps = [
         ":any_cc_proto",
         ":cc_test_protos",
+        ":empty_cc_proto",
         ":port",
         ":protobuf",
         ":test_util",

--- a/src/google/protobuf/text_format.h
+++ b/src/google/protobuf/text_format.h
@@ -567,6 +567,13 @@ class PROTOBUF_EXPORT TextFormat {
         custom_message_printers_;
 
     const Finder* finder_;
+
+    // Maximum recursion depth for expanding google.protobuf.Any messages.
+    // Used to prevent stack overflow from deeply nested Any-of-Any chains.
+    // Mutable because Print methods are const but need to track recursion
+    // depth during a single Print() call.
+    static constexpr int kDefaultAnyExpansionLimit = 100;
+    mutable int any_recursion_budget_ = kDefaultAnyExpansionLimit;
   };
 
   // Parses a text-format protocol message from the given input stream to


### PR DESCRIPTION
## Summary

Fixes #26071

The TextFormat Printer and Parser lack recursion depth tracking on the Any message expansion path, allowing deeply nested Any-of-Any chains to cause unbounded recursion and stack overflow (undefined behavior in C++).

**Printer fix:** `PrintAny()` → `Print()` → `PrintMessage()` → `PrintAny()` had no depth counter. Added a mutable recursion budget (`kDefaultAnyExpansionLimit = 100`) that decrements on each `PrintAny()` entry. When exceeded, `PrintAny()` returns false to gracefully fall back to non-expanded Any printing (raw `type_url` + `value` fields), preventing stack overflow without losing data.

**Parser fix:** `ConsumeAnyValue()` → `ConsumeMessage()` → `ConsumeField()` could recurse through the Any handling path without ever decrementing `recursion_limit_`, completely bypassing the recursion guard in `ConsumeFieldMessage()`. Added `recursion_limit_` tracking around the `ConsumeAnyValue()` call, consistent with the existing pattern.

This is the C++ TextFormat equivalent of the bugs fixed in CVE-2026-0994 (Python `json_format`) and CVE-2024-7254 (Java `JsonFormat`).

## Changes

- `text_format.h`: Added `mutable int any_recursion_budget_` to the Printer class
- `text_format.cc`: Recursion guard in `PrintAny()` (Printer) and around `ConsumeAnyValue()` (Parser)
- `text_format_unittest.cc`: Two regression tests for printer and parser
- `BUILD.bazel`: Added `:empty_cc_proto` dep for test

## Test plan

- [ ] `SetRecursionLimitAnyNesting` — Verifies parser rejects deeply nested Any-of-Any text format when recursion limit is set below nesting depth
- [ ] `PrintAnyRecursionLimit` — Verifies printer handles 200-deep Any-of-Any chain without crashing (stack overflow), falling back to non-expanded printing
- [ ] Existing `SetRecursionLimit*` tests continue to pass (no regression)