### PR TITLE
rm vulnerable tool link, add other 3p tool suggestions, investigate unpatched CVE usage

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -203,6 +203,7 @@ Inactive:
     *   https://ascopes.github.io/protobuf-maven-plugin
 *   [Protobuf Plugin for Gradle](https://github.com/google/protobuf-gradle-plugin)
 *   [Sbt plugin for Protocol Buffers](https://github.com/Atry/sbt-cppp)
+*   [proto-merge: .proto downloading, bundling, splitting tool](https://github.com/accretional/proto-merge)
 
 ## IDE
 
@@ -219,7 +220,7 @@ Inactive:
 ## Documentation
 
 *   [Documentation generator plugin (Markdown/HTML/DocBook/...)](https://github.com/pseudomuto/protoc-gen-doc)
-*   [DocBook generator for .proto files](https://code.google.com/p/protoc-gen-docbook/)
+*   [Istio's protoc-gen-docs](https://pkg.go.dev/istio.io/tools/cmd/protoc-gen-docs)
 
 ## Other Utilities
 


### PR DESCRIPTION
TLDR: Remove a link to a tool with very broken documentation/project info, >12y abandoned project containing source code/binaries with CVEs. Add newer tools to replace it, one from Istio to do something similar with docs, and a util we made at my company for merging and splitting .protos. Then, look into the CVE the project contained and perhaps find that the protobuf project itself is still distributing vulnerable/unpatched old releases too.

**I would suggest the protobuf maintainers/team to review other tools linked here to see if they too might contain CVEs or be abandoned/broken, since I only reviewed this one. I checked and found that, as far as I can tell, first-party protobuf releases still distributed via github also contain these CVEs. A search across github suggests they may be actively used by some large projects without patches.**

<details><summary>Investigating the broken site/tool and then the CVE</summary>

I stumbled upon this project by following https://protobuf.dev/programming-guides/addons/ to https://github.com/protocolbuffers/protobuf/blob/main/docs/third_party.md to https://github.com/protocolbuffers/protobuf/blob/cb5fe976f319683934d8153bdedb21355ab2e008/docs/third_party.md?plain=1#L222 but noticed that it was very stale and out of date. Git suggests it was added to the public git repo in 2016 https://github.com/protocolbuffers/protobuf/pull/1438/changes but even then as a migration from g3docs (where I suspect this project was added around ~2013 when it was created, and then left).

It's pretty broken. For example on https://code.google.com/archive/p/protoc-gen-docbook/ the link to http://protoc-gen-docbook.googlecode.com/svn/wiki/images/demo_nice.PNG is broken, the issue number links go to eg https://code.google.com/archive/p/protoc-gen-docbook/#4 (the additional url fragment doesn't do/display anything), all the other sample links on https://code.google.com/archive/p/protoc-gen-docbook/wikis/Samples.wiki are broken, the markdown formatting in https://code.google.com/archive/p/protoc-gen-docbook/wikis/CustomTemplateGuide.wiki, https://code.google.com/archive/p/protoc-gen-docbook/wikis/docbookProperties.wiki, and many of the hyperlinks across the wiki pages are broken. Docbook as of 2024 was shipping new changes per https://docbook.org/ but the binaries and plugsin from https://code.google.com/archive/p/protoc-gen-docbook/downloads haven't been updated since 2013, so the actual support/usability of the tool is pretty dubious.

Interestingly, the download links do seem to still work (eg https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/protoc-gen-docbook/protoc-gen-docbook-0.3.1-full.zip), but since they seem to be windows binaries that haven't been updated since 2013, I'm not sure that's a good thing. If they were built from the source code, e.g. https://code.google.com/archive/p/protoc-gen-docbook/source/default/source?page=2, then I'm guessing they may contain unpatched cves. For example, https://github.com/protocolbuffers/protobuf/issues/760 led to https://www.cvedetails.com/cve/CVE-2015-5237/ and it seems the source code at https://code.google.com/archive/p/protoc-gen-docbook/source/default/source contains that and another vulnerability (so the binaries may as well) https://nvd.nist.gov/vuln/search#/nvd/home?cpeFilterMode=cpe&cpeName=cpe:2.3:a:google:protobuf:2.5.0:*:*:*:*:*:*:*&resultType=records but based on https://code.google.com/archive/ though.

I guess this is archived user-generated content and not necessarily something Google would consider first party/their responsibility to fix. Even if it were, that probably is some other team's purview. But I think probably it shouldn't be linked here any more. 

</details>

I looked at the CVE because the 2GB message limitation is actually something I've run into, and I saw that https://www.cvedetails.com/cve/CVE-2015-5237/ is actually something that seems to have exposed a wide range of past protobuf releases to buffer overflow if messages exceeded that size. Based on https://www.openwall.com/lists/oss-security/2015/08/27/2 and https://github.com/protocolbuffers/protobuf/issues/760#issuecomment-338795454 it was at the time just fix-forwarded and retroactively considered as effecting versions < 3.4. Now https://github.com/advisories/GHSA-jwvw-v7c5-m82h lists the CVE for a few languages, but NOT C++, and this repo still is distributing unpatched vulnerable releases of that code in e.g. https://github.com/protocolbuffers/protobuf/releases/tag/v3.0.0-beta-1

 I think the communication/security stance in https://github.com/protocolbuffers/protobuf/issues/760#issuecomment-135519672 didn't properly understand the real security implications: it doesn't matter that 2GB rpcs may be uncommon (I don't think they are necessarily though, we've run into these limits several times in my current projects): **any protobuf message with a repeated field could be adversarially made to trigger the 2GB buffer overflow, so if an attacker could poison upstream data with large or repeated input that would later be passed to a grpc service, they could potentially trigger the exploit**.  I did some digging and some people seem to be directly downloading the vulnerable C++ releases still for their projects' builds.
 
 IMO something should probably be done here because basically all C++ grpc servers on versions < 3.1~3.4 seem potentially vulnerable to RCE even now, because the unpatched code is still being widely distributed and built against. I hope I'm missing or misunderstanding something but it does look like https://github.com/protocolbuffers/protobuf/releases/download/v3.0.2/protobuf-cpp-3.0.2.tar.gz is both vulnerable and actively used by several projects.