### PR TITLE
upb: validate wire type before promoting an unknown field to a message extension

### DIFF
--- a/upb/message/promote.c
+++ b/upb/message/promote.c
@@ -93,7 +93,8 @@ upb_GetExtension_Status upb_Message_GetOrPromoteExtension(
       const char* unknown_begin = ptr;
       ptr = upb_WireReader_ReadTag(ptr, &tag, &stream);
       if (!ptr) return kUpb_GetExtension_ParseError;
-      if (field_number == upb_WireReader_GetFieldNumber(tag)) {
+      if (field_number == upb_WireReader_GetFieldNumber(tag) &&
+          upb_WireReader_GetWireType(tag) == kUpb_WireType_Delimited) {
         upb_StringView data;
         found_count++;
         upb_EpsCopyCapture capture;

--- a/upb/message/promote_test.cc
+++ b/upb/message/promote_test.cc
@@ -139,6 +139,33 @@ TEST(GeneratedCode, PromoteFromMultiple) {
   upb_Arena_Free(arena);
 }
 
+TEST(GeneratedCode, PromoteIgnoresWrongWireType) {
+  upb_Arena* arena = upb_Arena_New();
+  std::string serialized;
+  uint32_t tag =
+      upb_MiniTableExtension_Number(upb_test_ModelExtension1_model_ext_ext)
+      << 3;
+  while (tag > 0x7f) {
+    serialized.push_back(static_cast<char>((tag & 0x7f) | 0x80));
+    tag >>= 7;
+  }
+  serialized.push_back(static_cast<char>(tag));
+  serialized.push_back(1);
+
+  upb_test_EmptyMessageWithExtensions* base_msg =
+      upb_test_EmptyMessageWithExtensions_parse(serialized.data(),
+                                                serialized.size(), arena);
+  ASSERT_NE(base_msg, nullptr);
+
+  upb_MessageValue value;
+  upb_GetExtension_Status status = upb_Message_GetOrPromoteExtension(
+      UPB_UPCAST(base_msg), upb_test_ModelExtension1_model_ext_ext, 0, arena,
+      &value);
+  EXPECT_EQ(kUpb_GetExtension_NotPresent, status);
+
+  upb_Arena_Free(arena);
+}
+
 TEST(GeneratedCode, Extensions) {
   upb_Arena* arena = upb_Arena_New();
   upb_test_ModelWithExtensions* msg = upb_test_ModelWithExtensions_new(arena);


### PR DESCRIPTION
## Summary

`upb_Message_GetOrPromoteExtension()` matches a message's unknown fields by field number only. A same-number unknown carrying a non-delimited wire type (varint or fixed) was still captured and handed to `upb_MiniTable_ParseUnknownMessage()`, which re-decodes the bytes as a length-delimited sub-message.

`ParseUnknownMessage()` reads a tag and then a varint length from those bytes:

```c
data = upb_WireReader_ReadTag(data, &tag, NULL);
data = upb_WireReader_ReadVarint(data, &message_len, NULL);
upb_Decode(data, message_len, ...);
```

For a varint field such as `08 01` (field 1, value 1), the value `1` is consumed as `message_len` and `data` is left one byte past the end of the captured field, so `upb_Decode()` reads out of bounds.

This adds a `kUpb_WireType_Delimited` check to the match. A same-number field with any other wire type now falls through to the existing `_upb_WireReader_SkipValue()` branch and is left as an unknown, exactly like an unrelated field.

## Tests

Added `PromoteIgnoresWrongWireType`: `ModelExtension1.model_ext` encoded with a varint wire type now returns `kUpb_GetExtension_NotPresent` instead of being promoted.

Also verified with a standalone `-fsanitize=address,undefined` build: the wrong-wire input no longer faults and returns `kUpb_GetExtension_NotPresent`, and a correctly length-delimited empty-message extension still promotes (`kUpb_GetExtension_Ok`, non-null message).

## Follow-up

The legacy `PromoteUnknownToMessage` / `...Array` / `...Map` paths reach the same `ParseUnknownMessage()` sink via the public `upb_Message_FindUnknown()`. I left that helper untouched to avoid changing its semantics; the same guard can be applied there in a follow-up if you'd prefer.