### PR TITLE
Remove python from UPB / Windows tests

### DIFF
--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: "upb-bazel-windows"
-          bazel: test --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 //upb/... //upb_generator/... //python/... //protos/... //protos_generator/...
+          bazel: test --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 //upb/... //upb_generator/... //protos/... //protos_generator/...
           exclude-targets: -//python:conformance_test -//upb:def_builder_test
 
   macos:


### PR DESCRIPTION
This was broken by a Github Runner Image bump from 3.9 to 3.12 which removed the setuptools dependency by default.

We could probably fix this but python isn't actually in support anymore in 25.x and we have this disabled in main anyways due to system_python's silent failure mode in windows: https://github.com/protocolbuffers/protobuf/commit/b882eb7205dd6bb0b550e740af99a3a0663fadd0