### PR TITLE
Reject negative size in mergeDelimitedFrom

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/AbstractMessageLite.java
+++ b/java/core/src/main/java/com/google/protobuf/AbstractMessageLite.java
@@ -316,6 +316,9 @@ public abstract class AbstractMessageLite<
         return false;
       }
       final int size = CodedInputStream.readRawVarint32(firstByte, input);
+      if (size < 0) {
+        throw InvalidProtocolBufferException.negativeSize();
+      }
       final InputStream limitedInput = new LimitedInputStream(input, size);
       mergeFrom(limitedInput, extensionRegistry);
       return true;


### PR DESCRIPTION
## Summary

`mergeDelimitedFrom` passes the return value of `readRawVarint32` directly to `LimitedInputStream` without checking for negative values. For 5-byte varints encoding values >= 2^31, `readRawVarint32` returns a negative int (e.g., `\x80\x80\x80\x80\x08` decodes to -2147483648).

`LimitedInputStream` with a negative limit immediately returns EOF (`if (limit <= 0) return -1`), causing the parser to produce a default/empty message and return `true` (success). The actual message body bytes remain unconsumed in the stream, permanently desynchronizing subsequent `parseDelimitedFrom` calls.

## Fix

Add `if (size < 0) throw InvalidProtocolBufferException.negativeSize()` before constructing `LimitedInputStream`.

## Test plan

- [x] Verified with PoC: 5-byte varint prefix encoding 2^31 previously produced empty message + stream desync; after fix, `negativeSize` exception thrown
- [ ] Existing unit tests pass