### PR TITLE
Reserve extension number 1306 for protosearch

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -563,3 +563,8 @@ about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/funinthecloud/protosource
     *   Extensions: 1296-1305
+
+1.  protosearch
+
+    *   Website: https://github.com/benwebber/protosearch
+    *   Extensions: 1306


### PR DESCRIPTION
[`protoc-gen-protosearch`](https://github.com/benwebber/protosearch) is a plugin to generate Elasticsearch/OpenSearch document mappings from message definitions.