### PR TITLE
security: validate codegen string options to prevent code injection

### DIFF
--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -8426,6 +8426,38 @@ void DescriptorBuilder::ValidateOptions(const FileDescriptor* file,
       }
     }
   }
+  // Reject control characters in code-generation string options to prevent
+  // code injection into generated source files. These option values are
+  // interpolated directly into generated Ruby, PHP, and C# source code;
+  // newlines and other control characters can break out of string literals
+  // or declarations and inject arbitrary code.
+  auto validate_codegen_option = [&](const std::string& value,
+                                     const char* option_name) {
+    for (char c : value) {
+      if (c < 0x20 || c == 0x7f || c == '"' || c == '\'' || c == '\\') {
+        AddError(file->name(), proto, DescriptorPool::ErrorCollector::OTHER,
+                 [&] {
+                   return absl::StrCat(
+                       "\"", option_name,
+                       "\" contains characters that are not safe for code "
+                       "generation. Only printable characters (excluding "
+                       "quotes and backslashes) are allowed.");
+                 });
+        return;
+      }
+    }
+  };
+  if (file->options().has_ruby_package()) {
+    validate_codegen_option(file->options().ruby_package(), "ruby_package");
+  }
+  if (file->options().has_php_namespace()) {
+    validate_codegen_option(file->options().php_namespace(), "php_namespace");
+  }
+  if (file->options().has_csharp_namespace()) {
+    validate_codegen_option(file->options().csharp_namespace(),
+                            "csharp_namespace");
+  }
+
   if (file->edition() == Edition::EDITION_PROTO3) {
     ValidateProto3(file, proto);
   }


### PR DESCRIPTION
## Summary

The `ruby_package`, `php_namespace`, and `csharp_namespace` file options are interpolated directly into generated source code without sanitization. The tokenizer processes `\n` escape sequences in string option values, converting them to literal newlines. These newlines break out of module/namespace declarations in the generated code, allowing arbitrary code injection.

## Fix

Adds validation in `ValidateOptions(FileDescriptor*)` to reject control characters, quotes, and backslashes in code-generation string options at parse time — before any code generator runs.

## Affected code paths

- `ruby_generator.cc:197` — `module $name$` interpolation
- `php/php_generator.cc` — namespace interpolation  
- `csharp/csharp_helpers.cc` — namespace interpolation

## Reproduction

```proto
syntax = "proto3";
option ruby_package = "Exploit::RCE\nend\nsystem('id')\nmodule X";
message Payload { string data = 1; }
```

`protoc --ruby_out=. poc.proto` generates a `.rb` file with `system('id')` injected outside module scope. `require './poc_pb'` executes it.