### PR TITLE
Reject [weak = true] on non-message fields to prevent SEGV

### DIFF
--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -8833,6 +8833,14 @@ void DescriptorBuilder::ValidateOptions(const FieldDescriptor* field,
     }
   }
 
+  // Only message type fields may be weak.
+  if (field->options().weak()) {
+    if (field->type() != FieldDescriptor::TYPE_MESSAGE) {
+      AddError(field->full_name(), proto, DescriptorPool::ErrorCollector::TYPE,
+               "[weak = true] can only be specified for submessage fields.");
+    }
+  }
+
   // Only repeated primitive fields may be packed.
   if (field->options().packed() && !field->is_packable()) {
     AddError(

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -7876,6 +7876,14 @@ void internal::DescriptorBuilder::ValidateOptions(
     }
   }
 
+  // Only message type fields may be weak.
+  if (field->options().weak()) {
+    if (field->type() != FieldDescriptor::TYPE_MESSAGE) {
+      AddError(field->full_name(), proto, DescriptorPool::ErrorCollector::TYPE,
+               "[weak = true] can only be specified for submessage fields.");
+    }
+  }
+
   // Only repeated primitive fields may be packed.
   if (field->options().packed() && !field->is_packable()) {
     AddError(

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -7060,6 +7060,19 @@ TEST_F(ValidationErrorTest, OutputTypeNotAMessage) {
 }
 
 
+TEST_F(ValidationErrorTest, WeakOnNonMessageField) {
+  BuildFileWithErrors(
+      "name: \"foo.proto\" "
+      "message_type { "
+      "  name: \"Foo\" "
+      "  field { name:\"bar\" number:1 label:LABEL_OPTIONAL "
+      "          type:TYPE_INT32 "
+      "          options { weak: true } } "
+      "} ",
+      "foo.proto: Foo.bar: TYPE: [weak = true] can only be specified for "
+      "submessage fields.\n");
+}
+
 TEST_F(ValidationErrorTest, IllegalPackedField) {
   BuildFileWithErrors(
       "name: \"foo.proto\" "

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -7542,6 +7542,19 @@ TEST_F(ValidationErrorTest, OutputTypeNotAMessage) {
 }
 
 
+TEST_F(ValidationErrorTest, WeakOnNonMessageField) {
+  BuildFileWithErrors(
+      "name: \"foo.proto\" "
+      "message_type { "
+      "  name: \"Foo\" "
+      "  field { name:\"bar\" number:1 label:LABEL_OPTIONAL "
+      "          type:TYPE_INT32 "
+      "          options { weak: true } } "
+      "} ",
+      "foo.proto: Foo.bar: TYPE: [weak = true] can only be specified for "
+      "submessage fields.\n");
+}
+
 TEST_F(ValidationErrorTest, IllegalPackedField) {
   BuildFileWithErrors(
       R"pb(


### PR DESCRIPTION
## Summary

A crafted `FileDescriptorProto` with `weak=true` on a scalar field (e.g., `TYPE_DOUBLE`) causes a **SEGV** (wild pointer dereference) when the resulting `DynamicMessage` is used with `ParseFromArray`. This is a DoS vulnerability affecting any application that builds descriptors from untrusted input with `AllowUnknownDependencies()` (gRPC server reflection, schema registries, protoc, dynamic config systems).

### Root cause

- `weak=true` on a non-message field causes `GetFieldHasbitModeWithoutProfile()` to return `kNoHasbit` (descriptor.cc:10751)
- When `DynamicMessage::ParseFromArray()` lazily generates the `TcParseTable` via `Reflection::CreateTcParseTable()`, the `kNoHasbit` hasbit index produces **incorrect field offsets** in the table entries
- `TcParser` writes the parsed field value at the wrong offset, corrupting `DynamicMessage`'s internal `type_info_` pointer
- Post-parse calls to `GetMetadata()` / `GetDescriptor()` / `IsInitialized()` dereference the corrupted pointer → **SEGV**

### Crash site

```
#0 Message::GetMetadata()         message.cc:430
#1 Message::GetDescriptor()       message.h:377
#2 TcParser::ReflectionFallback() generated_message_tctable_full.cc:69
#3 TcParser::TagDispatch()        generated_message_tctable_impl.h:1163
#4 TcParser::ParseLoop()          generated_message_tctable_impl.h:1205
#5 MergeFromImpl<false>()         message_lite.cc:227
```

### Fix

Add validation in `ValidateOptions()` to reject `[weak = true]` on non-message fields, following the identical pattern already used for `[lazy = true]` (line 8581). The `[weak]` option is only meaningful for message-type fields (cross-file dependency management) and has no valid use on scalar, enum, or group fields.

### Reproduction

```cpp
google::protobuf::FileDescriptorProto fdp;
fdp.set_name("test.proto");
fdp.set_syntax("proto2");
auto* msg = fdp.add_message_type();
msg->set_name("Msg");
auto* f = msg->add_field();
f->set_name("f");
f->set_number(1);
f->set_type(google::protobuf::FieldDescriptorProto::TYPE_DOUBLE);
f->set_label(google::protobuf::FieldDescriptorProto::LABEL_REPEATED);
f->mutable_options()->set_weak(true);  // ← weak on non-message

google::protobuf::DescriptorPool pool;
pool.AllowUnknownDependencies();
auto* fd = pool.BuildFile(fdp);    // succeeds (no validation)
google::protobuf::DynamicMessageFactory factory;
auto* proto = factory.GetPrototype(fd->message_type(0));
auto msg1 = std::unique_ptr<google::protobuf::Message>(proto->New());
uint8_t data[] = {0x09,0,0,0,0,0,0,0xf0,0x3f};  // field 1, double 1.0
msg1->ParseFromArray(data, sizeof(data));  // SEGV
```

Found by AFL++ fuzzing with custom harness targeting `BuildFile` + `DynamicMessageFactory` pipeline.