### PR TITLE
Fix null deref in TextFormat for invalid map_entry descriptors

### DIFF
--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -8090,6 +8090,15 @@ void DescriptorBuilder::CrossLinkMessage(Descriptor* message,
     }
   }
 
+  // Validate map_entry messages have exactly 2 fields (key and value).
+  // This check runs unconditionally, not only when a parent field references
+  // the message, to prevent construction of invalid map_entry descriptors
+  // that cause null dereferences in TextFormat::PrintMessage.
+  if (message->options().map_entry() && message->field_count() != 2) {
+    AddError(message->full_name(), proto, DescriptorPool::ErrorCollector::NAME,
+             "Messages with map_entry set must have exactly 2 fields.");
+  }
+
   for (int i = 0; i < message->field_count(); i++) {
     const FieldDescriptor* field = message->field(i);
     if (field->proto3_optional_) {

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -8036,6 +8036,37 @@ TEST_F(ValidationErrorTest, GroupFieldPointingToMapEntryIsNotMap) {
       "instead.\n");
 }
 
+TEST_F(ValidationErrorTest, MapEntryOrphanedWithZeroFields) {
+  // A map_entry message with 0 fields and no parent field referencing it.
+  // ValidateMapEntry only runs when a parent field references the map entry,
+  // so the field count check in CrossLinkMessage is needed to catch this.
+  BuildFileWithErrors(
+      "name: 'foo.proto' "
+      "message_type { "
+      "  name: 'OrphanedMapEntry' "
+      "  options { map_entry: true } "
+      "} ",
+
+      "foo.proto: OrphanedMapEntry: NAME: Messages with map_entry set must "
+      "have exactly 2 fields.\n");
+}
+
+TEST_F(ValidationErrorTest, MapEntryOrphanedWithOneField) {
+  // A map_entry message with only 1 field (missing value field).
+  BuildFileWithErrors(
+      "name: 'foo.proto' "
+      "message_type { "
+      "  name: 'OrphanedMapEntry' "
+      "  options { map_entry: true } "
+      "  field { "
+      "    name: 'key' number: 1 type: TYPE_INT32 label: LABEL_OPTIONAL "
+      "  } "
+      "} ",
+
+      "foo.proto: OrphanedMapEntry: NAME: Messages with map_entry set must "
+      "have exactly 2 fields.\n");
+}
+
 TEST_F(ValidationErrorTest, MapEntryExtensionRange) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);

--- a/src/google/protobuf/text_format.cc
+++ b/src/google/protobuf/text_format.cc
@@ -2585,7 +2585,7 @@ void TextFormat::Printer::PrintMessage(const Message& message,
   }
   const Reflection* reflection = message.GetReflection();
   std::vector<const FieldDescriptor*> fields;
-  if (descriptor->options().map_entry()) {
+  if (descriptor->options().map_entry() && descriptor->field_count() >= 2) {
     fields.push_back(descriptor->field(0));
     fields.push_back(descriptor->field(1));
   } else {


### PR DESCRIPTION
## Summary

`TextFormat::Printer::PrintMessage` (`text_format.cc:2585-2587`) unconditionally accesses `field(0)` and `field(1)` for messages with `options().map_entry() == true`, without checking `field_count()`. A malformed `map_entry` descriptor with fewer than 2 fields causes an out-of-bounds access:

```cpp
// text_format.cc:2585-2587
if (descriptor->options().map_entry()) {
  // unconditional access — crashes if field_count() < 2
  const FieldDescriptor* key_field = descriptor->field(0);
  const FieldDescriptor* value_field = descriptor->field(1);
```

### Root cause

`ValidateMapEntry` (`descriptor.cc:9388`) correctly checks that a `map_entry` message has exactly 2 fields, but it's only called from `ValidateField` (`descriptor.cc:8924`) — which runs per-field on messages that *reference* the map entry as a field type. If no parent field references the orphaned `map_entry` message, validation is skipped entirely, and the descriptor passes through `BuildFile` without error.

### Downstream impact

- **TextFormat** (`text_format.cc:2585-2587`): `PrintMessage` unconditionally accesses `field(0)` and `field(1)` for map_entry messages.
- **ReflectionOps** (`reflection_ops.cc:197, 280, 321`): `Merge`, `Clear`, and `IsInitialized` access `field(1)` on map_entry descriptors without bounds checks.

### Fix

Defense in depth (two changes):

1. `CrossLinkMessage` rejects map_entry messages with != 2 fields unconditionally. `CrossLinkMessage` runs for all messages during `BuildFileImpl()` → `CrossLinkFile()`, before `ValidateOptions` — so the validation cannot be bypassed by orphaned map_entry messages.
2. `text_format.cc:PrintMessage` guards `field(0)`/`field(1)` access with `field_count() >= 2`.

## Test plan

- [ ] Existing `*Map*` and `*TextFormat*` tests pass — no regression
- [ ] `map_entry` messages with != 2 fields are rejected by `BuildFile()`
