### PR TITLE
Fix merge sort corruption and integer overflow in upb compare_unknown

### DIFF
--- a/upb/message/internal/compare_unknown.c
+++ b/upb/message/internal/compare_unknown.c
@@ -102,7 +102,7 @@ static void upb_UnknownFields_Merge(upb_UnknownField* arr, size_t start,
   if (ptr1 < end1) {
     memcpy(out, ptr1, (end1 - ptr1) * sizeof(*out));
   } else if (ptr2 < end2) {
-    memcpy(out, ptr1, (end2 - ptr2) * sizeof(*out));
+    memcpy(out, ptr2, (end2 - ptr2) * sizeof(*out));
   }
 }
 
@@ -119,11 +119,12 @@ static void upb_UnknownFields_SortRecursive(upb_UnknownField* arr, size_t start,
 static void upb_UnknownFields_Sort(upb_UnknownField_Context* ctx,
                                    upb_UnknownFields* fields) {
   if (ctx->tmp_size < fields->size) {
-    const int oldsize = ctx->tmp_size * sizeof(*ctx->tmp);
+    const size_t oldsize = ctx->tmp_size * sizeof(*ctx->tmp);
     ctx->tmp_size = UPB_MAX(8, ctx->tmp_size);
     while (ctx->tmp_size < fields->size) ctx->tmp_size *= 2;
-    const int newsize = ctx->tmp_size * sizeof(*ctx->tmp);
+    const size_t newsize = ctx->tmp_size * sizeof(*ctx->tmp);
     ctx->tmp = upb_grealloc(ctx->tmp, oldsize, newsize);
+    if (!ctx->tmp) upb_UnknownFields_OutOfMemory(ctx);
   }
   upb_UnknownFields_SortRecursive(fields->fields, 0, fields->size, ctx->tmp);
 }

--- a/upb/message/internal/compare_unknown_test.cc
+++ b/upb/message/internal/compare_unknown_test.cc
@@ -107,6 +107,54 @@ TEST(CompareTest, UnknownFieldsOrdering) {
           {{1, Group({{2, Group({{4, Fixed64(123)}, {3, Fixed32(456)}})}})}}));
 }
 
+// This test triggers the merge sort bug in compare_unknown.c line 105.
+// The bug: in upb_UnknownFields_Merge(), the "else if (ptr2 < end2)" branch
+// copies from ptr1 (already exhausted) instead of ptr2 (the actual remainder).
+// This corrupts the sorted array, causing equal messages to compare as NotEqual.
+//
+// The key is to create field orderings where the RIGHT half of a merge has
+// remaining elements after the left half is exhausted. For example:
+//   Input [2, 1, 3] splits into [2] and [1, 3]
+//   After recursive sort: [2] and [1, 3]
+//   Merge: take 1 (from right), take 2 (from left) -> left exhausted
+//   Remainder: ptr2 points to [3] but the bug copies from ptr1 (stale data)
+TEST(CompareTest, MergeSortBug_RightHalfRemainder) {
+  // 3 elements: [2, 1, 3] vs [1, 2, 3] - simplest trigger
+  EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
+            CompareUnknown({{2, Varint(200)}, {1, Varint(100)}, {3, Varint(300)}},
+                           {{1, Varint(100)}, {2, Varint(200)}, {3, Varint(300)}}));
+
+  // 5 elements: [2, 4, 1, 3, 5] vs [1, 2, 3, 4, 5]
+  EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
+            CompareUnknown({{2, Varint(200)},
+                            {4, Varint(400)},
+                            {1, Varint(100)},
+                            {3, Varint(300)},
+                            {5, Varint(500)}},
+                           {{1, Varint(100)},
+                            {2, Varint(200)},
+                            {3, Varint(300)},
+                            {4, Varint(400)},
+                            {5, Varint(500)}}));
+
+  // 7 elements: complex shuffle that triggers multiple buggy merges
+  EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
+            CompareUnknown({{4, Varint(400)},
+                            {6, Varint(600)},
+                            {2, Varint(200)},
+                            {7, Varint(700)},
+                            {1, Varint(100)},
+                            {3, Varint(300)},
+                            {5, Varint(500)}},
+                           {{1, Varint(100)},
+                            {2, Varint(200)},
+                            {3, Varint(300)},
+                            {4, Varint(400)},
+                            {5, Varint(500)},
+                            {6, Varint(600)},
+                            {7, Varint(700)}}));
+}
+
 TEST(CompareTest, LongVarint) {
   EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
             CompareUnknownWithMaxDepth({{1, Varint(123)}, {2, Varint(456)}},


### PR DESCRIPTION
## Summary

Two bugs in `upb/message/internal/compare_unknown.c`:

### Bug 1: Merge sort data corruption (line 105)

In `upb_UnknownFields_Merge()`, the else-if branch that handles the right-half remainder copies from `ptr1` (the exhausted left pointer) instead of `ptr2` (the remaining right pointer):

```c
} else if (ptr2 < end2) {
    memcpy(out, ptr1, (end2 - ptr2) * sizeof(*out));  // BUG: ptr1 should be ptr2
}
```

When the left half is fully consumed first and the right half has unconsumed remaining elements, this copies stale data from the left half's end position instead of the actual remaining elements. This corrupts the sorted array, causing `_upb_Message_UnknownFieldsAreEqual` to return `NotEqual` for semantically identical messages whose unknown fields arrive in different order.

**Trigger:** Unknown fields with tags `[2, 4, 1, 3, 5]` sort to `[1, 2, 3, 4, 1]` instead of `[1, 2, 3, 4, 5]`.

### Bug 2: Integer overflow in tmp buffer allocation (lines 122-126)

`oldsize` and `newsize` are declared as `const int` but hold `size_t * sizeof(...)` products:

```c
const int oldsize = ctx->tmp_size * sizeof(*ctx->tmp);  // truncates to int
// ...
const int newsize = ctx->tmp_size * sizeof(*ctx->tmp);  // truncates to int
ctx->tmp = upb_grealloc(ctx->tmp, oldsize, newsize);    // no NULL check
```

`sizeof(upb_UnknownField) = 24` on 64-bit. When `tmp_size >= 89,478,486` (~89.5M fields), the product overflows `INT_MAX`. The negative `int` sign-extends to a massive `size_t` when passed to `upb_grealloc`, which calls `realloc()` with ~18 EB, returns NULL. No NULL check exists (unlike `map_sorter.c` line 118 which checks), so the merge sort writes to NULL → crash.

**Trigger:** A protobuf message with ~89.5M unsorted unknown varint fields (~170 MB wire data).

## Fix

1. Change `ptr1` to `ptr2` on line 105
2. Change `const int` to `const size_t` for `oldsize`/`newsize` on lines 122/125
3. Add NULL check after `upb_grealloc` (matching the `map_sorter.c` pattern)

## Test

Added `MergeSortBug_RightHalfRemainder` test with 3/5/7 element orderings that trigger the merge corruption. Without the fix, these tests fail with `NotEqual` instead of `Equal`.