### PR TITLE
avoid "unreachable code" msvc warning

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -701,11 +701,14 @@ inline map_index_t Hash(absl::string_view k, void* salt) {
   return absl::HashOf(k, salt);
 }
 inline map_index_t Hash(uint64_t k, void* salt) {
-  if constexpr (!HasCrc32()) return absl::HashOf(k, salt);
-  uintptr_t salt_int = reinterpret_cast<uintptr_t>(salt);
-  // Note: Crc32(salt_int, k) causes the random iteration order test to fail so
-  // we also rotate.
-  return Crc32(salt_int, absl::rotr(k, salt_int & 0x3f));
+  if constexpr (!HasCrc32()) {
+    return absl::HashOf(k, salt);
+  } else {
+    uintptr_t salt_int = reinterpret_cast<uintptr_t>(salt);
+    // Note: Crc32(salt_int, k) causes the random iteration order test to fail so
+    // we also rotate.
+    return Crc32(salt_int, absl::rotr(k, salt_int & 0x3f));
+  }
 }
 
 // KeyMapBase is a chaining hash map.


### PR DESCRIPTION
Under some circumstances, I am getting an "unreachable code" warning from google::protobuf::internal::Hash() with Visual C++ 17 and 18. It seems that the warning is only in my debug build, the release build probably optimizes the unreachable code away. 

In my specific case the header should be marked as external, with warning level 0, but for some reason I still get the warning. That might be an issue on Microsoft's side. The warning makes sense though, as far as I can tell, and is easy to fix without changing the meaning of the code.

When the "if constexpr" in this function is active, the rest of the code becomes unreachable. Putting the rest of the code into an else branch discards the unused code and avoids the warning.