### PR TITLE
Avoid toBigIntegerExact in JsonFormat to avoid degenerate parse behav…

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -1797,10 +1797,12 @@ public class JsonFormat {
       // "1.000" are treated as equal in JSON. For this reason we accept floating point values for
       // integer fields as well as long as it actually is an integer (i.e., round(value) == value).
       try {
-        BigDecimal decimalValue = new BigDecimal(json.getAsString());
-        BigInteger value = decimalValue.toBigIntegerExact();
+        BigDecimal value = new BigDecimal(json.getAsString());
         if (value.signum() < 0 || value.compareTo(MAX_UINT32) > 0) {
           throw new InvalidProtocolBufferException("Out of range uint32 value: " + json);
+        }
+        if (value.remainder(BigDecimal.ONE).signum() != 0) {
+          throw new InvalidProtocolBufferException("Not an uint32 value: " + json);
         }
         return value.intValue();
       } catch (RuntimeException e) {
@@ -1811,15 +1813,18 @@ public class JsonFormat {
       }
     }
 
-    private static final BigInteger MAX_UINT32 = new BigInteger("FFFFFFFF", 16);
-    private static final BigInteger MAX_UINT64 = new BigInteger("FFFFFFFFFFFFFFFF", 16);
+    private static final BigDecimal MAX_UINT32 = new BigDecimal(0xFFFFFFFFL);
+    private static final BigDecimal MAX_UINT64 =
+        new BigDecimal(new BigInteger("FFFFFFFFFFFFFFFF", 16));
 
     private long parseUint64(JsonElement json) throws InvalidProtocolBufferException {
       try {
-        BigDecimal decimalValue = new BigDecimal(json.getAsString());
-        BigInteger value = decimalValue.toBigIntegerExact();
-        if (value.compareTo(BigInteger.ZERO) < 0 || value.compareTo(MAX_UINT64) > 0) {
+        BigDecimal value = new BigDecimal(json.getAsString());
+        if (value.signum() < 0 || value.compareTo(MAX_UINT64) > 0) {
           throw new InvalidProtocolBufferException("Out of range uint64 value: " + json);
+        }
+        if (value.remainder(BigDecimal.ONE).signum() != 0) {
+          throw new InvalidProtocolBufferException("Not an uint64 value: " + json);
         }
         return value.longValue();
       } catch (RuntimeException e) {

--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -391,7 +391,6 @@ public class JsonFormatTest {
       assertWithMessage("Exception is expected.").fail();
     } catch (InvalidProtocolBufferException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("Not an uint32 value: 1.5");
-      assertThat(expected).hasCauseThat().isNotNull();
     }
   }
 
@@ -403,7 +402,50 @@ public class JsonFormatTest {
       assertWithMessage("Exception is expected.").fail();
     } catch (InvalidProtocolBufferException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("Not an uint64 value: 1.5");
-      assertThat(expected).hasCauseThat().isNotNull();
+    }
+  }
+
+  @Test
+  public void testRejectLargeQuotedExponentInt32() throws IOException {
+    TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+    try {
+      mergeFromJson("{\"optionalInt32\": \"1e536870000\"}", builder);
+      assertWithMessage("Exception is expected.").fail();
+    } catch (InvalidProtocolBufferException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("Not an int32 value: \"1e536870000\"");
+    }
+  }
+
+  @Test
+  public void testRejectLargeQuotedExponentUnsignedUint32() throws IOException {
+    TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+    try {
+      mergeFromJson("{\"optionalUint32\": \"1e536870000\"}", builder);
+      assertWithMessage("Exception is expected.").fail();
+    } catch (InvalidProtocolBufferException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("Out of range uint32 value: \"1e536870000\"");
+    }
+  }
+
+  @Test
+  public void testRejectLargeQuotedExponentInt64() throws IOException {
+    TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+    try {
+      mergeFromJson("{\"optionalInt64\": \"1e536870000\"}", builder);
+      assertWithMessage("Exception is expected.").fail();
+    } catch (InvalidProtocolBufferException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("Not an int64 value: \"1e536870000\"");
+    }
+  }
+
+  @Test
+  public void testRejectLargeQuotedExponentUnsignedUint64() throws IOException {
+    TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+    try {
+      mergeFromJson("{\"optionalUint64\": \"1e536870000\"}", builder);
+      assertWithMessage("Exception is expected.").fail();
+    } catch (InvalidProtocolBufferException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("Out of range uint64 value: \"1e536870000\"");
     }
   }
 


### PR DESCRIPTION
…ior in the face of large exponents.

https://github.com/protocolbuffers/protobuf/issues/26032

PiperOrigin-RevId: 874768607