### PR TITLE
fix python json_format WKT recursion depth bypass

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -1861,6 +1861,45 @@ class JsonFormatTest(JsonFormatBase):
         max_recursion_depth=5,
     )
 
+  def testStructRecursionDepthEnforcement(self):
+    message = struct_pb2.Struct()
+    nested_struct = {'k': {'k': {'k': {'k': 0}}}}
+
+    self.assertRaisesRegex(
+        json_format.ParseError,
+        'Message too deep. Max recursion depth is 3',
+        json_format.ParseDict,
+        nested_struct,
+        message,
+        max_recursion_depth=3,
+    )
+
+  def testListValueRecursionDepthEnforcement(self):
+    message = struct_pb2.ListValue()
+    nested_list = [[[[0]]]]
+
+    self.assertRaisesRegex(
+        json_format.ParseError,
+        'Message too deep. Max recursion depth is 3',
+        json_format.ParseDict,
+        nested_list,
+        message,
+        max_recursion_depth=3,
+    )
+
+  def testValueRecursionDepthEnforcement(self):
+    message = struct_pb2.Value()
+    nested_value = {'k': {'k': {'k': {'k': 0}}}}
+
+    self.assertRaisesRegex(
+        json_format.ParseError,
+        'Message too deep. Max recursion depth is 3',
+        json_format.ParseDict,
+        nested_value,
+        message,
+        max_recursion_depth=3,
+    )
+
   def testJsonNameConflictSerilize(self):
     message = more_messages_pb2.ConflictJsonName(value=2)
     self.assertEqual(

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -535,17 +535,19 @@ class _Parser(object):
               self.max_recursion_depth
           )
       )
-    message_descriptor = message.DESCRIPTOR
-    full_name = message_descriptor.full_name
-    if not path:
-      path = message_descriptor.name
-    if _IsWrapperMessage(message_descriptor):
-      self._ConvertWrapperMessage(value, message, path)
-    elif full_name in _WKTJSONMETHODS:
-      methodcaller(_WKTJSONMETHODS[full_name][1], value, message, path)(self)
-    else:
-      self._ConvertFieldValuePair(value, message, path)
-    self.recursion_depth -= 1
+    try:
+      message_descriptor = message.DESCRIPTOR
+      full_name = message_descriptor.full_name
+      if not path:
+        path = message_descriptor.name
+      if _IsWrapperMessage(message_descriptor):
+        self._ConvertWrapperMessage(value, message, path)
+      elif full_name in _WKTJSONMETHODS:
+        methodcaller(_WKTJSONMETHODS[full_name][1], value, message, path)(self)
+      else:
+        self._ConvertFieldValuePair(value, message, path)
+    finally:
+      self.recursion_depth -= 1
 
   def _ConvertFieldValuePair(self, js, message, path):
     """Convert field value pairs into regular message.
@@ -775,9 +777,9 @@ class _Parser(object):
   def _ConvertValueMessage(self, value, message, path):
     """Convert a JSON representation into Value message."""
     if isinstance(value, dict):
-      self._ConvertStructMessage(value, message.struct_value, path)
+      self.ConvertMessage(value, message.struct_value, path)
     elif isinstance(value, _LIST_LIKE):
-      self._ConvertListOrTupleValueMessage(value, message.list_value, path)
+      self.ConvertMessage(value, message.list_value, path)
     elif value is None:
       message.null_value = 0
     elif isinstance(value, bool):
@@ -801,7 +803,7 @@ class _Parser(object):
       )
     message.ClearField('values')
     for index, item in enumerate(value):
-      self._ConvertValueMessage(
+      self.ConvertMessage(
           item, message.values.add(), '{0}[{1}]'.format(path, index)
       )
 
@@ -815,7 +817,7 @@ class _Parser(object):
     # there are no values.
     message.Clear()
     for key in value:
-      self._ConvertValueMessage(
+      self.ConvertMessage(
           value[key], message.fields[key], '{0}.{1}'.format(path, key)
       )
     return


### PR DESCRIPTION
## Summary
- fix a recursion depth bypass in Python `json_format` for `google.protobuf.Struct`, `Value`, and `ListValue`
- make every nested WKT parse path go back through `ConvertMessage`, so `max_recursion_depth` is enforced consistently
- add regression tests for the three affected WKT entry points

## Vulnerability
`json_format.Parse()` and `ParseDict()` maintain recursion accounting in `ConvertMessage()`, but the well-known type helpers for `Value`, `Struct`, and `ListValue` were recursing through `_ConvertValueMessage()`, `_ConvertStructMessage()`, and `_ConvertListOrTupleValueMessage()` without returning to that shared entry point. As a result, a caller that explicitly configured `max_recursion_depth` could still parse deeply nested attacker-controlled JSON until the interpreter raised `RecursionError` instead of the intended `ParseError`.

In applications that parse protobuf JSON from external requests, that turns a configured depth guard into a low-request denial of service primitive.

## Fix
- route dict and list handling in `_ConvertValueMessage()` back through `ConvertMessage()`
- route nested `Struct` field values and `ListValue` elements through `ConvertMessage()` as well
- move the recursion depth decrement into a `finally` block so exceptions cannot leave the counter unbalanced

## Testing
- `BAZEL_NO_APPLE_CPP_TOOLCHAIN=1 bazel test //python:json_format_test --test_output=errors`
