### PR TITLE
Fix MessageSet recursion depth propagation in Python decoder

### DIFF
--- a/python/google/protobuf/internal/decoder.py
+++ b/python/google/protobuf/internal/decoder.py
@@ -922,7 +922,7 @@ def UnknownMessageSetItemDecoder():
   message_tag_bytes = encoder.TagBytes(3, wire_format.WIRETYPE_LENGTH_DELIMITED)
   item_end_tag_bytes = encoder.TagBytes(1, wire_format.WIRETYPE_END_GROUP)
 
-  def DecodeUnknownItem(buffer, current_depth=0):
+  def DecodeUnknownItem(buffer, current_depth):
     pos = 0
     end = len(buffer)
     message_start = -1

--- a/python/google/protobuf/internal/decoder.py
+++ b/python/google/protobuf/internal/decoder.py
@@ -866,7 +866,9 @@ def MessageSetItemDecoder(descriptor):
         break
       else:
         field_number, wire_type = DecodeTag(tag_bytes)
-        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type)
+        _, pos = _DecodeUnknownField(
+            buffer, pos, end, field_number, wire_type, current_depth
+        )
         if pos == -1:
           raise _DecodeError('Unexpected end-group tag.')
 
@@ -920,7 +922,7 @@ def UnknownMessageSetItemDecoder():
   message_tag_bytes = encoder.TagBytes(3, wire_format.WIRETYPE_LENGTH_DELIMITED)
   item_end_tag_bytes = encoder.TagBytes(1, wire_format.WIRETYPE_END_GROUP)
 
-  def DecodeUnknownItem(buffer):
+  def DecodeUnknownItem(buffer, current_depth=0):
     pos = 0
     end = len(buffer)
     message_start = -1
@@ -936,7 +938,9 @@ def UnknownMessageSetItemDecoder():
         break
       else:
         field_number, wire_type = DecodeTag(tag_bytes)
-        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type)
+        _, pos = _DecodeUnknownField(
+            buffer, pos, end, field_number, wire_type, current_depth
+        )
         if pos == -1:
           raise _DecodeError('Unexpected end-group tag.')
 

--- a/python/google/protobuf/internal/decoder_test.py
+++ b/python/google/protobuf/internal/decoder_test.py
@@ -154,6 +154,7 @@ class DecoderTest(parameterized.TestCase):
         'Unexpected end-group tag.',
         decode,
         memoryview(b'\054\014'),
+        0,
     )
 
   def test_message_set_item_decoder_preserves_current_depth(self):
@@ -172,7 +173,7 @@ class DecoderTest(parameterized.TestCase):
           0,
           len(item),
           proto,
-          proto._fields,  # pylint: disable=protected-access
+          {},
           1,
       )
     finally:

--- a/python/google/protobuf/internal/decoder_test.py
+++ b/python/google/protobuf/internal/decoder_test.py
@@ -14,6 +14,7 @@ import unittest
 from google.protobuf import message
 from google.protobuf.internal import api_implementation
 from google.protobuf.internal import decoder
+from google.protobuf.internal import encoder
 from google.protobuf.internal import message_set_extensions_pb2
 from google.protobuf.internal import testing_refleaks
 from google.protobuf.internal import wire_format
@@ -23,6 +24,18 @@ from absl.testing import parameterized
 
 _INPUT_BYTES = b'\x84r\x12'
 _EXPECTED = (14596, 18)
+
+
+def _MakeMessageSetItemWithUnknownGroup():
+  return (
+      encoder.TagBytes(10, wire_format.WIRETYPE_START_GROUP)
+      + encoder.TagBytes(10, wire_format.WIRETYPE_END_GROUP)
+      + encoder.TagBytes(2, wire_format.WIRETYPE_VARINT)
+      + b'\x01'
+      + encoder.TagBytes(3, wire_format.WIRETYPE_LENGTH_DELIMITED)
+      + b'\x00'
+      + encoder.TagBytes(1, wire_format.WIRETYPE_END_GROUP)
+  )
 
 
 @testing_refleaks.TestCase
@@ -142,6 +155,43 @@ class DecoderTest(parameterized.TestCase):
         decode,
         memoryview(b'\054\014'),
     )
+
+  def test_message_set_item_decoder_preserves_current_depth(self):
+    decode = decoder.MessageSetItemDecoder(
+        message_set_extensions_pb2.TestMessageSet.DESCRIPTOR
+    )
+    proto = message_set_extensions_pb2.TestMessageSet()
+    item = memoryview(_MakeMessageSetItemWithUnknownGroup())
+    decoder.SetRecursionLimit(2)
+    try:
+      self.assertRaisesRegex(
+          message.DecodeError,
+          'Error parsing message',
+          decode,
+          item,
+          0,
+          len(item),
+          proto,
+          proto._fields,  # pylint: disable=protected-access
+          1,
+      )
+    finally:
+      decoder.SetRecursionLimit(decoder.DEFAULT_RECURSION_LIMIT)
+
+  def test_unknown_message_set_decoder_preserves_current_depth(self):
+    decode = decoder.UnknownMessageSetItemDecoder()
+    item = memoryview(_MakeMessageSetItemWithUnknownGroup())
+    decoder.SetRecursionLimit(2)
+    try:
+      self.assertRaisesRegex(
+          message.DecodeError,
+          'Error parsing message',
+          decode,
+          item,
+          1,
+      )
+    finally:
+      decoder.SetRecursionLimit(decoder.DEFAULT_RECURSION_LIMIT)
 
   @parameterized.parameters(int(0), float(0.0), False, '')
   def test_default_scalar(self, value):

--- a/python/google/protobuf/unknown_fields.py
+++ b/python/google/protobuf/unknown_fields.py
@@ -68,7 +68,7 @@ else:
           msg_des.GetOptions().message_set_wire_format):
         local_decoder = decoder.UnknownMessageSetItemDecoder()
         for _, buffer in unknown_fields:
-          (field_number, data) = local_decoder(memoryview(buffer))
+          (field_number, data) = local_decoder(memoryview(buffer), 0)
           InternalAdd(field_number, wire_format.WIRETYPE_LENGTH_DELIMITED, data)
       else:
         for tag_bytes, buffer in unknown_fields:


### PR DESCRIPTION
## Summary

Preserve recursion depth accounting when Python MessageSet decoders recurse into unknown groups.

## Problem
`MessageSetItemDecoder` and `UnknownMessageSetItemDecoder` called `_DecodeUnknownField(...)` without forwarding `current_depth`.

That reset recursion accounting in the unknown-group path and allowed MessageSet parsing to bypass the intended nesting limit in this specific case.

## Fix
- forward `current_depth` from `MessageSetItemDecoder`
- forward `current_depth` from `UnknownMessageSetItemDecoder`
- add regression coverage for both paths

## Testing
- added regression tests for MessageSet depth propagation
- verified the bypass path now raises `DecodeError` when recursion depth is already exhausted
- verified the unknown MessageSet item path also preserves recursion depth

Fixes #26437