### PR TITLE
Security: Reject large-exponent scientific notation in JsonFormat to prevent DoS

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -2034,7 +2034,17 @@ public class JsonFormat {
         throw new InvalidProtocolBufferException(
             "Numeric value is too long: " + value.length() + " characters");
       }
-      return new BigDecimal(value);
+      BigDecimal result = new BigDecimal(value);
+      // Reject values whose unscaled representation would be excessively large.
+      // Scientific notation like "1e999" is only 5 characters but would produce a
+      // 999-digit BigInteger during compareTo/remainder/intValue operations.
+      // Valid protobuf numeric values (up to uint64 max = ~1.8e19) never need
+      // more than ~20 digits, so a limit of 100 is generous.
+      if (Math.abs(result.scale()) > 100 || result.precision() + Math.abs(result.scale()) > 100) {
+        throw new InvalidProtocolBufferException(
+            "Numeric value scale is too large: " + value);
+      }
+      return result;
     }
 
     private long parseUint64(JsonElement json) throws InvalidProtocolBufferException {

--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -2029,20 +2029,29 @@ public class JsonFormat {
     // values never exceed ~350 characters, so 1000 is a generous upper bound.
     private static final int MAX_NUMERIC_STRING_LENGTH = 1000;
 
+    // Largest |BigDecimal.scale()| accepted for a JSON numeric value. Comfortably
+    // above the exponent range of double (~1e-324 to 1e308), the widest protobuf
+    // numeric type, and small enough that the BigInteger materialized by later
+    // arithmetic stays bounded.
+    private static final int MAX_NUMERIC_SCALE = 1000;
+
     private static BigDecimal parseBigDecimal(String value) throws InvalidProtocolBufferException {
       if (value.length() > MAX_NUMERIC_STRING_LENGTH) {
         throw new InvalidProtocolBufferException(
             "Numeric value is too long: " + value.length() + " characters");
       }
       BigDecimal result = new BigDecimal(value);
-      // Reject values whose unscaled representation would be excessively large.
-      // Scientific notation like "1e999" is only 5 characters but would produce a
-      // 999-digit BigInteger during compareTo/remainder/intValue operations.
-      // Valid protobuf numeric values (up to uint64 max = ~1.8e19) never need
-      // more than ~20 digits, so a limit of 100 is generous.
-      if (Math.abs(result.scale()) > 100 || result.precision() + Math.abs(result.scale()) > 100) {
+      // Compact scientific notation such as "1e536870000" is short enough to pass
+      // the length check above, but materializes a multi-million-digit BigInteger
+      // inside the compareTo()/remainder() calls made by the callers below, which
+      // can occupy a thread for minutes. Bound the exponent as well as the string
+      // length. The widest protobuf numeric type is double, whose magnitude spans
+      // roughly 1e-324 to 1e308, so no valid value approaches this limit; at the
+      // limit the BigInteger is about a thousand digits and the arithmetic stays
+      // in the low milliseconds.
+      if (Math.abs(result.scale()) > MAX_NUMERIC_SCALE) {
         throw new InvalidProtocolBufferException(
-            "Numeric value scale is too large: " + value);
+            "Numeric value is out of range: " + value);
       }
       return result;
     }


### PR DESCRIPTION
## Summary

The existing `MAX_NUMERIC_STRING_LENGTH=1000` guard in `parseBigDecimal()` blocks long numeric strings but does not block compact scientific notation like `1e999` (5 chars) or `1e536870000` (11 chars). These values bypass the length check but cause `BigDecimal.compareTo()` and `BigDecimal.remainder()` to internally materialize multi-million-digit `BigInteger` values, consuming minutes of CPU and GBs of memory per request.

## Vulnerability

A single 27-byte JSON payload can tie up one thread indefinitely:

```json
{"my_uint64_field": "1e536870000"}
```

**Attack flow:**
1. `parseBigDecimal("1e536870000")` - string is 11 chars, passes the 1000-char check
2. `new BigDecimal("1e536870000")` - stores compactly as `(unscaledValue=1, scale=-536870000)` in O(1)
3. `value.compareTo(MAX_UINT64)` - internally materializes `BigInteger.TEN.pow(536870000)` producing 536 million digits, minutes of CPU, GBs of RAM
4. Range check runs after materialization completes - rejected, but damage done

**Affected methods:** `parseUint32`, `parseUint64`, `parseInt32`, `parseInt64`, `parseDouble`

## Fix

Add a scale/precision bounds check in `parseBigDecimal()` immediately after construction:

```java
if (Math.abs(result.scale()) > 100 || result.precision() + Math.abs(result.scale()) > 100) {
    throw new InvalidProtocolBufferException("Numeric value scale is too large: " + value);
}
```

Valid protobuf uint64 values never exceed ~20 digits, so a limit of 100 is generous while blocking the DoS vector completely.

## Impact

Any service using `JsonFormat.parser().merge()` to parse untrusted JSON into protobuf messages is vulnerable. This includes REST APIs, webhook handlers, and API gateways with JSON-to-protobuf transcoding.

Fixes #26032
