### PR TITLE
descriptor_pool.c: check if self->symtab exist before deallocing it

### DIFF
--- a/python/descriptor_pool.c
+++ b/python/descriptor_pool.c
@@ -90,8 +90,10 @@ static void PyUpb_DescriptorPool_Dealloc(PyUpb_DescriptorPool* self) {
 #endif
   PyObject_GC_UnTrack(self);
   PyUpb_DescriptorPool_Clear(self);
-  upb_DefPool_Free(self->symtab);
-  PyUpb_ObjCache_Delete(self->symtab);
+  if (self->symtab) {
+    upb_DefPool_Free(self->symtab);
+    PyUpb_ObjCache_Delete(self->symtab);
+  }
   PyUpb_Dealloc(self);
 }
 


### PR DESCRIPTION
upb_DefPool_Free performs freeing operations without further checks, so if invalid pointer is passed, it will result in Segmentation fault.

This situation can happen when upb_DefPool_New would fail from any reason, as it's calling upb_DefPool_Free itself on error, and then later PyUpb_DescriptorPool_Dealloc will be automatically called during PyUpb_DescriptorPool object deallocation and will try to free it again.

Thus checking existance of self->symtab before calling upb_DefPool_Free in PyUpb_DescriptorPool_Dealloc to handle this case.