### PR TITLE
Break protobuf dependency on Bazel's proto fragment. Only respect the…

### DIFF
--- a/bazel/flags/flags.bzl
+++ b/bazel/flags/flags.bzl
@@ -36,16 +36,16 @@ _FLAGS = {
         default = [".pb.cc"],
     ),
     "proto_toolchain_for_java": struct(
-        native = lambda ctx: getattr(ctx.attr, "_aspect_java_proto_toolchain"),
-        default = "@bazel_tools//tools/proto:java_toolchain",
+        native = lambda ctx: "//:java_toolchain",
+        default = "//:java_toolchain",
     ),
     "proto_toolchain_for_javalite": struct(
-        native = lambda ctx: getattr(ctx.attr, "_aspect_proto_toolchain_for_javalite"),
-        default = "@bazel_tools//tools/proto:javalite_toolchain",
+        native = lambda ctx: "//:javalite_toolchain",
+        default = "//:javalite_toolchain",
     ),
     "proto_toolchain_for_cc": struct(
-        native = lambda ctx: getattr(ctx.attr, "_aspect_cc_proto_toolchain"),
-        default = "@bazel_tools//tools/proto:cc_toolchain",
+        native = lambda ctx: "//:cc_toolchain",
+        default = "//:cc_toolchain",
     ),
 }
 

--- a/bazel/private/java_lite_proto_library.bzl
+++ b/bazel/private/java_lite_proto_library.bzl
@@ -13,8 +13,6 @@ load("//bazel/common:proto_info.bzl", "ProtoInfo")
 load("//bazel/private:java_proto_support.bzl", "JavaProtoAspectInfo", "java_compile_for_protos", "java_info_merge_for_protos")
 load("//bazel/private:toolchain_helpers.bzl", "toolchains")
 
-_PROTO_TOOLCHAIN_ATTR = "_aspect_proto_toolchain_for_javalite"
-
 _JAVA_LITE_PROTO_TOOLCHAIN = Label("//bazel/private:javalite_toolchain_type")
 
 def _aspect_impl(target, ctx):
@@ -71,9 +69,6 @@ _java_lite_proto_aspect = aspect(
     implementation = _aspect_impl,
     attr_aspects = ["deps", "exports"],
     attrs = toolchains.if_legacy_toolchain({
-        _PROTO_TOOLCHAIN_ATTR: attr.label(
-            default = configuration_field(fragment = "proto", name = "proto_toolchain_for_java_lite"),
-        ),
         "_proto_toolchain_for_javalite": attr.label(
             default = Label("//bazel/flags/java:proto_toolchain_for_javalite"),
         ),
@@ -167,9 +162,6 @@ The list of <a href="protocol-buffer.html#proto_library"><code>proto_library</co
 rules to generate Java code for.
 """),
     } | toolchains.if_legacy_toolchain({
-        _PROTO_TOOLCHAIN_ATTR: attr.label(
-            default = configuration_field(fragment = "proto", name = "proto_toolchain_for_java_lite"),
-        ),
         "_proto_toolchain_for_javalite": attr.label(
             default = Label("//bazel/flags/java:proto_toolchain_for_javalite"),
         ),

--- a/bazel/private/java_proto_library.bzl
+++ b/bazel/private/java_proto_library.bzl
@@ -37,7 +37,7 @@ def _java_proto_aspect_impl(target, ctx):
       runtime jars.
     """
     _proto_library = ctx.rule.attr
-    proto_toolchain_info = toolchains.find_toolchain(ctx, "proto_toolchain_for_java", _JAVA_PROTO_TOOLCHAIN)
+    proto_toolchain_info = toolchains.find_toolchain(ctx, "aspect_java_proto_toolchain", _JAVA_PROTO_TOOLCHAIN)
     source_jar = None
     if proto_common.experimental_should_generate_code(target[ProtoInfo], proto_toolchain_info, "java_proto_library", target.label):
         # Generate source jar using proto compiler.
@@ -74,9 +74,6 @@ java_proto_aspect = aspect(
     attrs = (
         toolchains.if_legacy_toolchain({
             "_aspect_java_proto_toolchain": attr.label(
-                default = configuration_field(fragment = "proto", name = "proto_toolchain_for_java"),
-            ),
-            "_proto_toolchain_for_java": attr.label(
                 default = "//bazel/flags/java:proto_toolchain_for_java",
             ),
         })
@@ -99,7 +96,7 @@ def _java_proto_library_rule_impl(ctx):
     Returns:
       ([JavaInfo, DefaultInfo, OutputGroupInfo])
     """
-    proto_toolchain = toolchains.find_toolchain(ctx, "proto_toolchain_for_java", _JAVA_PROTO_TOOLCHAIN)
+    proto_toolchain = toolchains.find_toolchain(ctx, "aspect_java_proto_toolchain", _JAVA_PROTO_TOOLCHAIN)
     for dep in ctx.attr.deps:
         proto_common.check_collocated(ctx.label, dep[ProtoInfo], proto_toolchain)
 
@@ -164,9 +161,6 @@ rules to generate Java code for.
         "licenses": attr.license() if hasattr(attr, "license") else attr.string_list(),
     } | toolchains.if_legacy_toolchain({
         "_aspect_java_proto_toolchain": attr.label(
-            default = configuration_field(fragment = "proto", name = "proto_toolchain_for_java"),
-        ),
-        "_proto_toolchain_for_java": attr.label(
             default = "//bazel/flags/java:proto_toolchain_for_java",
         ),
     }),  # buildifier: disable=attr-licenses (attribute called licenses)

--- a/bazel/private/oss/cc_proto_library.bzl
+++ b/bazel/private/oss/cc_proto_library.bzl
@@ -125,9 +125,6 @@ cc_proto_aspect = aspect(
                 ),
             } |
             toolchains.if_legacy_toolchain({
-                "_aspect_cc_proto_toolchain": attr.label(
-                    default = configuration_field(fragment = "proto", name = "proto_toolchain_for_cc"),
-                ),
                 "_proto_toolchain_for_cc": attr.label(
                     default = Label("//bazel/flags/cc:proto_toolchain_for_cc"),
                 ),
@@ -196,9 +193,6 @@ The list of <a href="protocol-buffer.html#proto_library"><code>proto_library</co
 rules to generate C++ code for.""",
         ),
     } | toolchains.if_legacy_toolchain({
-        "_aspect_cc_proto_toolchain": attr.label(
-            default = configuration_field(fragment = "proto", name = "proto_toolchain_for_cc"),
-        ),
         "_proto_toolchain_for_cc": attr.label(
             default = "//bazel/flags/cc:proto_toolchain_for_cc",
         ),

--- a/bazel/private/proto_lang_toolchain_rule.bzl
+++ b/bazel/private/proto_lang_toolchain_rule.bzl
@@ -157,7 +157,7 @@ Deprecated. Alias for <code>denylisted_protos</code>. Will be removed in a futur
             cfg = "exec",
             executable = True,
             allow_files = True,
-            default = configuration_field("proto", "proto_compiler"),
+            default = "//bazel/flags:proto_compiler",
         ),
     }),
     provides = [ProtoLangToolchainInfo],


### PR DESCRIPTION
… Starlark versions of --proto_toolchain_for*. This is a breaking change from 35.0, but matches the behavior in 34.x.

PiperOrigin-RevId: 926738235