### PR TITLE
Revert "Adding runzw to Protobuf maintainers metadata in 35.x"

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -111,12 +111,6 @@
       "name": "Runze Wang",
       "do_not_notify": true
     }
-    {
-      "email": "runze@google.com",
-      "github": "runzw",
-      "name": "Runze Wang",
-      "do_not_notify": true
-    }
   ],
   "repository": ["github:protocolbuffers/protobuf"],
   "versions": [],


### PR DESCRIPTION
Reverts protocolbuffers/protobuf#27378 which creates duplicate entries. I did not expect that to be auto-merged because it didn't pass tests. Should've closed that earlier.

The correct entry was already merged in #27387