### PR TITLE
Fix type confusion in PHP compare handlers for Message/RepeatedField/MapField

### DIFF
--- a/php/ext/google/protobuf/array.c
+++ b/php/ext/google/protobuf/array.c
@@ -79,6 +79,14 @@ static void RepeatedField_destructor(zend_object* obj) {
  *   $rf1 == $rf2
  */
 static int RepeatedField_compare_objects(zval* rf1, zval* rf2) {
+  // The engine passes the other operand through unchecked; do not reinterpret a
+  // non-object or a foreign object as a RepeatedField*.
+  if (Z_TYPE_P(rf1) != IS_OBJECT || Z_TYPE_P(rf2) != IS_OBJECT ||
+      Z_OBJCE_P(rf1) != RepeatedField_class_entry ||
+      Z_OBJCE_P(rf2) != RepeatedField_class_entry) {
+    return ZEND_UNCOMPARABLE;
+  }
+
   RepeatedField* intern1 = (RepeatedField*)Z_OBJ_P(rf1);
   RepeatedField* intern2 = (RepeatedField*)Z_OBJ_P(rf2);
 

--- a/php/ext/google/protobuf/map.c
+++ b/php/ext/google/protobuf/map.c
@@ -94,6 +94,14 @@ static void MapField_destructor(zend_object* obj) {
  *   $map1 == $map2
  */
 static int MapField_compare_objects(zval* map1, zval* map2) {
+  // The engine passes the other operand through unchecked; do not reinterpret a
+  // non-object or a foreign object as a MapField*.
+  if (Z_TYPE_P(map1) != IS_OBJECT || Z_TYPE_P(map2) != IS_OBJECT ||
+      Z_OBJCE_P(map1) != MapField_class_entry ||
+      Z_OBJCE_P(map2) != MapField_class_entry) {
+    return ZEND_UNCOMPARABLE;
+  }
+
   MapField* intern1 = (MapField*)Z_OBJ_P(map1);
   MapField* intern2 = (MapField*)Z_OBJ_P(map2);
 

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -220,6 +220,15 @@ bool ValueEq(upb_MessageValue val1, upb_MessageValue val2, TypeInfo type) {
  *   $m1 == $m2
  */
 static int Message_compare_objects(zval* m1, zval* m2) {
+  // The engine invokes this handler whenever *either* operand is a Message, and
+  // passes the other operand through unchecked. Do not reinterpret a non-object
+  // (e.g. an integer or string) or a non-Message object as a Message*.
+  if (Z_TYPE_P(m1) != IS_OBJECT || Z_TYPE_P(m2) != IS_OBJECT ||
+      !instanceof_function(Z_OBJCE_P(m1), message_ce) ||
+      !instanceof_function(Z_OBJCE_P(m2), message_ce)) {
+    return ZEND_UNCOMPARABLE;
+  }
+
   Message* intern1 = (Message*)Z_OBJ_P(m1);
   Message* intern2 = (Message*)Z_OBJ_P(m2);
   const upb_MessageDef* m = intern1->desc->msgdef;

--- a/php/tests/GeneratedClassTest.php
+++ b/php/tests/GeneratedClassTest.php
@@ -2091,6 +2091,33 @@ class GeneratedClassTest extends TestBase
         $m->getOptionalInt32();
     }
 
+    public function testCompareWithIncompatibleOperandDoesNotCrash()
+    {
+        // Regression test: the C extension's compare object handlers for
+        // Message/RepeatedField/MapField reinterpreted the *other* comparison
+        // operand as the corresponding C struct pointer without a type check.
+        // The engine invokes the handler with the other operand passed through
+        // unchecked, so `$msg == 5` reinterpreted the integer 5 as an object
+        // pointer (type confusion -> wild read). Comparing against a scalar or
+        // a foreign object must be safe and simply unequal.
+        $m = new TestMessage();
+        $this->assertFalse($m == 0x41414141);
+        $this->assertFalse(0x41414141 == $m);
+        $this->assertFalse($m == "string");
+        $this->assertFalse($m == new \stdClass());
+
+        $rf = new \Google\Protobuf\Internal\RepeatedField(
+            \Google\Protobuf\Internal\GPBType::INT32);
+        $this->assertFalse($rf == 0x42424242);
+        $this->assertFalse($rf == new \stdClass());
+
+        $map = new \Google\Protobuf\Internal\MapField(
+            \Google\Protobuf\Internal\GPBType::INT32,
+            \Google\Protobuf\Internal\GPBType::INT32);
+        $this->assertFalse($map == 0x43434343);
+        $this->assertFalse($map == new \stdClass());
+    }
+
     public function testNoExceptionWithVarDump()
     {
         $m = new Sub(['a' => 1]);


### PR DESCRIPTION
The custom `compare` object handlers for `Message`, `RepeatedField`, and
`MapField` cast **both** operands with `Z_OBJ_P()` and dereference them without
checking their type:

```c
static int Message_compare_objects(zval* m1, zval* m2) {
  Message* intern1 = (Message*)Z_OBJ_P(m1);
  Message* intern2 = (Message*)Z_OBJ_P(m2);
  const upb_MessageDef* m = intern1->desc->msgdef;
  ...
```

PHP invokes an object's `compare` handler whenever **either** operand is that
object, and passes the other operand through unchecked — it may be an integer,
string, or an unrelated object. So `$msg == 5` reinterprets the integer `5` as a
`zend_object*` and dereferences it, and `$msg == new stdClass()` reads past the
foreign object. The engine's standard handler (`zend_std_compare_objects`)
guards this and returns `ZEND_UNCOMPARABLE`; these handlers do not.

Reachable from any comparison (`==`, `!=`, `<`, …) as well as `sort()`,
`in_array()`, etc. Impact is a memory-safety violation (invalid read → crash).

## Fix

Return `ZEND_UNCOMPARABLE` unless both operands are objects of the expected
class, before dereferencing them — matching the standard object handler. Applied
to all three handlers.

## Test

Adds `testCompareWithIncompatibleOperandDoesNotCrash` to `GeneratedClassTest.php`,
covering integer, string, and foreign-object operands (in both orders) against a
`Message`, a `RepeatedField`, and a `MapField`.