### PR TITLE
Fix use-after-free in PHP extension during Timestamp conversion

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -1399,6 +1399,19 @@ PHP_METHOD(google_protobuf_Timestamp, toDateTime) {
   upb_MessageValue seconds = Message_getval(intern, "seconds");
   upb_MessageValue nanos = Message_getval(intern, "nanos");
 
+  // A google.protobuf.Timestamp requires 0 <= nanos < 1e9 (see the field
+  // documentation in timestamp.proto).  Out-of-range values are reachable from
+  // untrusted wire input, which is not range-checked on decode, and would
+  // render to a string date_create_from_format() cannot parse (e.g. a negative
+  // nanos produces "0.-01000"), so reject them up front with a clear error.
+  if (nanos.int32_val < 0 || nanos.int32_val >= 1000000000) {
+    zend_throw_exception_ex(NULL, 0,
+                            "Cannot convert Timestamp with nanos %d outside "
+                            "[0, 1000000000) to DateTime.",
+                            nanos.int32_val);
+    return;
+  }
+
   // Get formatted time string.
   char formatted_time[32];
   snprintf(formatted_time, sizeof(formatted_time), "%" PRId64 ".%06" PRId32,
@@ -1428,6 +1441,17 @@ PHP_METHOD(google_protobuf_Timestamp, toDateTime) {
   zval_dtor(&function_name);
   zval_dtor(&format_string);
   zval_dtor(&formatted_time_php);
+
+  // date_create_from_format() returns false (not a DateTime) when the formatted
+  // string fails to parse.  In that case its returned zval is IS_FALSE, but its
+  // value union still holds the DateTime that date_create_from_format() already
+  // freed, so running ZVAL_OBJ(Z_OBJ(datetime)) unconditionally would republish
+  // a freed object to the engine (use-after-free).  Check the type first and,
+  // like the pure-PHP implementation, return false on failure.
+  if (Z_TYPE(datetime) != IS_OBJECT) {
+    zval_dtor(&datetime);
+    RETURN_FALSE;
+  }
 
   ZVAL_OBJ(return_value, Z_OBJ(datetime));
 }

--- a/php/src/Google/Protobuf/Internal/TimestampBase.php
+++ b/php/src/Google/Protobuf/Internal/TimestampBase.php
@@ -26,6 +26,15 @@ class TimestampBase extends \Google\Protobuf\Internal\Message
      */
     public function toDateTime()
     {
+        // A google.protobuf.Timestamp requires 0 <= nanos < 1e9 (see the field
+        // documentation in timestamp.proto). Reject out-of-range values, which
+        // are reachable from untrusted wire input, rather than formatting an
+        // unparseable string and silently returning false.
+        if ($this->nanos < 0 || $this->nanos >= 1000000000) {
+            throw new \Exception(
+                'Cannot convert Timestamp with nanos ' . $this->nanos .
+                ' outside [0, 1000000000) to DateTime.');
+        }
         $time = sprintf('%s.%06d', $this->seconds, $this->nanos / 1000);
         return \DateTime::createFromFormat('U.u', $time);
     }

--- a/php/tests/WellKnownTest.php
+++ b/php/tests/WellKnownTest.php
@@ -356,6 +356,22 @@ class WellKnownTest extends TestBase {
         $this->assertSame($from->format('u'), $to->format('u'));
     }
 
+    public function testTimestampWithNanosOutOfRangeThrows()
+    {
+        // Regression test: a google.protobuf.Timestamp with nanos outside
+        // [0, 1e9) is reachable from untrusted wire input (nanos is not
+        // range-checked on decode) and must not be converted to a DateTime.
+        // In the C extension this previously formatted an unparseable string
+        // ("0.-01000") whose failed parse led to a use-after-free; both
+        // implementations now reject it with an exception.
+        $timestamp = new Timestamp();
+        $timestamp->setSeconds(0);
+        $timestamp->setNanos(-1000000);
+
+        $this->expectException(Exception::class);
+        $timestamp->toDateTime();
+    }
+
     public function testType()
     {
         $m = new Type();


### PR DESCRIPTION
`toDateTime()` calls `date_create_from_format("U.u", ...)` and only checked whether the call itself succeeded, not the value it returned. On a parse failure `date_create_from_format()` frees the `DateTime` it pre-allocated and returns `false`, but the freed object pointer is left in the returned zval, so running `ZVAL_OBJ()` on it republished a freed object. A negative `nanos` (which is not range-checked on decode) formats to `"0.-01000"` and fails to parse, making this reachable from untrusted input. Reject `nanos` outside `[0, 1e9)` and verify the result is an object before returning it, in both the C extension and the pure-PHP implementation.

Ref: https://issuetracker.google.com/issues/530142194