### PR TITLE
Mark bzlmod as requiring 8.x+

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@
 module(
     name = "protobuf",
     version = "35.0-dev",  # Automatically updated on release
+    bazel_compatibility = [">=8.0.0"],
     compatibility_level = 1,
     repo_name = "com_google_protobuf",
 )


### PR DESCRIPTION
7.x support was removed in 304c9ba5311db66a3b5dde7ed4ccafe9e0c0c893,
this enforces that in bzlmod
