### PR TITLE
Handle allocation failure during required field traversal

### DIFF
--- a/upb/util/required_fields.c
+++ b/upb/util/required_fields.c
@@ -169,11 +169,25 @@ static void upb_FieldPathVector_Reserve(upb_FindContext* ctx,
                                         upb_FieldPathVector* vec,
                                         size_t elems) {
   if (vec->cap - vec->size < elems) {
-    const int oldsize = vec->cap * sizeof(*vec->path);
+    if (vec->cap > SIZE_MAX / sizeof(*vec->path)) {
+      UPB_LONGJMP(ctx->err, 1);
+    }
+    const size_t oldsize = vec->cap * sizeof(*vec->path);
+    if (SIZE_MAX - vec->size < elems) {
+      UPB_LONGJMP(ctx->err, 1);
+    }
     size_t need = vec->size + elems;
     vec->cap = UPB_MAX(4, vec->cap);
-    while (vec->cap < need) vec->cap *= 2;
-    const int newsize = vec->cap * sizeof(*vec->path);
+    while (vec->cap < need) {
+      if (vec->cap > SIZE_MAX / 2) {
+        UPB_LONGJMP(ctx->err, 1);
+      }
+      vec->cap *= 2;
+    }
+    if (vec->cap > SIZE_MAX / sizeof(*vec->path)) {
+      UPB_LONGJMP(ctx->err, 1);
+    }
+    const size_t newsize = vec->cap * sizeof(*vec->path);
     vec->path = upb_grealloc(vec->path, oldsize, newsize);
     if (!vec->path) {
       UPB_LONGJMP(ctx->err, 1);
@@ -291,6 +305,14 @@ bool upb_util_HasUnsetRequired(const upb_Message* msg, const upb_MessageDef* m,
   ctx.ext_pool = ext_pool;
   upb_FieldPathVector_Init(&ctx.stack);
   upb_FieldPathVector_Init(&ctx.out_fields);
+
+  if (UPB_SETJMP(ctx.err)) {
+    upb_gfree(ctx.stack.path);
+    upb_gfree(ctx.out_fields.path);
+    if (fields) *fields = NULL;
+    return false;
+  }
+
   upb_util_FindUnsetRequiredInternal(&ctx, msg, m);
   upb_gfree(ctx.stack.path);
 

--- a/upb/util/required_fields_test.cc
+++ b/upb/util/required_fields_test.cc
@@ -23,6 +23,38 @@
 #include "upb/util/required_fields_test.upb.h"
 #include "upb/util/required_fields_test.upbdefs.h"
 
+namespace {
+
+struct FailingAllocState {
+  upb_alloc_func* delegate;
+  int fail_after;
+};
+
+static FailingAllocState g_failing_alloc_state;
+
+void* FailingAlloc(upb_alloc* alloc, void* ptr, size_t oldsize, size_t size,
+                   size_t* actual_size) {
+  if (size != 0 && g_failing_alloc_state.fail_after-- <= 0) return nullptr;
+  return g_failing_alloc_state.delegate(alloc, ptr, oldsize, size, actual_size);
+}
+
+class ScopedGlobalAllocFailure {
+ public:
+  explicit ScopedGlobalAllocFailure(int fail_after) {
+    old_func_ = upb_alloc_global.func;
+    g_failing_alloc_state.delegate = old_func_;
+    g_failing_alloc_state.fail_after = fail_after;
+    upb_alloc_global.func = FailingAlloc;
+  }
+
+  ~ScopedGlobalAllocFailure() { upb_alloc_global.func = old_func_; }
+
+ private:
+  upb_alloc_func* old_func_;
+};
+
+}  // namespace
+
 std::vector<std::string> PathsToText(upb_FieldPathEntry* entry) {
   std::vector<std::string> ret;
   char buf[1024];  // Larger than anything we'll use in this test.
@@ -220,4 +252,21 @@ TYPED_TEST(RequiredFieldsTest, TestRequired) {
       }
       )json",
       {R"(map_string_message["d\"ef"].required_int32)"});
+}
+
+TYPED_TEST(RequiredFieldsTest, AllocationFailureInPathCollectionIsHandled) {
+  upb::Arena arena;
+  upb::DefPool defpool;
+  auto* test_msg = TypeParam::NewMessage(arena.ptr());
+  upb::MessageDefPtr m = TypeParam::GetMessageDef(defpool.ptr());
+
+  upb_FieldPathEntry* entries = reinterpret_cast<upb_FieldPathEntry*>(0x1);
+  {
+    // First dynamic allocation in path collection fails deterministically.
+    ScopedGlobalAllocFailure fail_alloc(/*fail_after=*/0);
+    bool has_unset = upb_util_HasUnsetRequired(UPB_UPCAST(test_msg), m.ptr(),
+                                               defpool.ptr(), &entries);
+    EXPECT_FALSE(has_unset);
+    EXPECT_EQ(entries, nullptr);
+  }
 }


### PR DESCRIPTION
## Summary

Fixes allocation-failure handling in required field traversal by establishing the missing `UPB_SETJMP()` boundary before paths that may call `UPB_LONGJMP()`.

## Changes

* Add `UPB_SETJMP(ctx.err)` handling in `upb_util_HasUnsetRequired()`
* Clean up partially allocated path state on allocation failure
* Ensure `fields` is reset to `NULL` on failure
* Add a deterministic regression test covering allocation failure during required-field path collection

## Root Cause

`upb_FieldPathVector_Reserve()` may call `UPB_LONGJMP(ctx->err, 1)` on allocation failure, but `upb_util_HasUnsetRequired()` did not previously establish an active `UPB_SETJMP()` frame before traversal began.