### PR TITLE
Set edition = "2021" for all Rust targets

### DIFF
--- a/rust/BUILD
+++ b/rust/BUILD
@@ -32,6 +32,7 @@ package_group(
 rust_library(
     name = "protobuf",
     srcs = ["protobuf.rs"],
+    edition = "2021",
     rustc_flags = select({
         ":use_upb_kernel": ["--cfg=upb_kernel"],
         "//conditions:default": ["--cfg=cpp_kernel"],
@@ -113,6 +114,7 @@ rust_library(
         "upb_kernel/string.rs",
     ],
     crate_root = "shared.rs",
+    edition = "2021",
     proc_macro_deps = [
         "//rust/protobuf_macros",
         "@crate_index//:paste",
@@ -147,6 +149,7 @@ rust_library(
     name = "protobuf_upb_export",
     testonly = True,
     srcs = ["protobuf.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=upb_kernel"],
     visibility = [":protobuf_internal"],
     deps = [":protobuf_upb"],
@@ -170,6 +173,7 @@ rust_library(
         "cpp_kernel/string.rs",
     ],
     crate_root = "shared.rs",
+    edition = "2021",
     proc_macro_deps = [
         "//rust/protobuf_macros",
         "@crate_index//:paste",
@@ -187,6 +191,7 @@ rust_library(
 rust_test(
     name = "protobuf_cpp_test",
     crate = ":protobuf_cpp",
+    edition = "2021",
     rustc_flags = [
         "--cfg=cpp_kernel",
         "--cfg=bzl",
@@ -202,6 +207,7 @@ rust_library(
     name = "protobuf_cpp_export",
     testonly = True,
     srcs = ["protobuf.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=cpp_kernel"],
     visibility = [":protobuf_internal"],
     deps = [":protobuf_cpp"],
@@ -245,6 +251,7 @@ cc_library(
 rust_library(
     name = "rust_alloc_for_cpp_api",
     srcs = ["cpp_kernel/rust_alloc_for_cpp_api.rs"],
+    edition = "2021",
     visibility = [
         "//rust:__subpackages__",
     ],
@@ -258,6 +265,7 @@ rust_library(
         ":use_upb_kernel": {"//rust:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers_impl"},
         "//conditions:default": {"//rust:protobuf_gtest_matchers_cpp": "protobuf_gtest_matchers_impl"},
     }),
+    edition = "2021",
     visibility = ["//visibility:public"],
     deps = select({
         ":use_upb_kernel": [":protobuf_gtest_matchers_upb"],
@@ -272,6 +280,7 @@ rust_library(
     aliases = {
         "//rust:protobuf_cpp": "protobuf",
     },
+    edition = "2021",
     visibility = [":protobuf_internal"],
     deps = [
         ":protobuf_cpp",
@@ -286,6 +295,7 @@ rust_library(
     aliases = {
         "//rust:protobuf_upb": "protobuf",
     },
+    edition = "2021",
     visibility = [":protobuf_internal"],
     deps = [
         ":protobuf_upb",

--- a/rust/test/BUILD
+++ b/rust/test/BUILD
@@ -531,6 +531,7 @@ rust_library(
     name = "same_name_direct_deps_rust_consumer",
     testonly = True,
     srcs = ["same_name_direct_deps_consumer.rs"],
+    edition = "2021",
     deps = [":same_name_direct_deps_rust_proto"],
 )
 
@@ -554,6 +555,7 @@ rust_library(
     name = "same_name_exported_deps_rust_consumer",
     testonly = True,
     srcs = ["same_name_exported_deps_consumer.rs"],
+    edition = "2021",
     deps = [":same_name_exported_deps_rust_proto"],
 )
 
@@ -577,6 +579,7 @@ rust_library(
     name = "same_name_double_alias_exported_deps_rust_consumer",
     testonly = True,
     srcs = ["same_name_double_alias_exported_deps_consumer.rs"],
+    edition = "2021",
     deps = [":same_name_double_alias_exported_deps_rust_proto"],
 )
 

--- a/rust/test/cpp/BUILD
+++ b/rust/test/cpp/BUILD
@@ -48,6 +48,7 @@ rust_cc_proto_library(
 rust_test(
     name = "debug_test",
     srcs = ["debug_test.rs"],
+    edition = "2021",
     deps = [
         ":debug_cpp_rust_proto",
         ":optimize_for_lite_cpp_rust_proto",

--- a/rust/test/cpp/interop/BUILD
+++ b/rust/test/cpp/interop/BUILD
@@ -26,6 +26,7 @@ cc_library(
 rust_test(
     name = "interop_test",
     srcs = ["main.rs"],
+    edition = "2021",
     deps = [
         ":interop_test_cpp_rust_proto",
         ":test_utils",

--- a/rust/test/shared/BUILD
+++ b/rust/test/shared/BUILD
@@ -43,6 +43,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb_export",
@@ -57,6 +58,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp_export",
@@ -71,6 +73,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb_export",
@@ -86,6 +89,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp_export",
@@ -98,6 +102,7 @@ rust_test(
 rust_test(
     name = "edition2023_cpp_test",
     srcs = ["edition2023_test.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust/test:edition2023_cpp_rust_proto",
@@ -108,6 +113,7 @@ rust_test(
 rust_test(
     name = "edition2023_upb_test",
     srcs = ["edition2023_test.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust/test:edition2023_upb_rust_proto",
@@ -121,6 +127,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp_export",
@@ -136,6 +143,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb_export",
@@ -148,6 +156,7 @@ rust_test(
 rust_test(
     name = "import_public_cpp_test",
     srcs = ["import_public_test.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust/test:import_public_cpp_rust_proto",
@@ -158,6 +167,7 @@ rust_test(
 rust_test(
     name = "import_public_upb_test",
     srcs = ["import_public_test.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust/test:import_public_upb_rust_proto",
@@ -168,6 +178,7 @@ rust_test(
 rust_test(
     name = "package_cpp_test",
     srcs = ["package_test.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust/test:dots_in_package_cpp_rust_proto",
@@ -180,6 +191,7 @@ rust_test(
 rust_test(
     name = "package_upb_test",
     srcs = ["package_test.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust/test:dots_in_package_upb_rust_proto",
@@ -192,12 +204,14 @@ rust_test(
 rust_test(
     name = "package_disambiguation_cpp_test",
     srcs = ["package_disambiguation_test.rs"],
+    edition = "2021",
     deps = ["//rust/test:package_disabiguation_cpp_rust_proto"],
 )
 
 rust_test(
     name = "package_disambiguation_upb_test",
     srcs = ["package_disambiguation_test.rs"],
+    edition = "2021",
     deps = ["//rust/test:package_disabiguation_upb_rust_proto"],
 )
 
@@ -207,6 +221,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp_export",
@@ -222,6 +237,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb_export",
@@ -234,6 +250,7 @@ rust_test(
 rust_test(
     name = "nested_types_cpp_test",
     srcs = ["nested_types_test.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust/test:unittest_cpp_rust_proto",
@@ -244,6 +261,7 @@ rust_test(
 rust_test(
     name = "nested_types_upb_test",
     srcs = ["nested_types_test.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust/test:unittest_upb_rust_proto",
@@ -257,6 +275,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -275,6 +294,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -293,6 +313,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp_export",
@@ -308,6 +329,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb_export",
@@ -323,6 +345,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -342,6 +365,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -361,6 +385,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp_export",
@@ -376,6 +401,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb_export",
@@ -391,6 +417,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -408,6 +435,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -425,6 +453,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -444,6 +473,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -460,6 +490,7 @@ rust_test(
 rust_test(
     name = "fields_with_imported_types_cpp_test",
     srcs = ["fields_with_imported_types_test.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp_export",
@@ -472,6 +503,7 @@ rust_test(
 rust_test(
     name = "fields_with_imported_types_upb_test",
     srcs = ["fields_with_imported_types_test.rs"],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb_export",
@@ -487,6 +519,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp",
@@ -501,6 +534,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb",
@@ -515,6 +549,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp",
@@ -529,6 +564,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb",
@@ -543,6 +579,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp",
@@ -559,6 +596,7 @@ rust_test(
         "//rust:protobuf_upb": "protobuf",
         "//rust:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_gtest_matchers_upb",
@@ -576,6 +614,7 @@ rust_test(
         "//rust:protobuf_cpp": "protobuf",
         "//rust:protobuf_gtest_matchers_cpp": "protobuf_gtest_matchers",
     },
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -597,6 +636,7 @@ rust_test(
         "//rust:protobuf_upb": "protobuf",
         "//rust:protobuf_gtest_matchers_upb": "protobuf_gtest_matchers",
     },
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -617,6 +657,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp_export",
@@ -630,6 +671,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb_export",
@@ -643,6 +685,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_cpp_export",
@@ -657,6 +700,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "//rust:protobuf_upb_export",

--- a/rust/test/shared/utf8/BUILD
+++ b/rust/test/shared/utf8/BUILD
@@ -12,6 +12,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_cpp_export": "protobuf",
     },
+    edition = "2021",
     deps = [
         ":feature_verify_cpp_rust_proto",
         ":no_features_proto2_cpp_rust_proto",
@@ -27,6 +28,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     deps = [
         ":feature_verify_upb_rust_proto",
         ":no_features_proto2_upb_rust_proto",

--- a/rust/test/treeshaking/base/BUILD
+++ b/rust/test/treeshaking/base/BUILD
@@ -23,5 +23,6 @@ rust_binary(
     name = "treeshaking_app",
     testonly = True,
     srcs = ["main.rs"],
+    edition = "2021",
     deps = [":treeshaking_rust_proto"],
 )

--- a/rust/test/treeshaking/test/BUILD
+++ b/rust/test/treeshaking/test/BUILD
@@ -23,5 +23,6 @@ rust_binary(
     name = "treeshaking_app",
     testonly = True,
     srcs = ["main.rs"],
+    edition = "2021",
     deps = [":treeshaking_rust_proto"],
 )

--- a/rust/test/upb/BUILD
+++ b/rust/test/upb/BUILD
@@ -30,6 +30,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     deps = [
         "//rust:protobuf_upb_export",
         "//rust/test:unittest_proto3_upb_rust_proto",
@@ -42,6 +43,7 @@ rust_test(
 rust_test(
     name = "debug_string_test",
     srcs = ["debug_string_test.rs"],
+    edition = "2021",
     deps = [
         "//rust:protobuf_upb",
         "//rust/test:map_unittest_upb_rust_proto",
@@ -56,6 +58,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     deps = [
         "//rust:protobuf_upb_export",
         "//rust/test:unittest_upb_rust_proto",
@@ -69,6 +72,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     deps = [
         "//rust:protobuf_upb_export",
         "//rust/test:unittest_upb_rust_proto",
@@ -82,6 +86,7 @@ rust_test(
     aliases = {
         "//rust:protobuf_upb_export": "protobuf",
     },
+    edition = "2021",
     deps = [
         "//rust:protobuf_upb_export",
         "//rust/test:descriptor_upb_rust_proto",

--- a/rust/upb/BUILD
+++ b/rust/upb/BUILD
@@ -20,6 +20,7 @@ rust_library(
         "text.rs",
         "wire.rs",
     ],
+    edition = "2021",
     proc_macro_deps = [
         "@crate_index//:paste",
     ],
@@ -36,6 +37,7 @@ rust_library(
 rust_test(
     name = "upb_rs_crate_test",
     crate = ":upb",
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     deps = [
         "@crate_index//:googletest",

--- a/rust/upb/sys/BUILD
+++ b/rust/upb/sys/BUILD
@@ -34,6 +34,7 @@ rust_library(
         "wire/mod.rs",
         "wire/wire.rs",
     ],
+    edition = "2021",
     rustc_flags = ["--cfg=bzl"],
     visibility = ["//rust/upb:__subpackages__"],
     deps = [":upb_c_api"],
@@ -42,6 +43,7 @@ rust_library(
 rust_test(
     name = "sys_test",
     crate = ":sys",
+    edition = "2021",
     deps = [
         "@crate_index//:googletest",
     ],


### PR DESCRIPTION
Explicitly set edition to "2021" for all Rust libraries, tests, and binaries.  This prevents build failures when the default toolchain uses a different edition (like 2024) which is incompatible with these files.