### PR TITLE
Add overflow protection to the remaining packed fixed-size parser paths

### DIFF
--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -1526,6 +1526,8 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   while (size > nbytes) {
     int num = nbytes / sizeof(T);
     int old_entries = out->size();
+    GOOGLE_PROTOBUF_PARSER_ASSERT(num <=
+                                  std::numeric_limits<int>::max() - old_entries);
     out->ReserveWithArena(arena, old_entries + num);
     int block_size = num * sizeof(T);
     auto dst = out->AddNAlreadyReserved(num);
@@ -1546,6 +1548,8 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   int block_size = num * sizeof(T);
   if (num == 0) return size == block_size ? ptr : nullptr;
   int old_entries = out->size();
+  GOOGLE_PROTOBUF_PARSER_ASSERT(num <=
+                                std::numeric_limits<int>::max() - old_entries);
   out->ReserveWithArena(arena, old_entries + num);
   auto dst = out->AddNAlreadyReserved(num);
 #ifdef ABSL_IS_LITTLE_ENDIAN
@@ -1589,6 +1593,10 @@ const char* EpsCopyInputStream::ReadPackedVarintArrayWithField(
         if (VerifyBoolsAssumingLargeArray(ptr, end)) {
           // Each byte is 0 or 1.
           const int count = end - ptr;
+          if (ABSL_PREDICT_FALSE(count >
+                                 std::numeric_limits<int>::max() - out.size())) {
+            return nullptr;
+          }
           out.ReserveWithArena(arena, out.size() + count);
           T* x = out.AddNAlreadyReserved(count);
           // For T being bool, conv must be equivalent to a conversion to bool
@@ -1602,6 +1610,10 @@ const char* EpsCopyInputStream::ReadPackedVarintArrayWithField(
     if (count == end - ptr) {
       // We have exactly one element per byte, so avoid the costly varint
       // parsing.
+      if (ABSL_PREDICT_FALSE(count >
+                             std::numeric_limits<int>::max() - out.size())) {
+        return nullptr;
+      }
       out.ReserveWithArena(arena, out.size() + count);
       T* x = out.AddNAlreadyReserved(count);
       for (; ptr != end; ++ptr) {
@@ -1613,6 +1625,10 @@ const char* EpsCopyInputStream::ReadPackedVarintArrayWithField(
       // we need to account for that.
       if (end[-1] & 0x80) count++;
       int old_size = out.size();
+      if (ABSL_PREDICT_FALSE(count >
+                             std::numeric_limits<int>::max() - old_size)) {
+        return nullptr;
+      }
       out.ReserveWithArena(arena, old_size + count);
       T* x = out.AddNAlreadyReserved(count);
       ptr = ReadPackedVarintArray(ptr, end, [&](uint64_t varint) {

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -1527,7 +1527,7 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   while (size > nbytes) {
     int num = nbytes / sizeof(T);
     int old_entries = out->size();
-    out->ReserveWithArena(arena, old_entries + num);
+    out->ReserveWithArena(arena, internal::CheckedAdd(old_entries, num));
     int block_size = num * sizeof(T);
     auto dst = out->AddNAlreadyReserved(num);
 #ifdef ABSL_IS_LITTLE_ENDIAN
@@ -1547,7 +1547,7 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   int block_size = num * sizeof(T);
   if (num == 0) return size == block_size ? ptr : nullptr;
   int old_entries = out->size();
-  out->ReserveWithArena(arena, old_entries + num);
+  out->ReserveWithArena(arena, internal::CheckedAdd(old_entries, num));
   auto dst = out->AddNAlreadyReserved(num);
 #ifdef ABSL_IS_LITTLE_ENDIAN
   ABSL_CHECK(dst != nullptr) << out << "," << num;

--- a/src/google/protobuf/repeated_field_unittest.cc
+++ b/src/google/protobuf/repeated_field_unittest.cc
@@ -1631,7 +1631,7 @@ TEST(RepeatedFieldIsFullTest, DISABLED_MergeFrom) {
 }
 
 // TODO: Re-enable once parsing overflow is fixed.
-TEST(RepeatedFieldIsFullTest, DISABLED_MergeFromPacked) {
+TEST(RepeatedFieldIsFullTest, MergeFromPacked) {
   if (sizeof(void*) < 8) {
     GTEST_SKIP() << "Not enough memory for the test.";
   }

--- a/src/google/protobuf/wire_format_lite.h
+++ b/src/google/protobuf/wire_format_lite.h
@@ -1131,7 +1131,7 @@ inline bool WireFormatLite::ReadPackedFixedSizePrimitive(
   if (new_bytes <= buffer_size) {
     // Fast-path that pre-allocates *values to the final size.
 #if defined(ABSL_IS_LITTLE_ENDIAN)
-    values->resize(old_entries + new_entries, 0);
+    values->resize(internal::CheckedAdd(old_entries, new_entries), 0);
     // values->mutable_data() may change after resize(), so do this after:
     void* dest = reinterpret_cast<void*>(values->mutable_data() + old_entries);
     if (!input->ReadRaw(dest, new_bytes)) {
@@ -1139,7 +1139,7 @@ inline bool WireFormatLite::ReadPackedFixedSizePrimitive(
       return false;
     }
 #else
-    values->Reserve(old_entries + new_entries);
+    values->Reserve(internal::CheckedAdd(old_entries, new_entries));
     CType value;
     for (int i = 0; i < new_entries; ++i) {
       if (!ReadPrimitive<CType, DeclaredType>(input, &value)) return false;


### PR DESCRIPTION
## Summary

Follow-up to be5dad556 ("Add overflow protection for very large containers"), which routed the packed **varint** paths through `internal::CheckedAdd`. The packed **fixed-size** paths were not covered and still compute the new container size as an unchecked signed `int` addition:

| Location | Expression |
|---|---|
| `parse_context.h` — `EpsCopyInputStream::ReadPackedFixed`, multi-buffer loop | `out->ReserveWithArena(arena, old_entries + num)` |
| `parse_context.h` — `EpsCopyInputStream::ReadPackedFixed`, tail | `out->ReserveWithArena(arena, old_entries + num)` |
| `wire_format_lite.h` — `WireFormatLite::ReadPackedFixedSizePrimitive`, little-endian | `values->resize(old_entries + new_entries, 0)` |
| `wire_format_lite.h` — `WireFormatLite::ReadPackedFixedSizePrimitive`, otherwise | `values->Reserve(old_entries + new_entries)` |

`old_entries` is the current element count of the target `RepeatedField`; `num` / `new_entries` are derived from the length prefix of the incoming packed field. On a field that already holds close to `INT_MAX` elements the sum wraps negative, and:

- `ReserveWithArena()` then skips `Grow()` — the guard `new_size > Capacity` is false for any negative value — so the following `AddNAlreadyReserved(num)` / `memcpy` writes past the end of the existing allocation.
- `resize()` with a negative size takes the shrink path into `Truncate()`, whose only bound is an `ABSL_DCHECK_LE` that is compiled out under `NDEBUG`.

## Fix

Route all four through `internal::CheckedAdd`, matching what be5dad556 did ~60 lines away in `ReadPackedVarintArrayWithField`, so these terminate deterministically instead of triggering undefined behavior.

## Notes for review

- **This revision replaces the earlier contents of this branch.** The PR started as the parser-side sibling of the `RepeatedField::MergeFrom` overflow (#27607) and also covered the varint paths; be5dad556 landed those independently on 2026-07-23. What remains here is what is still unguarded upstream.
- **`wire_format_lite.h`** is reached through `WireFormatLite::ReadPackedPrimitive<uint32_t, TYPE_FIXED32>` and its five siblings — public API, still exercised by `WireFormatLiteTest`, although in-tree parsing now goes through the TC parser. Happy to drop that file if you would rather keep this to `parse_context.h`.
- **No new test, deliberately.** `RepeatedFieldIsFullTest` can reach the varint/bool overflow with a 2 GB `RepeatedField<bool>`. The fixed-size paths hold 4- and 8-byte elements, so the equivalent test needs the target field to hold ~8.6 GB (`fixed32`) or ~17 GB (`fixed64`) before the vulnerable addition is even reachable — past what `RunLargeMemoryTests()` machines can be expected to have. If you want coverage regardless, the cheap way is a `RepeatedField` test peer that sets `current_size_` without a backing allocation; I am happy to add one in this PR or a follow-up, just say which you prefer.

## Verification

Built from this branch with CMake/Ninja (GCC 13.3, `Release`, `-DNDEBUG`):

- `libprotobuf.a` links clean; `nm` confirms `EpsCopyInputStream::ReadPackedFixed<>` is instantiated for all six fixed-width types (`int`, `unsigned int`, `long`, `unsigned long`, `float`, `double`), so the changed lines are compiled, not dead template text.
- The full `tests` binary passes: `RepeatedFieldIsFullTest.*` together with `WireFormat*` and `*Packed*` is 118 tests, all green.
- Positive control: a temporary `EXPECT_DEATH` that resizes `packed_fixed32` to `INT_MAX - 4` and then merges a 10-element packed `fixed32` payload dies with a message containing `Integer overflow in CheckedAdd:` with this change applied.
- Negative control: with the two `parse_context.h` lines reverted, the same case instead reaches `AddNAlreadyReserved()` and dies at `repeated_field.cc:52` with `Value (2147483653) must be less than or equal to limit (2147483643)`. So in an open-source build, where `GetBoundsCheckMode()` is `kAbort`, the wrapped `Reserve()` is caught downstream — but the signed addition that produced it is still UB, and the downstream check is not present where that mode is not `kAbort`. That is the same reasoning as be5dad556 ("These will now deterministically terminate instead of triggering undefined behavior").

(Neither control test is part of this PR; they were local only.)
