### PR TITLE
Security: Add depth limit to Python FieldMask path parsing to prevent DoS

### DIFF
--- a/python/google/protobuf/internal/field_mask.py
+++ b/python/google/protobuf/internal/field_mask.py
@@ -201,6 +201,14 @@ class _FieldMaskTree(object):
     for path in field_mask.paths:
       self.AddPath(path)
 
+  # Maximum depth for FieldMask paths. FieldMask paths are flat strings on the
+  # wire (parsed at depth 1), so standard protobuf recursion limits don't apply.
+  # A malicious path like "a.a.a...a" with thousands of segments can build an
+  # arbitrarily deep tree, causing excessive memory/CPU usage or stack overflow
+  # when the tree is later traversed. This limit matches the standard protobuf
+  # recursion limit.
+  _MAX_DEPTH = 100
+
   def AddPath(self, path):
     """Adds a field path into the tree.
 
@@ -214,9 +222,18 @@ class _FieldMaskTree(object):
 
     Args:
       path: The field path to add.
+
+    Raises:
+      ValueError: If the path exceeds the maximum allowed depth.
     """
     node = self._root
-    for name in path.split('.'):
+    segments = path.split('.')
+    if len(segments) > self._MAX_DEPTH:
+      raise ValueError(
+          'FieldMask path exceeds maximum depth of {0}: got {1} segments'
+          .format(self._MAX_DEPTH, len(segments))
+      )
+    for name in segments:
       if name not in node:
         node[name] = {}
       elif not node[name]:


### PR DESCRIPTION
## Summary

Add a depth limit to `_FieldMaskTree.AddPath()` in the Python protobuf runtime to prevent denial-of-service via unbounded tree construction from malicious FieldMask paths.

## Vulnerability

FieldMask paths are flat strings on the wire (binary and JSON), parsed at depth 1. Standard protobuf recursion limits (100) are completely blind to the internal dot-separated structure. A malicious path with thousands of segments bypasses all guards:

```python
from google.protobuf import field_mask_pb2
from google.protobuf.internal import field_mask

# 2KB payload creates 2000-level deep tree -> crash
malicious_mask = field_mask_pb2.FieldMask()
malicious_mask.paths.append('.'.join(['a'] * 2000))

result = field_mask_pb2.FieldMask()
result.CanonicalFormFromMask(malicious_mask)  # RecursionError / memory exhaustion
```

**Attack scenario:** Any gRPC/REST API using FieldMask for update operations (AIP-134 pattern) that calls `Union()`, `Intersect()`, or `CanonicalFormFromMask()` on untrusted input.

## Fix

Add `_MAX_DEPTH = 100` check in `AddPath()` before tree construction. Paths exceeding 100 dot-separated segments raise `ValueError` immediately. Valid protobuf messages never have field paths deeper than ~20 levels, so 100 is generous.

## Impact

Remote DoS - a single ~2KB request crashes the Python worker process handling protobuf FieldMask operations.

Fixes #26489
