### PR TITLE
Handle OOM in upb JSON decoding

### DIFF
--- a/upb/json/BUILD
+++ b/upb/json/BUILD
@@ -73,7 +73,11 @@ proto_library(
     name = "test_proto",
     testonly = 1,
     srcs = ["test.proto"],
-    deps = ["//:struct_proto"],
+    deps = [
+        "//:any_proto",
+        "//:field_mask_proto",
+        "//:struct_proto",
+    ],
 )
 
 upb_c_proto_library(

--- a/upb/json/decode.c
+++ b/upb/json/decode.c
@@ -94,6 +94,10 @@ UPB_NORETURN static void jsondec_err(jsondec* d, const char* msg) {
   UPB_LONGJMP(d->err, 1);
 }
 
+UPB_NORETURN static void jsondec_oom(jsondec* d) {
+  jsondec_err(d, "Out of memory");
+}
+
 UPB_PRINTF(2, 3)
 UPB_NORETURN static void jsondec_errf(jsondec* d, const char* fmt, ...) {
   va_list argp;
@@ -888,12 +892,13 @@ static upb_MessageValue jsondec_bool(jsondec* d, const upb_FieldDef* f) {
 static void jsondec_array(jsondec* d, upb_Message* msg, const upb_FieldDef* f) {
   UPB_ASSERT(!upb_Message_IsFrozen(msg));
   upb_Array* arr = upb_Message_Mutable(msg, f, d->arena).array;
+  if (!arr) jsondec_oom(d);
 
   jsondec_arrstart(d);
   while (jsondec_arrnext(d)) {
     upb_JsonMessageValue elem = jsondec_value(d, f);
     if (!elem.ignore) {
-      upb_Array_Append(arr, elem.value, d->arena);
+      if (!upb_Array_Append(arr, elem.value, d->arena)) jsondec_oom(d);
     }
   }
   jsondec_arrend(d);
@@ -902,6 +907,7 @@ static void jsondec_array(jsondec* d, upb_Message* msg, const upb_FieldDef* f) {
 static void jsondec_map(jsondec* d, upb_Message* msg, const upb_FieldDef* f) {
   UPB_ASSERT(!upb_Message_IsFrozen(msg));
   upb_Map* map = upb_Message_Mutable(msg, f, d->arena).map;
+  if (!map) jsondec_oom(d);
   const upb_MessageDef* entry = upb_FieldDef_MessageSubDef(f);
   const upb_FieldDef* key_f = upb_MessageDef_FindFieldByNumber(entry, 1);
   const upb_FieldDef* val_f = upb_MessageDef_FindFieldByNumber(entry, 2);
@@ -914,7 +920,7 @@ static void jsondec_map(jsondec* d, upb_Message* msg, const upb_FieldDef* f) {
     jsondec_entrysep(d);
     val = jsondec_value(d, val_f);
     if (!val.ignore) {
-      upb_Map_Set(map, key.value, val.value, d->arena);
+      if (!upb_Map_Set(map, key.value, val.value, d->arena)) jsondec_oom(d);
     }
   }
   jsondec_objend(d);
@@ -934,6 +940,7 @@ static upb_MessageValue jsondec_msg(jsondec* d, const upb_FieldDef* f) {
   const upb_MessageDef* m = upb_FieldDef_MessageSubDef(f);
   const upb_MiniTable* layout = upb_MessageDef_MiniTable(m);
   upb_Message* msg = upb_Message_New(layout, d->arena);
+  if (!msg) jsondec_oom(d);
   upb_MessageValue val;
 
   jsondec_tomsg(d, msg, m);
@@ -995,6 +1002,7 @@ static void jsondec_field(jsondec* d, upb_Message* msg,
     jsondec_array(d, msg, f);
   } else if (upb_FieldDef_IsSubMessage(f)) {
     upb_Message* submsg = upb_Message_Mutable(msg, f, d->arena).msg;
+    if (!submsg) jsondec_oom(d);
     const upb_MessageDef* subm = upb_FieldDef_MessageSubDef(f);
     jsondec_tomsg(d, submsg, subm);
   } else {
@@ -1214,13 +1222,15 @@ static void jsondec_listvalue(jsondec* d, upb_Message* msg,
   const upb_MessageDef* value_m = upb_FieldDef_MessageSubDef(values_f);
   const upb_MiniTable* value_layout = upb_MessageDef_MiniTable(value_m);
   upb_Array* values = upb_Message_Mutable(msg, values_f, d->arena).array;
+  if (!values) jsondec_oom(d);
 
   jsondec_arrstart(d);
   while (jsondec_arrnext(d)) {
     upb_Message* value_msg = upb_Message_New(value_layout, d->arena);
+    if (!value_msg) jsondec_oom(d);
     upb_MessageValue value;
     value.msg_val = value_msg;
-    upb_Array_Append(values, value, d->arena);
+    if (!upb_Array_Append(values, value, d->arena)) jsondec_oom(d);
     jsondec_wellknownvalue(d, value_msg, value_m);
   }
   jsondec_arrend(d);
@@ -1235,14 +1245,16 @@ static void jsondec_struct(jsondec* d, upb_Message* msg,
   const upb_MessageDef* value_m = upb_FieldDef_MessageSubDef(value_f);
   const upb_MiniTable* value_layout = upb_MessageDef_MiniTable(value_m);
   upb_Map* fields = upb_Message_Mutable(msg, fields_f, d->arena).map;
+  if (!fields) jsondec_oom(d);
 
   jsondec_objstart(d);
   while (jsondec_objnext(d)) {
     upb_MessageValue key, value;
     upb_Message* value_msg = upb_Message_New(value_layout, d->arena);
+    if (!value_msg) jsondec_oom(d);
     key.str_val = jsondec_string(d);
     value.msg_val = value_msg;
-    upb_Map_Set(fields, key, value, d->arena);
+    if (!upb_Map_Set(fields, key, value, d->arena)) jsondec_oom(d);
     jsondec_entrysep(d);
     jsondec_wellknownvalue(d, value_msg, value_m);
   }
@@ -1290,12 +1302,14 @@ static void jsondec_wellknownvalue(jsondec* d, upb_Message* msg,
       /* Struct struct_value = 5; */
       f = upb_MessageDef_FindFieldByNumber(m, 5);
       submsg = upb_Message_Mutable(msg, f, d->arena).msg;
+      if (!submsg) jsondec_oom(d);
       jsondec_struct(d, submsg, upb_FieldDef_MessageSubDef(f));
       return;
     case JD_ARRAY:
       /* ListValue list_value = 6; */
       f = upb_MessageDef_FindFieldByNumber(m, 6);
       submsg = upb_Message_Mutable(msg, f, d->arena).msg;
+      if (!submsg) jsondec_oom(d);
       jsondec_listvalue(d, submsg, upb_FieldDef_MessageSubDef(f));
       return;
     default:
@@ -1320,6 +1334,7 @@ static upb_StringView jsondec_mask(jsondec* d, const char* buf,
   }
 
   out = upb_Arena_Malloc(d->arena, ret.size);
+  if (!out && ret.size != 0) jsondec_oom(d);
   ptr = buf;
   ret.data = out;
 
@@ -1344,6 +1359,7 @@ static void jsondec_fieldmask(jsondec* d, upb_Message* msg,
   /* repeated string paths = 1; */
   const upb_FieldDef* paths_f = upb_MessageDef_FindFieldByNumber(m, 1);
   upb_Array* arr = upb_Message_Mutable(msg, paths_f, d->arena).array;
+  if (!arr) jsondec_oom(d);
   upb_StringView str = jsondec_string(d);
   const char* ptr = str.data;
   const char* end = ptr + str.size;
@@ -1358,7 +1374,7 @@ static void jsondec_fieldmask(jsondec* d, upb_Message* msg,
       val.str_val = jsondec_mask(d, ptr, end);
       ptr = end;
     }
-    upb_Array_Append(arr, val, d->arena);
+    if (!upb_Array_Append(arr, val, d->arena)) jsondec_oom(d);
   }
 }
 
@@ -1448,10 +1464,12 @@ static void jsondec_any(jsondec* d, upb_Message* msg, const upb_MessageDef* m) {
 
   const upb_MiniTable* any_layout = upb_MessageDef_MiniTable(any_m);
   any_msg = upb_Message_New(any_layout, d->arena);
+  if (!any_msg) jsondec_oom(d);
 
   if (pre_type_data) {
     size_t len = pre_type_end - pre_type_data + 1;
     char* tmp = upb_Arena_Malloc(d->arena, len);
+    if (!tmp) jsondec_oom(d);
     const char* saved_ptr = d->ptr;
     const char* saved_end = d->end;
     memcpy(tmp, pre_type_data, len - 1);
@@ -1475,8 +1493,7 @@ static void jsondec_any(jsondec* d, upb_Message* msg, const upb_MessageDef* m) {
   upb_EncodeStatus status =
       upb_Encode(any_msg, upb_MessageDef_MiniTable(any_m), 0, d->arena,
                  (char**)&encoded.str_val.data, &encoded.str_val.size);
-  // TODO: We should fail gracefully here on a bad return status.
-  UPB_ASSERT(status == kUpb_EncodeStatus_Ok);
+  if (status != kUpb_EncodeStatus_Ok) jsondec_oom(d);
   upb_Message_SetFieldByDef(msg, value_f, encoded, d->arena);
 }
 

--- a/upb/json/decode_test.cc
+++ b/upb/json/decode_test.cc
@@ -33,6 +33,49 @@ static upb_test_Box* JsonDecode(const char* json, upb_Arena* a) {
   return ok ? box : nullptr;
 }
 
+struct DenyAlloc {
+  upb_alloc alloc;
+};
+
+static void* DenyAllocFunc(upb_alloc* alloc, void* ptr, size_t oldsize,
+                           size_t size, size_t* actual_size) {
+  (void)alloc;
+  (void)ptr;
+  (void)oldsize;
+  (void)size;
+  (void)actual_size;
+  return nullptr;
+}
+
+static bool JsonDecodeWithFixedArena(const std::string& json, size_t arena_size,
+                                     std::string* error) {
+  DenyAlloc deny = {{DenyAllocFunc}};
+  std::vector<char> arena_mem(arena_size);
+  upb_Arena* arena =
+      upb_Arena_Init(arena_mem.data(), arena_mem.size(), &deny.alloc);
+  EXPECT_NE(arena, nullptr);
+  if (!arena) return false;
+
+  upb::Status status;
+  upb::DefPool defpool;
+  upb::MessageDefPtr m(upb_test_Box_getmsgdef(defpool.ptr()));
+  EXPECT_TRUE(m.ptr() != nullptr);
+
+  upb::Arena msg_arena;
+  upb_test_Box* box = upb_test_Box_new(msg_arena.ptr());
+  EXPECT_NE(box, nullptr);
+  if (!box) {
+    upb_Arena_Free(arena);
+    return false;
+  }
+
+  bool ok = upb_JsonDecode(json.data(), json.size(), UPB_UPCAST(box), m.ptr(),
+                           defpool.ptr(), 0, arena, status.ptr());
+  if (error) *error = upb_Status_ErrorMessage(status.ptr());
+  upb_Arena_Free(arena);
+  return ok;
+}
+
 struct FloatTest {
   const std::string json;
   float f;
@@ -109,4 +152,26 @@ TEST(JsonTest, RejectsBase64WithHighBitBytes) {
   std::string json_string = R"({"data":"\u0080\u0080\u0080\u0080"})";
   upb_test_Box* box = JsonDecode(json_string.c_str(), a.ptr());
   EXPECT_EQ(box, nullptr);
+}
+
+TEST(JsonTest, FixedArenaOomFailsGracefullyForWellKnownTypes) {
+  const std::string long_path(4096, 'A');
+  const std::string long_string(4096, 'x');
+  const std::string many_nulls =
+      "null,null,null,null,null,null,null,null,null,null,null,null,null,null";
+  const std::vector<std::string> json_inputs = {
+      "{\"mask\":\"" + long_path + "\"}",
+      "{\"val\":[" + many_nulls + "]}",
+      "{\"val\":{\"a\":null,\"b\":null,\"c\":null,\"d\":null,\"e\":null,"
+      "\"f\":null,\"g\":null,\"h\":null}}",
+      "{\"any\":{\"value\":\"" + long_string +
+          "\",\"@type\":\"type.googleapis.com/google.protobuf.FieldMask\"}}",
+  };
+
+  for (const auto& json : json_inputs) {
+    SCOPED_TRACE(json);
+    std::string error;
+    EXPECT_FALSE(JsonDecodeWithFixedArena(json, 512, &error));
+    EXPECT_NE(error.find("Out of memory"), std::string::npos) << error;
+  }
 }

--- a/upb/json/test.proto
+++ b/upb/json/test.proto
@@ -9,6 +9,8 @@ syntax = "proto2";
 
 package upb_test;
 
+import "google/protobuf/any.proto";
+import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 
 enum Tag {
@@ -29,4 +31,6 @@ message Box {
   optional int32 value = 9 [json_name = "old_value"];
   optional int32 new_value = 10 [json_name = "value"];
   optional bytes data = 11;
+  optional google.protobuf.FieldMask mask = 12;
+  optional google.protobuf.Any any = 13;
 }


### PR DESCRIPTION
## Summary

This updates the upb JSON decoder to handle allocation failures in several JSON decoding paths by returning a controlled `Out of memory` decode error instead of continuing after failed arena allocations.

Covered paths include repeated fields, maps, submessages, and well-known type JSON decoding for `FieldMask`, `ListValue`, `Struct`, and `Any`.

## Testing

- Added `JsonTest.FixedArenaOomFailsGracefullyForWellKnownTypes`
- Verified locally with:

```bash
bazel test //upb/json:decode_test