### PR TITLE
Set TextFormat default recursion limit to 100

### DIFF
--- a/src/google/protobuf/text_format.cc
+++ b/src/google/protobuf/text_format.cc
@@ -1800,7 +1800,7 @@ TextFormat::Parser::Parser()
       allow_field_number_(false),
       allow_relaxed_whitespace_(false),
       allow_singular_overwrites_(false),
-      recursion_limit_(std::numeric_limits<int>::max()) {}
+      recursion_limit_(100) {}
 
 namespace {
 


### PR DESCRIPTION
## Summary

The `TextFormat::Parser` constructor initializes `recursion_limit_` to `std::numeric_limits<int>::max()` (2,147,483,647) at `text_format.cc:1803`. This is inconsistent with:
- Binary format parser: default **100** (`CodedInputStream::default_recursion_limit_`)
- JSON parser: default **64-100**
- UPB binary decoder: default **100** (`kUpb_WireFormat_DefaultDepthLimit`)

A textproto with ~5,000-10,000 nested messages overflows the C stack before the recursion check ever triggers, causing `SIGSEGV`.

## Fix

Change the default from `std::numeric_limits<int>::max()` to `100`, matching `CodedInputStream::default_recursion_limit_`. Users who need a different limit can still call `SetRecursionLimit()`.

## Reproducer

```cpp
// Parse deeply nested textproto
std::string textproto;
for (int i = 0; i < 10000; i++) textproto += "nested_type { ";
textproto += "name: \"x\"";
for (int i = 0; i < 10000; i++) textproto += " }";

DescriptorProto msg;
TextFormat::ParseFromString(textproto, &msg);  // SIGSEGV
```

```
$ ulimit -s 8192 && ./test
EXIT=139  (SIGSEGV - stack overflow)
```

## Test plan

- [x] Verified crash with default limit (exit 139)
- [x] `SetRecursionLimit()` API still works for custom limits
- [ ] Existing protobuf test suite passes