### PR TITLE
Fix keyword message names in Python stubs

### DIFF
--- a/src/google/protobuf/compiler/python/BUILD.bazel
+++ b/src/google/protobuf/compiler/python/BUILD.bazel
@@ -88,6 +88,18 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "pyi_generator_unittest",
+    srcs = ["pyi_generator_unittest.cc"],
+    copts = COPTS,
+    deps = [
+        ":python",
+        "//src/google/protobuf/compiler:command_line_interface_tester",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
 ################################################################################
 # Distribution packaging
 ################################################################################

--- a/src/google/protobuf/compiler/python/pyi_generator.cc
+++ b/src/google/protobuf/compiler/python/pyi_generator.cc
@@ -34,18 +34,98 @@ namespace protobuf {
 namespace compiler {
 namespace python {
 
+namespace {
+
+std::string MessageIndexPath(const Descriptor& descriptor) {
+  if (descriptor.containing_type() == nullptr) {
+    return absl::StrCat(descriptor.index());
+  }
+  return absl::StrCat(MessageIndexPath(*descriptor.containing_type()), "_",
+                      descriptor.index());
+}
+
+bool HasFileBinding(const FileDescriptor& file, absl::string_view identifier,
+                    bool include_services) {
+  return file.FindMessageTypeByName(identifier) != nullptr ||
+         file.FindEnumTypeByName(identifier) != nullptr ||
+         file.FindEnumValueByName(identifier) != nullptr ||
+         file.FindExtensionByName(identifier) != nullptr ||
+         (include_services &&
+          file.FindServiceByName(identifier) != nullptr);
+}
+
+bool HasMessageBinding(const Descriptor& message,
+                       absl::string_view identifier) {
+  return message.FindNestedTypeByName(identifier) != nullptr ||
+         message.FindEnumTypeByName(identifier) != nullptr ||
+         message.FindEnumValueByName(identifier) != nullptr ||
+         message.FindFieldByName(identifier) != nullptr ||
+         message.FindExtensionByName(identifier) != nullptr;
+}
+
+bool HasMessageIdentifierCollision(const Descriptor& descriptor,
+                                   absl::string_view identifier,
+                                   bool opensource_runtime) {
+  if (descriptor.containing_type() != nullptr) {
+    return HasMessageBinding(*descriptor.containing_type(), identifier);
+  }
+
+  const FileDescriptor& file = *descriptor.file();
+  if (HasFileBinding(file, identifier,
+                     opensource_runtime && HasGenericServices(&file))) {
+    return true;
+  }
+  for (int i = 0; i < file.public_dependency_count(); ++i) {
+    if (HasFileBinding(*file.public_dependency(i), identifier,
+                       /*include_services=*/false)) {
+      return true;
+    }
+  }
+  // PrintImportForDescriptor aliases include a "_pb2" suffix; private
+  // message identifiers append only descriptor indexes and underscores.
+  return false;
+}
+
+}  // namespace
+
 PyiGenerator::PyiGenerator() : file_(nullptr) {}
 
 PyiGenerator::~PyiGenerator() = default;
 
-template <typename DescriptorT>
-std::string PyiGenerator::ModuleLevelName(const DescriptorT& descriptor) const {
-  std::string name = NamePrefixedWithNestedTypes(descriptor, ".");
-  if (descriptor.file() != file_) {
+std::string PyiGenerator::MessageIdentifier(
+    const Descriptor& descriptor) const {
+  if (!IsPythonKeyword(descriptor.name())) {
+    return std::string(descriptor.name());
+  }
+  // Runtime lookup can expose a keyword-named message, but a stub needs a
+  // legal private name for types without advertising an unspellable alias.
+  // Index paths are unique within a file, and appended collision suffixes are
+  // never part of an index path, so keyword messages cannot collide with each
+  // other. Only bindings emitted in this message's Python scope matter.
+  std::string identifier =
+      absl::StrCat("_pb_message_", MessageIndexPath(descriptor));
+  while (HasMessageIdentifierCollision(descriptor, identifier,
+                                       opensource_runtime_)) {
+    identifier.append("_");
+  }
+  return identifier;
+}
+
+std::string PyiGenerator::MessageName(const Descriptor& descriptor) const {
+  std::string name = MessageIdentifier(descriptor);
+  if (descriptor.containing_type() != nullptr) {
+    name = absl::StrCat(MessageName(*descriptor.containing_type()), ".", name);
+  }
+  return name;
+}
+
+std::string PyiGenerator::QualifyModuleName(std::string name,
+                                            const FileDescriptor& file) const {
+  if (&file != file_) {
     std::string module_alias;
-    const absl::string_view filename = descriptor.file()->name();
+    const absl::string_view filename = file.name();
     if (import_map_.find(filename) == import_map_.end()) {
-      std::string module_name = ModuleName(descriptor.file()->name());
+      std::string module_name = ModuleName(file.name());
       std::vector<absl::string_view> tokens = absl::StrSplit(module_name, '.');
       module_alias = absl::StrCat("_", tokens.back());
     } else {
@@ -54,6 +134,19 @@ std::string PyiGenerator::ModuleLevelName(const DescriptorT& descriptor) const {
     name = absl::StrCat(module_alias, ".", name);
   }
   return name;
+}
+
+std::string PyiGenerator::ModuleLevelName(const Descriptor& descriptor) const {
+  return QualifyModuleName(MessageName(descriptor), *descriptor.file());
+}
+
+std::string PyiGenerator::ModuleLevelName(
+    const EnumDescriptor& descriptor) const {
+  std::string name(descriptor.name());
+  if (descriptor.containing_type() != nullptr) {
+    name = absl::StrCat(MessageName(*descriptor.containing_type()), ".", name);
+  }
+  return QualifyModuleName(std::move(name), *descriptor.file());
 }
 
 std::string PyiGenerator::PublicPackage() const { return "google.protobuf"; }
@@ -299,6 +392,11 @@ void PyiGenerator::PrintImports() const {
     std::string module_name = StrippedModuleName(public_dep->name());
     // Top level messages in public imports
     for (int i = 0; i < public_dep->message_type_count(); ++i) {
+      if (IsPythonKeyword(public_dep->message_type(i)->name())) {
+        // There is no legal public Python name for this runtime re-export.
+        // References use the defining module's private stub identity instead.
+        continue;
+      }
       printer_->Print(
           "from $module$ import $message_class$ as $message_class$\n", "module",
           module_name, "message_class", public_dep->message_type(i)->name());
@@ -403,7 +501,7 @@ std::string PyiGenerator::GetFieldType(
       // with the module name for disambiguation.
       std::string name = ModuleLevelName(*field_des.message_type());
       if ((containing_des.containing_type() != nullptr &&
-           name == containing_des.name())) {
+           name == MessageIdentifier(containing_des))) {
         std::string module = ModuleName(field_des.file()->name());
         name = absl::StrCat(module, ".", name);
       }
@@ -430,7 +528,7 @@ void PyiGenerator::PrintMessage(const Descriptor& message_descriptor,
   if (!is_nested) {
     printer_->Print("\n");
   }
-  const absl::string_view class_name = message_descriptor.name();
+  const std::string class_name = MessageIdentifier(message_descriptor);
   std::string extra_base;
   // A well-known type needs to inherit from its corresponding base class in
   // net/proto2/python/internal/well_known_types.

--- a/src/google/protobuf/compiler/python/pyi_generator.h
+++ b/src/google/protobuf/compiler/python/pyi_generator.h
@@ -28,6 +28,7 @@ namespace protobuf {
 class Descriptor;
 class EnumDescriptor;
 class FieldDescriptor;
+class FileDescriptor;
 class MethodDescriptor;
 class ServiceDescriptor;
 
@@ -79,8 +80,12 @@ class PROTOC_EXPORT PyiGenerator : public google::protobuf::compiler::CodeGenera
   void PrintServices() const;
   std::string GetFieldType(
       const FieldDescriptor& field_des, const Descriptor& containing_des) const;
-  template <typename DescriptorT>
-  std::string ModuleLevelName(const DescriptorT& descriptor) const;
+  std::string MessageIdentifier(const Descriptor& descriptor) const;
+  std::string MessageName(const Descriptor& descriptor) const;
+  std::string ModuleLevelName(const Descriptor& descriptor) const;
+  std::string ModuleLevelName(const EnumDescriptor& descriptor) const;
+  std::string QualifyModuleName(std::string name,
+                                const FileDescriptor& file) const;
   std::string PublicPackage() const;
   std::string InternalPackage() const;
   std::string ExtraInitTypes(const Descriptor& msg_des) const;

--- a/src/google/protobuf/compiler/python/pyi_generator_unittest.cc
+++ b/src/google/protobuf/compiler/python/pyi_generator_unittest.cc
@@ -1,0 +1,190 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include "google/protobuf/compiler/python/pyi_generator.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "google/protobuf/compiler/command_line_interface_tester.h"
+
+namespace google {
+namespace protobuf {
+namespace compiler {
+namespace python {
+namespace {
+
+class PyiGeneratorTest : public CommandLineInterfaceTester {
+ protected:
+  PyiGeneratorTest() {
+    RegisterGenerator("--pyi_out", "--pyi_opt",
+                      std::make_unique<PyiGenerator>(), "Python pyi generator");
+  }
+};
+
+TEST_F(PyiGeneratorTest, UsesPrivateTypeForKeywordMessage) {
+  CreateTempFile("keyword.proto", R"schema(
+    syntax = "proto3";
+    package keyword_test;
+
+    message None {}
+
+    message Holder {
+      None value = 1;
+    }
+  )schema");
+
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir --pyi_out=$tmpdir "
+      "keyword.proto");
+  ExpectNoErrors();
+
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi", "class _pb_message_0(_message.Message):");
+  ExpectFileContentContainsSubstring("keyword_pb2.pyi",
+                                     "value: _pb_message_0");
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi",
+      "def __init__(self, value: "
+      "_Optional[_Union[_pb_message_0, _Mapping]] = ...) -> None: ...");
+  ExpectFileContentNotContainsSubstring("keyword_pb2.pyi", "class None(");
+}
+
+TEST_F(PyiGeneratorTest, ScopesPrivateTypesForKeywordMessages) {
+  CreateTempFile("nested_scope.proto", R"schema(
+    syntax = "proto3";
+    package nested_scope_test;
+
+    message None {}
+
+    message Outer {
+      // This nested binding must not perturb the module-level None.
+      message _pb_message_0 {}
+      message None {}
+    }
+
+    message Holder {
+      None value = 1;
+    }
+  )schema");
+  CreateTempFile("module_collision.proto", R"schema(
+    syntax = "proto3";
+    package module_collision_test;
+
+    message None {}
+    // This module-level binding must force the module-level None to move.
+    message _pb_message_0 {}
+  )schema");
+
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir --pyi_out=$tmpdir "
+      "nested_scope.proto module_collision.proto");
+  ExpectNoErrors();
+
+  ExpectFileContentContainsSubstring(
+      "nested_scope_pb2.pyi", "class _pb_message_0(_message.Message):");
+  ExpectFileContentContainsSubstring(
+      "nested_scope_pb2.pyi", "class _pb_message_1_1(_message.Message):");
+  ExpectFileContentContainsSubstring("nested_scope_pb2.pyi",
+                                     "value: _pb_message_0");
+  ExpectFileContentNotContainsSubstring(
+      "nested_scope_pb2.pyi", "class _pb_message_0_(_message.Message):");
+
+  ExpectFileContentContainsSubstring(
+      "module_collision_pb2.pyi",
+      "class _pb_message_0_(_message.Message):");
+  ExpectFileContentContainsSubstring(
+      "module_collision_pb2.pyi",
+      "class _pb_message_0(_message.Message):");
+}
+
+TEST_F(PyiGeneratorTest, HandlesKeywordMessageReferences) {
+  CreateTempFile("keyword.proto", R"schema(
+    syntax = "proto3";
+    package keyword_test;
+
+    message None {}
+
+    message Outer {
+      message None {
+        keyword_test.None top_level = 1;
+      }
+
+      None value = 1;
+      repeated None values = 2;
+      map<string, None> by_name = 3;
+    }
+
+    message False {
+      message None {}
+      None value = 1;
+    }
+  )schema");
+  CreateTempFile("public_keyword.proto", R"schema(
+    syntax = "proto3";
+    package public_keyword_test;
+
+    message None {}
+  )schema");
+  CreateTempFile("public_facade.proto", R"schema(
+    syntax = "proto3";
+    package public_keyword_test;
+
+    import public "public_keyword.proto";
+
+    message Holder {
+      None value = 1;
+    }
+  )schema");
+
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir --pyi_out=$tmpdir "
+      "keyword.proto public_keyword.proto public_facade.proto");
+  ExpectNoErrors();
+
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi", "class _pb_message_0(_message.Message):");
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi", "class _pb_message_1_0(_message.Message):");
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi", "top_level: _pb_message_0");
+  ExpectFileContentContainsSubstring("keyword_pb2.pyi",
+                                     "value: Outer._pb_message_1_0");
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi",
+      "values: _containers.RepeatedCompositeFieldContainer["
+      "Outer._pb_message_1_0]");
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi",
+      "by_name: _containers.MessageMap[str, Outer._pb_message_1_0]");
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi", "_Union[Outer._pb_message_1_0, _Mapping]");
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi", "class _pb_message_2(_message.Message):");
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi", "class _pb_message_2_0(_message.Message):");
+  ExpectFileContentContainsSubstring(
+      "keyword_pb2.pyi", "value: _pb_message_2._pb_message_2_0");
+  ExpectFileContentNotContainsSubstring("keyword_pb2.pyi", "class None(");
+  ExpectFileContentNotContainsSubstring("keyword_pb2.pyi", "class False(");
+
+  ExpectFileContentContainsSubstring(
+      "public_facade_pb2.pyi",
+      "value: _public_keyword_pb2._pb_message_0");
+  ExpectFileContentContainsSubstring(
+      "public_facade_pb2.pyi",
+      "_Union[_public_keyword_pb2._pb_message_0, _Mapping]");
+  ExpectFileContentNotContainsSubstring(
+      "public_facade_pb2.pyi", "from public_keyword_pb2 import None");
+}
+
+}  // namespace
+}  // namespace python
+}  // namespace compiler
+}  // namespace protobuf
+}  // namespace google


### PR DESCRIPTION
A `.proto` file may legally declare a message whose name is a Python
keyword:

```proto
syntax = "proto3";

message None {}

message Holder {
  None value = 1;
}
```

For that schema:

```sh
protoc --pyi_out=. keyword.proto
python3 -m py_compile keyword_pb2.pyi
```

`protoc --pyi_out` currently emits:

```python
class None(_message.Message):
    __slots__ = ()
    def __init__(self) -> None: ...

class Holder(_message.Message):
    __slots__ = ("value",)
    VALUE_FIELD_NUMBER: _ClassVar[int]
    value: globals()['None']
    def __init__(self, value: _Optional[_Union[globals()['None'], _Mapping]] = ...) -> None: ...
```

`class None` is invalid Python syntax, so Python and type checkers
cannot parse the stub. The generated `.py` module does not have this
problem because it installs the binding dynamically.

Emit a deterministic private stub identity for a keyword-named message:

```python
class _pb_message_0(_message.Message):
    __slots__ = ()
    def __init__(self) -> None: ...

class Holder(_message.Message):
    __slots__ = ("value",)
    VALUE_FIELD_NUMBER: _ClassVar[int]
    value: _pb_message_0
    def __init__(self, value: _Optional[_Union[_pb_message_0, _Mapping]] = ...) -> None: ...
```

The private name provides a legal type identity without declaring a
public alias that Python source cannot spell. It is deterministic within
the message's actual Python scope, so unrelated nested bindings do not
perturb module-level names. References use the same identity for nested,
repeated, map, and cross-file cases; public imports skip keyword-named
messages because no legal public import can be emitted.

This changes only `.pyi` output for schemas with keyword-named messages.
It does not change generated `.py` output or `.pyi` output for schemas
without such messages. The generator tests cover the minimal reproducer,
scope-local collisions, nested/repeated/map references, and cross-file
public imports.
