### PR TITLE
Add field ownership check to SwapFields to prevent OOB memory access

### DIFF
--- a/src/google/protobuf/generated_message_reflection.cc
+++ b/src/google/protobuf/generated_message_reflection.cc
@@ -1309,6 +1309,11 @@ void Reflection::SwapFieldsImpl(
   absl::flat_hash_set<int> swapped_oneof;
 
   for (const auto* field : fields) {
+    ABSL_CHECK_EQ(field->containing_type(), descriptor_)
+        << "Field \"" << field->full_name()
+        << "\" does not belong to message type \"" << descriptor_->full_name()
+        << "\".  SwapFields() requires all fields to belong to the message's "
+           "own descriptor.";
     if (field->is_extension()) {
       if constexpr (unsafe_shallow_swap) {
         MutableExtensionSet(message1)->UnsafeShallowSwapExtension(

--- a/src/google/protobuf/generated_message_reflection.cc
+++ b/src/google/protobuf/generated_message_reflection.cc
@@ -1299,6 +1299,7 @@ void Reflection::SwapFieldsImpl(
   absl::flat_hash_set<int> swapped_oneof;
 
   for (const auto* field : fields) {
+    USAGE_CHECK_MESSAGE_TYPE(SwapFields);
     if (field->is_extension()) {
       if constexpr (unsafe_shallow_swap) {
         MutableExtensionSet(message1)->UnsafeShallowSwapExtension(

--- a/src/google/protobuf/generated_message_reflection_unittest.cc
+++ b/src/google/protobuf/generated_message_reflection_unittest.cc
@@ -1499,6 +1499,22 @@ TEST(GeneratedMessageReflectionTest, UsageErrors) {
       "  Problem     : Field does not match message type.");
 }
 
+TEST(GeneratedMessageReflectionTest, SwapFieldsForeignFieldCheck) {
+  unittest::TestAllTypes message1;
+  unittest::TestAllTypes message2;
+  const Reflection* reflection = message1.GetReflection();
+
+  // Passing a field descriptor from a different message type to SwapFields
+  // must fail. Without this check, a foreign field with a higher index than
+  // the target's field count causes an out-of-bounds read on the offsets
+  // array, leading to memory corruption.
+  const FieldDescriptor* foreign_field =
+      unittest::ForeignMessage::descriptor()->FindFieldByName("c");
+  std::vector<const FieldDescriptor*> fields = {foreign_field};
+  EXPECT_DEATH(reflection->SwapFields(&message1, &message2, fields),
+               "does not belong to message type");
+}
+
 #endif  // GTEST_HAS_DEATH_TEST
 
 class GeneratedMessageReflectionCordAccessorsTest : public testing::Test {

--- a/src/google/protobuf/generated_message_reflection_unittest.cc
+++ b/src/google/protobuf/generated_message_reflection_unittest.cc
@@ -1499,6 +1499,22 @@ TEST(GeneratedMessageReflectionTest, UsageErrors) {
       "  Problem     : Field does not match message type.");
 }
 
+TEST(GeneratedMessageReflectionTest, SwapFieldsForeignFieldCheck) {
+  unittest::TestAllTypes message1;
+  unittest::TestAllTypes message2;
+  const Reflection* reflection = message1.GetReflection();
+
+  // Passing a field descriptor from a different message type to SwapFields
+  // must fail. Without this check, a foreign field with a higher index than
+  // the target's field count causes an out-of-bounds read on the offsets
+  // array, leading to memory corruption.
+  const FieldDescriptor* foreign_field =
+      unittest::ForeignMessage::descriptor()->FindFieldByName("c");
+  std::vector<const FieldDescriptor*> fields = {foreign_field};
+  EXPECT_DEATH(reflection->SwapFields(&message1, &message2, fields),
+               "Field does not match message type");
+}
+
 #endif  // GTEST_HAS_DEATH_TEST
 
 class GeneratedMessageReflectionCordAccessorsTest : public testing::Test {


### PR DESCRIPTION
## Summary

`Reflection::SwapFieldsImpl()` validates that both messages belong to the correct Reflection object (`GetReflection() == this`), but does not verify that each field descriptor in the `fields` vector belongs to the message's own descriptor. This means a field from a different message type can be passed in, and its `index()` value can exceed the bounds of the target descriptor's `offsets_` array.

When this happens, `GetFieldOffset()` at `generated_message_reflection.h:127` reads `offsets_[field->index()]` out of bounds, producing an arbitrary offset value. The subsequent `std::swap` then writes 8 bytes at that offset relative to the message pointer, corrupting adjacent heap memory.

### Root cause

Every other `Reflection` write method (`SetInt32`, `SetString`, `HasField`, `ClearField`, `Swap`, `RemoveLast`, `MutableRawRepeatedField`, etc.) includes `USAGE_CHECK_MESSAGE_TYPE` which validates `field->containing_type() == descriptor_`. The `SwapFieldsImpl` path was the only write method missing this check.

### Fix

Add `ABSL_CHECK_EQ(field->containing_type(), descriptor_)` for each field at the top of the loop in `SwapFieldsImpl`, before any field operations. This matches the validation pattern used by all other Reflection methods.

### Impact

Without this check, passing a foreign field descriptor causes:
- Out-of-bounds read on `offsets_[]` array (reads heap data as a field offset)
- Out-of-bounds write via `std::swap` at the corrupted offset (overwrites adjacent heap objects)

## Test plan

- Added `SwapFieldsForeignFieldCheck` death test: passes a `ForeignMessage` field to `SwapFields` on a `TestAllTypes` message, verifies the check fires with "does not belong to message type"
- Follows the same pattern as the existing `UsageErrors` death test
- All existing `SwapFields*` tests should pass unchanged (they only use fields from the correct descriptor)