### PR TITLE
[Python] Expose DEFAULT_RECURSION_LIMIT constant for text_format parser

### DIFF
--- a/python/google/protobuf/internal/text_format_test.py
+++ b/python/google/protobuf/internal/text_format_test.py
@@ -810,6 +810,32 @@ class TextFormatParserTests(TextFormatBase):
           f'got {type(exc).__name__}: {exc}'
       )
 
+  def testRecommendedRecursionLimitConstant(self, message_module):
+    del message_module
+    # The exported constant matches the Java Text Format parser's default
+    # (TextFormat.Parser.Builder#setRecursionLimit initializes to 100) and the
+    # binary wire-format default across language ports, so a message that
+    # round-trips through those parsers also round-trips through Python Text
+    # Format when the constant is opted into.
+    self.assertEqual(text_format.DEFAULT_RECURSION_LIMIT, 100)
+    message = descriptor_pb2.DescriptorProto()
+    too_deep_text = 'nested_type {' * 200 + '}' * 200
+    with self.assertRaisesRegex(
+        text_format.ParseError, 'Message too deep'
+    ):
+      text_format.Parse(
+          too_deep_text,
+          message,
+          max_recursion_depth=text_format.DEFAULT_RECURSION_LIMIT,
+      )
+    # A shallow input still parses normally with the constant applied.
+    shallow_text = 'nested_type {' * 10 + '}' * 10
+    text_format.Parse(
+        shallow_text,
+        descriptor_pb2.DescriptorProto(),
+        max_recursion_depth=text_format.DEFAULT_RECURSION_LIMIT,
+    )
+
   def testParseAllFields(self, message_module):
     message = message_module.TestAllTypes()
     test_util.SetAllFields(message)

--- a/python/google/protobuf/text_format.py
+++ b/python/google/protobuf/text_format.py
@@ -46,6 +46,7 @@ from google.protobuf import unknown_fields
 
 # pylint: disable=g-import-not-at-top
 __all__ = [
+    'DEFAULT_RECURSION_LIMIT',
     'MessageToString',
     'Parse',
     'PrintMessage',
@@ -71,6 +72,20 @@ _ANY_FULL_TYPE_NAME = 'google.protobuf.Any'
 _DEBUG_STRING_SILENT_MARKER = '\t '
 
 _as_utf8_default = True
+
+# Recommended parser recursion depth for Text Format inputs from sources the
+# caller does not fully trust. The Python Text Format parser leaves
+# ``max_recursion_depth`` set to ``None`` (unbounded) by default to preserve
+# historical behavior on trusted configuration inputs, but callers that need a
+# defensive cap can opt in by passing
+# ``max_recursion_depth=text_format.DEFAULT_RECURSION_LIMIT`` to
+# :func:`Parse` / :func:`Merge` / :func:`ParseLines` / :func:`MergeLines`.
+# The value matches the default recursion limit used by the Java Text Format
+# parser (``TextFormat.Parser.Builder#setRecursionLimit`` initializes to 100)
+# and the binary wire-format parsers across language ports, so a message that
+# can round-trip through those parsers will also round-trip through Python
+# Text Format with this limit applied.
+DEFAULT_RECURSION_LIMIT = 100
 
 
 class Error(Exception):
@@ -725,7 +740,10 @@ def Parse(
         compatibility, the default of ``None`` (unbounded) is intentional. For
         better consistency with what messages will successfully round trip
         through binary wire format, or for the discouraged case of processing
-        untrusted Text Format inputs, setting a limit of 100 is recommended.
+        untrusted Text Format inputs, passing
+        ``max_recursion_depth=text_format.DEFAULT_RECURSION_LIMIT`` is the
+        recommended opt-in (the constant resolves to 100, matching the Java
+        Text Format parser and the wire-format parsers across language ports).
 
   Returns:
     Message: The same message passed as argument.
@@ -777,7 +795,10 @@ def Merge(
         compatibility, the default of ``None`` (unbounded) is intentional. For
         better consistency with what messages will successfully round trip
         through binary wire format, or for the discouraged case of processing
-        untrusted Text Format inputs, setting a limit of 100 is recommended.
+        untrusted Text Format inputs, passing
+        ``max_recursion_depth=text_format.DEFAULT_RECURSION_LIMIT`` is the
+        recommended opt-in (the constant resolves to 100, matching the Java
+        Text Format parser and the wire-format parsers across language ports).
 
   Returns:
     Message: The same message passed as argument.
@@ -827,7 +848,10 @@ def ParseLines(
         compatibility, the default of ``None`` (unbounded) is intentional. For
         better consistency with what messages will successfully round trip
         through binary wire format, or for the discouraged case of processing
-        untrusted Text Format inputs, setting a limit of 100 is recommended.
+        untrusted Text Format inputs, passing
+        ``max_recursion_depth=text_format.DEFAULT_RECURSION_LIMIT`` is the
+        recommended opt-in (the constant resolves to 100, matching the Java
+        Text Format parser and the wire-format parsers across language ports).
 
   Returns:
     The same message passed as argument.
@@ -876,7 +900,10 @@ def MergeLines(
         compatibility, the default of ``None`` (unbounded) is intentional. For
         better consistency with what messages will successfully round trip
         through binary wire format, or for the discouraged case of processing
-        untrusted Text Format inputs, setting a limit of 100 is recommended.
+        untrusted Text Format inputs, passing
+        ``max_recursion_depth=text_format.DEFAULT_RECURSION_LIMIT`` is the
+        recommended opt-in (the constant resolves to 100, matching the Java
+        Text Format parser and the wire-format parsers across language ports).
 
   Returns:
     The same message passed as argument.


### PR DESCRIPTION
## Summary

The Python `text_format` parser already accepts an opt-in `max_recursion_depth` argument that bounds nested-message parsing, but the recommended value (100, matching the Java `TextFormat.Parser.Builder#setRecursionLimit` default and the binary wire-format parsers across language ports) is only mentioned inline in four docstrings. Callers that want to opt into the recommended cap have to hard-code the literal `100`, which lets the recommendation and the runtime value drift apart over time and makes it harder to grep for usages that follow the recommendation.

This change exposes `text_format.DEFAULT_RECURSION_LIMIT = 100` at module level and adds it to `__all__`. The four `Parse` / `Merge` / `ParseLines` / `MergeLines` docstrings now reference the constant by name, so the recommended opt-in is spelled `text_format.Parse(..., max_recursion_depth=text_format.DEFAULT_RECURSION_LIMIT)`.

No runtime behavior change: the default of `max_recursion_depth=None` (unbounded) is preserved for backwards compatibility, and the existing `testParseDefaultBehaviorRemainsUnbounded` continues to pass. The new `testRecommendedRecursionLimitConstant` asserts the constant equals 100, that passing it rejects a 200-deep input with `ParseError`, and that shallow inputs still parse normally with the constant applied.

## Test plan

- [x] `bazel test //python:text_format_test` passes locally on darwin-arm64 with bazel 9.1.0 (283 tests, 2 skipped, 0 failed).
- [x] `testRecommendedRecursionLimitConstant` passes.
- [x] `testParseRecursionDepthLimit`, `testParseAnyRecursionDepthLimit`, `testParseDefaultBehaviorRemainsUnbounded` continue to pass unchanged.