### PR TITLE
Add assume_64_bit_php codegen option to the PHP generator

### DIFF
--- a/src/google/protobuf/compiler/php/generator_unittest.cc
+++ b/src/google/protobuf/compiler/php/generator_unittest.cc
@@ -137,6 +137,51 @@ TEST_F(PhpGeneratorTest, ImportPublic) {
   ExpectNoErrors();
 }
 
+TEST_F(PhpGeneratorTest, Assume64BitPhpFlagCollapsesInt64TypeHints) {
+  CreateTempFile("foo.proto",
+                 R"schema(
+    syntax = "proto3";
+    message Foo {
+      int64 scalar_i64 = 1;
+      uint64 scalar_u64 = 2;
+      repeated int64 repeated_i64 = 3;
+      int32 scalar_i32 = 4;
+    })schema");
+
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--php_out=assume_64_bit_php:$tmpdir foo.proto");
+
+  ExpectNoErrors();
+  ExpectFileContentContainsSubstring("Foo.php", "public function setScalarI64(int $var)");
+  ExpectFileContentContainsSubstring("Foo.php", "public function setScalarU64(int $var)");
+  ExpectFileContentContainsSubstring("Foo.php", "@param int $var");
+  ExpectFileContentContainsSubstring("Foo.php", "@return int");
+  ExpectFileContentContainsSubstring("Foo.php", "@return RepeatedField<int>");
+  ExpectFileContentNotContainsSubstring("Foo.php", "int|string");
+  ExpectFileContentNotContainsSubstring(
+      "Foo.php", "RepeatedField<int>|RepeatedField<string>");
+}
+
+TEST_F(PhpGeneratorTest, Assume64BitPhpFlagAbsentKeepsIntStringUnion) {
+  CreateTempFile("foo.proto",
+                 R"schema(
+    syntax = "proto3";
+    message Foo {
+      int64 scalar_i64 = 1;
+      repeated int64 repeated_i64 = 2;
+    })schema");
+
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir --php_out=$tmpdir foo.proto");
+
+  ExpectNoErrors();
+  ExpectFileContentContainsSubstring("Foo.php",
+                                     "public function setScalarI64(int|string $var)");
+  ExpectFileContentContainsSubstring(
+      "Foo.php", "@return RepeatedField<int>|RepeatedField<string>");
+}
+
 }  // namespace
 }  // namespace php
 }  // namespace compiler

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -55,6 +55,7 @@ struct Options {
   bool is_descriptor = false;
   bool aggregate_metadata = false;
   bool gen_c_wkt = false;
+  bool assume_64_bit_php = false;
   absl::flat_hash_set<std::string> aggregate_metadata_prefixes;
 };
 
@@ -80,9 +81,11 @@ void GenerateMessageConstructorDocComment(io::Printer* printer,
 void GenerateFieldDocComment(io::Printer* printer, const FieldDescriptor* field,
                              const Options& options, int function_type);
 void GenerateWrapperFieldGetterDocComment(io::Printer* printer,
-                                          const FieldDescriptor* field);
+                                          const FieldDescriptor* field,
+                                          const Options& options);
 void GenerateWrapperFieldSetterDocComment(io::Printer* printer,
-                                          const FieldDescriptor* field);
+                                          const FieldDescriptor* field,
+                                          const Options& options);
 void GenerateEnumDocComment(io::Printer* printer, const EnumDescriptor* enum_,
                             const Options& options);
 void GenerateEnumValueDocComment(io::Printer* printer,
@@ -412,7 +415,7 @@ std::string PhpSetterTypeName(const FieldDescriptor* field,
     case FieldDescriptor::TYPE_SINT64:
     case FieldDescriptor::TYPE_FIXED64:
     case FieldDescriptor::TYPE_SFIXED64:
-      type = "int|string";
+      type = options.assume_64_bit_php ? "int" : "int|string";
       break;
     case FieldDescriptor::TYPE_DOUBLE:
     case FieldDescriptor::TYPE_FLOAT:
@@ -460,7 +463,7 @@ std::string PhpDocSetterTypeName(const FieldDescriptor* field,
     case FieldDescriptor::TYPE_SINT64:
     case FieldDescriptor::TYPE_FIXED64:
     case FieldDescriptor::TYPE_SFIXED64:
-      type = "int|string";
+      type = options.assume_64_bit_php ? "int" : "int|string";
       break;
     case FieldDescriptor::TYPE_DOUBLE:
     case FieldDescriptor::TYPE_FLOAT:
@@ -493,13 +496,6 @@ std::string PhpDocSetterTypeName(const FieldDescriptor* field,
   return type;
 }
 
-std::string PhpDocSetterTypeName(const FieldDescriptor* field,
-                                 bool is_descriptor) {
-  Options options;
-  options.is_descriptor = is_descriptor;
-  return PhpDocSetterTypeName(field, options);
-}
-
 std::string PhpDocGetterTypeName(const FieldDescriptor* field,
                                  const Options& options) {
   if (field->is_map()) {
@@ -520,7 +516,7 @@ std::string PhpDocGetterTypeName(const FieldDescriptor* field,
     case FieldDescriptor::TYPE_SINT64:
     case FieldDescriptor::TYPE_FIXED64:
     case FieldDescriptor::TYPE_SFIXED64:
-      type = "int|string";
+      type = options.assume_64_bit_php ? "int" : "int|string";
       break;
     case FieldDescriptor::TYPE_DOUBLE:
     case FieldDescriptor::TYPE_FLOAT:
@@ -553,13 +549,6 @@ std::string PhpDocGetterTypeName(const FieldDescriptor* field,
     type = absl::StrCat("RepeatedField<", type, ">");
   }
   return type;
-}
-
-std::string PhpDocGetterTypeName(const FieldDescriptor* field,
-                                 bool is_descriptor) {
-  Options options;
-  options.is_descriptor = is_descriptor;
-  return PhpDocGetterTypeName(field, options);
 }
 
 std::string EnumOrMessageSuffix(const FieldDescriptor* field,
@@ -779,7 +768,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
   if (!field->is_map() && !field->is_repeated() &&
       field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE &&
       IsWrapperType(field)) {
-    GenerateWrapperFieldGetterDocComment(printer, field);
+    GenerateWrapperFieldGetterDocComment(printer, field, options);
     printer->Print(
         "public function get^camel_name^Unwrapped()\n"
         "{\n"
@@ -885,7 +874,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
   if (!field->is_map() && !field->is_repeated() &&
       field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE &&
       IsWrapperType(field)) {
-    GenerateWrapperFieldSetterDocComment(printer, field);
+    GenerateWrapperFieldSetterDocComment(printer, field, options);
     printer->Print(
         "public function set^camel_name^Unwrapped($var)\n"
         "{\n"
@@ -1740,7 +1729,8 @@ void GenerateFieldDocComment(io::Printer* printer, const FieldDescriptor* field,
 }
 
 void GenerateWrapperFieldGetterDocComment(io::Printer* printer,
-                                          const FieldDescriptor* field) {
+                                          const FieldDescriptor* field,
+                                          const Options& options) {
   // Generate a doc comment for the special getXXXValue methods that are
   // generated for wrapper types.
   const FieldDescriptor* primitiveField =
@@ -1753,12 +1743,13 @@ void GenerateWrapperFieldGetterDocComment(io::Printer* printer,
   printer->Print(" * Generated from protobuf field <code>^def^</code>\n", "def",
                  EscapePhpdoc(FirstLineOf(field->DebugString())));
   printer->Print(" * @return ^phpdoc_type^|null\n", "phpdoc_type",
-                 PhpDocGetterTypeName(primitiveField, false));
+                 PhpDocGetterTypeName(primitiveField, options));
   printer->Print(" */\n");
 }
 
 void GenerateWrapperFieldSetterDocComment(io::Printer* printer,
-                                          const FieldDescriptor* field) {
+                                          const FieldDescriptor* field,
+                                          const Options& options) {
   // Generate a doc comment for the special setXXXValue methods that are
   // generated for wrapper types.
   const FieldDescriptor* primitiveField =
@@ -1772,7 +1763,7 @@ void GenerateWrapperFieldSetterDocComment(io::Printer* printer,
   printer->Print(" * Generated from protobuf field <code>^def^</code>\n", "def",
                  EscapePhpdoc(FirstLineOf(field->DebugString())));
   printer->Print(" * @param ^phpdoc_type^|null $var\n", "phpdoc_type",
-                 PhpDocSetterTypeName(primitiveField, false));
+                 PhpDocSetterTypeName(primitiveField, options));
   printer->Print(" * @return $this\n");
   printer->Print(" */\n");
 }
@@ -2236,6 +2227,8 @@ bool Generator::GenerateAll(const std::vector<const FileDescriptor*>& files,
       options.is_descriptor = true;
     } else if (option_pair[0] == "internal_generate_c_wkt") {
       GenerateCWellKnownTypes(files, generator_context);
+    } else if (option_pair[0] == "assume_64_bit_php") {
+      options.assume_64_bit_php = true;
     } else {
       ABSL_LOG(FATAL) << "Unknown codegen option: " << option_pair[0];
     }


### PR DESCRIPTION
Generated PHP code currently type-hints 64-bit integer fields as
`int|string` to cover 32-bit PHP builds, where values that overflow a
native `int` are returned as strings. On 64-bit PHP — the mainstream
deployment — the runtime always returns native `int`, so the union is
dead weight that noisies up static analysis, IDE autocompletion, and
docs for everyone who has committed to 64-bit.

This change adds an opt-in CLI option, analogous to `aggregate_metadata`:

    protoc --php_out=assume_64_bit_php:. foo.proto

When the flag is present, INT64/UINT64/SINT64/FIXED64/SFIXED64 fields
emit `int` instead of `int|string` across setter signatures, PHPDoc
`@param` / `@return` / `@type`, and `RepeatedField<...>` generics
(which naturally collapse from `RepeatedField<int>|RepeatedField<string>`
to `RepeatedField<int>`). Wrapper types (`Int64Value`, `UInt64Value`)
honor the flag via `Options` threaded into the wrapper doc-comment
helpers. Default behavior (flag absent) is unchanged.

Scope:

- Codegen only. Runtime libraries (GPBUtil.php, convert.c) already
  return native `int` on 64-bit PHP regardless of this flag.
- No change to checked-in generated WKT .php files; they remain on
  default behavior unless regenerated with the flag.
- No new .proto file-level option.
- Descriptor-mode generation (`is_descriptor=true`) is intentionally
  unchanged.

Unit tests cover the flag-on and flag-absent paths, scalar and repeated
64-bit fields, and verify the `int|string` union is fully absent when
the flag is enabled.