### PR TITLE
Register proto2type extension number 1307

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -568,3 +568,8 @@ about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/benwebber/protosearch
     *   Extensions: 1306
+
+1.  proto2type
+
+    *   Website: https://github.com/protocgen/proto2type
+    *   Extensions: 1307


### PR DESCRIPTION
## Extension Registration Request

**Project:** proto2type
**Website:** https://github.com/protocgen/proto2type
**Requested Extension Number:** 1307

### What is proto2type?

proto2type is a protoc plugin that generates idiomatic, type-safe code from Protocol Buffer definitions. It provides custom field-level options for controlling code generation behavior (e.g., `omitempty`, `server_timestamp`).

This PR registers a single extension number (1307) in the global protobuf extension registry for proto2type's custom options.