### PR TITLE
[PHP] Reject malformed tag varints instead of treating them as end of input

### DIFF
--- a/conformance/failure_list_php.txt
+++ b/conformance/failure_list_php.txt
@@ -48,7 +48,3 @@ Required.*.DurationProtoNanosWrongSignNegativeSecs.JsonOutput # Should have fail
 Required.*.TimestampProtoNanoTooLarge.JsonOutput # Should have failed to serialize, but didn't.
 Required.*.TimestampProtoNegativeNanos.JsonOutput # Should have failed to serialize, but didn't.
 Required.*.JsonInput.SingleValueForRepeatedFieldInt32 # Should have failed to parse, but didn't.
-Required.*.ProtobufInput.BadTag_FieldNumberTooHigh                                                                 # Should have failed to parse, but didn't.
-Required.*.ProtobufInput.BadTag_FieldNumberSlightlyTooHigh                                                         # Should have failed to parse, but didn't.
-Required.*.ProtobufInput.BadTag_OverlongVarint                                                                     # Should have failed to parse, but didn't.
-Required.*.ProtobufInput.BadTag_VarintMoreThanTenBytes                                                             # Should have failed to parse, but didn't.

--- a/php/src/Google/Protobuf/Internal/CodedInputStream.php
+++ b/php/src/Google/Protobuf/Internal/CodedInputStream.php
@@ -26,6 +26,7 @@ class CodedInputStream
     private $total_bytes_read;
 
     const MAX_VARINT_BYTES = 10;
+    const MAX_TAG_BYTES = 5;
     const DEFAULT_RECURSION_LIMIT = 100;
     const DEFAULT_TOTAL_BYTES_LIMIT = 33554432; // 32 << 20, 32MB
 
@@ -258,14 +259,26 @@ class CodedInputStream
             return 0;
         }
 
+        // Bytes remain, so the buffer must hold a tag varint decoding to at
+        // most 2^32 - 1 (field number 2^29 - 1, wire type 7) within five
+        // bytes. A truncated, overlong, out of range, or zero tag varint is
+        // corruption, not a legitimate message end. Returning 0 for it would
+        // make the caller silently discard the remaining input.
+        $start = $this->current;
         $result = 0;
-        // The largest tag is 2^29 - 1, which can be represented by int32.
-        $success = $this->readVarint32($result);
-        if ($success) {
-            return $result;
-        } else {
-            return 0;
+        if (!$this->readVarint32($result)) {
+            throw new GPBDecodeException("Malformed tag varint.");
         }
+        $tag_bytes = $this->current - $start;
+        if ($tag_bytes > self::MAX_TAG_BYTES ||
+            ($tag_bytes === self::MAX_TAG_BYTES &&
+                ord($this->buffer[$this->current - 1]) > 0x0F)) {
+            throw new GPBDecodeException("Malformed tag varint.");
+        }
+        if ($result === 0) {
+            throw new GPBDecodeException("Illegal field number zero.");
+        }
+        return $result;
     }
 
     public function readRaw($size, &$buffer)

--- a/php/tests/EncodeDecodeTest.php
+++ b/php/tests/EncodeDecodeTest.php
@@ -2136,4 +2136,52 @@ class EncodeDecodeTest extends TestBase
         }
         $this->assertTrue($threwTooLarge, 'recursion_limit > 65535 must throw');
     }
+
+    public function testDecodeTruncatedTagVarintThrows()
+    {
+        $this->expectException(Exception::class);
+
+        $m = new TestMessage();
+        $m->mergeFromString("\x08\x01\x80");
+    }
+
+    public function testDecodeZeroTagThrows()
+    {
+        $this->expectException(Exception::class);
+
+        $m = new TestMessage();
+        $m->mergeFromString("\x00");
+    }
+
+    public function testDecodeOverlongTagVarintThrows()
+    {
+        $this->expectException(Exception::class);
+
+        $m = new TestMessage();
+        $m->mergeFromString("\x88\x80\x80\x80\x80\x80\x80\x80\x00\xd2\x09");
+    }
+
+    public function testDecodeTagVarintAboveUint32MaxThrows()
+    {
+        $this->expectException(Exception::class);
+
+        $m = new TestMessage();
+        $m->mergeFromString("\x88\x80\x80\x80\x40\xd2\x09");
+    }
+
+    public function testDecodeTagVarintMoreThanTenBytesThrows()
+    {
+        $this->expectException(Exception::class);
+
+        $m = new TestMessage();
+        $m->mergeFromString(
+            "\x88\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x00\xd2\x09");
+    }
+
+    public function testDecodeOverlongVarintValueIsAccepted()
+    {
+        $m = new TestMessage();
+        $m->mergeFromString("\x08\x81\x80\x80\x80\x80\x80\x80\x80\x80\x00");
+        $this->assertSame(1, $m->getOptionalInt32());
+    }
 }


### PR DESCRIPTION
The pure-PHP runtime's `CodedInputStream::readTag()` returns 0 when the tag varint fails to decode, which is indistinguishable from its clean end-of-stream signal, so `Message::parseFromStream()` treats corrupt input as a successful parse and silently discards the rest of the payload. A truncated buffer, an overlong tag varint, a tag varint above `UINT32_MAX`, or a stray zero tag byte all "parse" on the PHP backend while the C extension rejects them.

This change makes `readTag()` throw `GPBDecodeException` in those cases; overlong encodings of varint values remain accepted, and a test pins that down. This fixes the four `Required.*.ProtobufInput.BadTag_*` conformance cases, which are removed from `failure_list_php.txt`, aligning the pure-PHP backend with the C extension, which already passes them.