### PR TITLE
Fix null-dst memcpy UB in ReadPackedFixed while-loop body when nbytes < sizeof(T)

### DIFF
--- a/src/google/protobuf/lite_unittest.cc
+++ b/src/google/protobuf/lite_unittest.cc
@@ -1478,6 +1478,75 @@ TEST(LiteTest, FileWithOnlyAnEnumGeneratesProperValidationHooks) {
   EXPECT_FALSE(internal::ValidateEnum(6, data));
 }
 
+
+// Test that malformed packed fixed-width fields (where the declared payload
+// length is not a multiple of sizeof(T)) are rejected gracefully rather than
+// triggering undefined behavior (null-dst memcpy). This is a regression test
+// for a bug where ReadPackedFixed<T> would call AddNAlreadyReserved(0) on an
+// uninitialized RepeatedField, get a null pointer, and pass it to memcpy.
+TEST(LiteTest, TruncatedPackedFixedFieldParsing) {
+  // Construct a serialized TestPackedTypesLite where the packed_float field
+  // (field 100) has a declared length of 1 byte, which is less than
+  // sizeof(float)=4.  This triggers the ReadPackedFixed<float> path with
+  // size=1, which previously caused a null-dst memcpy UB.
+  //
+  // Wire format:
+  //   tag for field 100, wire type 2 (length-delimited): 0xA2 0x06
+  //   length varint: 0x01
+  //   payload: 0x00 (1 byte, less than sizeof(float))
+  const std::string malformed_packed_float =
+      std::string("\xA2\x06\x01\x00", 4);
+  proto2_unittest::TestPackedTypesLite m;
+  EXPECT_FALSE(m.ParseFromString(malformed_packed_float));
+  // The message should remain clear after a failed parse.
+  EXPECT_EQ(m.packed_float_size(), 0);
+
+  // Same test for packed_double (field 101, sizeof(double)=8) with 1-byte
+  // payload.
+  //   tag for field 101, wire type 2: 0xAA 0x06
+  //   length varint: 0x01
+  //   payload: 0x00
+  const std::string malformed_packed_double =
+      std::string("\xAA\x06\x01\x00", 4);
+  m.Clear();
+  EXPECT_FALSE(m.ParseFromString(malformed_packed_double));
+  EXPECT_EQ(m.packed_double_size(), 0);
+
+  // Same test for packed_fixed32 (field 96, sizeof(uint32_t)=4) with 1-byte
+  // payload.
+  //   tag for field 96, wire type 2: 0x82 0x06
+  //   length varint: 0x01
+  //   payload: 0x00
+  const std::string malformed_packed_fixed32 =
+      std::string("\x82\x06\x01\x00", 4);
+  m.Clear();
+  EXPECT_FALSE(m.ParseFromString(malformed_packed_fixed32));
+  EXPECT_EQ(m.packed_fixed32_size(), 0);
+
+  // Same test for packed_fixed64 (field 97, sizeof(uint64_t)=8) with 1-byte
+  // payload.
+  //   tag for field 97, wire type 2: 0x8A 0x06
+  //   length varint: 0x01
+  //   payload: 0x00
+  const std::string malformed_packed_fixed64 =
+      std::string("\x8A\x06\x01\x00", 4);
+  m.Clear();
+  EXPECT_FALSE(m.ParseFromString(malformed_packed_fixed64));
+  EXPECT_EQ(m.packed_fixed64_size(), 0);
+
+  // Verify that well-formed packed data still parses correctly.
+  // packed_float (field 100) with exactly one float (4 bytes).
+  //   tag: 0xA2 0x06
+  //   length: 0x04
+  //   payload: 4 bytes representing 0.0f
+  const std::string valid_packed_float =
+      std::string("\xA2\x06\x04\x00\x00\x00\x00", 7);
+  m.Clear();
+  EXPECT_TRUE(m.ParseFromString(valid_packed_float));
+  EXPECT_EQ(m.packed_float_size(), 1);
+  EXPECT_FLOAT_EQ(m.packed_float(0), 0.0f);
+}
+
 }  // namespace
 }  // namespace protobuf
 }  // namespace google

--- a/src/google/protobuf/lite_unittest.cc
+++ b/src/google/protobuf/lite_unittest.cc
@@ -1479,72 +1479,21 @@ TEST(LiteTest, FileWithOnlyAnEnumGeneratesProperValidationHooks) {
 }
 
 
-// Test that malformed packed fixed-width fields (where the declared payload
-// length is not a multiple of sizeof(T)) are rejected gracefully rather than
-// triggering undefined behavior (null-dst memcpy). This is a regression test
-// for a bug where ReadPackedFixed<T> would call AddNAlreadyReserved(0) on an
-// uninitialized RepeatedField, get a null pointer, and pass it to memcpy.
-TEST(LiteTest, TruncatedPackedFixedFieldParsing) {
-  // Construct a serialized TestPackedTypesLite where the packed_float field
-  // (field 100) has a declared length of 1 byte, which is less than
-  // sizeof(float)=4.  This triggers the ReadPackedFixed<float> path with
-  // size=1, which previously caused a null-dst memcpy UB.
-  //
-  // Wire format:
-  //   tag for field 100, wire type 2 (length-delimited): 0xA2 0x06
-  //   length varint: 0x01
-  //   payload: 0x00 (1 byte, less than sizeof(float))
-  const std::string malformed_packed_float =
-      std::string("\xA2\x06\x01\x00", 4);
-  proto2_unittest::TestPackedTypesLite m;
-  EXPECT_FALSE(m.ParseFromString(malformed_packed_float));
-  // The message should remain clear after a failed parse.
-  EXPECT_EQ(m.packed_float_size(), 0);
+// Regression test for ReadPackedFixed() when a fixed-width packed field starts
+// near the end of an input buffer. The first 4-byte block contains the tag,
+// length, and only one payload byte, so the loop sees size > nbytes with
+// nbytes < sizeof(float).
+TEST(LiteTest, PackedFixedFieldCrossesInputBufferWithPartialElement) {
+  const std::string packed_float =
+      std::string("\xA2\x06\x08\x00\x00\x00\x00\x00\x00\x00\x00",
+                  11);
+  io::ArrayInputStream input(packed_float.data(), packed_float.size(), 4);
+  proto2_unittest::TestPackedTypesLite message;
 
-  // Same test for packed_double (field 101, sizeof(double)=8) with 1-byte
-  // payload.
-  //   tag for field 101, wire type 2: 0xAA 0x06
-  //   length varint: 0x01
-  //   payload: 0x00
-  const std::string malformed_packed_double =
-      std::string("\xAA\x06\x01\x00", 4);
-  m.Clear();
-  EXPECT_FALSE(m.ParseFromString(malformed_packed_double));
-  EXPECT_EQ(m.packed_double_size(), 0);
-
-  // Same test for packed_fixed32 (field 96, sizeof(uint32_t)=4) with 1-byte
-  // payload.
-  //   tag for field 96, wire type 2: 0x82 0x06
-  //   length varint: 0x01
-  //   payload: 0x00
-  const std::string malformed_packed_fixed32 =
-      std::string("\x82\x06\x01\x00", 4);
-  m.Clear();
-  EXPECT_FALSE(m.ParseFromString(malformed_packed_fixed32));
-  EXPECT_EQ(m.packed_fixed32_size(), 0);
-
-  // Same test for packed_fixed64 (field 97, sizeof(uint64_t)=8) with 1-byte
-  // payload.
-  //   tag for field 97, wire type 2: 0x8A 0x06
-  //   length varint: 0x01
-  //   payload: 0x00
-  const std::string malformed_packed_fixed64 =
-      std::string("\x8A\x06\x01\x00", 4);
-  m.Clear();
-  EXPECT_FALSE(m.ParseFromString(malformed_packed_fixed64));
-  EXPECT_EQ(m.packed_fixed64_size(), 0);
-
-  // Verify that well-formed packed data still parses correctly.
-  // packed_float (field 100) with exactly one float (4 bytes).
-  //   tag: 0xA2 0x06
-  //   length: 0x04
-  //   payload: 4 bytes representing 0.0f
-  const std::string valid_packed_float =
-      std::string("\xA2\x06\x04\x00\x00\x00\x00", 7);
-  m.Clear();
-  EXPECT_TRUE(m.ParseFromString(valid_packed_float));
-  EXPECT_EQ(m.packed_float_size(), 1);
-  EXPECT_FLOAT_EQ(m.packed_float(0), 0.0f);
+  EXPECT_TRUE(message.ParseFromZeroCopyStream(&input));
+  ASSERT_EQ(message.packed_float_size(), 2);
+  EXPECT_FLOAT_EQ(message.packed_float(0), 0.0f);
+  EXPECT_FLOAT_EQ(message.packed_float(1), 0.0f);
 }
 
 }  // namespace

--- a/src/google/protobuf/lite_unittest.cc
+++ b/src/google/protobuf/lite_unittest.cc
@@ -1483,8 +1483,8 @@ TEST(LiteTest, FileWithOnlyAnEnumGeneratesProperValidationHooks) {
 // starts near the end of an input buffer. Each 4-byte first block contains the
 // two-byte tag, one-byte length, and only one payload byte. ReadPackedFixed()
 // therefore enters its while-loop with nbytes == 1 and num == 0. Each parse
-// starts with an unbacked RepeatedField so UBSan detects the null-destination
-// zero-byte memcpy if the guard is removed.
+// starts with an unbacked RepeatedField, exercising the exact path protected by
+// the num > 0 guard.
 TEST(LiteTest, PackedFixedFieldsCrossInputBufferBeforeFirstElement) {
   {
     const std::string data =

--- a/src/google/protobuf/lite_unittest.cc
+++ b/src/google/protobuf/lite_unittest.cc
@@ -1479,21 +1479,51 @@ TEST(LiteTest, FileWithOnlyAnEnumGeneratesProperValidationHooks) {
 }
 
 
-// Regression test for ReadPackedFixed() when a fixed-width packed field starts
-// near the end of an input buffer. The first 4-byte block contains the tag,
-// length, and only one payload byte, so the loop sees size > nbytes with
-// nbytes < sizeof(float).
-TEST(LiteTest, PackedFixedFieldCrossesInputBufferWithPartialElement) {
-  const std::string packed_float =
-      std::string("\xA2\x06\x08\x00\x00\x00\x00\x00\x00\x00\x00",
-                  11);
-  io::ArrayInputStream input(packed_float.data(), packed_float.size(), 4);
-  proto2_unittest::TestPackedTypesLite message;
-
-  EXPECT_TRUE(message.ParseFromZeroCopyStream(&input));
-  ASSERT_EQ(message.packed_float_size(), 2);
-  EXPECT_FLOAT_EQ(message.packed_float(0), 0.0f);
-  EXPECT_FLOAT_EQ(message.packed_float(1), 0.0f);
+// Regression tests for ReadPackedFixed() when a fixed-width packed field
+// starts near the end of an input buffer. Each 4-byte first block contains the
+// two-byte tag, one-byte length, and only one payload byte. ReadPackedFixed()
+// therefore enters its while-loop with nbytes == 1 and num == 0. Each parse
+// starts with an unbacked RepeatedField so UBSan detects the null-destination
+// zero-byte memcpy if the guard is removed.
+TEST(LiteTest, PackedFixedFieldsCrossInputBufferBeforeFirstElement) {
+  {
+    const std::string data =
+        std::string("\xA2\x06\x04\x00\x00\x00\x00", 7);
+    io::ArrayInputStream input(data.data(), data.size(), 4);
+    proto2_unittest::TestPackedTypesLite message;
+    ASSERT_TRUE(message.ParseFromZeroCopyStream(&input));
+    ASSERT_EQ(message.packed_float_size(), 1);
+    EXPECT_FLOAT_EQ(message.packed_float(0), 0.0f);
+  }
+  {
+    const std::string data =
+        std::string("\xAA\x06\x08\x00\x00\x00\x00\x00\x00\x00\x00",
+                    11);
+    io::ArrayInputStream input(data.data(), data.size(), 4);
+    proto2_unittest::TestPackedTypesLite message;
+    ASSERT_TRUE(message.ParseFromZeroCopyStream(&input));
+    ASSERT_EQ(message.packed_double_size(), 1);
+    EXPECT_DOUBLE_EQ(message.packed_double(0), 0.0);
+  }
+  {
+    const std::string data =
+        std::string("\x82\x06\x04\x00\x00\x00\x00", 7);
+    io::ArrayInputStream input(data.data(), data.size(), 4);
+    proto2_unittest::TestPackedTypesLite message;
+    ASSERT_TRUE(message.ParseFromZeroCopyStream(&input));
+    ASSERT_EQ(message.packed_fixed32_size(), 1);
+    EXPECT_EQ(message.packed_fixed32(0), 0);
+  }
+  {
+    const std::string data =
+        std::string("\x8A\x06\x08\x00\x00\x00\x00\x00\x00\x00\x00",
+                    11);
+    io::ArrayInputStream input(data.data(), data.size(), 4);
+    proto2_unittest::TestPackedTypesLite message;
+    ASSERT_TRUE(message.ParseFromZeroCopyStream(&input));
+    ASSERT_EQ(message.packed_fixed64_size(), 1);
+    EXPECT_EQ(message.packed_fixed64(0), 0);
+  }
 }
 
 }  // namespace

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -1525,16 +1525,22 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   int nbytes = BytesAvailable(ptr);
   while (size > nbytes) {
     int num = nbytes / sizeof(T);
-    int old_entries = out->size();
-    out->ReserveWithArena(arena, old_entries + num);
     int block_size = num * sizeof(T);
-    auto dst = out->AddNAlreadyReserved(num);
+    // Only reserve/write when there is at least one complete element in this
+    // buffer chunk.  When num==0 the AddNAlreadyReserved call would return a
+    // null pointer (uninitialized RepeatedField), making the memcpy UB even
+    // though block_size is 0 (C11 §7.1.4, __nonnull).
+    if (num > 0) {
+      int old_entries = out->size();
+      out->ReserveWithArena(arena, old_entries + num);
+      auto dst = out->AddNAlreadyReserved(num);
 #ifdef ABSL_IS_LITTLE_ENDIAN
-    std::memcpy(dst, ptr, block_size);
+      std::memcpy(dst, ptr, block_size);
 #else
-    for (int i = 0; i < num; i++)
-      dst[i] = UnalignedLoad<T>(ptr + i * sizeof(T));
+      for (int i = 0; i < num; i++)
+        dst[i] = UnalignedLoad<T>(ptr + i * sizeof(T));
 #endif
+    }
     size -= block_size;
     if (limit_ <= kSlopBytes) return nullptr;
     ptr = Next();


### PR DESCRIPTION
## Summary

`EpsCopyInputStream::ReadPackedFixed` has an unguarded path in the `while (size > nbytes)` loop body where `num = nbytes / sizeof(T)` can be 0 when the available buffer bytes are fewer than `sizeof(T)` (1-3 bytes for `float`). In that case:

- `out->ReserveWithArena(arena, old_entries + 0)` is a no-op, no allocation is made
- `dst = out->AddNAlreadyReserved(0)` returns `unsafe_elements() + old_size`. If the `RepeatedField` is empty and not yet backed (`arena_or_elements_ == nullptr`), this evaluates to `nullptr`
- `std::memcpy(nullptr, ptr, 0)` is undefined behavior per C11 §7.1.4 / `__nonnull` attribute on `memcpy`

## Discovery context

Discovered while fuzzing OpenCV's bundled protobuf **3.19.1** using a crafted Caffe binary model containing a packed `repeated float` field with a wire-format payload length of 1-3 bytes. The crash manifests as a UBSan SIGILL: `null pointer passed as argument 1, which is declared to never be null`.

## Relationship to existing fix

The **tail block** of `ReadPackedFixed` already has the guard:
```cpp
if (num == 0) return size == block_size ? ptr : nullptr;
```

The **while-loop body** is missing the equivalent guard. This PR adds a symmetric `if (num > 0)` guard.

## Related

- OpenCV issue: https://github.com/opencv/opencv/issues/29152
- OpenCV PR (backport to bundled 3.19.1): https://github.com/opencv/opencv/pull/29153
