### PR TITLE
fix: propagate current_depth in MessageSet decoders to prevent recursion bypass

### DIFF
--- a/python/google/protobuf/internal/decoder.py
+++ b/python/google/protobuf/internal/decoder.py
@@ -910,7 +910,7 @@ def MessageSetItemDecoder(descriptor):
         break
       else:
         field_number, wire_type = DecodeTag(tag_bytes)
-        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type)
+        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type, current_depth)
         if pos == -1:
           raise _DecodeError('Unexpected end-group tag.')
 
@@ -964,7 +964,7 @@ def UnknownMessageSetItemDecoder():
   message_tag_bytes = encoder.TagBytes(3, wire_format.WIRETYPE_LENGTH_DELIMITED)
   item_end_tag_bytes = encoder.TagBytes(1, wire_format.WIRETYPE_END_GROUP)
 
-  def DecodeUnknownItem(buffer):
+  def DecodeUnknownItem(buffer, current_depth=0):
     pos = 0
     end = len(buffer)
     message_start = -1
@@ -980,7 +980,7 @@ def UnknownMessageSetItemDecoder():
         break
       else:
         field_number, wire_type = DecodeTag(tag_bytes)
-        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type)
+        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type, current_depth)
         if pos == -1:
           raise _DecodeError('Unexpected end-group tag.')
 

--- a/python/google/protobuf/internal/decoder_test.py
+++ b/python/google/protobuf/internal/decoder_test.py
@@ -142,6 +142,122 @@ class DecoderTest(parameterized.TestCase):
         memoryview(b'\054\014'),
     )
 
+  def test_messageset_item_decoder_propagates_current_depth(self):
+    """DecodeItem must forward current_depth to _DecodeUnknownField.
+
+    Without the fix, _DecodeUnknownField defaults current_depth=0
+    regardless of the caller's actual depth, allowing an attacker to reset
+    the recursion counter within a MessageSet item (GHSA-8qvm-5x2c-j2w7
+    bypass).
+    """
+    if api_implementation.Type() != 'python':
+      self.skipTest('Pure-Python decoder-specific test')
+
+    # Build a MessageSet item body with a type_id, empty message, and
+    # several nested unknown groups (field 5, START/END_GROUP).
+    num_nested = 5
+    content = (
+        b'\x10\x63'              # field 2 (type_id) varint = 99
+        + b'\x1a\x00'            # field 3 (message) length-delimited, size 0
+        + b'\x2b' * num_nested   # 5 x field 5 START_GROUP
+        + b'\x2c' * num_nested   # 5 x field 5 END_GROUP
+        + b'\x0c'                # field 1 END_GROUP (item end)
+    )
+    buf = memoryview(content)
+
+    decode_item = decoder.MessageSetItemDecoder(
+        message_set_extensions_pb2.TestMessageSet.DESCRIPTOR
+    )
+
+    old_limit = decoder._recursion_limit
+    decoder.SetRecursionLimit(10)
+    try:
+      # Starting at depth 0, 5 nested groups (max depth 5) < 10 -> succeeds.
+      msg = message_set_extensions_pb2.TestMessageSet()
+      decode_item(buf, 0, len(buf), msg, msg._fields, current_depth=0)
+
+      # Starting at depth 8, the 2nd nested group reaches depth 10 >= limit
+      # -> must raise DecodeError.  Without the fix the depth resets to 0
+      # and the call would silently succeed.
+      msg2 = message_set_extensions_pb2.TestMessageSet()
+      self.assertRaisesRegex(
+          message.DecodeError,
+          'Error parsing message',
+          decode_item,
+          buf,
+          0,
+          len(buf),
+          msg2,
+          msg2._fields,
+          8,
+      )
+    finally:
+      decoder.SetRecursionLimit(old_limit)
+
+  def test_unknown_message_set_decoder_propagates_current_depth(self):
+    """DecodeUnknownItem must forward current_depth to _DecodeUnknownField.
+
+    Mirrors the MessageSetItemDecoder test for the
+    UnknownMessageSetItemDecoder code path.
+    """
+    # Same item body layout: type_id=99, empty message, 5 nested groups.
+    num_nested = 5
+    item_data = (
+        b'\x10\x63'
+        + b'\x1a\x00'
+        + b'\x2b' * num_nested
+        + b'\x2c' * num_nested
+        + b'\x0c'
+    )
+
+    decode = decoder.UnknownMessageSetItemDecoder()
+
+    old_limit = decoder._recursion_limit
+    decoder.SetRecursionLimit(10)
+    try:
+      # Depth 0 -> max depth 5 < 10 -> succeeds and returns type_id.
+      type_id, _ = decode(memoryview(item_data), current_depth=0)
+      self.assertEqual(type_id, 99)
+
+      # Depth 8 -> reaches limit -> DecodeError.
+      self.assertRaisesRegex(
+          message.DecodeError,
+          'Error parsing message',
+          decode,
+          memoryview(item_data),
+          8,
+      )
+    finally:
+      decoder.SetRecursionLimit(old_limit)
+
+  def test_messageset_deeply_nested_unknown_groups_raises_decode_error(self):
+    """Deeply nested unknown groups in a MessageSet raise DecodeError.
+
+    Verifies that the parser raises message.DecodeError (not
+    RecursionError) when unknown groups inside a MessageSet item exceed the
+    recursion limit.
+    """
+    if api_implementation.Type() != 'python':
+      self.skipTest('Pure-Python decoder-specific test')
+
+    # 150 nested unknown groups exceed the default recursion limit of 100.
+    num_nested = 150
+    data = (
+        b'\x0b'                  # Item START_GROUP (field 1)
+        + b'\x10\x63'            # type_id = 99
+        + b'\x1a\x00'            # message = empty
+        + b'\x2b' * num_nested   # field 5 START_GROUP
+        + b'\x2c' * num_nested   # field 5 END_GROUP
+        + b'\x0c'                # Item END_GROUP (field 1)
+    )
+    proto = message_set_extensions_pb2.TestMessageSet()
+    self.assertRaisesRegex(
+        message.DecodeError,
+        'Error parsing message',
+        proto.ParseFromString,
+        data,
+    )
+
   @parameterized.parameters(int(0), float(0.0), False, '')
   def test_default_scalar(self, value):
     self.assertTrue(decoder.IsDefaultScalarValue(value))


### PR DESCRIPTION
Fixes #26437

## Summary

The `MessageSetItemDecoder.DecodeItem` and `UnknownMessageSetItemDecoder.DecodeUnknownItem` functions in `decoder.py` call `_DecodeUnknownField()` **without passing the `current_depth` parameter**. Because `_DecodeUnknownField` defaults `current_depth=0`, the recursion counter is silently reset to zero for every unknown item within a MessageSet.

This is a **direct bypass of the fix for GHSA-8qvm-5x2c-j2w7** (recursion DoS). An attacker can craft a message with 100 nested unknown groups beneath a depth-100 MessageSet item, reaching depth 200 and triggering a `RecursionError` / stack overflow DoS.

## Root Cause

```python
# decoder.py line 913 (MessageSetItemDecoder.DecodeItem)
_, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type)
#                            ^^^ missing current_depth ^^^

# decoder.py line 983 (UnknownMessageSetItemDecoder.DecodeUnknownItem)
_, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type)
#                            ^^^ missing current_depth ^^^
```

## Fix

1. Pass `current_depth` to both `_DecodeUnknownField()` calls
2. Add `current_depth=0` parameter to `DecodeUnknownItem` signature

```diff
 # MessageSetItemDecoder.DecodeItem (line 913)
-        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type)
+        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type, current_depth)

 # UnknownMessageSetItemDecoder.DecodeUnknownItem (line 967/983)
-  def DecodeUnknownItem(buffer):
+  def DecodeUnknownItem(buffer, current_depth=0):
     ...
-        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type)
+        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type, current_depth)
```

## Impact

- **Severity:** HIGH (DoS via stack overflow)
- **Attack:** Unauthenticated remote DoS against any service parsing untrusted protobuf
- **Bypasses:** GHSA-8qvm-5x2c-j2w7 fix
- **Previous PR:** #26710 was closed without merge — this PR provides the minimal correct fix
