### PR TITLE
Restore field type guard in ProtoJSON null WKT handling

### DIFF
--- a/src/google/protobuf/json/internal/parser.cc
+++ b/src/google/protobuf/json/internal/parser.cc
@@ -398,9 +398,11 @@ absl::Status ParseSingular(JsonLexer& lex, Field<Traits> field,
   if (lex.Peek(JsonLexer::kNull)) {
     auto message_type = ClassifyMessage(Traits::FieldTypeName(field));
 
-    if (message_type == MessageType::kNull) {
+    if (message_type == MessageType::kNull &&
+        field_type == FieldDescriptor::TYPE_ENUM) {
       Traits::SetEnum(field, msg, 0);
-    } else if (message_type == MessageType::kValue) {
+    } else if (message_type == MessageType::kValue &&
+               field_type == FieldDescriptor::TYPE_MESSAGE) {
       return Traits::NewMsg(
           field, msg,
           [&](const Desc<Traits>& type, Msg<Traits>& msg) -> absl::Status {
@@ -1247,7 +1249,12 @@ absl::Status ParseField(JsonLexer& lex, const Desc<Traits>& desc,
   // (b/519557203).
   if (lex.Peek(JsonLexer::kNull)) {
     MessageType type = ClassifyMessage(Traits::FieldTypeName(*field));
-    if (type != MessageType::kValue && type != MessageType::kNull) {
+    auto ft = Traits::FieldType(*field);
+    bool is_wkt_null = type == MessageType::kNull &&
+                       ft == FieldDescriptor::TYPE_ENUM;
+    bool is_wkt_value = type == MessageType::kValue &&
+                        ft == FieldDescriptor::TYPE_MESSAGE;
+    if (!is_wkt_null && !is_wkt_value) {
       return lex.Expect("null");
     }
   }


### PR DESCRIPTION
## Summary

The refactor in 118c27a85 removed the `FieldDescriptor::Type` switch from `ParseSingular`, so WKT name classification alone now drives `SetEnum`/`NewMsg` calls for JSON null values. Because `ClassifyMessage` matches by full type name string and `FieldTypeName` returns names for both message and enum fields, a dynamic descriptor pool can shadow WKT names and trigger wrong reflection API calls.

Specifically, a `message google.protobuf.NullValue {}` in a dynamic pool causes `SetEnumValue` to be called on a message-typed field, which hits `ABSL_LOG(FATAL)` and aborts the process.

This PR restores the field type guard so that:
- `kNull` only calls `SetEnum` when `field_type == TYPE_ENUM`
- `kValue` only calls `NewMsg` when `field_type == TYPE_MESSAGE`

This matches the behavior before the refactor.

## Reproduction

```cpp
// Dynamic descriptor with message named google.protobuf.NullValue
DescriptorProto* spoof = file.add_message_type();
spoof->set_name("NullValue");  // message, not enum

DescriptorProto* victim = file.add_message_type();
victim->set_name("Victim");
// field f is TYPE_MESSAGE referencing the spoofed NullValue
f->set_type(FieldDescriptorProto::TYPE_MESSAGE);
f->set_type_name(".google.protobuf.NullValue");

// Triggers FATAL abort without fix:
json::JsonStringToMessage("{\"f\":null}", msg.get());
```

Without fix: `FATAL reflection usage error → SIGABRT (exit 134)`
With fix: `Parse returned: OK (exit 0)`

## Test plan

- [x] Verified crash without fix on current main
- [x] Verified clean parse with fix applied
- [ ] Existing ProtoJSON tests should continue to pass (WKT null handling for real `google.protobuf.NullValue` enum and `google.protobuf.Value` message is unchanged)