### PR TITLE
Add integer overflow guards to upb buffer growth functions

### DIFF
--- a/upb/io/string.h
+++ b/upb/io/string.h
@@ -84,8 +84,13 @@ UPB_INLINE bool upb_String_Reserve(upb_String* s, size_t size) {
 
 UPB_INLINE bool upb_String_Append(upb_String* s, const char* data,
                                   size_t size) {
+  // Guard against size_ + size overflowing size_t.
+  if (size > SIZE_MAX - s->size_) return false;
   if (s->capacity_ <= s->size_ + size) {
-    const size_t new_cap = 2 * (s->size_ + size) + 1;
+    const size_t sum = s->size_ + size;
+    // Guard against 2 * sum + 1 overflowing size_t.
+    if (sum > (SIZE_MAX - 1) / 2) return false;
+    const size_t new_cap = 2 * sum + 1;
     if (!upb_String_Reserve(s, new_cap)) return false;
   }
 

--- a/upb/io/string_test.cc
+++ b/upb/io/string_test.cc
@@ -7,6 +7,7 @@
 
 #include "upb/io/string.h"
 
+#include <stdint.h>
 #include <string.h>
 
 #include <gtest/gtest.h>
@@ -104,4 +105,35 @@ TEST(StringTest, Erase) {
   upb_String_Erase(&foo, 0, 4);
   EXPECT_EQ(upb_String_Size(&foo), 0);
   EXPECT_EQ(strcmp(upb_String_Data(&foo), ""), 0);
+}
+
+TEST(StringTest, AppendOverflowReturnsFailure) {
+  upb::Arena arena;
+
+  upb_String s;
+  EXPECT_TRUE(upb_String_Init(&s, arena.ptr()));
+  EXPECT_TRUE(upb_String_Append(&s, "hello", 5));
+  EXPECT_EQ(upb_String_Size(&s), 5);
+
+  // Attempt an append where size_ + size would overflow size_t.
+  // SIZE_MAX - 4 + 5 = SIZE_MAX + 1 which wraps to 0.
+  // The overflow check should catch this and return false.
+  EXPECT_FALSE(upb_String_Append(&s, "x", SIZE_MAX - 4));
+
+  // The string should be unchanged after the failed append.
+  EXPECT_EQ(upb_String_Size(&s), 5);
+  EXPECT_EQ(strcmp(upb_String_Data(&s), "hello"), 0);
+}
+
+TEST(StringTest, AppendNormalStillWorks) {
+  upb::Arena arena;
+
+  upb_String s;
+  EXPECT_TRUE(upb_String_Init(&s, arena.ptr()));
+
+  // Normal appends should still succeed.
+  EXPECT_TRUE(upb_String_Append(&s, "abc", 3));
+  EXPECT_TRUE(upb_String_Append(&s, "def", 3));
+  EXPECT_EQ(upb_String_Size(&s), 6);
+  EXPECT_EQ(strcmp(upb_String_Data(&s), "abcdef"), 0);
 }

--- a/upb/json/decode.c
+++ b/upb/json/decode.c
@@ -425,7 +425,11 @@ static size_t jsondec_unicode(jsondec* d, char* out) {
 static void jsondec_resize(jsondec* d, char** buf, char** end, char** buf_end) {
   size_t oldsize = *buf_end - *buf;
   size_t len = *end - *buf;
-  size_t size = UPB_MAX(8, 2 * oldsize);
+  size_t size;
+  if (oldsize > SIZE_MAX / 2) {
+    jsondec_err(d, "JSON string too large");
+  }
+  size = UPB_MAX(8, 2 * oldsize);
 
   *buf = upb_Arena_Realloc(d->arena, *buf, len, size);
   if (!*buf) jsondec_err(d, "Out of memory");

--- a/upb/message/array.c
+++ b/upb/message/array.c
@@ -124,7 +124,10 @@ bool UPB_PRIVATE(_upb_Array_Realloc)(upb_Array* array, size_t min_capacity,
   void* ptr = upb_Array_MutableDataPtr(array);
 
   // Log2 ceiling of size.
-  while (new_capacity < min_capacity) new_capacity *= 2;
+  while (new_capacity < min_capacity) {
+    if (new_capacity > SIZE_MAX / 2) return false;
+    new_capacity *= 2;
+  }
 
   const size_t new_bytes = new_capacity << lg2;
   ptr = upb_Arena_Realloc(arena, ptr, old_bytes, new_bytes);

--- a/upb/reflection/desc_state.c
+++ b/upb/reflection/desc_state.c
@@ -21,7 +21,8 @@ bool _upb_DescState_Grow(upb_DescState* d, upb_Arena* a) {
     d->e.end = d->buf + d->bufsize;
   }
 
-  if (oldbufsize - used < kUpb_MtDataEncoder_MinSize) {
+  if (used > oldbufsize || oldbufsize - used < kUpb_MtDataEncoder_MinSize) {
+    if (d->bufsize > SIZE_MAX / 2) return false;
     d->bufsize *= 2;
     d->buf = upb_Arena_Realloc(a, d->buf, oldbufsize, d->bufsize);
     if (!d->buf) return false;


### PR DESCRIPTION
## Summary

Add overflow checks to buffer doubling in upb's string, JSON decoder, array, and descriptor state modules. These prevent silent `size_t` wraparound when buffers are doubled repeatedly.

Split from #26530 per reviewer request — that PR now contains only the `php/ext` fix.

## Changes

- **`upb/io/string.h`**: Add `SIZE_MAX` guard before `size + size` in `upb_String_Append`
- **`upb/json/decode.c`**: Add `SIZE_MAX / 2` guard before `oldsize * 2` in `jsondec_resize`
- **`upb/message/array.c`**: Add `SIZE_MAX / 2` guard before `new_capacity * 2` in `UPB_PRIVATE(_upb_Array_Realloc)`
- **`upb/reflection/desc_state.c`**: Add `SIZE_MAX / 2` guard before `new_cap * 2` in `_upb_DescState_Grow`
- **`upb/io/string_test.cc`**: Add `AppendOverflowReturnsFailure` test exercising the wrap path