### PR TITLE
Harden portable_strdup against overflow and remove unsafe strcpy

### DIFF
--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
 #include <string>
 
 #ifndef _WIN32
@@ -290,10 +291,15 @@ Subprocess::~Subprocess() {
 
 namespace {
 char* portable_strdup(const char* s) {
-  char* ns = (char*)malloc(strlen(s) + 1);
-  if (ns != nullptr) {
-    strcpy(ns, s);
-  }
+  if (s == nullptr) return nullptr;
+
+  const size_t len = strlen(s);
+  if (len > SIZE_MAX-1) return nullptr;
+
+  char* ns = (char*)malloc(len + 1);
+  if (ns == nullptr) return nullptr;
+
+  memcpy(ns, s, len + 1);
   return ns;
 }
 }  // namespace


### PR DESCRIPTION
This PR hardens the portable_strdup implementation to improve memory safety.

Changes made:
- Added nullptr check for input string.
- Stored strlen result in a local variable to avoid duplicate evaluation.
- Added overflow protection for (len + 1) allocation.
- Replaced unsafe strcpy with memcpy using explicit length.
- Added malloc failure handling.