### PR TITLE
Fix UBSAN warnings for null pointer in memcpy

### DIFF
--- a/src/google/protobuf/io/coded_stream.cc
+++ b/src/google/protobuf/io/coded_stream.cc
@@ -239,6 +239,9 @@ bool CodedInputStream::GetDirectBufferPointer(const void** data, int* size) {
 bool CodedInputStream::ReadRaw(void* buffer, int size) {
   int current_buffer_size;
   while ((current_buffer_size = BufferSize()) < size) {
+    if (current_buffer_size <= 0) {
+      return false;
+    }
     // Reading past end of buffer.  Copy what we have, then refresh.
     memcpy(buffer, buffer_, current_buffer_size);
     buffer = reinterpret_cast<uint8_t*>(buffer) + current_buffer_size;


### PR DESCRIPTION
Fix the UBSAN warnings in https://github.com/protocolbuffers/protobuf/issues/26546.

The CodedInputStream should return false gracefully when reading past EOF. However, the current implementation will still invoke memcpy on the NULL buffer, which introduces UBSAN warnings.

This patch fixes this issue by directly exiting the reading procedure when there is no byte to read.