### PR TITLE
Second try at fixing the release_prep.sh file path!

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -9,7 +9,7 @@ TAG=$1
 PREFIX="protobuf-${TAG:1}"
 ARCHIVE="$PREFIX.bazel.tar.gz"
 ARCHIVE_TMP=$(mktemp)
-INTEGRITY_FILE=${PREFIX}/bazel/private/oss/toolchains/prebuilt/protoc_toolchain.bzl
+INTEGRITY_FILE=${PREFIX}/bazel/private/oss/toolchains/prebuilt/tool_integrity.bzl
 
 # NB: configuration for 'git archive' is in /.gitattributes
 git archive --format=tar --prefix=${PREFIX}/ ${TAG} > $ARCHIVE_TMP


### PR DESCRIPTION
Earlier attempt at https://github.com/protocolbuffers/protobuf/commit/15811028e468f4b6511e07b999cb0d9d2e0b7fd0.

PiperOrigin-RevId: 875344622