### PR TITLE
Explicitly cast to the narrowing type

### DIFF
--- a/src/google/protobuf/compiler/cpp/message.cc
+++ b/src/google/protobuf/compiler/cpp/message.cc
@@ -1427,7 +1427,7 @@ void MessageGenerator::GenerateFieldAccessorDefinitions(io::Printer* p) {
     if (field->is_repeated()) {
       p->Emit(R"cc(
         inline int $Msg$::_internal_$name_internal$_size() const {
-          return _internal_$name_internal$().size();
+          return static_cast<int>(_internal_$name_internal$().size());
         }
         inline int $Msg$::$name$_size() const {
           $WeakDescriptorSelfPin$;

--- a/src/google/protobuf/compiler/cpp/message.cc
+++ b/src/google/protobuf/compiler/cpp/message.cc
@@ -1384,7 +1384,7 @@ void MessageGenerator::GenerateFieldAccessorDefinitions(io::Printer* p) {
     if (field->is_repeated()) {
       p->Emit(R"cc(
         inline int $Msg$::_internal_$name_internal$_size() const {
-          return _internal_$name_internal$().size();
+          return static_cast<int>(_internal_$name_internal$().size());
         }
         inline int $Msg$::$name$_size() const {
           $WeakDescriptorSelfPin$;

--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -698,14 +698,14 @@ struct KeyNode : NodeBase {
 
 inline map_index_t Hash(absl::string_view k, void* salt) {
   // Note: we could potentially also use CRC32-based hashing here.
-  return absl::HashOf(k, salt);
+  return static_cast<map_index_t>(absl::HashOf(k, salt));
 }
 inline map_index_t Hash(uint64_t k, void* salt) {
-  if constexpr (!HasCrc32()) return absl::HashOf(k, salt);
+  if constexpr (!HasCrc32()) return static_cast<map_index_t>(absl::HashOf(k, salt));
   uintptr_t salt_int = reinterpret_cast<uintptr_t>(salt);
   // Note: Crc32(salt_int, k) causes the random iteration order test to fail so
   // we also rotate.
-  return Crc32(salt_int, absl::rotr(k, salt_int & 0x3f));
+  return Crc32(static_cast<uint32_t>(salt_int), absl::rotr(k, salt_int & 0x3f));
 }
 
 // KeyMapBase is a chaining hash map.
@@ -902,21 +902,21 @@ class KeyMapBase : public UntypedMapBase {
 
   // For a particular size, calculate the lowest capacity `cap` where
   // `size <= CalculateHiCutoff(cap)`.
-  static size_type CalculateCapacityForSize(size_type size) {
+  static map_index_t CalculateCapacityForSize(size_type size) {
     ABSL_DCHECK_NE(size, 0u);
 
     if (size > kMaxTableSize / 2) {
       return kMaxTableSize;
     }
 
-    size_t capacity = size_type{1} << (std::numeric_limits<size_type>::digits -
-                                       absl::countl_zero(size - 1));
+    map_index_t capacity = size_type{1} << (std::numeric_limits<size_type>::digits -
+                                            absl::countl_zero(size - 1));
 
     if (size > CalculateHiCutoff(capacity)) {
       capacity *= 2;
     }
 
-    return std::max<size_type>(capacity, kMinTableSize);
+    return std::max(capacity, kMinTableSize);
   }
 
   void AssertLoadFactor() const {
@@ -960,7 +960,7 @@ class KeyMapBase : public UntypedMapBase {
       size_type new_num_buckets = std::max<size_type>(
           kMinTableSize, num_buckets_ >> lg2_of_size_reduction_factor);
       if (new_num_buckets != num_buckets_) {
-        Resize(arena, new_num_buckets);
+        Resize(arena, static_cast<map_index_t>(new_num_buckets));
         return true;
       }
     }
@@ -985,7 +985,7 @@ class KeyMapBase : public UntypedMapBase {
     ABSL_DCHECK_EQ(arena, this->arena());
 
     ResizeIfLoadIsOutOfRangeForMultiInsert(arena, num_nodes);
-    num_elements_ = num_nodes;
+    num_elements_ = static_cast<map_index_t>(num_nodes);
     AssertLoadFactor();
     Inserter inserter(this, table_, num_buckets_);
     for (size_t i = 0; i < num_nodes; ++i) {

--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -696,16 +696,16 @@ struct KeyNode : NodeBase {
 
 inline map_index_t Hash(absl::string_view k, void* salt) {
   // Note: we could potentially also use CRC32-based hashing here.
-  return absl::HashOf(k, salt);
+  return static_cast<map_index_t>(absl::HashOf(k, salt));
 }
 inline map_index_t Hash(uint64_t k, void* salt) {
   if constexpr (!HasCrc32()) {
-    return absl::HashOf(k, salt);
+    return static_cast<map_index_t>(absl::HashOf(k, salt));
   } else {
     uintptr_t salt_int = reinterpret_cast<uintptr_t>(salt);
     // Note: Crc32(salt_int, k) causes the random iteration order test to fail
     // so we also rotate.
-    return Crc32(salt_int, absl::rotr(k, salt_int & 0x3f));
+    return Crc32(static_cast<uint32_t>(salt_int), absl::rotr(k, salt_int & 0x3f));
   }
 }
 
@@ -903,21 +903,21 @@ class KeyMapBase : public UntypedMapBase {
 
   // For a particular size, calculate the lowest capacity `cap` where
   // `size <= CalculateHiCutoff(cap)`.
-  static size_type CalculateCapacityForSize(size_type size) {
+  static map_index_t CalculateCapacityForSize(size_type size) {
     ABSL_DCHECK_NE(size, 0u);
 
     if (size > kMaxTableSize / 2) {
       return kMaxTableSize;
     }
 
-    size_t capacity = size_type{1} << (std::numeric_limits<size_type>::digits -
-                                       absl::countl_zero(size - 1));
+    map_index_t capacity = size_type{1} << (std::numeric_limits<size_type>::digits -
+                                            absl::countl_zero(size - 1));
 
     if (size > CalculateHiCutoff(capacity)) {
       capacity *= 2;
     }
 
-    return std::max<size_type>(capacity, kMinTableSize);
+    return std::max(capacity, kMinTableSize);
   }
 
   void AssertLoadFactor() const {
@@ -961,7 +961,7 @@ class KeyMapBase : public UntypedMapBase {
       size_type new_num_buckets = std::max<size_type>(
           kMinTableSize, num_buckets_ >> lg2_of_size_reduction_factor);
       if (new_num_buckets != num_buckets_) {
-        Resize(arena, new_num_buckets);
+        Resize(arena, static_cast<map_index_t>(new_num_buckets));
         return true;
       }
     }
@@ -986,7 +986,7 @@ class KeyMapBase : public UntypedMapBase {
     ABSL_DCHECK_EQ(arena, this->arena());
 
     ResizeIfLoadIsOutOfRangeForMultiInsert(arena, num_nodes);
-    num_elements_ = num_nodes;
+    num_elements_ = static_cast<map_index_t>(num_nodes);
     AssertLoadFactor();
     Inserter inserter(this, table_, num_buckets_);
     for (size_t i = 0; i < num_nodes; ++i) {

--- a/src/google/protobuf/map_test.cc
+++ b/src/google/protobuf/map_test.cc
@@ -168,7 +168,7 @@ TEST(MapTest, CopyConstructionMaintainsProperLoadFactor) {
 
 TEST(MapTest, CalculateCapacityForSizeTest) {
   for (size_t size = 1; size < 1000; ++size) {
-    size_t capacity = MapTestPeer::CalculateCapacityForSize(size);
+    map_index_t capacity = MapTestPeer::CalculateCapacityForSize(size);
     // Verify is large enough for `size`.
     EXPECT_LE(size, MapTestPeer::CalculateHiCutoff(capacity));
     if (capacity > MapTestPeer::kMinTableSize) {

--- a/src/google/protobuf/map_test.inc
+++ b/src/google/protobuf/map_test.inc
@@ -123,7 +123,7 @@ struct MapTestPeer {
     return Map<int, int>::CalculateHiCutoff(num_buckets);
   }
 
-  static size_t CalculateCapacityForSize(size_t size) {
+  static map_index_t CalculateCapacityForSize(size_t size) {
     return Map<int, int>::CalculateCapacityForSize(size);
   }
 

--- a/src/google/protobuf/micro_string.h
+++ b/src/google/protobuf/micro_string.h
@@ -75,18 +75,18 @@ class PROTOBUF_EXPORT MicroString {
 
     absl::string_view view() const { return {payload, size}; }
     char* owned_head() {
-      ABSL_DCHECK_GE(capacity, kOwned);
+      ABSL_DCHECK_GE(capacity, static_cast<uint32_t>(kOwned));
       return reinterpret_cast<char*>(this + 1);
     }
 
     void SetExternalBuffer(absl::string_view buffer) {
       payload = const_cast<char*>(buffer.data());
-      size = buffer.size();
+      size = static_cast<uint32_t>(buffer.size());
     }
 
     void SetInitialSize(size_t size) {
       PoisonMemoryRegion(owned_head() + size, capacity - size);
-      this->size = size;
+      this->size = static_cast<uint32_t>(size);
     }
 
     void Unpoison() { UnpoisonMemoryRegion(owned_head(), capacity); }
@@ -94,7 +94,7 @@ class PROTOBUF_EXPORT MicroString {
     void ChangeSize(size_t new_size) {
       PoisonMemoryRegion(owned_head() + new_size, capacity - new_size);
       UnpoisonMemoryRegion(owned_head(), new_size);
-      size = new_size;
+      size = static_cast<uint32_t>(new_size);
     }
   };
 

--- a/src/google/protobuf/micro_string.h
+++ b/src/google/protobuf/micro_string.h
@@ -77,18 +77,18 @@ class PROTOBUF_EXPORT MicroString {
 
     absl::string_view view() const { return {payload, size}; }
     char* owned_head() {
-      ABSL_DCHECK_GE(capacity, (unsigned)kOwned);
+      ABSL_DCHECK_GE(capacity, static_cast<uint32_t>(kOwned));
       return reinterpret_cast<char*>(this + 1);
     }
 
     void SetExternalBuffer(absl::string_view buffer) {
       payload = const_cast<char*>(buffer.data());
-      size = buffer.size();
+      size = static_cast<uint32_t>(buffer.size());
     }
 
     void SetInitialSize(size_t size) {
       PoisonMemoryRegion(owned_head() + size, capacity - size);
-      this->size = size;
+      this->size = static_cast<uint32_t>(size);
     }
 
     void Unpoison() { UnpoisonMemoryRegion(owned_head(), capacity); }
@@ -96,7 +96,7 @@ class PROTOBUF_EXPORT MicroString {
     void ChangeSize(size_t new_size) {
       PoisonMemoryRegion(owned_head() + new_size, capacity - new_size);
       UnpoisonMemoryRegion(owned_head(), new_size);
-      size = new_size;
+      size = static_cast<uint32_t>(new_size);
     }
   };
 

--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -2126,16 +2126,16 @@ class RustRepeatedMessageHelper {
   }
 
   static void Reserve(RepeatedPtrFieldBase& field, size_t additional) {
-    field.ReserveWithArena(field.GetArena(), field.size() + additional);
+    field.ReserveWithArena(field.GetArena(), static_cast<int>(field.size() + additional));
   }
 
   static const MessageLite& At(const RepeatedPtrFieldBase& field,
                                size_t index) {
-    return field.at<GenericTypeHandler<MessageLite>>(index);
+    return field.at<GenericTypeHandler<MessageLite>>(static_cast<int>(index));
   }
 
   static MessageLite& At(RepeatedPtrFieldBase& field, size_t index) {
-    return field.at<GenericTypeHandler<MessageLite>>(index);
+    return field.at<GenericTypeHandler<MessageLite>>(static_cast<int>(index));
   }
 };
 

--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -2131,16 +2131,16 @@ class RustRepeatedMessageHelper {
   }
 
   static void Reserve(RepeatedPtrFieldBase& field, size_t additional) {
-    field.ReserveWithArena(field.GetArena(), field.size() + additional);
+    field.ReserveWithArena(field.GetArena(), static_cast<int>(field.size() + additional));
   }
 
   static const MessageLite& At(const RepeatedPtrFieldBase& field,
                                size_t index) {
-    return field.at<GenericTypeHandler<MessageLite>>(index);
+    return field.at<GenericTypeHandler<MessageLite>>(static_cast<int>(index));
   }
 
   static MessageLite& At(RepeatedPtrFieldBase& field, size_t index) {
-    return field.at<GenericTypeHandler<MessageLite>>(index);
+    return field.at<GenericTypeHandler<MessageLite>>(static_cast<int>(index));
   }
 };
 


### PR DESCRIPTION
- Address MSVC warnings about narrowing conversions
- Every place capacity and CalculateCapacityForSize are used they are used as map_index_t, so modify that from size_t

I've validated that every place where a narrowing conversion was used already had guards in place, so the only issue is the implicit narrowing conversion itself.