### PR TITLE
Add engine-public/protoc-gen-openapi to options documentation

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -573,3 +573,8 @@ about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/protocgen/proto2type
     *   Extensions: 1307
+  
+1. protoc-gen-openapi
+
+    * Website: https://github.com/engine-public/protoc-gen-openapi
+    * Extensions: 1308


### PR DESCRIPTION
Add options to various FileDescriptorProto types to provide override capabilities to a protoc compiler that generates OAS 3.1 specs.  

The  available annotations can be found [here](https://github.com/engine-public/protoc-gen-openapi/blob/main/model/src/main/proto/engine/protoc/openapi/annotations.proto#L143-L169).  They provide a mix of direct OAS definition, overrides, and syntactic sugar to make annotating gRPC services compile-time consistent with the output specs.