### PR TITLE
feat: enable generic access to message full names

### DIFF
--- a/rust/codegen_traits.rs
+++ b/rust/codegen_traits.rs
@@ -31,6 +31,18 @@ impl<T: EntityType<Tag = entity_tag::MessageTag>> MessageTypeHelper<entity_tag::
 pub trait MessageType {}
 impl<T> MessageType for T where T: EntityType + MessageTypeHelper<T::Tag> {}
 
+/// Provides compile-time access to a generated message's protobuf full name.
+///
+/// This exists for generic code that needs to name message types without going
+/// through runtime reflection or descriptor APIs.
+///
+/// Bring `protobuf::MessageFullName` into scope to use `MyMessage::FULL_NAME`.
+/// Without the trait in scope, use `<MyMessage as protobuf::MessageFullName>::FULL_NAME`.
+pub trait MessageFullName: MessageType {
+    /// The protobuf full name for the generated message type.
+    const FULL_NAME: &'static str;
+}
+
 /// A trait that all generated owned message types implement.
 pub trait Message: SealedInternal
   + EntityType<Tag = entity_tag::MessageTag>

--- a/rust/shared.rs
+++ b/rust/shared.rs
@@ -22,7 +22,7 @@ pub use crate::codegen_traits::{
     create::Parse,
     read::Serialize,
     write::{Clear, ClearAndParse, CopyFrom, MergeFrom, TakeFrom},
-    Message, MessageMut, MessageType, MessageView,
+    Message, MessageFullName, MessageMut, MessageType, MessageView,
 };
 pub use crate::cord::{ProtoBytesCow, ProtoStringCow};
 pub use crate::extension::ExtensionId;

--- a/rust/test/shared/BUILD
+++ b/rust/test/shared/BUILD
@@ -116,6 +116,34 @@ rust_test(
 )
 
 rust_test(
+    name = "full_name_cpp_test",
+    srcs = ["full_name_test.rs"],
+    aliases = {
+        "//rust:protobuf_cpp_export": "protobuf",
+    },
+    rustc_flags = ["--cfg=bzl"],
+    deps = [
+        "//rust:protobuf_cpp_export",
+        "//rust/test:unittest_cpp_rust_proto",
+        "@crate_index//:googletest",
+    ],
+)
+
+rust_test(
+    name = "full_name_upb_test",
+    srcs = ["full_name_test.rs"],
+    aliases = {
+        "//rust:protobuf_upb_export": "protobuf",
+    },
+    rustc_flags = ["--cfg=bzl"],
+    deps = [
+        "//rust:protobuf_upb_export",
+        "//rust/test:unittest_upb_rust_proto",
+        "@crate_index//:googletest",
+    ],
+)
+
+rust_test(
     name = "enum_cpp_test",
     srcs = ["enum_test.rs"],
     aliases = {

--- a/rust/test/shared/full_name_test.rs
+++ b/rust/test/shared/full_name_test.rs
@@ -1,0 +1,59 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2026 Google LLC.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+use googletest::prelude::*;
+use protobuf::MessageFullName;
+use unittest_rust_proto::{test_all_types, NestedTestAllTypes, TestAllTypes};
+
+#[gtest]
+fn generated_messages_expose_full_name_via_concrete_syntax() {
+    assert_that!(TestAllTypes::FULL_NAME, eq("rust_unittest.TestAllTypes"));
+    assert_that!(
+        NestedTestAllTypes::FULL_NAME,
+        eq("rust_unittest.NestedTestAllTypes")
+    );
+    assert_that!(
+        test_all_types::NestedMessage::FULL_NAME,
+        eq("rust_unittest.TestAllTypes.NestedMessage")
+    );
+}
+
+fn generic_message_full_name<T: MessageFullName>() -> &'static str {
+    T::FULL_NAME
+}
+
+#[gtest]
+fn generated_messages_expose_full_name_via_generic_trait() {
+    assert_that!(
+        generic_message_full_name::<TestAllTypes>(),
+        eq("rust_unittest.TestAllTypes")
+    );
+    assert_that!(
+        generic_message_full_name::<NestedTestAllTypes>(),
+        eq("rust_unittest.NestedTestAllTypes")
+    );
+    assert_that!(
+        generic_message_full_name::<test_all_types::NestedMessage>(),
+        eq("rust_unittest.TestAllTypes.NestedMessage")
+    );
+}
+
+#[gtest]
+fn generated_messages_expose_full_name_via_ufcs() {
+    assert_that!(
+        <TestAllTypes as MessageFullName>::FULL_NAME,
+        eq(TestAllTypes::FULL_NAME)
+    );
+    assert_that!(
+        <NestedTestAllTypes as MessageFullName>::FULL_NAME,
+        eq(NestedTestAllTypes::FULL_NAME)
+    );
+    assert_that!(
+        <test_all_types::NestedMessage as MessageFullName>::FULL_NAME,
+        eq(test_all_types::NestedMessage::FULL_NAME)
+    );
+}

--- a/rust/test/shared/full_name_test.rs
+++ b/rust/test/shared/full_name_test.rs
@@ -5,6 +5,11 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#[cfg(not(bzl))]
+mod protos;
+#[cfg(not(bzl))]
+use protos::*;
+
 use googletest::prelude::*;
 use protobuf::MessageFullName;
 use unittest_rust_proto::{test_all_types, NestedTestAllTypes, TestAllTypes};

--- a/src/google/protobuf/compiler/rust/message.cc
+++ b/src/google/protobuf/compiler/rust/message.cc
@@ -514,6 +514,7 @@ void GenerateRs(Context& ctx, const Descriptor& msg, const upb::DefPool& pool) {
                CppGeneratedMessageTraitImpls(ctx, msg);
              }
            }},
+          {"full_name", msg.full_name()},
           {"type_conversions_impl", [&] { TypeConversions(ctx, msg); }},
           {"unwrap_upb",
            [&] {
@@ -761,6 +762,10 @@ void GenerateRs(Context& ctx, const Descriptor& msg, const upb::DefPool& pool) {
           fn clone(&self) -> Self {
             self.as_view().to_owned()
           }
+        }
+
+        impl $pb$::MessageFullName for $Msg$ {
+          const FULL_NAME: &'static str = "$full_name$";
         }
 
         impl $pb$::AsView for $Msg$ {


### PR DESCRIPTION
- Generic Rust code needs a stable way to refer to protobuf message full names without relying on unstable descriptor or reflection APIs.
- Message full names are known at code generation time, so exposing them as compile-time metadata avoids adding runtime lookup costs or kernel-specific reflection behavior.
- Keeping the API narrow and metadata-specific makes the new surface easier to reason about while covering both direct and generic Rust use cases.
