### PR TITLE
Harden UntypedMapBase::UntypedMergeFrom against self-merge

### DIFF
--- a/src/google/protobuf/map.cc
+++ b/src/google/protobuf/map.cc
@@ -17,6 +17,7 @@
 #include "absl/base/optimization.h"
 #include "absl/functional/overload.h"
 #include "absl/log/absl_check.h"
+#include "absl/log/absl_log.h"
 #include "google/protobuf/arena.h"
 #include "google/protobuf/field_with_arena.h"
 #include "google/protobuf/message_lite.h"
@@ -38,6 +39,14 @@ NodeBase* const kGlobalEmptyTable[kGlobalEmptyTableSize] = {};
 void UntypedMapBase::UntypedMergeFrom(Arena* arena,
                                       const UntypedMapBase& other) {
   ABSL_DCHECK_EQ(arena, this->arena());
+  if (ABSL_PREDICT_FALSE(&other == this)) {
+    // Merging a map with itself inserts into the table while iterating it
+    // below (InsertOrReplaceNode rehashes/replaces the nodes the iterator is
+    // walking), a use-after-free. Self-merge is undefined; terminate loudly,
+    // mirroring RepeatedField::MergeFrom (internal::LogSelfMergeAndAbort).
+    ABSL_LOG(FATAL) << "UntypedMergeFrom called with self-reference; "
+                       "merging a map with itself is undefined behavior.";
+  }
   if (other.empty()) return;
 
   // Do the merging in steps to avoid Key*Value number of instantiations and

--- a/src/google/protobuf/map_field_test.cc
+++ b/src/google/protobuf/map_field_test.cc
@@ -320,6 +320,18 @@ TEST_P(MapFieldStateTest, MergeFromRepeatedDirty) {
   Expect(other.get(), CLEAN, 1, 1);
 }
 
+#if GTEST_HAS_DEATH_TEST
+TEST_P(MapFieldStateTest, MergeFromSelfTerminates) {
+  // The two-arg (reflection) MapFieldBase::MergeFrom routes to
+  // UntypedMapBase::UntypedMergeFrom, where a self-merge inserts into the table
+  // while iterating that same table (InsertOrReplaceNode rehashes/replaces the
+  // nodes the iterator is walking), a use-after-free. Self-merge is undefined
+  // and is now a well-defined termination, mirroring RepeatedField::MergeFrom.
+  EXPECT_DEATH(map_field_base_->MergeFrom(arena_.get(), *map_field_base_),
+               "self-reference");
+}
+#endif  // GTEST_HAS_DEATH_TEST
+
 TEST_P(MapFieldStateTest, SwapClean) {
   ArenaHolder<MapFieldType> other(arena_.get());
   AddOneStillClean(other.get());


### PR DESCRIPTION
## What
`UntypedMapBase::UntypedMergeFrom` allocates and inserts the merged nodes into the table while iterating that same table. When called with `&other == this` (self-merge), `InsertOrReplaceNode` rehashes/replaces the very nodes the `other.begin()..End()` iterator is still walking, so subsequent iterator steps read freed memory — a use-after-free.

This detects `&other == this` at the top of `UntypedMergeFrom` and terminates with `ABSL_LOG(FATAL)`, giving self-merge a well-defined termination, mirroring `RepeatedField::MergeFrom` (`internal::LogSelfMergeAndAbort`).

## Reachability (defense-in-depth, not externally reachable)
To be clear about scope: I could **not** find a public / untrusted-input path that reaches `UntypedMergeFrom` with `&other == this`. Every public message-merge entry already prevents it:

- **Typed generated merge** (`Message::MergeFrom` fast path): the generated map-field merge calls the one-arg `TypeDefinedMapFieldBase::MergeFrom` -> `internal::MapMergeFrom`, an element-wise per-key copy (`dest[k] = v`). For self-merge it overwrites already-present keys with no rehash — benign, and it never calls `UntypedMergeFrom`.
- **Reflection merge**: `ReflectionOps::Merge` guards `ABSL_CHECK_NE(&from, to)` before any field is touched.

`UntypedMergeFrom(self)` is therefore only reachable by calling the internal two-arg `MapFieldBase::MergeFrom` directly with the same field. This PR hardens that internal invariant (the map sibling of the `RepeatedField::MergeFrom` guard) rather than fixing an externally-triggerable bug.

## Test
`MapFieldStateTest.MergeFromSelfTerminates` drives the internal reflection merge path (`MapFieldBase::MergeFrom` -> `UntypedMergeFrom`) that actually reaches the guard, and asserts termination. (The earlier revision tested `message.MergeFrom(message)`, which takes the benign element-wise path and never reaches this code — corrected here.)
