### PR TITLE
bound message length in upb_MiniTable_ParseUnknownMessage

### DIFF
--- a/upb/message/promote.c
+++ b/upb/message/promote.c
@@ -51,12 +51,22 @@ static upb_UnknownToMessageRet upb_MiniTable_ParseUnknownMessage(
   size_t size;
   if (unknown->type == kUpb_MessageUnknownType_StringView) {
     const char* ptr = unknown->value.bytes.data;
+    const char* const end = ptr + unknown->value.bytes.size;
     uint32_t tag;
     uint64_t message_len = 0;
     // This assumes that the unknown field is a message type, so it is
     // a delimited wire type.
     ptr = upb_WireReader_ReadTag(ptr, &tag, NULL);
     ptr = upb_WireReader_ReadVarint(ptr, &message_len, NULL);
+    // The captured field must be length-delimited with a payload that fits in
+    // the remaining bytes. A field stored with a different wire type, or a
+    // length that runs past the buffer, would otherwise hand upb_Decode a range
+    // that reads well beyond the captured bytes.
+    if (upb_WireReader_GetWireType(tag) != kUpb_WireType_Delimited ||
+        ptr > end || message_len > (uint64_t)(end - ptr)) {
+      ret.status = kUpb_UnknownToMessage_ParseError;
+      return ret;
+    }
     data = ptr;
     size = message_len;
   } else {
@@ -287,15 +297,18 @@ upb_UnknownToMessageRet upb_MiniTable_PromoteUnknownToMessage(
       case kUpb_FindUnknown_Ok: {
         ret = upb_MiniTable_ParseUnknownMessage(
             &unknown.unknown, sub_mini_table, message, decode_options, arena);
-        if (ret.status == kUpb_UnknownToMessage_Ok) {
-          message = ret.message;
-          upb_Message_DeleteUnknownStatus del_status =
-              upb_Message_DeleteUnknown2(msg, &unknown.unknown, &(unknown.iter),
-                                         arena);
-          if (del_status == kUpb_DeleteUnknown_AllocFail) {
-            ret.status = kUpb_UnknownToMessage_OutOfMemory;
-            return ret;
-          }
+        if (ret.status != kUpb_UnknownToMessage_Ok) {
+          // A parse failure would otherwise leave the unknown field in place and
+          // the loop would keep re-finding it.
+          return ret;
+        }
+        message = ret.message;
+        upb_Message_DeleteUnknownStatus del_status =
+            upb_Message_DeleteUnknown2(msg, &unknown.unknown, &(unknown.iter),
+                                       arena);
+        if (del_status == kUpb_DeleteUnknown_AllocFail) {
+          ret.status = kUpb_UnknownToMessage_OutOfMemory;
+          return ret;
         }
       } break;
       case kUpb_FindUnknown_ParseError:

--- a/upb/message/promote_test.cc
+++ b/upb/message/promote_test.cc
@@ -394,6 +394,43 @@ TEST(GeneratedCode, PromoteUnknownMessageOld) {
   upb_Arena_Free(arena);
 }
 
+// A message-typed field carried as an unknown field with a non-delimited wire
+// type must be rejected during promotion. Otherwise its varint value is treated
+// as a message length and handed to upb_Decode, reading past the captured field.
+TEST(GeneratedCode, PromoteUnknownMessageWrongWireType) {
+  upb_Arena* arena = upb_Arena_New();
+  upb::MtDataEncoder e;
+  e.StartMessage(0);
+  e.PutField(kUpb_FieldType_Message, 5, 0);
+  upb_Status status;
+  upb_Status_Clear(&status);
+  upb_MiniTable* mini_table =
+      upb_MiniTable_Build(e.data().data(), e.data().size(), arena, &status);
+  ASSERT_EQ(status.ok, true);
+
+  // Field 5 as a varint (wire type 0) holding ~4 GiB. The wire type does not
+  // match the message field, so it lands in the unknown fields.
+  const char unknown[] = {static_cast<char>((5 << 3) | 0),
+                          '\xff', '\xff', '\xff', '\xff', '\x0f'};
+  upb_Message* msg = _upb_Message_New(mini_table, arena);
+  upb_DecodeStatus decode_status =
+      upb_Decode(unknown, sizeof(unknown), msg, mini_table, nullptr, 0, arena);
+  ASSERT_EQ(decode_status, kUpb_DecodeStatus_Ok);
+  ASSERT_EQ(upb_Message_FindUnknown(msg, 5, 0).status, kUpb_FindUnknown_Ok);
+
+  upb_MiniTable_SetSubMessage(
+      mini_table,
+      (upb_MiniTableField*)upb_MiniTable_GetFieldByIndex(mini_table, 0),
+      &upb_0test__ModelWithExtensions_msg_init);
+  upb_UnknownToMessageRet promote_result =
+      upb_MiniTable_PromoteUnknownToMessage(
+          msg, mini_table, upb_MiniTable_GetFieldByIndex(mini_table, 0),
+          &upb_0test__ModelWithExtensions_msg_init,
+          upb_DecodeOptions_MaxDepth(0), arena);
+  EXPECT_EQ(promote_result.status, kUpb_UnknownToMessage_ParseError);
+  upb_Arena_Free(arena);
+}
+
 TEST(GeneratedCode, PromoteUnknownRepeatedMessageOld) {
   upb_Arena* arena = upb_Arena_New();
   upb_test_ModelWithSubMessages* input_msg =


### PR DESCRIPTION
upb_MiniTable_ParseUnknownMessage reads a length varint out of the captured unknown field and hands it to upb_Decode as the input length, without checking it against the field's size or wire type. A message-typed field that arrives as an unknown field with a non-delimited wire type makes that length a stray varint value, so upb_Decode reads well past the captured bytes. Require the field to be length-delimited with a payload that fits the remaining bytes, and stop PromoteUnknownToMessage from re-finding the same field forever once a parse fails.