### PR TITLE
fix(php): fix whitespace and null case formatting

### DIFF
--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -1482,7 +1482,7 @@ bool GenerateMessageFile(const FileDescriptor* file, const Descriptor* message,
   printer.Print("\n");
 
   GenerateMessageConstructorDocComment(&printer, message, options);
-  printer->Print("public function __construct($data = null)\n{\n");
+  printer.Print("public function __construct($data = null)\n{\n");
   Indent(&printer);
 
   std::string metadata_filename = GeneratedMetadataFileName(file, options);

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -890,7 +890,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, const Options& options,
         "public function set^camel_name^Unwrapped($var)\n"
         "{\n"
         "    $this->writeWrapperValue(\"^field_name^\", $var);\n"
-        "    return $this;"
+        "    return $this;\n"
         "}\n\n",
         "camel_name", UnderscoresToCamelCase(field->name(), true), "field_name",
         field->name());
@@ -1482,7 +1482,7 @@ bool GenerateMessageFile(const FileDescriptor* file, const Descriptor* message,
   printer.Print("\n");
 
   GenerateMessageConstructorDocComment(&printer, message, options);
-  printer.Print("public function __construct($data = NULL) {\n");
+  printer->Print("public function __construct($data = null)\n{\n");
   Indent(&printer);
 
   std::string metadata_filename = GeneratedMetadataFileName(file, options);


### PR DESCRIPTION
fixes #27735 

 - use `null` instead of `NULL` in constructor declaration
 - newline after constructor function declaration
 - newline after oneOf setter

TODO:
 - [ ] Fix unnecessary use of doublequotes in accessing oneof