### PR TITLE
fix(rust): mark `crate_universe` extension as `dev_dependency` [arguable]

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -194,7 +194,7 @@ rust.toolchain(
     versions = ["1.85.0"],
 )
 
-crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
+crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate", dev_dependency = True)
 crate.spec(
     package = "googletest",
     version = ">0.0.0",


### PR DESCRIPTION
Fixes #28224.

`rules_rust` 0.71.1 (bazelbuild/rules_rust#4109) rejects any non-root `crate_universe` extension call without a `lockfile`.
A Bazel build depending on `protobuf` and using `rules_rust` >= 0.71.1 therefore fails to resolve:
```
crate_universe extension call `crates` is in a non-root module but has no lockfile. [...]
```

`dev_dependency = True` makes Bazel skip the extension entirely when `protobuf` is not the root module, sidestepping the lockfile requirement without committing large generated files.

This is only viable for consumers that do not build protobuf's own Rust targets (those depend on `@crate_index` which becomes unavailable).

**See the sibling PR #28230 for an alternative that works unconditionally.**