### PR TITLE
Rename protoc-gen-swagger to protoc-gen-openapiv2

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -196,7 +196,7 @@ about your project (name and website) so we can add an entry for you.
     *   Website: https://github.com/MarquisIO/go-grpcmw
     *   Extensions: 1041
 
-1.  grpc-gateway protoc-gen-swagger
+1.  grpc-gateway protoc-gen-openapiv2
 
     *   Website: https://github.com/grpc-ecosystem/grpc-gateway
     *   Extensions: 1042


### PR DESCRIPTION
This rename happened *checks notes* [5.5 years ago](https://github.com/grpc-ecosystem/grpc-gateway/releases/tag/v2.0.0), whoops!