### PR TITLE
Propagate descriptor errors from MessageMeta

### DIFF
--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -1392,6 +1392,25 @@ class MessageTest(unittest.TestCase):
       except AttributeError:
         self.fail(f'Attribute {attribute} is not accessible.')
 
+  def testMessageMetaDescriptorErrorsPropagate(self, message_module):
+    message_cls = message_module.TestAllTypes
+
+    for exc_type in (KeyboardInterrupt, MemoryError, SystemExit):
+      attr_name = f'_bomb_descriptor_for_test_{exc_type.__name__}'
+
+      class _BombDescriptor(object):
+
+        def __get__(self, obj, objtype=None):
+          raise exc_type('should not be swallowed')
+
+      setattr(message_cls, attr_name, _BombDescriptor())
+      try:
+        with self.subTest(exc_type=exc_type.__name__):
+          with self.assertRaisesRegex(exc_type, 'should not be swallowed'):
+            getattr(message_cls, attr_name)
+      finally:
+        delattr(message_cls, attr_name)
+
   def testEquality(self, message_module):
     m = message_module.TestAllTypes()
     m2 = message_module.TestAllTypes()

--- a/python/message.c
+++ b/python/message.c
@@ -2025,6 +2025,7 @@ static PyObject* PyUpb_MessageMeta_GetAttr(PyObject* self, PyObject* name) {
   // that were previously calculated and cached in the type's dict.
   PyObject* ret = cpython_bits.type_getattro(self, name);
   if (ret) return ret;
+  if (!PyErr_ExceptionMatches(PyExc_AttributeError)) return NULL;
 
   // We did not find a cached attribute. Try to calculate the attribute
   // dynamically, using the descriptor as an argument.
@@ -2037,6 +2038,7 @@ static PyObject* PyUpb_MessageMeta_GetAttr(PyObject* self, PyObject* name) {
     return ret;
   }
 
+  if (PyErr_Occurred()) return NULL;
   PyErr_SetObject(PyExc_AttributeError, name);
   return NULL;
 }


### PR DESCRIPTION
Summary
- stop rewriting non-`AttributeError` failures to `AttributeError` in `PyUpb_MessageMeta_GetAttr`
- add a focused regression test covering `KeyboardInterrupt`, `MemoryError`, and `SystemExit`

Impact
- message class descriptors can currently hide control-flow and fatal exceptions behind a missing-attribute error
- this keeps the protobuf dynamic attribute fallback for real misses while preserving descriptor-raised exceptions

Testing
- `cmake -S . -B build-cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -Dprotobuf_BUILD_TESTS=ON -Dprotobuf_BUILD_CONFORMANCE=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -Dprotobuf_WITH_ZLIB=ON`
- `cmake --build build-cmake --parallel 8`
- `ctest --test-dir build-cmake --output-on-failure -R '^(lite-test|full-test|upb-test)$'`
- `build-cmake/protoc --version`
- in a temporary Python 3.10 venv using a repo-backed `_message` build sourced from this checkout:
  - `python setup.py build_ext --inplace`
  - `python python/google/protobuf/internal/message_meta_getattr_test.py`

Notes
- this addresses bug 2 from `#26596`