### PR TITLE
Fix upb JSON conformance: quoted exponent/decimal integers and empty Any

### DIFF
--- a/conformance/failure_list_jruby_ffi.txt
+++ b/conformance/failure_list_jruby_ffi.txt
@@ -1,8 +1,6 @@
 Recommended.*.JsonInput.FieldNameDuplicate                                  # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing1                  # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing2                  # Should have failed to parse, but didn't.
-Required.*.JsonInput.Int32FieldQuotedExponentialValue.*                     # Failed to parse input or produce output.
-Required.*.JsonInput.AnyWithNoType.*                                        # Failed to parse input or produce output.
 # TODO: Uncomment once conformance tests can express failures that are not expected to be fixed.
 # Recommended.Editions_Proto2.ProtobufInput.RejectInvalidUtf8.String.MapKey   # Should have failed to parse, but didn't.
 # Recommended.Editions_Proto2.ProtobufInput.RejectInvalidUtf8.String.MapValue # Should have failed to parse, but didn't.

--- a/conformance/failure_list_php.txt
+++ b/conformance/failure_list_php.txt
@@ -36,8 +36,6 @@ Required.*.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput
 Required.*.ProtobufInput.ValidDataRepeated.FLOAT.PackedInput.JsonOutput
 Required.*.ProtobufInput.ValidDataRepeated.FLOAT.UnpackedInput.JsonOutput
 Required.*.ProtobufInput.ValidDataScalar.FLOAT[2].JsonOutput
-Required.*.JsonInput.Int32FieldQuotedExponentialValue.*                                                            # Failed to parse input or produce output.
-Required.*.JsonInput.AnyWithNoType.*
 Required.*.JsonInput.TimestampWithMissingColonInOffset                                                             # Should have failed to parse, but didn't.
 Required.Editions_Proto3.JsonInput.DoubleFieldTooLarge                                                             # Should have failed to parse, but didn't.
 Required.Proto3.JsonInput.DoubleFieldTooLarge                                                                      # Should have failed to parse, but didn't.

--- a/conformance/failure_list_php_c.txt
+++ b/conformance/failure_list_php_c.txt
@@ -2,7 +2,6 @@ Recommended.*.JsonInput.FieldNameDuplicate                                      
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing1                                           # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing2                                           # Should have failed to parse, but didn't.
 Recommended.Proto2.JsonInput.FieldNameExtension.Validator
-Required.*.JsonInput.Int32FieldQuotedExponentialValue.*                                                            # Failed to parse input or produce output.
 Required.Proto2.JsonInput.BoolFieldFalse.JsonOutput
 Required.Proto2.JsonInput.BoolFieldFalse.ProtobufOutput
 Required.Proto2.JsonInput.EnumField.JsonOutput
@@ -10,4 +9,3 @@ Required.Proto2.JsonInput.EnumField.ProtobufOutput
 Required.Proto2.JsonInput.EnumFieldNumericValueZero.JsonOutput
 Required.Proto2.JsonInput.EnumFieldNumericValueZero.ProtobufOutput
 Required.Proto2.JsonInput.StoresDefaultPrimitive.Validator
-Required.*.JsonInput.AnyWithNoType.*

--- a/conformance/failure_list_ruby.txt
+++ b/conformance/failure_list_ruby.txt
@@ -1,8 +1,6 @@
 Recommended.*.JsonInput.FieldNameDuplicate                                  # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing1                  # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing2                  # Should have failed to parse, but didn't.
-Required.*.JsonInput.Int32FieldQuotedExponentialValue.*                     # Failed to parse input or produce output.
-Required.*.JsonInput.AnyWithNoType.*
 # TODO: Uncomment once conformance tests can express failures that are not expected to be fixed.
 # Recommended.Editions_Proto2.ProtobufInput.RejectInvalidUtf8.String.MapKey   # Should have failed to parse, but didn't.
 # Recommended.Editions_Proto2.ProtobufInput.RejectInvalidUtf8.String.MapValue # Should have failed to parse, but didn't.

--- a/upb/conformance/conformance_upb_failures.txt
+++ b/upb/conformance/conformance_upb_failures.txt
@@ -1,8 +1,6 @@
 Recommended.*.JsonInput.FieldNameDuplicate                                  # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing1                  # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing2                  # Should have failed to parse, but didn't.
-Required.*.JsonInput.Int32FieldQuotedExponentialValue.*                     # Failed to parse input or produce output.
-Required.*.JsonInput.AnyWithNoType.*                                        # Failed to parse input or produce output.
 # TODO: Uncomment once conformance tests can express failures that are not expected to be fixed.
 # Recommended.Editions_Proto2.ProtobufInput.RejectInvalidUtf8.String.MapKey   # Should have failed to parse, but didn't.
 # Recommended.Editions_Proto2.ProtobufInput.RejectInvalidUtf8.String.MapValue # Should have failed to parse, but didn't.

--- a/upb/json/decode.c
+++ b/upb/json/decode.c
@@ -661,11 +661,97 @@ static const char* jsondec_buftoint64(jsondec* d, const char* ptr,
   return out;
 }
 
+static bool jsondec_isdigit_char(char ch) { return ch >= '0' && ch <= '9'; }
+
+static void jsondec_check_number_string(jsondec* d, upb_StringView str) {
+  const char* ptr = str.data;
+  const char* end = str.data + str.size;
+  if (ptr == end) {
+    jsondec_err(d, "Non-number characters in quoted integer");
+  }
+  if (*ptr == '-') ptr++;
+  if (ptr == end || !jsondec_isdigit_char(*ptr)) {
+    jsondec_err(d, "Non-number characters in quoted integer");
+  }
+  if (*ptr == '0') {
+    ptr++;
+  } else {
+    while (ptr < end && jsondec_isdigit_char(*ptr)) ptr++;
+  }
+  if (ptr < end && *ptr == '.') {
+    ptr++;
+    if (ptr == end || !jsondec_isdigit_char(*ptr)) {
+      jsondec_err(d, "Non-number characters in quoted integer");
+    }
+    while (ptr < end && jsondec_isdigit_char(*ptr)) ptr++;
+  }
+  if (ptr < end && (*ptr == 'e' || *ptr == 'E')) {
+    ptr++;
+    if (ptr < end && (*ptr == '+' || *ptr == '-')) ptr++;
+    if (ptr == end || !jsondec_isdigit_char(*ptr)) {
+      jsondec_err(d, "Non-number characters in quoted integer");
+    }
+    while (ptr < end && jsondec_isdigit_char(*ptr)) ptr++;
+  }
+  if (ptr != end) {
+    jsondec_err(d, "Non-number characters in quoted integer");
+  }
+}
+
+static double jsondec_strtod_checked(jsondec* d, upb_StringView str) {
+  char nullz[64];
+  char* end;
+  double val;
+  jsondec_check_number_string(d, str);
+  if (str.size > sizeof(nullz) - 1) {
+    jsondec_err(d, "excessively long number");
+  }
+  memcpy(nullz, str.data, str.size);
+  nullz[str.size] = '\0';
+  val = strtod(nullz, &end);
+  if (end != nullz + str.size) {
+    jsondec_err(d, "Non-number characters in quoted integer");
+  }
+  if (val > DBL_MAX || val < -DBL_MAX) {
+    jsondec_err(d, "Number out of range");
+  }
+  return val;
+}
+
+static int64_t jsondec_strtoint64_slow(jsondec* d, upb_StringView str) {
+  double dbl = jsondec_strtod_checked(d, str);
+  int64_t ret;
+  if (dbl > 9223372036854774784.0 || dbl < -9223372036854775808.0) {
+    jsondec_err(d, "JSON number is out of range.");
+  }
+  ret = dbl; /* must be guarded, overflow here is UB */
+  if (ret != dbl) {
+    jsondec_errf(d, "JSON number was not integral (%f != %" PRId64 ")", dbl,
+                 ret);
+  }
+  return ret;
+}
+
+static uint64_t jsondec_strtouint64_slow(jsondec* d, upb_StringView str) {
+  double dbl = jsondec_strtod_checked(d, str);
+  uint64_t ret;
+  if (dbl > 18446744073709549568.0 || dbl < 0) {
+    jsondec_err(d, "JSON number is out of range.");
+  }
+  ret = dbl; /* must be guarded, overflow here is UB */
+  if (ret != dbl) {
+    jsondec_errf(d, "JSON number was not integral (%f != %" PRIu64 ")", dbl,
+                 ret);
+  }
+  return ret;
+}
+
 static uint64_t jsondec_strtouint64(jsondec* d, upb_StringView str) {
   const char* end = str.data + str.size;
   uint64_t ret;
-  if (jsondec_buftouint64(d, str.data, end, &ret) != end) {
-    jsondec_err(d, "Non-number characters in quoted integer");
+  if (str.size == 0 || !jsondec_isdigit_char(str.data[0]) ||
+      jsondec_buftouint64(d, str.data, end, &ret) != end) {
+    return jsondec_strtouint64_slow(d, str);
   }
   return ret;
 }
@@ -673,8 +759,10 @@ static uint64_t jsondec_strtouint64(jsondec* d, upb_StringView str) {
 static int64_t jsondec_strtoint64(jsondec* d, upb_StringView str) {
   const char* end = str.data + str.size;
   int64_t ret;
-  if (jsondec_buftoint64(d, str.data, end, &ret, NULL) != end) {
-    jsondec_err(d, "Non-number characters in quoted integer");
+  size_t digits_at = (str.size > 0 && str.data[0] == '-') ? 1 : 0;
+  if (str.size == digits_at || !jsondec_isdigit_char(str.data[digits_at]) ||
+      jsondec_buftoint64(d, str.data, end, &ret, NULL) != end) {
+    return jsondec_strtoint64_slow(d, str);
   }
   return ret;
 }
@@ -1469,6 +1557,10 @@ static void jsondec_any(jsondec* d, upb_Message* msg, const upb_MessageDef* m) {
   }
 
   if (!any_m) {
+    if (!pre_type_data) {
+      jsondec_objend(d);
+      return;
+    }
     jsondec_err(d, "Any object didn't contain a '@type' field");
   }
 

--- a/upb/json/encode.c
+++ b/upb/json/encode.c
@@ -375,6 +375,12 @@ static void jsonenc_any(jsonenc* e, const upb_Message* msg,
   const upb_FieldDef* value_f = upb_MessageDef_FindFieldByNumber(m, 2);
   upb_StringView type_url = upb_Message_GetFieldByDef(msg, type_url_f).str_val;
   upb_StringView value = upb_Message_GetFieldByDef(msg, value_f).str_val;
+
+  if (type_url.size == 0 && value.size == 0) {
+    jsonenc_putstr(e, "{}");
+    return;
+  }
+
   const upb_MessageDef* any_m = jsonenc_getanymsg(e, type_url);
   const upb_MiniTable* any_layout = upb_MessageDef_MiniTable(any_m);
   upb_Arena* arena = jsonenc_arena(e);


### PR DESCRIPTION
upb's JSON codec fails two Required conformance test families that are currently suppressed via failure lists wherever upb's JSON code is used (upb, Ruby, PHP, JRuby FFI):

```
  Required.*.JsonInput.Int32FieldQuotedExponentialValue.*
  Required.*.JsonInput.AnyWithNoType.*
```

Decoder: quoted integer fields only accepted plain digit strings (upb_BufToInt64/Uint64), rejecting values like "1e5" or "100.000" that ProtoJSON requires and C++/Python accept. Add a strtod-based slow path, taken only when the fast path fails, that validates the string is a well-formed JSON number, requires the value to be integral (quoted "0.5" still fails, per `Required.*.JsonInput.Int64FieldNotInteger`), and range-checks before converting. Also route digit-less strings ("", "-") to the checked path; `upb_BufToInt64` accepts a bare "-" as 0.

Decoder: a JSON `{}` for `google.protobuf.Any` must parse to an empty Any; only fail on a missing `@type` when other members are present.
Encoder: an `Any` with empty `type_url` and value must serialize as `{}` instead of erroring on the empty type URL.

Remove the corresponding failure-list entries.