### PR TITLE
Add message depth limit for Any in JSON serialization

### DIFF
--- a/src/google/protobuf/json/internal/unparser.cc
+++ b/src/google/protobuf/json/internal/unparser.cc
@@ -768,7 +768,11 @@ absl::Status WriteAny(JsonWriter& writer, const Msg<Traits>& msg,
           any_bytes = *bytes;
         }
 
-        return Traits::WithDecodedMessage(
+        if (!writer.IncrementMessageDepth()) {
+          return absl::InvalidArgumentError(
+              "Any message nesting depth exceeded");
+        }
+        absl::Status any_status = Traits::WithDecodedMessage(
             any_desc, any_bytes,
             [&](const Msg<Traits>& unerased) -> absl::Status {
               bool first = false;
@@ -791,6 +795,8 @@ absl::Status WriteAny(JsonWriter& writer, const Msg<Traits>& msg,
               writer.Write("}");
               return absl::OkStatus();
             });
+        writer.DecrementMessageDepth();
+        return any_status;
       });
 }
 

--- a/src/google/protobuf/json/internal/writer.h
+++ b/src/google/protobuf/json/internal/writer.h
@@ -90,6 +90,13 @@ class JsonWriter {
   void Push() { ++indent_; }
   void Pop() { --indent_; }
 
+  // Track message nesting depth to prevent unbounded recursion via Any.
+  static constexpr int kMaxMessageDepth = 100;
+  bool IncrementMessageDepth() {
+    return ++message_depth_ <= kMaxMessageDepth;
+  }
+  void DecrementMessageDepth() { --message_depth_; }
+
   // The many overloads of Write() will write a value to the underlying stream.
   // Some values may want to be quoted; the Quoted<> type will automatically add
   // quotes and escape sequences.
@@ -203,6 +210,7 @@ class JsonWriter {
   io::zc_sink_internal::ZeroCopyStreamByteSink sink_;
   WriterOptions options_;
   int indent_ = 0;
+  int message_depth_ = 0;
 
   std::string scratch_buf_;
 };

--- a/src/google/protobuf/json/json_test.cc
+++ b/src/google/protobuf/json/json_test.cc
@@ -1199,6 +1199,24 @@ TEST_P(JsonTest, TestAny) {
   EXPECT_EQ(round_trip->value(), "");
 }
 
+
+TEST_P(JsonTest, DeeplyNestedAnyRejected) {
+  // Verify that deeply nested Any messages are rejected during JSON
+  // serialization rather than causing unbounded stack recursion.
+  std::string inner;
+  google::protobuf::Any msg;
+  for (int i = 0; i < 200; ++i) {
+    msg.Clear();
+    msg.set_type_url("type.googleapis.com/google.protobuf.Any");
+    msg.set_value(inner);
+    inner = msg.SerializeAsString();
+  }
+  google::protobuf::Any outer;
+  outer.set_type_url("type.googleapis.com/google.protobuf.Any");
+  outer.set_value(inner);
+  EXPECT_THAT(ToJson(outer), StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
 TEST_P(JsonTest, TestDuration) {
   auto m = ToProto<proto3::TestDuration>(R"json(
     {


### PR DESCRIPTION
WriteAny() in the C++ JSON serializer creates a fresh CodedInputStream for each nested Any's value bytes via WithDecodedMessage(), resetting the recursion budget. Neither JsonWriter nor WriteMessage tracks overall nesting depth. Deeply nested Any messages cause unbounded stack recursion during MessageToJsonString() or BinaryToJsonString().

The fix adds a message depth counter to JsonWriter, checked in WriteAny before decoding the inner message. This matches the approach used in the Java fix (94c7f7382) for the same issue.

Affects both the reflection path (MessageToJsonString) and the TypeResolver path (BinaryToJsonString).