### PR TITLE
Fix RepeatedField::MergeFrom self-merge heap pointer disclosure

### DIFF
--- a/src/google/protobuf/repeated_field.cc
+++ b/src/google/protobuf/repeated_field.cc
@@ -56,6 +56,11 @@ void LogIndexOutOfBounds(int index, int size) {
   }
   ABSL_UNREACHABLE();
 }
+
+[[noreturn]] void LogSelfMergeAndAbort() noexcept {
+  ABSL_LOG(FATAL) << "MergeFrom called with self-reference; "
+                     "merging a RepeatedField with itself is undefined behavior.";
+}
 }  // namespace internal
 
 template <>

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -1228,8 +1228,7 @@ inline void RepeatedField<Element>::Clear() {
 
 template <typename Element>
 inline void RepeatedField<Element>::MergeFrom(const RepeatedField& other) {
-  if (&other == this) return;
-  ABSL_DCHECK_NE(&other, this);
+  ABSL_CHECK_NE(&other, this);
   const bool other_is_soo = other.is_soo();
   if (auto other_size = other.size()) {
     const int old_size = size();

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -254,6 +254,11 @@ class SooRep {
   };
 };
 
+// Out-of-line abort for MergeFrom self-reference. Declared here (not in the
+// call site) so that the failure path does not pull ABSL_CHECK streaming
+// support into every inlined MergeFrom instantiation.
+[[noreturn]] PROTOBUF_EXPORT void LogSelfMergeAndAbort() noexcept;
+
 }  // namespace internal
 
 // RepeatedField is used to represent repeated fields of a primitive type (in
@@ -1228,7 +1233,10 @@ inline void RepeatedField<Element>::Clear() {
 
 template <typename Element>
 inline void RepeatedField<Element>::MergeFrom(const RepeatedField& other) {
-  ABSL_CHECK_NE(&other, this);
+  if (ABSL_PREDICT_FALSE(&other == this)) {
+    PROTOBUF_NO_MERGE internal::LogSelfMergeAndAbort();
+  }
+  ABSL_DCHECK_NE(&other, this);
   const bool other_is_soo = other.is_soo();
   if (auto other_size = other.size()) {
     const int old_size = size();

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -1236,7 +1236,6 @@ inline void RepeatedField<Element>::MergeFrom(const RepeatedField& other) {
   if (ABSL_PREDICT_FALSE(&other == this)) {
     PROTOBUF_NO_MERGE internal::LogSelfMergeAndAbort();
   }
-  ABSL_DCHECK_NE(&other, this);
   const bool other_is_soo = other.is_soo();
   if (auto other_size = other.size()) {
     const int old_size = size();

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -1228,6 +1228,7 @@ inline void RepeatedField<Element>::Clear() {
 
 template <typename Element>
 inline void RepeatedField<Element>::MergeFrom(const RepeatedField& other) {
+  if (&other == this) return;
   ABSL_DCHECK_NE(&other, this);
   const bool other_is_soo = other.is_soo();
   if (auto other_size = other.size()) {

--- a/src/google/protobuf/repeated_field_unittest.cc
+++ b/src/google/protobuf/repeated_field_unittest.cc
@@ -551,6 +551,16 @@ TEST(RepeatedField, MergeFrom) {
   EXPECT_EQ(5, destination.Get(4));
 }
 
+TEST(RepeatedField, MergeFromSelfFailsWithATermination) {
+  // Self-merge is undefined behavior and is now a well-defined termination.
+  // Use a SOO-capacity field (2 elements for int32_t), the case that
+  // previously appended heap-pointer bytes in release builds.
+  RepeatedField<int32_t> field;
+  field.Add(1);
+  field.Add(2);
+  EXPECT_DEATH(field.MergeFrom(field), "self-reference");
+}
+
 
 TEST(RepeatedField, CopyFrom) {
   RepeatedField<int> source, destination;


### PR DESCRIPTION
## Summary

`RepeatedField<T>::MergeFrom` has an unsafe self-merge path. When `MergeFrom(self)` is called on a field at SOO capacity (2 elements for `int32_t`), `Reserve()` triggers a SOO→heap transition. The `other_is_soo` flag captured before `Reserve()` becomes stale — `other.elements(stale_true)` returns `soo_data_[]`, which now holds the raw `HeapRep*` pointer bytes. `UninitializedCopyN` then copies those bytes as `int32_t` values, appending two elements containing the low/high 32 bits of the heap address.

`ABSL_DCHECK_NE(&other, this)` caught this in debug builds but was compiled out with `-DNDEBUG`, so release builds proceeded silently and produced corrupted contents / heap-address disclosure.

## Fix

Self-merge is undefined behavior. Rather than silently no-op, this turns it into a well-defined termination: an out-of-line `internal::LogSelfMergeAndAbort()` that fires `ABSL_LOG(FATAL)` in all build modes.

```cpp
template <typename Element>
inline void RepeatedField<Element>::MergeFrom(const RepeatedField& other) {
  if (ABSL_PREDICT_FALSE(&other == this)) {
    PROTOBUF_NO_MERGE internal::LogSelfMergeAndAbort();
  }
  ...
```

The abort helper is declared out-of-line (in `repeated_field.cc`) so the failure path does not pull `ABSL_LOG` streaming support into every inlined `MergeFrom` instantiation. The previously-existing `ABSL_DCHECK_NE(&other, this)` is now dead code (the self-reference branch terminates before reaching it) and has been removed.

## Test

`RepeatedField.MergeFromSelfFailsWithATermination` exercises the SOO-capacity self-merge — the case that previously appended heap-pointer bytes in release builds — and asserts it now terminates:

```cpp
RepeatedField<int32_t> field;
field.Add(1);
field.Add(2);
EXPECT_DEATH(field.MergeFrom(field), "self-reference");
```
