### PR TITLE
Check for uint16_t field_count overflow in upb_MtDecoder_Parse()

### DIFF
--- a/upb/mini_descriptor/decode.c
+++ b/upb/mini_descriptor/decode.c
@@ -481,6 +481,11 @@ static const char* upb_MtDecoder_Parse(upb_MtDecoder* d, const char* ptr,
         return --ptr;
       }
       upb_MiniTableField* field = fields;
+      if (*field_count == UINT16_MAX) {
+        upb_MdDecoder_ErrorJmp(&d->base,
+                               "Fields in message exceed the limit of %u",
+                               UINT16_MAX);
+      }
       *field_count += 1;
       fields = (char*)fields + field_size;
       uint32_t number = ++last_field_number;

--- a/upb/mini_descriptor/internal/encode_test.cc
+++ b/upb/mini_descriptor/internal/encode_test.cc
@@ -161,6 +161,19 @@ TEST_P(MiniTableTest, AllScalarTypesOneof) {
   EXPECT_EQ(0, table->UPB_PRIVATE(required_count));
 }
 
+TEST_P(MiniTableTest, FieldCountOverflow) {
+  upb::Arena arena;
+  upb::MtDataEncoder e;
+  ASSERT_TRUE(e.StartMessage(0));
+  for (uint32_t i = 1; i <= UINT16_MAX + 1; i++) {
+    ASSERT_TRUE(e.PutField(kUpb_FieldType_Bool, i, 0));
+  }
+  upb::Status status;
+  upb_MiniTable* table = _upb_MiniTable_Build(
+      e.data().data(), e.data().size(), GetParam(), arena.ptr(), status.ptr());
+  EXPECT_EQ(nullptr, table);
+}
+
 TEST_P(MiniTableTest, SizeOverflow) {
   upb::Arena arena;
   upb::MtDataEncoder e;


### PR DESCRIPTION
In the field parsing logic of `upb_MtDecoder_Parse()`, the `uint16_t field_count` is incremented for each parsed field with no overflow check. A MiniTable with more than `UINT16_MAX` fields will then wrap the field counter. This sets the `upb_MessageDef.layout->field_count` to an invalid value smaller than the total number of fields. `upb_MtDecoder_ParseMessage()` then calls `upb_Arena_ShrinkLast()` with the wrapped `field_count` size. 

Later `_upb_MessageDef_LinkMiniTable()` uses `int m->field_count` as an index loop bound  for `m->layout->UPB_PRIVATE(fields)`, creating a mismatch between the array and index bounds.

To fix the bug, I opt for a simple integer overflow check before incrementing.
 
This bug has been reported to [Google's OSS VRP](https://issuetracker.google.com/u/0/issues/503166184).