### PR TITLE
reject mini_tables whose presence index overflows int16_t

### DIFF
--- a/upb/mini_descriptor/decode.c
+++ b/upb/mini_descriptor/decode.c
@@ -639,6 +639,9 @@ static void upb_MtDecoder_AssignHasbits(upb_MtDecoder* d) {
     upb_MiniTableField* field =
         (upb_MiniTableField*)&d->table.UPB_PRIVATE(fields)[i];
     if (field->UPB_PRIVATE(offset) == kHasbitPresence) {
+      if (last_hasbit >= INT16_MAX) {
+        upb_MdDecoder_ErrorJmp(&d->base, "Too many fields with presence");
+      }
       field->presence = ++last_hasbit;
     }
   }
@@ -668,6 +671,12 @@ static void upb_MtDecoder_AssignOffsets(upb_MtDecoder* d) {
   for (upb_OneOfLayoutItem* item = d->oneofs.data; item < oneof_end; item++) {
     upb_MiniTableField* f = &d->fields[item->field_index];
     uint16_t case_offset = upb_MtDecoder_Place(d, kUpb_OneOf_CaseFieldRep);
+    // The case offset is stored negated in the int16_t presence field, so it
+    // must fit in the positive int16_t range or it would alias a hasbit index.
+    if (case_offset > INT16_MAX) {
+      upb_MdDecoder_ErrorJmp(&d->base,
+                             "Message size exceeded maximum size for oneofs");
+    }
     uint16_t data_offset = upb_MtDecoder_Place(d, item->rep);
     while (true) {
       f->presence = ~case_offset;

--- a/upb/mini_descriptor/internal/encode_test.cc
+++ b/upb/mini_descriptor/internal/encode_test.cc
@@ -199,6 +199,48 @@ TEST_P(MiniTableTest, SizeOverflow) {
   ASSERT_EQ(nullptr, table2) << status.error_message();
 }
 
+TEST_P(MiniTableTest, PresenceOverflow) {
+  // Each hasbit field consumes one int16_t presence index. A message with more
+  // presence fields than fit in that index must be rejected instead of
+  // truncating the index, which would alias a scalar field onto a oneof.
+  upb::Arena arena;
+  upb::MtDataEncoder e;
+  ASSERT_TRUE(e.StartMessage(0));
+  // Far more presence fields than the int16_t index holds, but few enough bytes
+  // to stay under the message size limit.
+  for (uint32_t i = 1; i <= 40000; i++) {
+    ASSERT_TRUE(e.PutField(kUpb_FieldType_Bool, i, 0));
+  }
+  upb::Status status;
+  upb_MiniTable* table = _upb_MiniTable_Build(
+      e.data().data(), e.data().size(), GetParam(), arena.ptr(), status.ptr());
+  EXPECT_EQ(nullptr, table);
+}
+
+TEST_P(MiniTableTest, OneofCaseOverflow) {
+  // The oneof case offset is stored negated in the int16_t presence field, so a
+  // oneof whose case is placed beyond the positive int16_t range must be
+  // rejected instead of aliasing the oneof onto a hasbit field.
+  upb::Arena arena;
+  upb::MtDataEncoder e;
+  ASSERT_TRUE(e.StartMessage(0));
+  uint32_t field_num = 0;
+  // No-presence single-byte fields push the oneof case offset past INT16_MAX
+  // while keeping the message under the size limit.
+  for (uint32_t i = 0; i < 40000; i++) {
+    ASSERT_TRUE(e.PutField(kUpb_FieldType_Bool, ++field_num,
+                           kUpb_FieldModifier_IsProto3Singular));
+  }
+  uint32_t oneof_field = ++field_num;
+  ASSERT_TRUE(e.PutField(kUpb_FieldType_Bool, oneof_field, 0));
+  ASSERT_TRUE(e.StartOneof());
+  ASSERT_TRUE(e.PutOneofField(oneof_field));
+  upb::Status status;
+  upb_MiniTable* table = _upb_MiniTable_Build(
+      e.data().data(), e.data().size(), GetParam(), arena.ptr(), status.ptr());
+  EXPECT_EQ(nullptr, table);
+}
+
 INSTANTIATE_TEST_SUITE_P(Platforms, MiniTableTest,
                          testing::Values(kUpb_MiniTablePlatform_32Bit,
                                          kUpb_MiniTablePlatform_64Bit));


### PR DESCRIPTION
The MiniDescriptor decoder stores a field's presence in an int16_t, where a positive value is a hasbit index and a negative value is a negated oneof case offset. `upb_MtDecoder_AssignHasbits` hands out incrementing hasbit indices with no upper bound (the required-field loop right above it has a cap, but the hasbit loop does not), and `upb_MtDecoder_AssignOffsets` writes `~case_offset` into the same field. A descriptor with more than ~32704 presence fields, or a oneof whose case lands past INT16_MAX, wraps the value so a plain scalar field is silently reclassified as a oneof member (or the reverse), and accessing it then reads or writes at the wrong offset. Both messages still pass the existing 65535-byte size cap, so the corrupt mini_table is accepted. Add the missing range checks at both sites, matching the existing "Too many required fields" guard.