### PR TITLE
upb: Preserve limit type in fast delimited parsing

### DIFF
--- a/upb/wire/internal/eps_copy_input_stream.h
+++ b/upb/wire/internal/eps_copy_input_stream.h
@@ -330,7 +330,7 @@ UPB_FORCEINLINE bool upb_EpsCopyInputStream_TryParseDelimitedFast(
   // Fast case: Sub-message is <128 bytes and fits in the current buffer.
   // This means we can preserve limit/limit_ptr verbatim.
   const char* saved_limit_ptr = e->limit_ptr;
-  int saved_limit = e->limit;
+  ptrdiff_t saved_limit = e->limit;
   e->limit_ptr = *ptr + size;
   e->limit = e->limit_ptr - e->end;
   UPB_ASSERT(e->limit_ptr == e->end + UPB_MIN(0, e->limit));


### PR DESCRIPTION
`upb_EpsCopyInputStream.limit` is a `ptrdiff_t`, but the fast delimited parse helper saved it in an `int` before restoring it. Use `ptrdiff_t` for the saved value so the limit is preserved without narrowing on 64-bit platforms.