### PR TITLE
Fix signed integer overflow in TcParser::RepeatedVarint reserve size

### DIFF
--- a/src/google/protobuf/generated_message_tctable_lite.cc
+++ b/src/google/protobuf/generated_message_tctable_lite.cc
@@ -1215,6 +1215,16 @@ PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedVarint(
   } while (ctx->DataAvailable(ptr2) &&
            UnalignedLoad<TagType>(ptr2) == expected_tag);
   int added = 0;
+  // Defend against signed-int overflow of the reserve size: `field.size()`
+  // accumulates across chunks/merges and can approach INT_MAX, so
+  // `field.size() + len` may overflow to a negative value, which makes
+  // Reserve a no-op and AddNAlreadyReserved write out of bounds. The packed
+  // path guards this (see PackedVarint's int64 clamp); the expanded path did
+  // not. A repeated field cannot hold more than INT_MAX elements, so treat
+  // the overflow as malformed input.
+  if (ABSL_PREDICT_FALSE(len > std::numeric_limits<int>::max() - field.size())) {
+    PROTOBUF_MUSTTAIL return Error(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+  }
   field.Reserve(field.size() + len);
   // Allows us to skip SOO checks.
   FieldType* x = field.AddNAlreadyReserved(len);


### PR DESCRIPTION
## What
`TcParser::RepeatedVarint` preallocates the destination repeated field with:

```cpp
field.Reserve(field.size() + len);
FieldType* x = field.AddNAlreadyReserved(len);
```

`field.size()` and `len` are `int`. `field.size()` accumulates across buffer chunks (and across merges / concatenated messages), so `field.size() + len` can overflow to a negative value. `RepeatedField::Reserve` only grows, so a negative argument is a no-op — leaving the subsequent `AddNAlreadyReserved(len)` without the reserved capacity it assumes. With bounds checks enabled this is a controlled abort; without them it is an out-of-bounds write.

## Why this path
The **packed** counterpart already guards exactly this case — see the `ReserveWithArena` site for packed varints/enums, which computes the new size in `int64` and clamps to `INT32_MAX`, with the comment *"it's possible we overflow int32 (imagine that field->size() and size_bytes are both large)"*. The **expanded** (non-packed) `RepeatedVarint` path was missed.

`RepeatedFixed` is unaffected (it appends per element via `AddWithArena`, no bulk `size + n` reserve).

## Fix
A repeated field cannot hold more than `INT_MAX` elements, so on overflow the input is malformed — fail the parse via the function's existing `Error(...)` path, mirroring the packed-field overflow fix in #27611:

```cpp
if (ABSL_PREDICT_FALSE(len > std::numeric_limits<int>::max() - field.size())) {
  PROTOBUF_MUSTTAIL return Error(PROTOBUF_TC_PARAM_NO_DATA_PASS);
}
field.Reserve(field.size() + len);
```

(Clamping like the packed path is not appropriate here: this path then does a single bulk `AddNAlreadyReserved(len)`, so a clamped-short reserve would itself overflow the capacity. Failing the parse is correct.)

Sibling of #27611 (packed-field reserve overflow).
