### PR TITLE
Guard against null stream_ in EpsCopyOutputStream::EnableAliasing

### DIFF
--- a/src/google/protobuf/io/coded_stream.cc
+++ b/src/google/protobuf/io/coded_stream.cc
@@ -734,7 +734,7 @@ bool CodedInputStream::Refresh() {
 // CodedOutputStream =================================================
 
 void EpsCopyOutputStream::EnableAliasing(bool enabled) {
-  aliasing_enabled_ = enabled && stream_->AllowsAliasing();
+  aliasing_enabled_ = enabled && stream_ != nullptr && stream_->AllowsAliasing();
 }
 
 int64_t EpsCopyOutputStream::ByteCount(uint8_t* ptr) const {


### PR DESCRIPTION
Fix the issue described in https://github.com/protocolbuffers/protobuf/issues/27099.



`EpsCopyOutputStream` can be constructed in "array-only" mode via `EpsCopyOutputStream(void*, int, bool)`, which intentionally sets `stream_` to nullptr (no backing `ZeroCopyOutputStream`). Calling `EnableAliasing()` in this state unconditionally dereferenced `stream_` to call the virtual `AllowsAliasing()`, causing a null pointer dereference (UBSan: member call on null pointer) and immediate SIGSEGV.

The fix adds a null check before the virtual dispatch. When `stream_` is null, `AllowsAliasing()` is meaningless and the result correctly evaluates to false, leaving `aliasing_enabled_` unset.