### PR TITLE
Accept buffer inputs in Python upb parsing

### DIFF
--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -15,6 +15,7 @@ serialization code in the whole library.
 
 __author__ = 'gps@google.com (Gregory P. Smith)'
 
+import array
 import collections
 import copy
 import math
@@ -878,6 +879,23 @@ class MessageTest(unittest.TestCase):
     self.assertIsInstance(m1.repeated_bytes[0], bytes)
     self.assertIsInstance(m1.optional_string, str)
     self.assertIsInstance(m1.repeated_string[0], str)
+
+  def testMergeFromStringUsingContiguousBuffer(self, message_module):
+    if api_implementation.Type() != 'upb':
+      self.skipTest('contiguous buffer parsing is upb-specific')
+
+    m2 = message_module.TestAllTypes()
+    m2.optional_string = 'scalar string'
+    serialized = m2.SerializeToString()
+
+    buffer = array.array('B', serialized)
+    m1 = message_module.TestAllTypes.FromString(buffer)
+    self.assertEqual(m1.optional_string, 'scalar string')
+
+    prefixed = bytearray(b'prefix') + serialized + bytearray(b'suffix')
+    sliced = memoryview(prefixed)[6 : 6 + len(serialized)]
+    m3 = message_module.TestAllTypes.FromString(sliced)
+    self.assertEqual(m3.optional_string, 'scalar string')
 
   def testMergeFromEmpty(self, message_module):
     m1 = message_module.TestAllTypes()

--- a/python/message.c
+++ b/python/message.c
@@ -1348,17 +1348,29 @@ PyObject* PyUpb_Message_MergeFromString(PyObject* _self, PyObject* arg) {
   Py_ssize_t size;
   PyObject* bytes = NULL;
 
-  if (PyMemoryView_Check(arg)) {
-    bytes = PyBytes_FromObject(arg);
-    // Cannot fail when passed something of the correct type.
-    int err = PyBytes_AsStringAndSize(bytes, &buf, &size);
+  if (PyBytes_Check(arg)) {
+    // Cannot fail when passed a bytes object.
+    int err = PyBytes_AsStringAndSize(arg, &buf, &size);
     (void)err;
     assert(err >= 0);
   } else if (PyByteArray_Check(arg)) {
     buf = PyByteArray_AsString(arg);
     size = PyByteArray_Size(arg);
-  } else if (PyBytes_AsStringAndSize(arg, &buf, &size) < 0) {
-    return NULL;
+  } else {
+    PyObject* memoryview = NULL;
+    PyObject* view_arg = arg;
+    if (!PyMemoryView_Check(arg)) {
+      memoryview = PyMemoryView_FromObject(arg);
+      if (!memoryview) return NULL;
+      view_arg = memoryview;
+    }
+    bytes = PyBytes_FromObject(view_arg);
+    Py_XDECREF(memoryview);
+    if (!bytes) return NULL;
+    // Cannot fail when passed a bytes object.
+    int err = PyBytes_AsStringAndSize(bytes, &buf, &size);
+    (void)err;
+    assert(err >= 0);
   }
 
   PyUpb_Message_EnsureReified(self);


### PR DESCRIPTION
Handle bytes before rarer input types in MergeFromString(), preserving the direct bytearray path and existing memoryview copy behavior.

For other buffer-exporting objects, create a memoryview and copy through bytes accepting inputs such as array.array.