### PR TITLE
Fix RepeatedField::MergeFrom self-merge heap pointer disclosure

### DIFF
--- a/src/google/protobuf/repeated_field.cc
+++ b/src/google/protobuf/repeated_field.cc
@@ -56,6 +56,11 @@ void LogIndexOutOfBounds(int index, int size) {
   }
   ABSL_UNREACHABLE();
 }
+
+[[noreturn]] void LogSelfMergeAndAbort() noexcept {
+  ABSL_LOG(FATAL) << "MergeFrom called with self-reference; "
+                     "merging a RepeatedField with itself is undefined behavior.";
+}
 }  // namespace internal
 
 template <>

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -1228,8 +1228,7 @@ inline void RepeatedField<Element>::Clear() {
 
 template <typename Element>
 inline void RepeatedField<Element>::MergeFrom(const RepeatedField& other) {
-  if (&other == this) return;
-  ABSL_DCHECK_NE(&other, this);
+  ABSL_CHECK_NE(&other, this);
   const bool other_is_soo = other.is_soo();
   if (auto other_size = other.size()) {
     const int old_size = size();

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -254,6 +254,11 @@ class SooRep {
   };
 };
 
+// Out-of-line abort for MergeFrom self-reference. Declared here (not in the
+// call site) so that the failure path does not pull ABSL_CHECK streaming
+// support into every inlined MergeFrom instantiation.
+[[noreturn]] PROTOBUF_EXPORT void LogSelfMergeAndAbort() noexcept;
+
 }  // namespace internal
 
 // RepeatedField is used to represent repeated fields of a primitive type (in
@@ -1228,7 +1233,10 @@ inline void RepeatedField<Element>::Clear() {
 
 template <typename Element>
 inline void RepeatedField<Element>::MergeFrom(const RepeatedField& other) {
-  ABSL_CHECK_NE(&other, this);
+  if (ABSL_PREDICT_FALSE(&other == this)) {
+    PROTOBUF_NO_MERGE internal::LogSelfMergeAndAbort();
+  }
+  ABSL_DCHECK_NE(&other, this);
   const bool other_is_soo = other.is_soo();
   if (auto other_size = other.size()) {
     const int old_size = size();

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -1228,6 +1228,7 @@ inline void RepeatedField<Element>::Clear() {
 
 template <typename Element>
 inline void RepeatedField<Element>::MergeFrom(const RepeatedField& other) {
+  if (&other == this) return;
   ABSL_DCHECK_NE(&other, this);
   const bool other_is_soo = other.is_soo();
   if (auto other_size = other.size()) {


### PR DESCRIPTION
## Summary

`RepeatedField<T>::MergeFrom` has an unsafe self-merge path that discloses heap addresses in release builds.

When `MergeFrom(self)` is called on a field at SOO capacity (2 elements for `int32_t`), `Reserve()` triggers a SOO→heap transition. The `other_is_soo` flag captured before `Reserve()` becomes stale — `other.elements(stale_true)` returns `soo_data_[]`, which now contains the raw `HeapRep*` pointer bytes. `UninitializedCopyN` copies those bytes as `int32_t` values, appending two elements containing the low/high 32 bits of the heap address to the field.

`ABSL_DCHECK_NE(&other, this)` catches this in debug builds but is compiled out with `-DNDEBUG`, so release builds proceed silently.

`CopyFrom` already has the correct guard at line 1245. This PR adds the same one-line check to `MergeFrom`.

## Fix

```cpp
template <typename Element>
inline void RepeatedField<Element>::MergeFrom(const RepeatedField& other) {
  if (&other == this) return;  // mirrors CopyFrom guard
  ABSL_DCHECK_NE(&other, this);
  ...
```

## Reproduction

```cpp
google::protobuf::RepeatedField<int32_t> field;
field.Add(0x41414141);
field.Add(0x42424242);
field.MergeFrom(field);  // self-merge on 2-element SOO field
// field.size() == 4
// field.Get(2) and field.Get(3) contain heap_rep_* pointer bytes
```

Compile with `-DNDEBUG` (release build simulation) to reproduce — debug builds abort at the `ABSL_DCHECK`.