### PR TITLE
Fix default recursion limit in TextFormat SkipFieldValue

### DIFF
--- a/src/google/protobuf/text_format.cc
+++ b/src/google/protobuf/text_format.cc
@@ -1938,7 +1938,7 @@ TextFormat::Parser::Parser()
       allow_field_number_(false),
       allow_relaxed_whitespace_(false),
       allow_singular_overwrites_(false),
-      recursion_limit_(std::numeric_limits<int>::max()) {}
+      recursion_limit_(100) {}
 
 namespace {
 


### PR DESCRIPTION
## Summary

`SkipFieldValue()` in `text_format.cc` recurses on nested bracket tokens (`[`) to handle repeated field values. The recursion guard at line 1095 checks `--recursion_limit_ < 0`, but the default `recursion_limit_` is `std::numeric_limits<int>::max()` (2,147,483,647), making the guard ineffective. An input with ~5,000 nested brackets exhausts the call stack and crashes the process (SIGSEGV).

This is the same bug class as:
- **CVE-2024-7254** — unbounded recursion in the binary wire format parser, fixed by introducing a default recursion limit of 100
- **CVE-2026-0994** — recursion limit bypass in the Python protobuf parser via nested Any messages

PR #26916 (commit 1a40379, "Fix TextFormat parser recursion limit enforcement issue in the face of Any-of-Any") centralized the recursion depth check in `ConsumeMessage` but did not modify `SkipFieldValue()`, leaving this separate recursive code path uncovered.

## Fix

Set the default `recursion_limit_` to 100, consistent with the binary format parser limit established in the CVE-2024-7254 fix. Users who need deeper nesting can still call `SetRecursionLimit()` explicitly.

## Trigger conditions

1. Application uses `TextFormat::Parser` with `AllowUnknownField(true)`
2. Application parses text-format protobuf from untrusted input
3. Input contains a field value with deeply nested `[` brackets
4. No explicit `SetRecursionLimit()` configured (default is INT_MAX)

## Reproduction

```cpp
#include <string>
#include <google/protobuf/text_format.h>
#include <google/protobuf/descriptor.pb.h>

int main() {
    std::string input = "x: ";
    input.append(50000, '[');

    google::protobuf::FileDescriptorProto msg;
    google::protobuf::TextFormat::Parser parser;
    parser.AllowUnknownField(true);
    parser.ParseFromString(input, &msg);
    return 0;
}
```

Build with ASAN (`g++ -fsanitize=address -g poc.cc -lprotobuf -o poc`) and run — produces `stack-overflow` with ~248 recursive `SkipFieldValue` frames.

## ASAN trace (abbreviated)

```
==1284127==ERROR: AddressSanitizer: stack-overflow on address 0x7ffc9f5ccfe8
    #0 __asan_memcpy
    #1 google::protobuf::io::Tokenizer::Token::operator=() tokenizer.h:127
    #2 google::protobuf::io::Tokenizer::Next() tokenizer.cc:609
    #3 google::protobuf::TextFormat::Parser::ParserImpl::TryConsume() text_format.cc:1520
    #4 google::protobuf::TextFormat::Parser::ParserImpl::SkipFieldValue() text_format.cc:1110
    #5-#248 SkipFieldValue() text_format.cc:1114 [244 identical recursive frames]
```

Signed-off-by: Anthony Hurtado <amhurtado@pm.me>