### PR TITLE
[ObjC] Carry recursion depth across MessageSet item parsing

### DIFF
--- a/objectivec/GPBCodedInputStream.m
+++ b/objectivec/GPBCodedInputStream.m
@@ -389,6 +389,20 @@ void GPBCodedInputStreamCheckLastTagWas(GPBCodedInputStreamState *state, int32_t
   return self;
 }
 
+- (instancetype)initWithData:(NSData *)data parentRecursionDepth:(NSUInteger)parentDepth {
+  if ((self = [self initWithData:data])) {
+    // The parent stream had already entered `parentDepth` nested parses; we
+    // are about to begin one more level in this child stream, so seed the
+    // depth accordingly and verify the limit before parsing starts. This
+    // matches the convention used by the C++ ParseContext spawn helper,
+    // which increments and checks the depth before recursing into a payload
+    // that has been read into a fresh buffer.
+    state_.recursionDepth = parentDepth + 1;
+    CheckRecursionLimit(&state_);
+  }
+  return self;
+}
+
 - (void)dealloc {
   [buffer_ release];
   [super dealloc];

--- a/objectivec/GPBCodedInputStream_PackagePrivate.h
+++ b/objectivec/GPBCodedInputStream_PackagePrivate.h
@@ -33,6 +33,16 @@ typedef struct GPBCodedInputStreamState {
   NSData *buffer_;
 }
 
+// Initializes a new stream over `data` whose initial recursion depth is one
+// deeper than `parentDepth`. Used when a parser needs to spawn a fresh
+// CodedInputStream to decode a payload that has already been read into a
+// separate buffer (e.g. MessageSet items), so that the native call stack
+// growth is still bounded by kDefaultRecursionLimit. The initializer raises
+// GPBCodedInputStreamErrorRecursionDepthExceeded if `parentDepth` is already
+// at the limit. Mirrors the depth-inheritance done by the C++ ParseContext
+// spawn helper.
+- (instancetype)initWithData:(NSData *)data parentRecursionDepth:(NSUInteger)parentDepth;
+
 // Group support is deprecated, so we hide this interface from users, but
 // support for older data.
 - (void)readGroup:(int32_t)fieldNumber

--- a/objectivec/GPBMessage.m
+++ b/objectivec/GPBMessage.m
@@ -2444,7 +2444,16 @@ void GPBClearMessageAutocreator(GPBMessage *self) {
       [self setExtension:extension value:targetMessage];
       [targetMessage release];
     }
-    GPBCodedInputStream *newInput = [[GPBCodedInputStream alloc] initWithData:rawBytes];
+    // Parsing the MessageSet item payload requires a fresh CodedInputStream
+    // because the payload bytes are read into a separate buffer before the
+    // item's type-id and payload tags are correlated. Carry the parent
+    // stream's recursion depth across to the child stream so that nested
+    // MessageSet items (which would otherwise reset the depth to 0 on every
+    // hop) remain bounded by kDefaultRecursionLimit. This mirrors the
+    // depth-inheritance behavior of the C++ ParseContext spawn helper.
+    GPBCodedInputStream *newInput =
+        [[GPBCodedInputStream alloc] initWithData:rawBytes
+                             parentRecursionDepth:input->state_.recursionDepth];
     @try {
       [targetMessage mergeFromCodedInputStream:newInput
                              extensionRegistry:extensionRegistry

--- a/objectivec/Tests/GPBWireFormatTests.m
+++ b/objectivec/Tests/GPBWireFormatTests.m
@@ -428,4 +428,58 @@ const int kUnknownTypeId2 = 1550056;
   }
 }
 
+- (void)testParseMessageSetRecursionDepthCarriedFromParent {
+  // Each MSetMessage carries a single MSetMessageExtension1, whose
+  // `recursive` field is again a MSetMessage. Chaining N of these produces
+  // a MessageSet-of-MessageSet payload nested N levels deep. The parser
+  // for each MessageSet item allocates a fresh CodedInputStream, so depth
+  // tracking has to be inherited across those streams for the documented
+  // kDefaultRecursionLimit (100) to actually apply. A depth well past 100
+  // must be rejected with GPBCodedInputStreamErrorRecursionDepthExceeded
+  // rather than silently parsed.
+  const NSUInteger kDepth = 200;
+
+  MSetMessage* innermost = [MSetMessage message];
+  MSetMessageExtension1* innermostExt = [MSetMessageExtension1 message];
+  innermostExt.i = 1;
+#if defined(GPB_UNITTEST_USE_C_FUNCTION_FOR_EXTENSIONS)
+  [innermost setExtension:MSetMessageExtension1_extension_MessageSetExtension()
+                    value:innermostExt];
+#else
+  [innermost setExtension:[MSetMessageExtension1 messageSetExtension] value:innermostExt];
+#endif
+
+  MSetMessage* current = innermost;
+  for (NSUInteger i = 1; i < kDepth; ++i) {
+    MSetMessageExtension1* ext = [MSetMessageExtension1 message];
+    ext.recursive = current;
+    MSetMessage* parent = [MSetMessage message];
+#if defined(GPB_UNITTEST_USE_C_FUNCTION_FOR_EXTENSIONS)
+    [parent setExtension:MSetMessageExtension1_extension_MessageSetExtension() value:ext];
+#else
+    [parent setExtension:[MSetMessageExtension1 messageSetExtension] value:ext];
+#endif
+    current = parent;
+  }
+
+  NSData* data = [current data];
+  XCTAssertNotNil(data);
+
+  NSError* error = nil;
+#if defined(GPB_UNITTEST_USE_C_FUNCTION_FOR_EXTENSIONS)
+  MSetMessage* parsed =
+      [MSetMessage parseFromData:data
+               extensionRegistry:MSet_Objc_Protobuf_Tests_Mset_MSetUnittestMsetRoot_Registry()
+                           error:&error];
+#else
+  MSetMessage* parsed = [MSetMessage parseFromData:data
+                                 extensionRegistry:[MSetUnittestMsetRoot extensionRegistry]
+                                             error:&error];
+#endif
+  XCTAssertNil(parsed);
+  XCTAssertNotNil(error);
+  XCTAssertEqualObjects(error.domain, GPBCodedInputStreamErrorDomain);
+  XCTAssertEqual(error.code, GPBCodedInputStreamErrorRecursionDepthExceeded);
+}
+
 @end


### PR DESCRIPTION
## Summary

`GPBMessage::parseMessageSet:` reads each MessageSet item's payload bytes into a separate buffer (because the type-id and payload tags can appear in any order), then allocates a fresh `GPBCodedInputStream` to decode that buffer. The fresh stream's `state_.recursionDepth` starts at `0` even when the parent stream is already several MessageSet items deep, so a chain of nested MessageSet items grows the native call stack without ever tripping the documented `kDefaultRecursionLimit` (100). Other parser entry points that recurse on the same stream (`readGroup:`, `readMessage:`, `readMapEntry:`, `SkipToEndGroupInternal`) already increment and check `recursionDepth`; the MessageSet path was the only spot where depth tracking did not cross the stream boundary.

This change adds a package-private `-initWithData:parentRecursionDepth:` initializer to `GPBCodedInputStream` that seeds the child stream's depth from the parent's and runs `CheckRecursionLimit` before parsing begins. `parseMessageSet:` now uses that initializer, so depth tracking carries across the fresh stream. This mirrors the depth-inheritance done by the C++ `ParseContext` spawn helper.

Regression coverage: `testParseMessageSetRecursionDepthCarriedFromParent` in `GPBWireFormatTests` builds a 200-deep MessageSet-of-MessageSet payload (each layer is `MSetMessage -> MSetMessageExtension1.recursive -> MSetMessage -> ...`) and asserts the parse fails with `GPBCodedInputStreamErrorRecursionDepthExceeded`. Existing `testErrorRecursionDepthReached` and the rest of `GPBWireFormatTests` continue to pass unchanged.

## Test plan

- [ ] Existing ObjC test suite passes (`GPBWireFormatTests`, `GPBMessageTests+Serialization`, `GPBCodedInputStreamTests`, `GPBUnknownFieldsTest`).
- [ ] New `testParseMessageSetRecursionDepthCarriedFromParent` passes.
- [ ] I was unable to run the full ObjC test suite locally (no full Xcode install on the dev machine, only Command Line Tools). The runtime sources (`GPBCodedInputStream.m`, `GPBMessage.m`) compile cleanly via `clang -fno-objc-arc`. Please verify via the project's macOS CI.