### PR TITLE
fix(protoc): correct plugin-not-found hint for exact-name plugins

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -4662,9 +4662,13 @@ TEST_F(CommandLineInterfaceTest, GeneratorPluginNotFoundInPath) {
       "--proto_path=$tmpdir error.proto");
 
 #ifdef _WIN32
+  // On Windows a PATH-searched plugin is launched through `cmd.exe /c`, which
+  // starts successfully and then fails to find the plugin, exiting nonzero.
+  // cmd.exe's own "not recognized" message is locale dependent, so assert on
+  // the stable status-code line protoc emits for the failed child.
   ExpectErrorSubstring(
-      absl::StrCat("--no_such_plugin_out: prefix-gen-no_such_plugin: ",
-                   Subprocess::Win32ErrorMessage(ERROR_FILE_NOT_FOUND)));
+      "--no_such_plugin_out: prefix-gen-no_such_plugin: Plugin failed with "
+      "status code");
 #else
   // Error written to stdout by child process after exec() fails.
   ExpectErrorSubstring(

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -4636,13 +4636,50 @@ TEST_F(CommandLineInterfaceTest, GeneratorPluginNotFound) {
   // Error written to stdout by child process after exec() fails.
   ExpectErrorSubstring("no_such_file: program not found or is not executable");
 
+  // The plugin was registered with an explicit path (--plugin=name=path), so
+  // it is run by exact name and the PATH is never consulted. The suggestion
+  // must not point at the PATH, which would be misleading here.
+  ExpectErrorSubstring(
+      "Please specify a program using an absolute path or a path "
+      "relative to the current working directory");
+
+  // Error written by parent process when child fails.
+  ExpectErrorSubstring(
+      "--badplug_out: prefix-gen-badplug: Plugin failed with status code 1.");
+#endif
+}
+
+TEST_F(CommandLineInterfaceTest, GeneratorPluginNotFoundInPath) {
+  // Test the error when a plugin run via the PATH (SEARCH_PATH mode) isn't
+  // found. No --plugin is given, so protoc derives the plugin executable name
+  // from the output directive and looks for it on the PATH.
+
+  CreateTempFile("error.proto",
+                 "syntax = \"proto2\";\n"
+                 "message Foo {}\n");
+
+  Run("protocol_compiler --no_such_plugin_out=TestParameter:$tmpdir "
+      "--proto_path=$tmpdir error.proto");
+
+#ifdef _WIN32
+  ExpectErrorSubstring(
+      absl::StrCat("--no_such_plugin_out: prefix-gen-no_such_plugin: ",
+                   Subprocess::Win32ErrorMessage(ERROR_FILE_NOT_FOUND)));
+#else
+  // Error written to stdout by child process after exec() fails.
+  ExpectErrorSubstring(
+      "prefix-gen-no_such_plugin: program not found or is not executable");
+
+  // Here the plugin really is looked up on the PATH, so suggesting it is
+  // correct.
   ExpectErrorSubstring(
       "Please specify a program using absolute path or make sure "
       "the program is available in your PATH system variable");
 
   // Error written by parent process when child fails.
   ExpectErrorSubstring(
-      "--badplug_out: prefix-gen-badplug: Plugin failed with status code 1.");
+      "--no_such_plugin_out: prefix-gen-no_such_plugin: Plugin failed with "
+      "status code 1.");
 #endif
 }
 

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -4724,9 +4724,13 @@ TEST_F(CommandLineInterfaceTest, GeneratorPluginNotFoundInPath) {
       "--proto_path=$tmpdir error.proto");
 
 #ifdef _WIN32
+  // On Windows a PATH-searched plugin is launched through `cmd.exe /c`, which
+  // starts successfully and then fails to find the plugin, exiting nonzero.
+  // cmd.exe's own "not recognized" message is locale dependent, so assert on
+  // the stable status-code line protoc emits for the failed child.
   ExpectErrorSubstring(
-      absl::StrCat("--no_such_plugin_out: prefix-gen-no_such_plugin: ",
-                   Subprocess::Win32ErrorMessage(ERROR_FILE_NOT_FOUND)));
+      "--no_such_plugin_out: prefix-gen-no_such_plugin: Plugin failed with "
+      "status code");
 #else
   // Error written to stdout by child process after exec() fails.
   ExpectErrorSubstring(

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -4698,13 +4698,50 @@ TEST_F(CommandLineInterfaceTest, GeneratorPluginNotFound) {
   // Error written to stdout by child process after exec() fails.
   ExpectErrorSubstring("no_such_file: program not found or is not executable");
 
+  // The plugin was registered with an explicit path (--plugin=name=path), so
+  // it is run by exact name and the PATH is never consulted. The suggestion
+  // must not point at the PATH, which would be misleading here.
+  ExpectErrorSubstring(
+      "Please specify a program using an absolute path or a path "
+      "relative to the current working directory");
+
+  // Error written by parent process when child fails.
+  ExpectErrorSubstring(
+      "--badplug_out: prefix-gen-badplug: Plugin failed with status code 1.");
+#endif
+}
+
+TEST_F(CommandLineInterfaceTest, GeneratorPluginNotFoundInPath) {
+  // Test the error when a plugin run via the PATH (SEARCH_PATH mode) isn't
+  // found. No --plugin is given, so protoc derives the plugin executable name
+  // from the output directive and looks for it on the PATH.
+
+  CreateTempFile("error.proto",
+                 "syntax = \"proto2\";\n"
+                 "message Foo {}\n");
+
+  Run("protocol_compiler --no_such_plugin_out=TestParameter:$tmpdir "
+      "--proto_path=$tmpdir error.proto");
+
+#ifdef _WIN32
+  ExpectErrorSubstring(
+      absl::StrCat("--no_such_plugin_out: prefix-gen-no_such_plugin: ",
+                   Subprocess::Win32ErrorMessage(ERROR_FILE_NOT_FOUND)));
+#else
+  // Error written to stdout by child process after exec() fails.
+  ExpectErrorSubstring(
+      "prefix-gen-no_such_plugin: program not found or is not executable");
+
+  // Here the plugin really is looked up on the PATH, so suggesting it is
+  // correct.
   ExpectErrorSubstring(
       "Please specify a program using absolute path or make sure "
       "the program is available in your PATH system variable");
 
   // Error written by parent process when child fails.
   ExpectErrorSubstring(
-      "--badplug_out: prefix-gen-badplug: Plugin failed with status code 1.");
+      "--no_such_plugin_out: prefix-gen-no_such_plugin: Plugin failed with "
+      "status code 1.");
 #endif
 }
 

--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -367,10 +367,17 @@ void Subprocess::Start(const std::string& program, SearchMode search_mode,
     // stuff that is unsafe here.
     int ignored;
     ignored = write(STDERR_FILENO, argv[0], strlen(argv[0]));
+    // The PATH is only consulted in SEARCH_PATH mode, so only suggest it then.
+    // In EXACT_NAME mode the program is run by its exact path (e.g. a plugin
+    // registered via --plugin=name=path), so pointing at PATH is misleading.
     const char* message =
-        ": program not found or is not executable\n"
-        "Please specify a program using absolute path or make sure "
-        "the program is available in your PATH system variable\n";
+        search_mode == SEARCH_PATH
+            ? ": program not found or is not executable\n"
+              "Please specify a program using absolute path or make sure "
+              "the program is available in your PATH system variable\n"
+            : ": program not found or is not executable\n"
+              "Please specify a program using an absolute path or a path "
+              "relative to the current working directory\n";
     ignored = write(STDERR_FILENO, message, strlen(message));
     (void)ignored;
 


### PR DESCRIPTION
When a plugin is registered with an explicit path via `--plugin=name=path`, protoc runs it in `EXACT_NAME` mode and never searches the PATH, yet the not-found error still tells users to make the program available on their PATH. This selects the hint based on the search mode, so the PATH suggestion only appears for `SEARCH_PATH` lookups; for exact-name plugins it points at an absolute or working-directory-relative path instead.

Fixes #10302.

Tested on macOS: `ninja -C build protoc tests && ./build/tests --gtest_filter='*GeneratorPluginNotFound*'` -> 2 tests pass. The new `GeneratorPluginNotFoundInPath` test covers the `SEARCH_PATH` case; the existing `GeneratorPluginNotFound` test covers the `EXACT_NAME` case.