### PR TITLE
Fix: Enforce recursion limit in ParseWithLengthInlined to prevent depth-budget bypass

### DIFF
--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -1455,12 +1455,12 @@ inline const char* ParseContext::ReadSizeAndPushLimitAndDepthInlined(
   return ptr;
 }
 
-// Note that "length" is read outside of this function.
 template <typename Func>
 [[nodiscard]] PROTOBUF_ALWAYS_INLINE const char*
 ParseContext::ParseWithLengthInlined(const char* ptr, uint32_t length,
                                      const Func& func) {
   ABSL_DCHECK_NE(ptr, nullptr);
+  if (ABSL_PREDICT_FALSE(depth_ <= 0)) return nullptr;
   LimitToken old;
   old = PushLimit(ptr, length);
   --depth_;


### PR DESCRIPTION
This PR addresses a depth-budget bypass vulnerability identified during a security audit of the Protobuf parsing core.

Issue: In ParseWithLengthInlined, the recursion depth_ counter was decremented unconditionally without verifying that it had not already reached zero. This allowed a parsing path to bypass the recursion limit.

Fix: Added a defensive check ABSL_PREDICT_FALSE(depth_ <= 0) to abort parsing if the budget is exhausted. This ensures consistency with other depth-tracking paths like ReadSizeAndPushLimitAndDepthInlined.

References: This fix relates to the security report filed under issue 502348238.

Please let me know if any further changes or test cases are requested