### PR TITLE
Limit inherited secrets in test workflows

### DIFF
--- a/.github/workflows/staleness_check.yml
+++ b/.github/workflows/staleness_check.yml
@@ -15,6 +15,9 @@ on:
         required: false
         description: "The SHA key for the commit we want to run over"
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test_bazel.yml
+++ b/.github/workflows/test_bazel.yml
@@ -16,6 +16,9 @@ on:
         required: true
         description: "The string continuous-only tests should be prefixed with when displaying test results."
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -17,6 +17,9 @@ on:
         description: "The string continuous-only tests should be prefixed with when displaying test
           results."
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 
 permissions:

--- a/.github/workflows/test_csharp.yml
+++ b/.github/workflows/test_csharp.yml
@@ -7,6 +7,9 @@ on:
         required: true
         description: "The SHA key for the commit we want to run over"
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/test_hpb.yml
+++ b/.github/workflows/test_hpb.yml
@@ -7,6 +7,9 @@ on:
         required: true
         description: "The SHA key for the commit we want to run over"
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/test_java.yml
+++ b/.github/workflows/test_java.yml
@@ -17,6 +17,9 @@ on:
         description: "The string continuous-only tests should be prefixed with when displaying test
           results."
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 
 permissions:

--- a/.github/workflows/test_objectivec.yml
+++ b/.github/workflows/test_objectivec.yml
@@ -17,6 +17,9 @@ on:
         description: "The string continuous-only tests should be prefixed with when displaying test
           results."
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 
 permissions:

--- a/.github/workflows/test_php.yml
+++ b/.github/workflows/test_php.yml
@@ -18,6 +18,9 @@ on:
         description: "The string continuous-only tests should be prefixed with when displaying test
           results."
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 
 permissions:

--- a/.github/workflows/test_php_ext.yml
+++ b/.github/workflows/test_php_ext.yml
@@ -17,6 +17,9 @@ on:
         description: "The string continuous-only tests should be prefixed with when displaying test
           results."
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 
 permissions:

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -17,6 +17,9 @@ on:
         description: "The string continuous-only tests should be prefixed with when displaying test
           results."
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 
 permissions:

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -17,6 +17,9 @@ on:
         description: "The string continuous-only tests should be prefixed with when displaying test
           results."
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 
 permissions:

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -138,7 +138,8 @@ jobs:
       continuous-run: ${{ needs.set-vars.outputs.continuous-run }}
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
       continuous-prefix: ${{ needs.set-vars.outputs.continuous-prefix }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   cpp:
     name: C++
@@ -148,7 +149,8 @@ jobs:
       continuous-run: ${{ needs.set-vars.outputs.continuous-run }}
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
       continuous-prefix: ${{ needs.set-vars.outputs.continuous-prefix }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   java:
     name: Java
@@ -158,7 +160,8 @@ jobs:
       continuous-run: ${{ needs.set-vars.outputs.continuous-run }}
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
       continuous-prefix: ${{ needs.set-vars.outputs.continuous-prefix }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   python:
     name: Python
@@ -168,7 +171,8 @@ jobs:
       continuous-run: ${{ needs.set-vars.outputs.continuous-run }}
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
       continuous-prefix: ${{ needs.set-vars.outputs.continuous-prefix }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   ruby:
     name: Ruby
@@ -178,7 +182,8 @@ jobs:
       continuous-run: ${{ needs.set-vars.outputs.continuous-run }}
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
       continuous-prefix: ${{ needs.set-vars.outputs.continuous-prefix }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   php:
     name: PHP
@@ -188,7 +193,8 @@ jobs:
       continuous-run: ${{ needs.set-vars.outputs.continuous-run }}
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
       continuous-prefix: ${{ needs.set-vars.outputs.continuous-prefix }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   php-ext:
     name: PHP Extension
@@ -198,7 +204,8 @@ jobs:
       continuous-run: ${{ needs.set-vars.outputs.continuous-run }}
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
       continuous-prefix: ${{ needs.set-vars.outputs.continuous-prefix }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   csharp:
     name: C#
@@ -206,7 +213,8 @@ jobs:
     uses: ./.github/workflows/test_csharp.yml
     with:
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   objectivec:
     name: Objective-C
@@ -216,7 +224,8 @@ jobs:
       continuous-run: ${{ needs.set-vars.outputs.continuous-run }}
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
       continuous-prefix: ${{ needs.set-vars.outputs.continuous-prefix }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   rust:
     name: Rust
@@ -224,7 +233,8 @@ jobs:
     uses: ./.github/workflows/test_rust.yml
     with:
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   upb:
     name: μpb
@@ -234,7 +244,8 @@ jobs:
       continuous-run: ${{ needs.set-vars.outputs.continuous-run }}
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
       continuous-prefix: ${{ needs.set-vars.outputs.continuous-prefix }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   hpb:
     name: hpb
@@ -242,7 +253,8 @@ jobs:
     uses: ./.github/workflows/test_hpb.yml
     with:
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   staleness:
     name: Staleness
@@ -253,7 +265,8 @@ jobs:
     with:
       continuous-run: ${{ needs.set-vars.outputs.continuous-run }}
       safe-checkout: ${{ needs.set-vars.outputs.checkout-sha }}
-    secrets: inherit
+    secrets:
+      GAR_SERVICE_ACCOUNT: ${{ secrets.GAR_SERVICE_ACCOUNT }}
 
   # This test depends on all blocking tests and indicates whether they all suceeded.
   all-blocking-tests:

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -7,6 +7,9 @@ on:
         required: true
         description: "The SHA key for the commit we want to run over"
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/test_upb.yml
+++ b/.github/workflows/test_upb.yml
@@ -17,6 +17,9 @@ on:
         description: "The string continuous-only tests should be prefixed with when displaying test
           results."
         type: string
+    secrets:
+      GAR_SERVICE_ACCOUNT:
+        required: true
 
 
 permissions:


### PR DESCRIPTION
Summary:
- replace blanket `secrets: inherit` in the test workflow fanout with an explicit `GAR_SERVICE_ACCOUNT` mapping
- declare `GAR_SERVICE_ACCOUNT` on the reusable test workflows that consume it
- leave the existing fork-PR approval flow and safe-checkout behavior unchanged

Security rationale:
The test runner can execute approved fork PR code after a protobuf team member applies the safe-for-tests label. These reusable test workflows only reference `GAR_SERVICE_ACCOUNT`, so passing every parent workflow secret increases the blast radius unnecessarily. Passing only the required GAR credential keeps the existing approval model while reducing secret exposure.

Validation:
- `python3 .github/scripts/validate_yaml.py`
- `git diff --check`
- targeted Zizmor scan over the touched workflows: `secrets-inherit: 0`, `template-injection: 0`; the remaining `dangerous-triggers` result is the existing intentional `pull_request_target` trigger.