### PR TITLE
Fix Ruby repeated enum const getter for unset fields

### DIFF
--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -401,6 +401,9 @@ static VALUE Message_field_accessor(VALUE _self, const upb_FieldDef* f,
       if (upb_FieldDef_IsRepeated(f)) {
         // Map repeated fields to a new type with ints
         VALUE arr = rb_ary_new();
+        if (msgval.array_val == NULL) {
+          return arr;
+        }
         size_t i, n = upb_Array_Size(msgval.array_val);
         for (i = 0; i < n; i++) {
           upb_MessageValue elem = upb_Array_Get(msgval.array_val, i);

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -783,6 +783,10 @@ module CommonTests
     assert_equal [:A, :C], m.repeated_enum
     assert_equal [1, 3], m.repeated_enum_const
     assert_equal [proto_module::TestEnum::A, proto_module::TestEnum::C], m.repeated_enum_const
+
+    m = proto_module::Enumer.new
+    assert_equal [], m.repeated_enum_const
+    assert_equal [], proto_module::Enumer.decode("".b).repeated_enum_const
   end
 
   def test_enum_getter_oneof


### PR DESCRIPTION
This fixes the Ruby native extension's repeated enum `_const` accessor when the field is unset.

`METHOD_ENUM_GETTER` creates a Ruby array for repeated enum helpers, but it called `upb_Array_Size(msgval.array_val)` even when the repeated field was absent. In that case `upb_Message_GetFieldByDef()` returns a null array pointer.

The fix returns the newly-created empty Ruby array when `msgval.array_val` is null. Regression coverage checks both constructed and wire-decoded unset repeated enum messages.

Validation:

- `ruby -Ilib -Itests tests/basic.rb --name=test_enum_getter`
- GitHub CI is passing for the Ruby matrix and blocking checks.

`rake test` was also run locally; it built and ran the Ruby suite but reported one baseline-reproduced failure in `RepeatedFieldTest#test_sort_by!`, outside this enum getter path.