### PR TITLE
Use CheckedAdd for packed-field reserve sizes to prevent int overflow

### DIFF
--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -1526,7 +1526,7 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   while (size > nbytes) {
     int num = nbytes / sizeof(T);
     int old_entries = out->size();
-    out->ReserveWithArena(arena, old_entries + num);
+    out->ReserveWithArena(arena, CheckedAdd(old_entries, num));
     int block_size = num * sizeof(T);
     auto dst = out->AddNAlreadyReserved(num);
 #ifdef ABSL_IS_LITTLE_ENDIAN
@@ -1546,7 +1546,7 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   int block_size = num * sizeof(T);
   if (num == 0) return size == block_size ? ptr : nullptr;
   int old_entries = out->size();
-  out->ReserveWithArena(arena, old_entries + num);
+  out->ReserveWithArena(arena, CheckedAdd(old_entries, num));
   auto dst = out->AddNAlreadyReserved(num);
 #ifdef ABSL_IS_LITTLE_ENDIAN
   ABSL_CHECK(dst != nullptr) << out << "," << num;
@@ -1589,7 +1589,7 @@ const char* EpsCopyInputStream::ReadPackedVarintArrayWithField(
         if (VerifyBoolsAssumingLargeArray(ptr, end)) {
           // Each byte is 0 or 1.
           const int count = end - ptr;
-          out.ReserveWithArena(arena, out.size() + count);
+          out.ReserveWithArena(arena, CheckedAdd(out.size(), count));
           T* x = out.AddNAlreadyReserved(count);
           // For T being bool, conv must be equivalent to a conversion to bool
           // (zigzag encoding is not applicable), so it can be skipped.
@@ -1602,7 +1602,7 @@ const char* EpsCopyInputStream::ReadPackedVarintArrayWithField(
     if (count == end - ptr) {
       // We have exactly one element per byte, so avoid the costly varint
       // parsing.
-      out.ReserveWithArena(arena, out.size() + count);
+      out.ReserveWithArena(arena, CheckedAdd(out.size(), count));
       T* x = out.AddNAlreadyReserved(count);
       for (; ptr != end; ++ptr) {
         *x = conv(static_cast<uint8_t>(*ptr));
@@ -1613,7 +1613,7 @@ const char* EpsCopyInputStream::ReadPackedVarintArrayWithField(
       // we need to account for that.
       if (end[-1] & 0x80) count++;
       int old_size = out.size();
-      out.ReserveWithArena(arena, old_size + count);
+      out.ReserveWithArena(arena, CheckedAdd(old_size, count));
       T* x = out.AddNAlreadyReserved(count);
       ptr = ReadPackedVarintArray(ptr, end, [&](uint64_t varint) {
         *x = conv(varint);


### PR DESCRIPTION
## Problem

`EpsCopyInputStream::ReadPackedFixed` and `ReadPackedVarintArrayWithField`
(`parse_context.h`) compute the reserve size for the output `RepeatedField`
as a plain signed-`int` addition before allocating:

```cpp
int old_entries = out->size();
out->ReserveWithArena(arena, old_entries + num);   // unchecked
auto dst = out->AddNAlreadyReserved(num);
std::memcpy(dst, ptr, block_size);                 // writes past buffer
```

When `old_entries + num` (or `out.size() + count` / `old_size + count`)
exceeds `INT_MAX`, the signed addition wraps to a negative value.
`ReserveWithArena` only grows when `new_size > Capacity(...)`, so a negative
size is never `> capacity` and growth is **skipped**. `AddNAlreadyReserved`
then returns a pointer past the (un-grown) buffer and the subsequent
`memcpy` / element loop writes out of bounds.

This is the parse-time analogue of the overflow already guarded in
`RepeatedField`/`RepeatedPtrField::MergeFrom`, which wrap the same
`old + n` reserve computation in `CheckedAdd`.

## Fix

Wrap the five reserve-size additions in `CheckedAdd` (already declared in
`port.h`, included here), so an oversized packed field hits the existing
`HandleAddOverflow` path and aborts cleanly instead of overflowing the
output buffer. The five sites:

- `ReadPackedFixed` loop body and final block (`old_entries + num`)
- `ReadPackedVarintArrayWithField` bool fast-path and one-byte-per-element
  path (`out.size() + count`)
- `ReadPackedVarintArrayWithField` varint path (`old_size + count`)

No behavior change for valid inputs; only over-`INT_MAX` reserve sizes,
which previously corrupted the heap, are now rejected.
