### PR TITLE
Security: replace strcpy with std::copy in portable_strdup

### DIFF
--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -309,9 +309,10 @@ Subprocess::~Subprocess() {
 
 namespace {
 char* portable_strdup(const char* s) {
-  char* ns = (char*)malloc(strlen(s) + 1);
+  size_t len = strlen(s);
+  char* ns = (char*)malloc(len + 1);
   if (ns != nullptr) {
-    std::copy(s, s + strlen(s) + 1, ns);
+    std::copy(s, s + len + 1, ns);
   }
   return ns;
 }

--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -311,7 +311,7 @@ namespace {
 char* portable_strdup(const char* s) {
   char* ns = (char*)malloc(strlen(s) + 1);
   if (ns != nullptr) {
-    strcpy(ns, s);
+    std::copy(s, s + strlen(s) + 1, ns);
   }
   return ns;
 }


### PR DESCRIPTION
This PR replaces the unsafe `strcpy` with `std::copy` in `portable_strdup` inside `subprocess.cc` to avoid potential security warnings and unsafe operations.