### PR TITLE
Fix reversed string key sort order in upb map sorter

### DIFF
--- a/upb/message/map_sorter.c
+++ b/upb/message/map_sorter.c
@@ -78,7 +78,7 @@ static int _upb_mapsorter_cmpstr(const void* _a, const void* _b) {
   _upb_mapsorter_getkeys(_a, _b, &a, &b, UPB_MAPTYPE_STRING);
   size_t common_size = UPB_MIN(a.size, b.size);
   int cmp = memcmp(a.data, b.data, common_size);
-  if (cmp) return -cmp;
+  if (cmp) return cmp;
   return a.size < b.size ? -1 : a.size > b.size;
 }
 


### PR DESCRIPTION
## Summary
- Fix `_upb_mapsorter_cmpstr` which negated the `memcmp` result (`return -cmp`), causing string-keyed maps to be sorted in **descending** byte order instead of ascending
- Affects deterministic serialization, text format, and debug string encoding
- Since upb backs Python, Ruby, and PHP protobuf runtimes, all those languages produce wrong map entry order for string keys

## Root Cause
In `upb/message/map_sorter.c:81`, the comparison function for string keys returns `-cmp` where `cmp` is the result of `memcmp`. Since `memcmp` already returns the correct sign for ascending order, negating it reverses the sort.

All other key type comparators (cmpi32, cmpu32, cmpi64, cmpu64, cmpbool) in the same file do NOT negate their results.

## Test plan
- [x] Standalone C PoC confirms all pairwise string comparisons are reversed
- [x] Output: `fig, elderberry, date, cherry, banana, apple` instead of `apple, banana, cherry, date, elderberry, fig`
- [ ] Cross-language verification: Python deterministic encoding vs C++ deterministic encoding for same message with string-keyed map

🤖 Generated with [Claude Code](https://claude.com/claude-code)