### PR TITLE
Fix the unchecked huge allocation in GzipOutputStream

### DIFF
--- a/src/google/protobuf/io/gzip_stream.cc
+++ b/src/google/protobuf/io/gzip_stream.cc
@@ -210,7 +210,9 @@ void GzipOutputStream::Init(ZeroCopyOutputStream* sub_stream,
   sub_data_ = nullptr;
   sub_data_size_ = 0;
 
-  input_buffer_length_ = options.buffer_size;
+  input_buffer_length_ = (options.buffer_size == -1)
+                             ? kDefaultBufferSize
+                             : static_cast<size_t>(options.buffer_size);
   input_buffer_ = operator new(input_buffer_length_);
   ABSL_CHECK(input_buffer_ != nullptr);
 


### PR DESCRIPTION
This fixes the unchecked huge allocation issue in https://github.com/protocolbuffers/protobuf/issues/27097.

`GzipOutputStream::Init` now treats `buffer_size == -1` as a sentinel meaning "use the default buffer size" (64 KB), consistent with the long-standing behavior of `GzipInputStream`. Previously, the raw `int` value was assigned directly to the size_t field [`nput_buffer_length_` without any bounds check, causing -1 to wrap silently to SIZE_MAX and making the subsequent `operator new` call request ~16 EB of memory — an immediate abort under ASAN or an uncatchable std::bad_alloc in production. The one-line guard mirrors the identical check already present in `GzipInputStream` and closes the API asymmetry between the two stream classes.

With this patch, the ASAN warnings in https://github.com/protocolbuffers/protobuf/issues/27097 was calmed.