### PR TITLE
fix: implement DescriptorDatabase extension lookups

### DIFF
--- a/python/google/protobuf/descriptor_database.py
+++ b/python/google/protobuf/descriptor_database.py
@@ -31,6 +31,9 @@ class DescriptorDatabase(object):
     self._file_desc_protos_by_symbol: Dict[
         str, 'descriptor_pb2.FileDescriptorProto'
     ] = {}
+    self._file_desc_protos_by_extension: Dict[
+        str, Dict[int, 'descriptor_pb2.FileDescriptorProto']
+    ] = {}
 
   def Add(self, file_desc_proto: 'descriptor_pb2.FileDescriptorProto') -> None:
     """Adds the FileDescriptorProto and its types to this database.
@@ -66,15 +69,14 @@ class DescriptorDatabase(object):
             '.'.join((package, enum_value.name)) if package else enum_value.name
         ] = file_desc_proto
     for extension in file_desc_proto.extension:
-      self._AddSymbol(
-          ('.'.join((package, extension.name)) if package else extension.name),
-          file_desc_proto,
-      )
+      self._AddExtension(package, extension, file_desc_proto)
     for service in file_desc_proto.service:
       self._AddSymbol(
           ('.'.join((package, service.name)) if package else service.name),
           file_desc_proto,
       )
+    for message in file_desc_proto.message_type:
+      self._AddNestedExtensions(message, file_desc_proto)
 
   def FindFileByName(self, name: str) -> 'descriptor_pb2.FileDescriptorProto':
     """Finds the file descriptor proto by file name.
@@ -143,14 +145,14 @@ class DescriptorDatabase(object):
         raise KeyError(symbol)
 
   def FindFileContainingExtension(
-      self, extendee_name: str, extension_number: int  # pylint: disable=unused-argument
+      self, extendee_name: str, extension_number: int
   ) -> Optional['descriptor_pb2.FileDescriptorProto']:
-    # TODO: implement this API.
-    return None
+    return self._file_desc_protos_by_extension.get(extendee_name, {}).get(
+        extension_number
+    )
 
-  def FindAllExtensionNumbers(self, extendee_name: str) -> list[int]:  # pylint: disable=unused-argument
-    # TODO: implement this API.
-    return []
+  def FindAllExtensionNumbers(self, extendee_name: str) -> list[int]:
+    return sorted(self._file_desc_protos_by_extension.get(extendee_name, {}))
 
   def _AddSymbol(
       self, name: str, file_desc_proto: 'descriptor_pb2.FileDescriptorProto'
@@ -162,6 +164,32 @@ class DescriptorDatabase(object):
                   self._file_desc_protos_by_symbol[name].name + '"')
       warnings.warn(warn_msg, RuntimeWarning)
     self._file_desc_protos_by_symbol[name] = file_desc_proto
+
+  def _AddExtension(
+      self,
+      package: str,
+      extension: 'descriptor_pb2.FieldDescriptorProto',
+      file_desc_proto: 'descriptor_pb2.FileDescriptorProto',
+  ) -> None:
+    self._AddSymbol(
+        '.'.join((package, extension.name)) if package else extension.name,
+        file_desc_proto,
+    )
+    if extension.extendee.startswith('.'):
+      self._file_desc_protos_by_extension.setdefault(
+          extension.extendee[1:], {}
+      )[extension.number] = file_desc_proto
+
+  def _AddNestedExtensions(
+      self,
+      desc_proto: 'descriptor_pb2.DescriptorProto',
+      file_desc_proto: 'descriptor_pb2.FileDescriptorProto',
+  ) -> None:
+    package = file_desc_proto.package
+    for nested_type in desc_proto.nested_type:
+      self._AddNestedExtensions(nested_type, file_desc_proto)
+    for extension in desc_proto.extension:
+      self._AddExtension(package, extension, file_desc_proto)
 
 
 def _ExtractSymbols(

--- a/python/google/protobuf/internal/descriptor_database_test.py
+++ b/python/google/protobuf/internal/descriptor_database_test.py
@@ -123,5 +123,26 @@ class DescriptorDatabaseTest(unittest.TestCase):
           'already defined in file '
           '"google/protobuf/unittest.proto"', str(w[0].message))
 
+  def testFindExtensions(self):
+    db = descriptor_database.DescriptorDatabase()
+    file_desc_proto = descriptor_pb2.FileDescriptorProto.FromString(
+        factory_test2_pb2.DESCRIPTOR.serialized_pb
+    )
+    db.Add(file_desc_proto)
+
+    extendee_name = 'google.protobuf.python.internal.Factory1Message'
+    self.assertEqual(
+        file_desc_proto, db.FindFileContainingExtension(extendee_name, 1001)
+    )
+    self.assertEqual(
+        file_desc_proto, db.FindFileContainingExtension(extendee_name, 1004)
+    )
+    self.assertIsNone(db.FindFileContainingExtension(extendee_name, 9999))
+    self.assertEqual(
+        [1001, 1002, 1003, 1004], db.FindAllExtensionNumbers(extendee_name)
+    )
+    self.assertEqual([], db.FindAllExtensionNumbers('does.not.exist'))
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION

**Repo:** protocolbuffers/protobuf (⭐ 66000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +59/-10

## What
Implemented the pure-Python `DescriptorDatabase` extension lookup APIs by indexing fully-qualified extendees during `Add()`, covering both file-scope and nested message extensions. Added a focused unit test that verifies `FindFileContainingExtension()` and `FindAllExtensionNumbers()` return the expected results for the existing `factory_test2` test proto.

## Why
`DescriptorDatabase.FindFileContainingExtension()` and `FindAllExtensionNumbers()` were still TODO stubs in Python, even though `DescriptorPool` fallback logic already calls them. This change closes that gap for generated descriptors, bringing the Python database closer to the documented C++ behavior and making extension discovery work when a `DescriptorPool` is backed by a Python descriptor database.

## Testing
Ran `python3 -m py_compile` on the two changed Python files successfully. Also ran a direct Python validation script that loaded the patched module from disk, built an in-memory `FileDescriptorProto`, and verified extension lookups for nested and file-scope extensions. I did not run `descriptor_database_test.py` directly because this checkout does not include the generated Python test modules that file imports.

## Risk
Low - the change is isolated to the pure-Python descriptor database path and only populates extension indexes for fully-qualified extendees, matching the repo's documented semantics.
