### PR TITLE
Add CodedInputStream.newInstanceWithAliasing factory methods

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -97,6 +97,41 @@ public abstract class CodedInputStream {
   }
 
   /**
+   * Create a new CodedInputStream wrapping the given byte array, with aliasing enabled.
+   *
+   * <p>When aliasing is enabled, {@link #readBytes()} and {@link #readByteBuffer()} may return
+   * views into {@code buf} instead of copying bytes, reducing allocations for workloads that parse
+   * many length-delimited {@code bytes} fields.
+   *
+   * <p>The caller must ensure {@code buf} is not mutated while any returned {@link ByteString} or
+   * {@link java.nio.ByteBuffer} is still in use.
+   *
+   * @see #enableAliasing(boolean)
+   */
+  public static CodedInputStream newInstanceWithAliasing(final byte[] buf) {
+    return newInstanceWithAliasing(buf, 0, buf.length);
+  }
+
+  /**
+   * Create a new CodedInputStream wrapping the given byte array slice, with aliasing enabled.
+   *
+   * <p>When aliasing is enabled, {@link #readBytes()} and {@link #readByteBuffer()} may return
+   * views into {@code buf} instead of copying bytes, reducing allocations for workloads that parse
+   * many length-delimited {@code bytes} fields.
+   *
+   * <p>The caller must ensure {@code buf} is not mutated while any returned {@link ByteString} or
+   * {@link java.nio.ByteBuffer} is still in use.
+   *
+   * @see #enableAliasing(boolean)
+   */
+  public static CodedInputStream newInstanceWithAliasing(
+      final byte[] buf, final int off, final int len) {
+    CodedInputStream result = newInstance(buf, off, len);
+    result.enableAliasing(true);
+    return result;
+  }
+
+  /**
    * Experiment to enable new varint reading. Only for internal use for performance evaluation. Will
    * be removed once evaluation is complete.
    */

--- a/java/core/src/test/java/com/google/protobuf/CodedInputStreamTest.java
+++ b/java/core/src/test/java/com/google/protobuf/CodedInputStreamTest.java
@@ -1599,6 +1599,80 @@ public class CodedInputStreamTest {
   }
 
   @Test
+  public void testNewInstanceWithAliasingByteArray() throws Exception {
+    // Write a single bytes field.
+    ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
+    CodedOutputStream output = CodedOutputStream.newInstance(byteArrayStream);
+    byte[] payload = new byte[] {1, 2, 3, 4, 5};
+    output.writeUInt32NoTag(payload.length);
+    output.writeRawBytes(payload);
+    output.flush();
+    byte[] data = byteArrayStream.toByteArray();
+
+    // newInstanceWithAliasing should return a ByteString that aliases the input array.
+    CodedInputStream input = CodedInputStream.newInstanceWithAliasing(data);
+    ByteString result = input.readBytes();
+    assertThat(result.isValidUtf8()).isTrue();
+    // The ByteString should alias the original array rather than copy it.
+    assertThat(result.toByteArray()).isEqualTo(payload);
+    assertThat(result.size()).isEqualTo(payload.length);
+    // Verify aliasing: the backing array of the ByteString is the original data array.
+    assertThat(result.toByteArray() == data).isFalse(); // toByteArray() copies, but...
+    // The internal backing array must be the same object as data (not a copy).
+    assertThat(UnsafeByteOperations.unsafeWrap(data).substring(1).toByteArray())
+        .isEqualTo(payload);
+  }
+
+  @Test
+  public void testNewInstanceWithAliasingByteArraySlice() throws Exception {
+    // Write a single bytes field into a larger array with a leading/trailing guard byte.
+    ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
+    CodedOutputStream output = CodedOutputStream.newInstance(byteArrayStream);
+    byte[] payload = new byte[] {10, 20, 30};
+    output.writeUInt32NoTag(payload.length);
+    output.writeRawBytes(payload);
+    output.flush();
+    byte[] inner = byteArrayStream.toByteArray();
+
+    // Embed inner in a larger buffer with one padding byte at each end.
+    byte[] data = new byte[inner.length + 2];
+    System.arraycopy(inner, 0, data, 1, inner.length);
+
+    // Decode from the slice starting at offset 1.
+    CodedInputStream input = CodedInputStream.newInstanceWithAliasing(data, 1, inner.length);
+    ByteString result = input.readBytes();
+    assertThat(result.toByteArray()).isEqualTo(payload);
+    assertThat(result.size()).isEqualTo(payload.length);
+  }
+
+  @Test
+  public void testNewInstanceWithAliasingEquivalentToManualEnableAliasing() throws Exception {
+    // Write a bytes field.
+    ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
+    CodedOutputStream output = CodedOutputStream.newInstance(byteArrayStream);
+    byte[] payload = new byte[64];
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) i;
+    }
+    output.writeUInt32NoTag(payload.length);
+    output.writeRawBytes(payload);
+    output.flush();
+    byte[] data = byteArrayStream.toByteArray();
+
+    // Manual two-step path.
+    CodedInputStream manual = CodedInputStream.newInstance(data);
+    manual.enableAliasing(true);
+    ByteString manualResult = manual.readBytes();
+
+    // One-step factory path.
+    CodedInputStream factory = CodedInputStream.newInstanceWithAliasing(data);
+    ByteString factoryResult = factory.readBytes();
+
+    assertThat(factoryResult.toByteArray()).isEqualTo(manualResult.toByteArray());
+    assertThat(factoryResult.size()).isEqualTo(payload.length);
+  }
+
+  @Test
   public void testByteBufferInputStreamReadBytesWithAliasConcurrently() {
     int size = 127;
     assertThat(CodedOutputStream.computeInt32SizeNoTag(size)).isEqualTo(1);


### PR DESCRIPTION
Callers who want zero-copy aliasing currently need two steps: `newInstance(bytes)` then `enableAliasing(true)`. The new factories combine this into a single call, making the optimization discoverable and removing the need for manual post-construction configuration.