### PR TITLE
Fix dependency_out Makefile escaping

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -130,6 +130,36 @@ constexpr absl::string_view kDefaultDirectDependenciesViolationMsg =
 constexpr absl::string_view kDefaultOptionDependenciesViolationMsg =
     "File is option imported but not declared in --option_dependencies: %s";
 
+std::string EscapeMakefileDependency(absl::string_view filename) {
+  std::string result;
+  result.reserve(filename.size());
+  for (char c : filename) {
+    switch (c) {
+      case '\n':
+        result.append("\\n");
+        break;
+      case '\r':
+        result.append("\\r");
+        break;
+      case '$':
+        result.append("$$");
+        break;
+      case ' ':
+      case '\t':
+      case '#':
+      case ':':
+      case '\\':
+        result.push_back('\\');
+        result.push_back(c);
+        break;
+      default:
+        result.push_back(c);
+        break;
+    }
+  }
+  return result;
+}
+
 // Returns true if the text begins with a Windows-style absolute path, starting
 // with a drive letter.  Example:  "C:\foo".
 static bool StartsWithWindowsAbsolutePath(absl::string_view text) {
@@ -2924,7 +2954,7 @@ bool CommandLineInterface::GenerateDependencyManifestFile(
     io::Printer printer(&out, '$');
 
     for (size_t i = 0; i < output_filenames.size(); ++i) {
-      printer.Print(output_filenames[i]);
+      printer.PrintRaw(EscapeMakefileDependency(output_filenames[i]));
       if (i == output_filenames.size() - 1) {
         printer.Print(":");
       } else {
@@ -2938,7 +2968,8 @@ bool CommandLineInterface::GenerateDependencyManifestFile(
       std::string disk_file;
       if (source_tree &&
           source_tree->VirtualFileToDiskFile(virtual_file, &disk_file)) {
-        printer.Print(" $disk_file$", "disk_file", disk_file);
+        printer.Print(" ");
+        printer.PrintRaw(EscapeMakefileDependency(disk_file));
         if (i < file_set.file_size() - 1) printer.Print("\\\n");
       } else {
         std::cerr << "Unable to identify path for file " << virtual_file

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -3895,6 +3895,36 @@ TEST_F(CommandLineInterfaceTest, WriteDependencyManifestFileForAbsolutePath) {
                     "$tmpdir/foo.proto\\\n $tmpdir/bar.proto");
 }
 
+TEST_F(CommandLineInterfaceTest, WriteDependencyManifestFileEscapesMakeSyntax) {
+  const std::string dependency = "foo$(shell touch DEP).proto";
+  const std::string input = "bar$(shell touch PWNED).proto";
+
+  CreateTempFile(dependency,
+                 "syntax = \"proto2\";\n"
+                 "message Foo {}\n");
+  CreateTempFile(input,
+                 absl::StrCat("syntax = \"proto2\";\n"
+                              "import \"",
+                              dependency,
+                              "\";\n"
+                              "message Bar {\n"
+                              "  optional Foo foo = 1;\n"
+                              "}\n"));
+
+  SwitchToTempDirectory();
+  DisallowPlugins();
+  RunWithArgs({"protocol_compiler", "--dependency_out=manifest", "--test_out=.",
+               input});
+
+  ExpectNoErrors();
+
+  ExpectFileContent(
+      "manifest",
+      "bar$$(shell\\ touch\\ PWNED).proto.MockCodeGenerator.test_generator: "
+      "foo$$(shell\\ touch\\ DEP).proto\\\n"
+      " bar$$(shell\\ touch\\ PWNED).proto");
+}
+
 TEST_F(CommandLineInterfaceTest,
        WriteDependencyManifestFileWithDescriptorSetOut) {
   CreateTempFile("foo.proto",


### PR DESCRIPTION
This fixes a Makefile command injection risk in `protoc --dependency_out`.

`--dependency_out` writes a Make-compatible dependency file. Before this change, `GenerateDependencyManifestFile()` wrote generated output filenames and source dependency paths directly into the depfile. If a downstream build includes that depfile, Make syntax embedded in a `.proto` filename or imported dependency path can be evaluated by Make instead of being treated as a literal filename.

This PR follows the project-maintainer remediation path for a security report involving `protoc --dependency_out`.

Changes:
- Add Make depfile escaping for generated output targets and source dependency paths.
- Escape `$`, whitespace, `#`, `:`, and backslash before writing filenames to the depfile.
- Add regression coverage for filenames containing Make function syntax in both the generated target and imported dependency paths.

Tests:
- `cmake --build build-pr-tests --target tests -j2`
- `./tests --gtest_filter=CommandLineInterfaceTest.WriteDependencyManifestFileEscapesMakeSyntax`
- `./tests --gtest_filter=CommandLineInterfaceTest.WriteDependencyManifestFile*`
- Verified the original `--dependency_out` Make-include reproduction no longer creates the marker file with the patched `protoc`.
- Verified the variant matrix and CI-secret exfiltration repro no longer execute through the generated depfile with the patched `protoc`.
