### PR TITLE
python: fix duplicate proto field detection to use field number instead of JSON name

### DIFF
--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -619,14 +619,14 @@ class _Parser(object):
                   [f.json_name for f in message_descriptor.fields],
               )
           )
-        if name in names:
+        if field.number in names:
           raise ParseError(
               'Message type "{0}" should not have multiple '
               '"{1}" fields at "{2}".'.format(
                   message.DESCRIPTOR.full_name, name, path
               )
           )
-        names.append(name)
+        names.append(field.number)
         value = js[name]
         # Check no other oneof field is parsed.
         if field.containing_oneof is not None and value is not None:


### PR DESCRIPTION
## Summary

Fix duplicate proto field detection in the Python JSON parser to use resolved field identity instead of raw JSON key strings.

## Root cause

`_ConvertMessage()` tracked seen fields by their raw JSON key string. Because every proto field with an underscore has two valid JSON representations (snake_case proto name and camelCase `json_name`), a payload containing both aliases passed the duplicate check undetected.

## Fix

```python
# Before
if name in names:
    raise ParseError(...)
names.append(name)

# After
if field.number in names:
    raise ParseError(...)
names.append(field.number)
```

Field numbers are unique per message and independent of JSON representation, so both aliases for the same field are correctly detected as a duplicate.

## Conformance

This brings the Python implementation into conformance with the proto3 JSON specification:

> *"Parsers are required to reject JSON that contains the same field (either by proto field name or by JSON name) more than once."*

The C++ and Go implementations already handle this correctly.