### PR TITLE
Remove 9.x tests from BCR presubmit until its fully working.

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -3,7 +3,7 @@ bcr_test_module:
   module_path: examples
   matrix:
     platform: ["debian10", "macos", "macos_arm64", "ubuntu2004", "windows"]
-    bazel: [8.x, 9.x]
+    bazel: [8.x]
 
   tasks:
     verify_targets:


### PR DESCRIPTION
Remove this from 34.x for now to ensure we don't end up blocked on this for release again.

We'll want to re-enable this when we land / patch full Bazel 9 support and tests.

PiperOrigin-RevId: 886913821