### PR TITLE
Fix Any recursion depth for packed regular messages

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -1882,6 +1882,39 @@ class JsonFormatTest(JsonFormatBase):
         max_recursion_depth=5,
     )
 
+  def testAnyPackedRegularMessageRecursionDepthEnforcement(self):
+    """Test Any messages count packed regular messages in recursion depth."""
+    message = any_pb2.Any()
+
+    nested_any = {
+        '@type': 'type.googleapis.com/proto3.TestAny',
+        'value': {
+            '@type': 'type.googleapis.com/proto3.TestAny',
+            'value': {
+                '@type': 'type.googleapis.com/proto3.TestAny',
+                'value': {},
+            },
+        },
+    }
+
+    self.assertRaisesRegex(
+        json_format.ParseError,
+        'Message too deep. Max recursion depth is 5',
+        json_format.ParseDict,
+        nested_any,
+        message,
+        max_recursion_depth=5,
+    )
+
+    shallow_any = {
+        '@type': 'type.googleapis.com/proto3.TestAny',
+        'value': {
+            '@type': 'type.googleapis.com/proto3.TestAny',
+            'value': {},
+        },
+    }
+    json_format.ParseDict(shallow_any, message, max_recursion_depth=5)
+
   def testJsonNameConflictSerilize(self):
     message = more_messages_pb2.ConflictJsonName(value=2)
     self.assertEqual(

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -521,28 +521,28 @@ class _Parser(object):
     Raises:
       ParseError: In case of convert problems.
     """
-    # Increment recursion depth at message entry. The max_recursion_depth limit
-    # is exclusive: a depth value equal to max_recursion_depth will trigger an
-    # error. For example, with max_recursion_depth=5, nesting up to depth 4 is
-    # allowed, but attempting depth 5 raises ParseError.
+    # Increment recursion depth at message entry. A depth greater than
+    # max_recursion_depth raises ParseError.
     self.recursion_depth += 1
-    if self.recursion_depth > self.max_recursion_depth:
-      raise ParseError(
-          'Message too deep. Max recursion depth is {0}'.format(
-              self.max_recursion_depth
-          )
-      )
-    message_descriptor = message.DESCRIPTOR
-    full_name = message_descriptor.full_name
-    if not path:
-      path = message_descriptor.name
-    if _IsWrapperMessage(message_descriptor):
-      self._ConvertWrapperMessage(value, message, path)
-    elif full_name in _WKTJSONMETHODS:
-      methodcaller(_WKTJSONMETHODS[full_name][1], value, message, path)(self)
-    else:
-      self._ConvertFieldValuePair(value, message, path)
-    self.recursion_depth -= 1
+    try:
+      if self.recursion_depth > self.max_recursion_depth:
+        raise ParseError(
+            'Message too deep. Max recursion depth is {0}'.format(
+                self.max_recursion_depth
+            )
+        )
+      message_descriptor = message.DESCRIPTOR
+      full_name = message_descriptor.full_name
+      if not path:
+        path = message_descriptor.name
+      if _IsWrapperMessage(message_descriptor):
+        self._ConvertWrapperMessage(value, message, path)
+      elif full_name in _WKTJSONMETHODS:
+        methodcaller(_WKTJSONMETHODS[full_name][1], value, message, path)(self)
+      else:
+        self._ConvertFieldValuePair(value, message, path)
+    finally:
+      self.recursion_depth -= 1
 
   def _ConvertFieldValuePair(self, js, message, path):
     """Convert field value pairs into regular message.
@@ -751,7 +751,7 @@ class _Parser(object):
     else:
       del value['@type']
       try:
-        self._ConvertFieldValuePair(value, sub_message, path)
+        self.ConvertMessage(value, sub_message, path)
       finally:
         value['@type'] = type_url
     # Sets Any message


### PR DESCRIPTION
This updates Python ProtoJSON parsing so regular messages packed inside `Any` are routed through `ConvertMessage()` instead of directly through `_ConvertFieldValuePair()`.

  `ConvertMessage()` owns `max_recursion_depth` accounting. The existing nested-`Any` fix already uses it for well-known types, but the regular-message branch still bypassed one message-entry depth step. That
  allowed alternating `Any -> regular message -> Any -> regular message` inputs to consume less recursion budget than equivalent nested messages.

  The patch also restores the recursion-depth counter with `finally`, so failed parses do not leave stale parser state.

  A regression test covers:
  - deeply nested `Any` values packing `proto3.TestAny`, which now fail at `max_recursion_depth=5`
  - a shallower packed regular-message chain that still parses successfully

  Validation:
  - `python3 -m py_compile python/google/protobuf/json_format.py python/google/protobuf/internal/json_format_test.py`
  - `git diff --check origin/main..HEAD`
  - local dynamic-descriptor harness confirming 2 packed regular wrappers pass at depth 5 and 3 wrappers fail