### PR TITLE
Add custom option numbers for use by ProtoWire

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -588,3 +588,8 @@ about your project (name and website) so we can add an entry for you.
 
     *   Website: https://goteleport.com
     *   Extensions: 1310
+
+1.  ProtoWire
+
+    *   Website: https://protowire.org
+    *   Extensions: 1311-1360


### PR DESCRIPTION
Reserves a range of custom option numbers for **ProtoWire** (https://protowire.org), an open interchange stack (text/binary codecs, schema-extension compiler, validation engine) built on protobuf descriptors.

Since the original request (10 numbers for two annotation groups), the project's published option surface has grown to five orthogonal families, all currently parked in the internal 50000+ space and being migrated to registered numbers ahead of an IETF draft submission:

| Family | Extendees | In use | Growth headroom |
|---|---|---|---|
| PXF text-format annotations (`pxf.*`) | FieldOptions | 3 | +2 |
| SBE binary-format annotations (`sbe.*`) | File/Message/FieldOptions | 5 | +5 |
| Schema-extension carriers (`protowire.schema.v1.*`) | all 8 Options messages (one shared number) + FileOptions | 5 | +5 |
| Validation constraints (`protocheck.*`) | Field/Message/OneofOptions | 3 | +5 |
| OpenAPI generation options | Method/ServiceOptions | 0 | +5 |

That's 16 numbers in active published use with a documented path to ~40, hence the request for a contiguous block of 50: **1311–1360** (1307–1310 having been claimed since this PR was filed).