### PR TITLE
Serialize length-prefixed protos once

### DIFF
--- a/python/google/protobuf/internal/proto_test.py
+++ b/python/google/protobuf/internal/proto_test.py
@@ -77,6 +77,29 @@ class ProtoTest(unittest.TestCase):
         str(context.exception),
     )
 
+  def test_serialize_length_prefixed_serializes_once(self, message_module):
+    del message_module
+
+    class CountingMessage:
+
+      def __init__(self):
+        self.serialize_count = 0
+
+      def SerializeToString(self, deterministic=None):
+        self.serialize_count += 1
+        return b'abc'
+
+      def ByteSize(self):
+        raise AssertionError('serialize_length_prefixed should not call ByteSize')
+
+    msg = CountingMessage()
+    out = io.BytesIO()
+
+    proto.serialize_length_prefixed(msg, out)
+
+    self.assertEqual(b'\x03abc', out.getvalue())
+    self.assertEqual(1, msg.serialize_count)
+
   def test_byte_size(self, message_module):
     msg = message_module.TestAllTypes()
     self.assertEqual(0, proto.byte_size(msg))

--- a/python/google/protobuf/proto.py
+++ b/python/google/protobuf/proto.py
@@ -64,9 +64,10 @@ def serialize_length_prefixed(message: _MESSAGE, output: io.BytesIO) -> None:
     message: The protocol buffer message that should be serialized.
     output: BytesIO or custom buffered IO that data should be written to.
   """
-  size = message.ByteSize()
+  payload = serialize(message)
+  size = len(payload)
   encoder._VarintEncoder()(output.write, size)
-  out_size = output.write(serialize(message))
+  out_size = output.write(payload)
 
   if out_size != size:
     raise TypeError(


### PR DESCRIPTION
Avoid calling ByteSize() separately in serialize_length_prefixed(). The serialized payload already carries the exact length to prefix, so this keeps behavior intact while avoiding a duplicate serialization-sized pass.