### PR TITLE
Adding runzw to Protobuf maintainers metadata in 34.x

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -111,6 +111,12 @@
       "name": "Karen Wu",
       "do_not_notify": true
     }
+    {
+      "email": "runze@google.com",
+      "github": "runzw",
+      "name": "Runze Wang",
+      "do_not_notify": true
+    }
   ],
   "repository": ["github:protocolbuffers/protobuf"],
   "versions": [],


### PR DESCRIPTION
Adding runzw to Protobuf maintainers metadata