### PR TITLE
csharp: propagate recursion depth into JsonReplayTokenizer to honor Any nesting limit

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
@@ -942,6 +942,36 @@ namespace Google.Protobuf
             Assert.Throws<InvalidProtocolBufferException>(() => insufficientLimitParser.Parse<Value>(json));
         }
 
+        /// <summary>
+        /// Regression test: deeply-nested google.protobuf.Any payloads must
+        /// honor JsonParser.Settings.RecursionLimit. Previously the
+        /// JsonReplayTokenizer constructed for each Any body started at depth
+        /// zero, allowing the limit to be bypassed and producing an
+        /// uncatchable StackOverflowException. See the equivalent fixes in
+        /// Java (mergeAnyMessage) and Python (_ConvertAnyMessage).
+        /// </summary>
+        [Test]
+        public void MaliciousRecursionOfAnyInAny()
+        {
+            int depth = 100;
+            const string anyHeader = "{\"@type\":\"type.googleapis.com/google.protobuf.Any\",\"value\":";
+            string json =
+                string.Concat(Enumerable.Repeat(anyHeader, depth)) +
+                "{}" +
+                new string('}', depth);
+
+            var registry = TypeRegistry.FromMessages(Any.Descriptor);
+
+            // A generous limit must still successfully parse the document.
+            var sufficientLimitParser = new JsonParser(new JsonParser.Settings(depth * 2, registry));
+            Assert.DoesNotThrow(() => sufficientLimitParser.Parse<Any>(json));
+
+            // A limit smaller than the nesting depth must throw a recoverable
+            // protobuf exception rather than overflowing the stack.
+            var insufficientLimitParser = new JsonParser(new JsonParser.Settings(10, registry));
+            Assert.Throws<InvalidProtocolBufferException>(() => insufficientLimitParser.Parse<Any>(json));
+        }
+
         [Test]
         [TestCase("AQI")]
         [TestCase("_-==")]

--- a/csharp/src/Google.Protobuf/JsonTokenizer.cs
+++ b/csharp/src/Google.Protobuf/JsonTokenizer.cs
@@ -163,9 +163,13 @@ namespace Google.Protobuf
             {
                 this.tokens = tokens;
                 this.nextTokenizer = nextTokenizer;
+                // Inherit recursion depth from the parent tokenizer so that the
+                // JsonParser.RecursionLimit check applies across replayed Any
+                // bodies. Without this, deeply-nested google.protobuf.Any
+                // payloads can bypass the limit and cause a StackOverflowException.
+                this.RecursionDepth = nextTokenizer.RecursionDepth;
             }
 
-            // FIXME: Object depth not maintained...
             protected override JsonToken NextImpl()
             {
                 if (nextTokenIndex >= tokens.Count)


### PR DESCRIPTION
## Summary

`JsonParser.MergeAny()` records the JSON token stream of an Any body and replays it through a fresh `JsonReplayTokenizer` to parse the inner message. The replay tokenizer's `RecursionDepth` was never initialized from the parent tokenizer, so it defaulted to zero — and the recursion-depth check in `JsonParser.Merge()` reads the **tokenizer's** depth field. As a result, every nested `google.protobuf.Any` started at depth zero and the `Settings.RecursionLimit` check never fired.

A pathological JSON document such as

```json
{"@type":"type.googleapis.com/google.protobuf.Any","value":
 {"@type":"type.googleapis.com/google.protobuf.Any","value":
  {"@type":"type.googleapis.com/google.protobuf.Any","value": ... }}}
```

recurses through `MergeAny -> MergeWellKnownTypeAnyBody -> Merge -> MergeAny -> ...` until the .NET stack is exhausted, raising an uncatchable `StackOverflowException` and terminating the host process.

The pre-existing `// FIXME: Object depth not maintained...` comment in `JsonReplayTokenizer` already acknowledged the gap.

## Prior art

The same bug class has previously been fixed in the sibling language implementations of protobuf:

- **Java** — `mergeAnyMessage` was missing the `currentDepth` increment.
- **Python** — `_ConvertAnyMessage` reached via `methodcaller(...)` bypassed the depth tracking.

The C# `MergeAny` path was overlooked at the time. A C# *array* recursion fix landed previously, but the Any case was not covered.

## Fix

Inherit the parent tokenizer's `RecursionDepth` when constructing a `JsonReplayTokenizer`, so that `JsonParser.Merge()`'s existing limit check applies across the replay boundary.

```csharp
internal JsonReplayTokenizer(IList<JsonToken> tokens, JsonTokenizer nextTokenizer)
{
    this.tokens = tokens;
    this.nextTokenizer = nextTokenizer;
    this.RecursionDepth = nextTokenizer.RecursionDepth;
}
```

## Tests

Added `JsonParserTest.MaliciousRecursionOfAnyInAny`, mirroring the existing `MaliciousRecursionOfObjectsInValue` / `MaliciousRecursionOfArraysInValue` regression tests:

- Builds a 100-deep Any-of-Any document.
- A parser with a generous limit parses it without exception.
- A parser with an insufficient limit throws `InvalidProtocolBufferException` (rather than overflowing the stack).

Without the fix, the second assertion either spins past the configured limit (because each replay tokenizer resets depth to zero) or terminates the test runner with `StackOverflowException`.