### PR TITLE
fix(php): Remove public and weak dependencies from generated PHP.

### DIFF
--- a/src/google/protobuf/compiler/php/generator_unittest.cc
+++ b/src/google/protobuf/compiler/php/generator_unittest.cc
@@ -105,6 +105,38 @@ TEST_F(PhpGeneratorTest, ClosedEnumError) {
   ExpectErrorSubstring("Can't generate PHP code for closed enum Foo");
 }
 
+TEST_F(PhpGeneratorTest, ImportPublic) {
+  CreateTempFile("common.proto",
+                 R"schema(
+    syntax = "proto3";
+    package prototest;
+    message Common {
+      string data = 1;
+    })schema");
+
+  CreateTempFile("prototest.proto",
+                 R"schema(
+    syntax = "proto3";
+    package prototest;
+    import public "common.proto";
+    )schema");
+
+  CreateTempFile("usecase.proto",
+                 R"schema(
+    syntax = "proto3";
+    package usecasetest;
+    import "prototest.proto";
+    message UseCase {
+      prototest.Common commonUse = 1;
+    })schema");
+
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir --php_out=$tmpdir "
+      "common.proto prototest.proto usecase.proto");
+
+  ExpectNoErrors();
+}
+
 }  // namespace
 }  // namespace php
 }  // namespace compiler

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -1047,6 +1047,12 @@ void GenerateAddFileToPool(const FileDescriptor* file, const Options& options,
         }
       }
 
+      // Clear public_dependency and weak_dependency since they contain indices
+      // into the dependency array which we just modified above. PHP handles
+      // dependency loading through initOnce() calls instead.
+      file_proto->clear_public_dependency();
+      file_proto->clear_weak_dependency();
+
       // Filter out all extensions, since we do not support extension yet.
       file_proto->clear_extension();
       RepeatedPtrField<DescriptorProto>* message_type =
@@ -1172,6 +1178,12 @@ void GenerateAddFilesToPool(const FileDescriptor* file, const Options& options,
           break;
         }
       }
+
+      // Clear public_dependency and weak_dependency since they contain indices
+      // into the dependency array which we just modified above. PHP handles
+      // dependency loading through initOnce() calls instead.
+      file_proto->clear_public_dependency();
+      file_proto->clear_weak_dependency();
 
       // Filter out all extensions, since we do not support extension yet.
       file_proto->clear_extension();


### PR DESCRIPTION
In issue #11146 people reported problems with the PHP package version 3.20.0RC3 and above crashing when the native extension was used with protobufs that had transitive dependencies. [This comment](https://github.com/protocolbuffers/protobuf/issues/11146#issuecomment-1939557722) noted that it looked like an issue with the dependency list being modified.

This PR resolves the issue by also removing public and weak dependency references in the emitted PHP metadata classes. 
I've added a unit test showing that it compiles OK, but the unit tests don't exercise the PHP side so I've taken the liberty of extending the reproducer case kindly provided by @tforesti and pushed a version that shows the fix to [github.com/alowde/php-protobuf-ext-issue](https://github.com/alowde/php-protobuf-ext-issue/tree/master). The [Dockerfile](https://github.com/alowde/php-protobuf-ext-issue/blob/master/DockerfileOKPatchedLatest) builds a copy of `protoc` from my branch and shows that the patched version doesn't cause a crash on import when the image is launced.

An LLM was used to investigate the issue and write the unit test, with human review. The fix itself and the fix demonstration  were written by @alowde. The fix demo builds on the failure case Dockerfile by @tforesti to provide a clear demonstration of the fix.

Please let me know if any further information or changes would be useful. Thanks!