### PR TITLE
Configure extra compile args in setup.py

### DIFF
--- a/python/dist/setup.py
+++ b/python/dist/setup.py
@@ -33,9 +33,12 @@ def GetVersion():
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 extra_link_args = []
+extra_compile_args = []
 
 if sys.platform.startswith('win'):
   extra_link_args = ['-static']
+else:
+  extra_compile_args = ['-fvisibility=hidden']
 
 # If at some point the fasttable decoder is ready for prime time, we could
 # enable it here. But even then we'll need to disable it on platforms where
@@ -86,7 +89,7 @@ setup(
             include_dirs=[current_dir, os.path.join(current_dir, 'utf8_range')],
             language='c',
             extra_link_args=extra_link_args,
-            extra_compile_args=["-fvisibility=hidden"],
+            extra_compile_args=extra_compile_args,
         )
     ],
     python_requires='>=3.10',

--- a/python/dist/setup.py
+++ b/python/dist/setup.py
@@ -86,6 +86,7 @@ setup(
             include_dirs=[current_dir, os.path.join(current_dir, 'utf8_range')],
             language='c',
             extra_link_args=extra_link_args,
+            extra_compile_args=["-fvisibility=hidden"],
         )
     ],
     python_requires='>=3.10',


### PR DESCRIPTION
Fixes https://github.com/protocolbuffers/protobuf/issues/28261 by setting symbol visibility in `setup.py`, similar to `py_extension.bzl`, using the existing branching logic to bypass the flag on MSVC.

This issue manifests in the [NixOS/nixpkgs](https://github.com/NixOS/nixpkgs) build of the `protobuf` python package, which contains upb symbols, and causes fatal failures when loaded in a process that separately links/loads libprotobuf. We'll supply a patch there as well, until this can be backported or released in future protobuf versions.