### PR TITLE
fix: declare protoc authenticity action toolchain

### DIFF
--- a/bazel/private/oss/toolchains/prebuilt/protoc_authenticity.bzl
+++ b/bazel/private/oss/toolchains/prebuilt/protoc_authenticity.bzl
@@ -19,6 +19,7 @@ def _protoc_authenticity_impl(ctx):
         mnemonic = "ProtocAuthenticityCheck",
         outputs = [validation_output],
         tools = [proto_lang_toolchain_info.proto_compiler],
+        toolchain = toolchains.PROTO_TOOLCHAIN,
         command = """\
         {protoc} --version > {validation_output}
         grep -q -e "-dev$" {validation_output} && {{


### PR DESCRIPTION
The --incompatible_auto_exec_groups flag requires Starlark actions to declare whether their executable/tools come from an action toolchain. This is not a Bazel default today, but it is exposed through strict preset configurations and is intended to catch rules that rely on implicit action toolchain inference.

protoc_authenticity runs protoc from protobuf's proto toolchain, but the validation action does not declare that action toolchain. Declare the matching proto toolchain so the action's toolchain behavior is explicit without changing its inputs or execution model.