### PR TITLE
Make rust_proto_library usable externally

### DIFF
--- a/rust/BUILD
+++ b/rust/BUILD
@@ -335,7 +335,7 @@ config_setting(
     flag_values = {
         ":rust_proto_library_kernel": "upb",
     },
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 pkg_files(

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -45,13 +45,13 @@ def rust_proto_library(name, deps, **args):
     rust_upb_proto_library(
         name = name + "_upb_rust_proto",
         deps = deps,
-        visibility = ["//rust/test:__subpackages__"],
+        visibility = [Label("//rust/test:__subpackages__")],
         **args
     )
 
     rust_cc_proto_library(
         name = name + "_cpp_rust_proto",
         deps = deps,
-        visibility = ["//rust/test:__subpackages__"],
+        visibility = [Label("//rust/test:__subpackages__")],
         **args
     )


### PR DESCRIPTION
Allow `rust_proto_library()` to be used from external projects. This makes `use_upb_kernel` public, and uses `Label` to ensure internal labels (for visibility and configuration) resolve to the protobuf repository instead of the downstream project.