### PR TITLE
Fix signed integer overflow in packed fixed-size field accumulation

### DIFF
--- a/src/google/protobuf/generated_message_tctable_lite_test.cc
+++ b/src/google/protobuf/generated_message_tctable_lite_test.cc
@@ -990,7 +990,24 @@ TEST(GeneratedMessageTctableLiteTest,
   EXPECT_LE(proto.vals().Capacity(), 2048);
 }
 
+TEST(GeneratedMessageTctableLiteTest, PackedFixed32LargeSize) {
+  uint8_t serialize_buffer[64];
+  uint8_t* serialize_ptr = serialize_buffer;
+  serialize_ptr = WireFormatLite::WriteTagToArray(
+      96, WireFormatLite::WIRETYPE_LENGTH_DELIMITED, serialize_ptr);
+  uint32_t claimed_length =
+      (static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) / 4) * 4;
+  serialize_ptr =
+      WireFormatLite::WriteUInt32NoTagToArray(claimed_length, serialize_ptr);
 
+  absl::string_view serialized{
+      reinterpret_cast<char*>(&serialize_buffer[0]),
+      static_cast<size_t>(serialize_ptr - serialize_buffer)};
+
+  proto2_unittest::TestPackedTypes proto;
+  proto.add_packed_fixed32(42);
+  EXPECT_FALSE(proto.MergeFromString(serialized));
+}
 
 }  // namespace internal
 }  // namespace protobuf

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -1526,6 +1526,10 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   while (size > nbytes) {
     int num = nbytes / sizeof(T);
     int old_entries = out->size();
+    if (ABSL_PREDICT_FALSE(num >
+                           std::numeric_limits<int>::max() - old_entries)) {
+      return nullptr;
+    }
     out->ReserveWithArena(arena, old_entries + num);
     int block_size = num * sizeof(T);
     auto dst = out->AddNAlreadyReserved(num);
@@ -1546,6 +1550,10 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   int block_size = num * sizeof(T);
   if (num == 0) return size == block_size ? ptr : nullptr;
   int old_entries = out->size();
+  if (ABSL_PREDICT_FALSE(num >
+                         std::numeric_limits<int>::max() - old_entries)) {
+    return nullptr;
+  }
   out->ReserveWithArena(arena, old_entries + num);
   auto dst = out->AddNAlreadyReserved(num);
 #ifdef ABSL_IS_LITTLE_ENDIAN

--- a/src/google/protobuf/wire_format_lite.h
+++ b/src/google/protobuf/wire_format_lite.h
@@ -1142,6 +1142,10 @@ inline bool WireFormatLite::ReadPackedFixedSizePrimitive(
     bytes_limit =
         (std::min)(bytes_limit, static_cast<int64_t>(input->BytesUntilLimit()));
   }
+  if (ABSL_PREDICT_FALSE(new_entries >
+                         std::numeric_limits<int>::max() - old_entries)) {
+    return false;
+  }
   if (bytes_limit >= new_bytes) {
     // Fast-path that pre-allocates *values to the final size.
 #if defined(ABSL_IS_LITTLE_ENDIAN)

--- a/src/google/protobuf/wire_format_unittest.cc
+++ b/src/google/protobuf/wire_format_unittest.cc
@@ -13,11 +13,13 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <string>
 
 #include "absl/base/casts.h"
 #include "absl/strings/cord.h"
 #include "absl/strings/string_view.h"
+#include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/repeated_ptr_field.h"
 #include "google/protobuf/unittest.pb.h"
 #include "google/protobuf/unittest_import.pb.h"
@@ -218,6 +220,92 @@ TEST(WireFormatTest, CppTypeForWorksForAllSupportedTypes) {
             WFL::CPPTYPE_MESSAGE);
 }
 
+TEST(WireFormatLiteTest, ReadPackedFixed32) {
+  uint8_t buffer[64];
+  uint8_t* ptr = buffer;
+  *ptr++ = 12;  // varint: 3 * sizeof(uint32_t)
+  ptr = WireFormatLite::WriteFixed32NoTagToArray(1, ptr);
+  ptr = WireFormatLite::WriteFixed32NoTagToArray(2, ptr);
+  ptr = WireFormatLite::WriteFixed32NoTagToArray(3, ptr);
+
+  io::CodedInputStream input(buffer, static_cast<int>(ptr - buffer));
+  RepeatedField<uint32_t> result;
+  EXPECT_TRUE(
+      (WireFormatLite::ReadPackedPrimitive<uint32_t,
+                                           WireFormatLite::TYPE_FIXED32>(
+          &input, &result)));
+  ASSERT_EQ(result.size(), 3);
+  EXPECT_EQ(result.Get(0), 1u);
+  EXPECT_EQ(result.Get(1), 2u);
+  EXPECT_EQ(result.Get(2), 3u);
+}
+
+TEST(WireFormatLiteTest, ReadPackedFixed64) {
+  uint8_t buffer[64];
+  uint8_t* ptr = buffer;
+  *ptr++ = 16;  // varint: 2 * sizeof(uint64_t)
+  ptr = WireFormatLite::WriteFixed64NoTagToArray(100, ptr);
+  ptr = WireFormatLite::WriteFixed64NoTagToArray(200, ptr);
+
+  io::CodedInputStream input(buffer, static_cast<int>(ptr - buffer));
+  RepeatedField<uint64_t> result;
+  EXPECT_TRUE(
+      (WireFormatLite::ReadPackedPrimitive<uint64_t,
+                                           WireFormatLite::TYPE_FIXED64>(
+          &input, &result)));
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_EQ(result.Get(0), 100u);
+  EXPECT_EQ(result.Get(1), 200u);
+}
+
+TEST(WireFormatLiteTest, ReadPackedFixed32RejectsUnalignedLength) {
+  uint8_t buffer[6];
+  buffer[0] = 5;  // not a multiple of sizeof(uint32_t)
+  std::memset(buffer + 1, 0, 5);
+
+  io::CodedInputStream input(buffer, sizeof(buffer));
+  RepeatedField<uint32_t> result;
+  EXPECT_FALSE(
+      (WireFormatLite::ReadPackedPrimitive<uint32_t,
+                                           WireFormatLite::TYPE_FIXED32>(
+          &input, &result)));
+}
+
+TEST(WireFormatLiteTest, ReadPackedFixed32Accumulates) {
+  uint8_t buf1[64];
+  uint8_t* p1 = buf1;
+  *p1++ = 8;  // 2 fixed32s
+  p1 = WireFormatLite::WriteFixed32NoTagToArray(10, p1);
+  p1 = WireFormatLite::WriteFixed32NoTagToArray(20, p1);
+
+  uint8_t buf2[64];
+  uint8_t* p2 = buf2;
+  *p2++ = 12;  // 3 fixed32s
+  p2 = WireFormatLite::WriteFixed32NoTagToArray(30, p2);
+  p2 = WireFormatLite::WriteFixed32NoTagToArray(40, p2);
+  p2 = WireFormatLite::WriteFixed32NoTagToArray(50, p2);
+
+  RepeatedField<uint32_t> result;
+
+  io::CodedInputStream input1(buf1, static_cast<int>(p1 - buf1));
+  EXPECT_TRUE(
+      (WireFormatLite::ReadPackedPrimitive<uint32_t,
+                                           WireFormatLite::TYPE_FIXED32>(
+          &input1, &result)));
+
+  io::CodedInputStream input2(buf2, static_cast<int>(p2 - buf2));
+  EXPECT_TRUE(
+      (WireFormatLite::ReadPackedPrimitive<uint32_t,
+                                           WireFormatLite::TYPE_FIXED32>(
+          &input2, &result)));
+
+  ASSERT_EQ(result.size(), 5);
+  EXPECT_EQ(result.Get(0), 10u);
+  EXPECT_EQ(result.Get(1), 20u);
+  EXPECT_EQ(result.Get(2), 30u);
+  EXPECT_EQ(result.Get(3), 40u);
+  EXPECT_EQ(result.Get(4), 50u);
+}
 
 }  // namespace
 }  // namespace internal


### PR DESCRIPTION
old_entries + new_entries is computed as signed int with no overflow guard in ReadPackedFixedSizePrimitive (wire_format_lite.h) and ReadPackedFixed (parse_context.h). On overflow the sum wraps to INT_MIN; resize/Reserve becomes a no-op and ReadRaw/memcpy writes past the heap allocation.

Add new_entries > INT_MAX - old_entries guards at each accumulation site. Returns false/nullptr on overflow; no behavior change for valid inputs. parse_context.h also addressed in #27611; wire_format_lite.h is not covered there.

## Summary

`WireFormatLite::ReadPackedFixedSizePrimitive` (`wire_format_lite.h`)
and `EpsCopyInputStream::ReadPackedFixed` (`parse_context.h`) compute
`old_entries + new_entries` as a signed `int` without overflow protection.
After accumulating ~2.1 B entries across repeated `MergeFrom` calls, the
next parse triggers signed overflow → `resize(INT_MIN)` silently truncates
`current_size_` without reallocating, and `ReadRaw`/`memcpy` writes
attacker-controlled bytes past the heap allocation.

Note: `parse_context.h` is also addressed by #27611. This PR adds the
missing guard to `wire_format_lite.h` (`ReadPackedFixedSizePrimitive`),
which #27611 does not cover.

## Fix

```cpp
if (ABSL_PREDICT_FALSE(new_entries >
                       std::numeric_limits<int>::max() - old_entries)) {
  return false;   // wire_format_lite.h
  // return nullptr; // parse_context.h
}

Affected types

TYPE_FLOAT, TYPE_DOUBLE, TYPE_FIXED32, TYPE_SFIXED32, TYPE_FIXED64, TYPE_SFIXED64