### PR TITLE
Avoid bash for protoc authenticity checks on Windows

### DIFF
--- a/bazel/private/oss/toolchains/prebuilt/BUILD.bazel
+++ b/bazel/private/oss/toolchains/prebuilt/BUILD.bazel
@@ -5,7 +5,7 @@ In particular, see comment below on the toolchain#toolchain attribute.
 """
 
 load("//toolchain:platforms.bzl", "PROTOBUF_PLATFORMS")
-load(":protoc_authenticity.bzl", "protoc_authenticity")
+load(":protoc_authenticity.bzl", "protoc_authenticity", "protoc_authenticity_is_windows")
 
 [
     toolchain(
@@ -22,6 +22,10 @@ load(":protoc_authenticity.bzl", "protoc_authenticity")
 ]
 
 # Support verification of user-registered toolchains
+protoc_authenticity_is_windows(
+    name = "is_windows",
+)
+
 protoc_authenticity(
     name = "authenticity_validation",
     fail_on_mismatch = select({

--- a/bazel/private/oss/toolchains/prebuilt/protoc_authenticity.bzl
+++ b/bazel/private/oss/toolchains/prebuilt/protoc_authenticity.bzl
@@ -4,6 +4,109 @@ load("//bazel/common:proto_common.bzl", "proto_common")
 load("//bazel/private:toolchain_helpers.bzl", "toolchains")
 load(":tool_integrity.bzl", "RELEASE_VERSION")
 
+_ProtocAuthenticityOsInfo = provider(
+    doc = "Information about the protoc authenticity action's execution platform.",
+    fields = ["is_windows"],
+)
+
+def _protoc_authenticity_is_windows_impl(ctx):
+    return _ProtocAuthenticityOsInfo(
+        is_windows = ctx.target_platform_has_constraint(
+            ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
+        ),
+    )
+
+protoc_authenticity_is_windows = rule(
+    implementation = _protoc_authenticity_is_windows_impl,
+    attrs = {
+        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
+    },
+)
+
+def _protoc_authenticity_unix_script(
+        protoc,
+        validation_output,
+        expected_version,
+        severity,
+        suppression_note,
+        mismatch_exit_code):
+    return """\
+{protoc} --version > {validation_output}
+grep -q -e "-dev$" {validation_output} && {{
+  echo 'WARNING: Detected a development version of protoc.
+  Development versions are not validated for authenticity.
+  To ensure a secure build, please use a released version of protoc.'
+  exit 0
+}}
+grep -q "^libprotoc {expected_version}" {validation_output} || {{
+  echo '{severity}: protoc version does not match protobuf Bazel module; we do not support this.
+  It is considered undefined behavior that is expected to break in the future even if it appears to work today.'
+  echo '{suppression_note}'
+  echo 'Expected: libprotoc {expected_version}'
+  echo -n 'Actual:   '
+  cat {validation_output}
+  exit {mismatch_exit_code}
+}} >&2
+""".format(
+        protoc = protoc,
+        validation_output = validation_output,
+        expected_version = expected_version,
+        severity = severity,
+        suppression_note = suppression_note,
+        mismatch_exit_code = mismatch_exit_code,
+    )
+
+def _protoc_authenticity_windows_script(
+        protoc,
+        validation_output,
+        expected_version,
+        severity,
+        suppression_note,
+        mismatch_exit_code):
+    mismatch_lines = [
+        "  1>&2 echo {severity}: protoc version does not match protobuf Bazel module; we do not support this.".format(
+            severity = severity,
+        ),
+        "  1>&2 echo It is considered undefined behavior that is expected to break in the future even if it appears to work today.",
+    ]
+    if suppression_note:
+        mismatch_lines.append(
+            "  1>&2 echo {suppression_note}".format(suppression_note = suppression_note),
+        )
+    mismatch_lines.extend([
+        "  1>&2 echo Expected: libprotoc {expected_version}".format(expected_version = expected_version),
+        "  1>&2 echo Actual:",
+        '  type "{validation_output}" 1>&2'.format(validation_output = validation_output),
+        "  exit /B {mismatch_exit_code}".format(mismatch_exit_code = mismatch_exit_code),
+    ])
+
+    return "\r\n".join([
+        "@echo off",
+        "setlocal",
+        '"{protoc}" --version > "{validation_output}"'.format(
+            protoc = protoc,
+            validation_output = validation_output,
+        ),
+        'findstr /R /C:"-dev$" "{validation_output}" >NUL'.format(
+            validation_output = validation_output,
+        ),
+        "if %ERRORLEVEL% EQU 0 (",
+        "  echo WARNING: Detected a development version of protoc.",
+        "  echo Development versions are not validated for authenticity.",
+        "  echo To ensure a secure build, please use a released version of protoc.",
+        "  exit /B 0",
+        ")",
+        'findstr /R /C:"^libprotoc {expected_version}" "{validation_output}" >NUL'.format(
+            expected_version = expected_version,
+            validation_output = validation_output,
+        ),
+        "if %ERRORLEVEL% NEQ 0 (",
+    ] + mismatch_lines + [
+        ")",
+        "exit /B 0",
+        "",
+    ])
+
 def _protoc_authenticity_impl(ctx):
     # When this flag is disabled, then users have no way to replace the protoc binary with their own toolchain registration.
     # Therefore there's no validation to perform.
@@ -15,37 +118,58 @@ def _protoc_authenticity_impl(ctx):
     proto_lang_toolchain_info = toolchain.proto
     validation_output = ctx.actions.declare_file("validation_output.txt")
 
-    ctx.actions.run_shell(
+    expected_version = RELEASE_VERSION.removeprefix("v")
+    suppression_note = ""
+    if ctx.attr.fail_on_mismatch:
+        suppression_note = (
+            "To suppress this error, run Bazel with "
+            "--@com_google_protobuf//bazel/toolchains:allow_nonstandard_protoc"
+        )
+    mismatch_exit_code = 1 if ctx.attr.fail_on_mismatch else 0
+    severity = "ERROR" if ctx.attr.fail_on_mismatch else "INFO"
+
+    is_windows = ctx.attr._exec_is_windows[_ProtocAuthenticityOsInfo].is_windows
+    if is_windows:
+        script = ctx.actions.declare_file(ctx.label.name + "_authenticity_check.bat")
+        script_content = _protoc_authenticity_windows_script(
+            protoc = proto_lang_toolchain_info.proto_compiler.executable.path.replace(
+                "/",
+                "\\",
+            ),
+            validation_output = validation_output.path.replace("/", "\\"),
+            expected_version = expected_version,
+            severity = severity,
+            suppression_note = suppression_note,
+            mismatch_exit_code = mismatch_exit_code,
+        )
+        executable = "cmd.exe"
+        arguments = ["/C", script.path.replace("/", "\\")]
+    else:
+        script = ctx.actions.declare_file(ctx.label.name + "_authenticity_check.sh")
+        script_content = _protoc_authenticity_unix_script(
+            protoc = proto_lang_toolchain_info.proto_compiler.executable.path,
+            validation_output = validation_output.path,
+            expected_version = expected_version,
+            severity = severity,
+            suppression_note = suppression_note,
+            mismatch_exit_code = mismatch_exit_code,
+        )
+        executable = "bash"
+        arguments = [script.path]
+
+    ctx.actions.write(
+        output = script,
+        content = script_content,
+    )
+    ctx.actions.run(
         mnemonic = "ProtocAuthenticityCheck",
         outputs = [validation_output],
         tools = [proto_lang_toolchain_info.proto_compiler],
-        command = """\
-        {protoc} --version > {validation_output}
-        grep -q -e "-dev$" {validation_output} && {{
-          echo 'WARNING: Detected a development version of protoc.
-          Development versions are not validated for authenticity.
-          To ensure a secure build, please use a released version of protoc.'
-          exit 0
-        }}
-        grep -q "^libprotoc {RELEASE_VERSION}" {validation_output} || {{
-          echo '{severity}: protoc version does not match protobuf Bazel module; we do not support this.
-          It is considered undefined behavior that is expected to break in the future even if it appears to work today.'
-          echo '{suppression_note}'
-          echo 'Expected: libprotoc {RELEASE_VERSION}'
-          echo -n 'Actual:   '
-          cat {validation_output}
-          exit {mismatch_exit_code}
-        }} >&2
-        """.format(
-            protoc = proto_lang_toolchain_info.proto_compiler.executable.path,
-            validation_output = validation_output.path,
-            RELEASE_VERSION = RELEASE_VERSION.removeprefix("v"),
-            suppression_note = (
-                "To suppress this error, run Bazel with --@com_google_protobuf//bazel/toolchains:allow_nonstandard_protoc" if ctx.attr.fail_on_mismatch else ""
-            ),
-            mismatch_exit_code = 1 if ctx.attr.fail_on_mismatch else 0,
-            severity = "ERROR" if ctx.attr.fail_on_mismatch else "INFO",
-        ),
+        inputs = [script],
+        executable = executable,
+        arguments = arguments,
+        use_default_shell_env = True,
+        toolchain = None,
     )
     return [OutputGroupInfo(_validation = depset([validation_output]))]
 
@@ -56,6 +180,10 @@ protoc_authenticity = rule(
         "fail_on_mismatch": attr.bool(
             default = True,
             doc = "If true, the build will fail when the protoc binary does not match the expected version.",
+        ),
+        "_exec_is_windows": attr.label(
+            default = ":is_windows",
+            cfg = "exec",
         ),
     } | toolchains.if_legacy_toolchain({
         "_proto_compiler": attr.label(

--- a/bazel/tests/BUILD
+++ b/bazel/tests/BUILD
@@ -6,6 +6,7 @@ load(":bazel_proto_library_tests.bzl", "bazel_proto_library_test_suite")
 load(":cc_proto_library_tests.bzl", "cc_proto_library_test_suite")
 load(":cc_toolchain_tests.bzl", "cc_toolchain_test_suite")
 load(":java_proto_library_tests.bzl", "java_proto_library_test_suite")
+load(":protoc_authenticity_tests.bzl", "protoc_authenticity_test_suite")
 load(":proto_bzl_test_suite_tests.bzl", "proto_bzl_test_suite_tests")
 load(":proto_common_check_collocated_tests.bzl", "proto_common_check_collocated_test_suite")
 load(":proto_common_compile_tests.bzl", "proto_common_compile_test_suite")
@@ -29,6 +30,8 @@ cc_toolchain_test_suite(name = "cc_toolchain_test_suite")
 java_proto_library_test_suite(name = "java_proto_library_test_suite")
 
 cc_proto_library_test_suite(name = "cc_proto_library_tests")
+
+protoc_authenticity_test_suite(name = "protoc_authenticity_tests")
 
 proto_bzl_test_suite_tests(name = "proto_bzl_test_suite")
 

--- a/bazel/tests/protoc_authenticity_tests.bzl
+++ b/bazel/tests/protoc_authenticity_tests.bzl
@@ -1,0 +1,33 @@
+"""Tests for protoc authenticity validation actions."""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load("@rules_testing//lib:truth.bzl", "matching")
+
+def protoc_authenticity_test_suite(name):
+    test_suite(
+        name = name,
+        tests = [
+            _test_authenticity_action_uses_generated_script,
+        ],
+    )
+
+def _test_authenticity_action_uses_generated_script(name):
+    analysis_test(
+        name = name,
+        target = "//bazel/private/oss/toolchains/prebuilt:authenticity_validation",
+        impl = _test_authenticity_action_uses_generated_script_impl,
+    )
+
+def _test_authenticity_action_uses_generated_script_impl(env, target):
+    action = env.expect.that_target(target).action_generating(
+        "bazel/private/oss/toolchains/prebuilt/validation_output.txt",
+    )
+    action.mnemonic().equals("ProtocAuthenticityCheck")
+    action.argv().contains_predicate(
+        matching.str_matches("*authenticity_validation_authenticity_check.sh"),
+    )
+
+    script_action = env.expect.that_target(target).action_generating(
+        "bazel/private/oss/toolchains/prebuilt/authenticity_validation_authenticity_check.sh",
+    )
+    script_action.content().contains("grep -q")


### PR DESCRIPTION
Fixes #27307

## Summary
- replace the protoc authenticity `run_shell` action with a generated script executed via `ctx.actions.run`
- use a Windows `.bat` script through `cmd.exe` on Windows execution platforms, while keeping the existing Bash validation flow on other platforms
- add an analysis test covering the generated-script validation action

## Tests
- `python3` syntax compile for the changed Starlark/BUILD files
- `git diff --check`

Not run locally:
- `bazel test //bazel/tests:protoc_authenticity_tests` (`bazel` is not installed here)
- `bazelisk test //bazel/tests:protoc_authenticity_tests` (`bazelisk` is not installed here)
- `buildifier -mode=check ...` (`buildifier` is not installed here)