### PR TITLE
Fix 1-byte stack overflow in PHP extension int64 formatting

### DIFF
--- a/php/ext/google/protobuf/convert.c
+++ b/php/ext/google/protobuf/convert.c
@@ -431,7 +431,7 @@ void Convert_UpbToPhp(upb_MessageValue upb_val, zval* php_val, TypeInfo type,
       ZVAL_LONG(php_val, upb_val.int64_val);
 #else
     {
-      char buf[20];
+      char buf[21];
       int size = sprintf(buf, "%lld", upb_val.int64_val);
       ZVAL_NEW_STR(php_val, zend_string_init(buf, size, 0));
     }
@@ -442,7 +442,7 @@ void Convert_UpbToPhp(upb_MessageValue upb_val, zval* php_val, TypeInfo type,
       ZVAL_LONG(php_val, upb_val.uint64_val);
 #else
     {
-      char buf[20];
+      char buf[21];
       int size = sprintf(buf, "%lld", (int64_t)upb_val.uint64_val);
       ZVAL_NEW_STR(php_val, zend_string_init(buf, size, 0));
     }


### PR DESCRIPTION
`php/ext/google/protobuf/convert.c` lines 434 and 445: `char buf[20]` is used with `sprintf(buf, "%lld", ...)` to format 64-bit integers. `INT64_MIN` (-9223372036854775808) requires 20 characters plus a null terminator = 21 bytes, causing a 1-byte stack buffer overflow.

Fix: increase buffer from 20 to 21 bytes.