### PR TITLE
fix(cmake): guard uninitialized variable reads in module compatibility shim

### DIFF
--- a/cmake/protobuf-module.cmake.in
+++ b/cmake/protobuf-module.cmake.in
@@ -184,6 +184,8 @@ foreach(Camel
     Protobuf_LITE_LIBRARY
     Protobuf_LITE_LIBRARY_DEBUG
     )
-    string(TOUPPER ${Camel} UPPER)
-    set(${UPPER} ${${Camel}})
+    if(DEFINED ${Camel})
+        string(TOUPPER ${Camel} UPPER)
+        set(${UPPER} ${${Camel}})
+    endif()
 endforeach()


### PR DESCRIPTION
The backwards-compatibility loop at the bottom of protobuf-module.cmake.in maps each camel-case output variable to its uppercase alias with set(${UPPER} ${${Camel}}), but does not check the source is defined first. Configuring a consumer with --warn-uninitialized then reports uninitialized reads for the optional variables (Protobuf_SRC_ROOT_FOLDER, Protobuf_IMPORT_DIRS, Protobuf_DEBUG, and the *_DEBUG library variables).

The sibling loop just above, which maps in the other direction, already guards with if(DEFINED ${UPPER}). This applies the same guard to the second loop, which the earlier fix in #1778 missed.

Fixes #19683.

Test plan: reproduced the warning and confirmed the fix with plain cmake, no build required. Extracting the loop into a script and running `cmake -P block.cmake --warn-uninitialized` reports 5 uninitialized-variable warnings before the change and 0 after. Behavior is unchanged when the variables are defined: the uppercase alias is still set.