### PR TITLE
Harden JSON bytes base64 decoding to avoid undefined behavior

### DIFF
--- a/src/google/protobuf/json/internal/parser.cc
+++ b/src/google/protobuf/json/internal/parser.cc
@@ -114,6 +114,13 @@ uint32_t Base64Lookup(char c) {
 
 // Decodes `base64` in-place, shrinking the length as appropriate.
 absl::StatusOr<absl::Span<char>> DecodeBase64InPlace(absl::Span<char> base64) {
+  // Handle empty input up front to avoid pointer arithmetic on a potentially
+  // null data pointer, which is undefined in C++ even if the result is not
+  // dereferenced.
+  if (base64.empty()) {
+    return base64;
+  }
+
   // We decode in place. This is safe because this is a new buffer (not
   // aliasing the input) and because base64 decoding shrinks 4 bytes into 3.
   char* out = base64.data();
@@ -321,12 +328,14 @@ absl::StatusOr<std::string> ParseStrOrBytes(JsonLexer& lex,
 
   if (Traits::FieldType(field) == FieldDescriptor::TYPE_BYTES) {
     std::string& b64 = str->value.ToString();
-    absl::StatusOr<absl::Span<char>> decoded =
-        DecodeBase64InPlace(absl::MakeSpan(&b64[0], b64.size()));
-    if (!decoded.ok()) {
-      return str->loc.Invalid(decoded.status().message());
+    if (!b64.empty()) {
+      absl::StatusOr<absl::Span<char>> decoded =
+          DecodeBase64InPlace(absl::MakeSpan(b64.data(), b64.size()));
+      if (!decoded.ok()) {
+        return str->loc.Invalid(decoded.status().message());
+      }
+      b64.resize(decoded->size());
     }
-    b64.resize(decoded->size());
   }
 
   return std::move(str->value.ToString());


### PR DESCRIPTION
## Background

The C++ JSON parser in this repository is widely used to process untrusted JSON input, including messages that carry `bytes` fields encoded as base64. These code paths are part of the security-critical parsing surface for many applications that depend on Protocol Buffers.

## Problem

In the existing implementation of `ParseStrOrBytes` and `DecodeBase64InPlace`:

- `ParseStrOrBytes` constructs a span over `&b64[0]` even when the underlying `std::string` may be empty.
- `DecodeBase64InPlace` immediately performs pointer arithmetic on `base64.data()` without guarding against zero-length inputs.

While this typically works in practice, it relies on undefined behavior in C++: performing pointer arithmetic based on a pointer to an empty buffer is not guaranteed to be valid by the standard, and can be caught by sanitizers or behave differently under aggressive optimization.

## Solution

This change introduces a small, targeted hardening of the JSON bytes parsing pipeline:

- `DecodeBase64InPlace` now explicitly handles empty `absl::Span<char>` inputs by returning early without touching the underlying pointer.
- `ParseStrOrBytes` now:
  - Skips base64 decoding entirely for empty `TYPE_BYTES` JSON strings.
  - Uses `std::string::data()` together with the string size when constructing the span passed to `DecodeBase64InPlace`, avoiding any indexing into an empty string.

The observable behavior for valid, non-empty base64 inputs is unchanged. Empty JSON strings for `bytes` fields continue to decode to empty byte strings.

## Security benefits

- Removes a source of undefined behavior in a security-sensitive parsing path handling untrusted JSON input.
- Makes the JSON bytes decoding path more robust under sanitizers and across different compilers and optimization levels.
- Contributes to a broader "secure-by-design memory safety improvement" theme for protobuf parsing, by ensuring that even edge-case inputs are handled in a well-defined way.

## Testing

- Compiled the C++ source with the updated implementation.
- Recommended:
  - `bazel test //src/google/protobuf/json:json_test`
  - Or run the equivalent CTest/CMake target that includes `json_test.cc`.

No changes to public APIs or wire formats are introduced; the change is internal to the JSON parser implementation.

## Compatibility

- No API, ABI, or wire format changes.
- Behavior for valid inputs is preserved.
- The only difference is that empty `bytes` JSON strings are now handled without invoking undefined behavior in the C++ standard.