### PR TITLE
[PHP] Merge duplicated singular message fields when parsing instead of replacing them

### DIFF
--- a/conformance/failure_list_php.txt
+++ b/conformance/failure_list_php.txt
@@ -7,7 +7,6 @@ Recommended.*.JsonInput.FieldMaskInvalidCharacter
 Recommended.*.JsonInput.FieldNameDuplicate                                                           # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing1                                           # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing2                                           # Should have failed to parse, but didn't.
-Recommended.*.ProtobufInput.ValidDataOneofBinary.MESSAGE.Merge.ProtobufOutput
 Recommended.*.ValueRejectInfNumberValue.JsonOutput                                                                 # Should have failed to serialize, but didn't.
 Recommended.*.ValueRejectNanNumberValue.JsonOutput                                                                 # Should have failed to serialize, but didn't.
 Required.*.JsonInput.DoubleFieldTooSmall
@@ -29,10 +28,6 @@ Required.*.JsonInput.Uint64FieldNotInteger
 Recommended.*.JsonInput.ListValueDeepNesting200                                                                      # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.StructDeepNesting200                                                                         # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.ValueDeepNesting200                                                                          # Should have failed to parse, but didn't.
-Required.*.ProtobufInput.RepeatedScalarMessageMerge.JsonOutput
-Required.*.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput
-Required.*.ProtobufInput.ValidDataOneof.MESSAGE.Merge.JsonOutput
-Required.*.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput
 Required.*.ProtobufInput.ValidDataRepeated.FLOAT.PackedInput.JsonOutput
 Required.*.ProtobufInput.ValidDataRepeated.FLOAT.UnpackedInput.JsonOutput
 Required.*.ProtobufInput.ValidDataScalar.FLOAT[2].JsonOutput

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -416,7 +416,7 @@ class Message
             case GPBType::MESSAGE:
                 if ($field->isMap()) {
                     $value = new MapEntry($field->getMessageType());
-                } else {
+                } elseif (is_null($value)) {
                     $klass = $field->getMessageType()->getClass();
                     $value = new $klass;
                 }
@@ -500,6 +500,16 @@ class Message
             $this->skipField($input, $tag);
             return;
         } elseif ($value_format === GPBWire::NORMAL_FORMAT) {
+            if ($field->getType() === GPBType::MESSAGE &&
+                !$field->isMap() &&
+                !$field->isRepeated()) {
+                // A duplicated singular message field must merge into the
+                // existing submessage rather than replace it. Oneof getters
+                // use readOneof(), which returns null unless that exact case
+                // is set, so a switched oneof case still starts fresh.
+                $getter = $field->getGetter();
+                $value = $this->$getter();
+            }
             self::parseFieldFromStreamNoTag($input, $field, $value);
         } elseif ($value_format === GPBWire::PACKED_FORMAT) {
             $length = 0;

--- a/php/tests/EncodeDecodeTest.php
+++ b/php/tests/EncodeDecodeTest.php
@@ -2136,4 +2136,99 @@ class EncodeDecodeTest extends TestBase
         }
         $this->assertTrue($threwTooLarge, 'recursion_limit > 65535 must throw');
     }
+
+    public function testDecodeDuplicatedSingularMessageFieldMerges()
+    {
+        $first = new TestMessage();
+        $sub = new Sub();
+        $sub->setA(1);
+        $sub->setB([1]);
+        $first->setOptionalMessage($sub);
+
+        $second = new TestMessage();
+        $sub = new Sub();
+        $sub->setB([2]);
+        $second->setOptionalMessage($sub);
+
+        $m = new TestMessage();
+        $m->mergeFromString(
+            $first->serializeToString() . $second->serializeToString());
+
+        $this->assertSame(1, $m->getOptionalMessage()->getA());
+        $this->assertSame(2, count($m->getOptionalMessage()->getB()));
+        $this->assertSame(1, $m->getOptionalMessage()->getB()[0]);
+        $this->assertSame(2, $m->getOptionalMessage()->getB()[1]);
+    }
+
+    public function testDecodeDuplicatedOneofMessageFieldMerges()
+    {
+        $first = new TestMessage();
+        $sub = new Sub();
+        $sub->setA(1);
+        $sub->setB([1]);
+        $first->setOneofMessage($sub);
+
+        $second = new TestMessage();
+        $sub = new Sub();
+        $sub->setB([2]);
+        $second->setOneofMessage($sub);
+
+        $m = new TestMessage();
+        $m->mergeFromString(
+            $first->serializeToString() . $second->serializeToString());
+
+        $this->assertSame(1, $m->getOneofMessage()->getA());
+        $this->assertSame(2, count($m->getOneofMessage()->getB()));
+        $this->assertSame(1, $m->getOneofMessage()->getB()[0]);
+        $this->assertSame(2, $m->getOneofMessage()->getB()[1]);
+    }
+
+    public function testDecodeOneofMessageAfterOtherCaseStartsFresh()
+    {
+        $first = new TestMessage();
+        $sub = new Sub();
+        $sub->setA(1);
+        $first->setOneofMessage($sub);
+
+        $second = new TestMessage();
+        $second->setOneofInt32(5);
+
+        $third = new TestMessage();
+        $sub = new Sub();
+        $sub->setB([2]);
+        $third->setOneofMessage($sub);
+
+        $m = new TestMessage();
+        $m->mergeFromString(
+            $first->serializeToString() .
+            $second->serializeToString() .
+            $third->serializeToString());
+
+        $this->assertSame(0, $m->getOneofMessage()->getA());
+        $this->assertSame(1, count($m->getOneofMessage()->getB()));
+        $this->assertSame(2, $m->getOneofMessage()->getB()[0]);
+    }
+
+    public function testMergeFromStringIntoPopulatedMessageMergesSubmessage()
+    {
+        $first = new TestMessage();
+        $sub = new Sub();
+        $sub->setA(1);
+        $sub->setB([1]);
+        $first->setOptionalMessage($sub);
+
+        $second = new TestMessage();
+        $sub = new Sub();
+        $sub->setB([2]);
+        $second->setOptionalMessage($sub);
+
+        $m = new TestMessage();
+        $m->mergeFromString($first->serializeToString());
+        $m->mergeFromString($second->serializeToString());
+
+        $this->assertSame(1, $m->getOptionalMessage()->getA());
+        $this->assertSame(2, count($m->getOptionalMessage()->getB()));
+        $this->assertSame(1, $m->getOptionalMessage()->getB()[0]);
+        $this->assertSame(2, $m->getOptionalMessage()->getB()[1]);
+    }
 }


### PR DESCRIPTION
When the pure-PHP runtime parses a singular message field that appears more than once in a payload, `parseFieldFromStreamNoTag()` constructs a fresh instance for every occurrence and the setter replaces the previous one, so fields set only by an earlier occurrence are silently dropped. The wire format requires the occurrences to be merged, `mergeFromString()`'s documentation already promises the `mergeFrom()` merging behavior, `mergeFrom()` itself merges submessages recursively, and the C extension parses this correctly, so the binary parser is the one inconsistent path.

This change seeds the parse with the existing submessage when one is set, so `GPBWire::readMessage()` parses into it and merges. For oneof members the getter goes through `readOneof()`, which returns the current value only when that exact case is set, so a oneof case that was switched away still starts from a fresh submessage, and repeated and map fields keep their append and last-key-wins behavior. This fixes the `RepeatedScalarMessageMerge` and `ValidDataOneof.MESSAGE.Merge` conformance cases, which are removed from `failure_list_php.txt`.