### PR TITLE
fix(upb): guard NULL sub-enum table when decoding closed-enum fields

### DIFF
--- a/upb/mini_descriptor/internal/encode_test.cc
+++ b/upb/mini_descriptor/internal/encode_test.cc
@@ -22,10 +22,13 @@
 #include "upb/mini_descriptor/decode.h"
 #include "upb/mini_descriptor/internal/base92.h"
 #include "upb/mini_descriptor/internal/modifiers.h"
+#include "upb/message/message.h"
+#include "upb/mini_descriptor/internal/modifiers.h"
 #include "upb/mini_table/enum.h"
 #include "upb/mini_table/field.h"
 #include "upb/mini_table/internal/message.h"
 #include "upb/mini_table/message.h"
+#include "upb/wire/decode.h"
 
 // Must be last.
 #include "upb/port/def.inc"
@@ -338,4 +341,32 @@ TEST_P(MiniTableTest, Extendible) {
   ASSERT_NE(nullptr, table);
   EXPECT_EQ(kUpb_ExtMode_Extendable,
             table->UPB_PRIVATE(ext) & kUpb_ExtMode_Extendable);
+}
+
+// A MiniTable built from a mini descriptor has its closed-enum fields unlinked
+// (upb_MiniTable_GetSubEnumTable returns NULL) until upb_MiniTable_Link runs.
+// Decoding wire data against such a table must treat the enum value as an
+// unknown field rather than dereferencing the NULL sub-enum table.
+TEST_P(MiniTableTest, DecodeClosedEnumFieldWithUnlinkedSubEnum) {
+  upb::Arena arena;
+  upb::MtDataEncoder e;
+  ASSERT_TRUE(e.StartMessage(0));
+  ASSERT_TRUE(
+      e.PutField(kUpb_FieldType_Enum, 1, kUpb_FieldModifier_IsClosedEnum));
+
+  upb::Status status;
+  upb_MiniTable* table = _upb_MiniTable_Build(
+      e.data().data(), e.data().size(), GetParam(), arena.ptr(), status.ptr());
+  ASSERT_NE(nullptr, table);
+  // The sub-enum was never linked, so it is NULL.
+  ASSERT_EQ(nullptr, upb_MiniTable_GetSubEnumTable(
+                         upb_MiniTable_FindFieldByNumber(table, 1)));
+
+  // Field 1, varint, value 52: hits the closed-enum check path in the decoder.
+  const char wire[] = {0x08, 0x34};
+  upb_Message* msg = upb_Message_New(table, arena.ptr());
+  // Must not crash; the value is dropped to the unknown field set.
+  upb_DecodeStatus st =
+      upb_Decode(wire, sizeof(wire), msg, table, nullptr, 0, arena.ptr());
+  EXPECT_EQ(kUpb_DecodeStatus_Ok, st);
 }

--- a/upb/wire/decode.c
+++ b/upb/wire/decode.c
@@ -322,7 +322,10 @@ static const char* _upb_Decoder_DecodeEnumPacked(
   while (!upb_EpsCopyInputStream_IsDone(EPS(d), &ptr)) {
     wireval elem;
     ptr = upb_WireReader_ReadVarint(ptr, &elem.uint64_val, EPS(d));
-    if (!upb_MiniTableEnum_CheckValue(e, elem.uint64_val)) {
+    // e is NULL when the field's sub-enum has not been linked (a MiniTable
+    // built from a mini descriptor before upb_MiniTable_Link). Route every
+    // value to the unknown field set rather than dereferencing NULL.
+    if (!e || !upb_MiniTableEnum_CheckValue(e, elem.uint64_val)) {
       upb_Message* unknown_msg =
           field->UPB_PRIVATE(mode) & kUpb_LabelFlags_IsExtension
               ? d->original_msg
@@ -890,7 +893,10 @@ const char* _upb_Decoder_DecodeWireValue(upb_Decoder* d, const char* ptr,
       ptr = upb_WireReader_ReadVarint(ptr, &val->uint64_val, EPS(d));
       if (upb_MiniTableField_IsClosedEnum(field)) {
         const upb_MiniTableEnum* e = upb_MiniTable_GetSubEnumTable(field);
-        if (!upb_MiniTableEnum_CheckValue(e, val->uint64_val)) {
+        // A MiniTable built from a mini descriptor has unlinked sub-enums until
+        // upb_MiniTable_Link() runs, so e may be NULL here. Treat the value as
+        // unknown rather than dereferencing NULL in CheckValue.
+        if (!e || !upb_MiniTableEnum_CheckValue(e, val->uint64_val)) {
           *op = kUpb_DecodeOp_UnknownField;
           return ptr;
         }


### PR DESCRIPTION
A MiniTable produced by `upb_MiniTable_Build` has its closed-enum fields unlinked until `upb_MiniTable_Link` runs, so `upb_MiniTable_GetSubEnumTable` returns NULL. The decoder passed that pointer straight into `upb_MiniTableEnum_CheckValue`, which dereferences it unconditionally, so decoding wire data against such a table was a reliable NULL-pointer dereference. Callers that build MiniTables from untrusted mini descriptors and then decode untrusted wire data could be crashed (denial of service).

This guards both closed-enum decode paths (the scalar varint path and the packed path) with a NULL check, routing the value to the unknown field set when the sub-enum is unlinked. That matches how an out-of-range closed-enum value is already handled, so no data is lost and behavior for linked tables is unchanged.

Fixes #26857.

Test plan: added a regression test in `upb/mini_descriptor/internal/encode_test.cc` that builds a MiniTable with a closed-enum field (leaving the sub-enum unlinked) and decodes a varint for that field. Verified against a Release build (asserts off, matching the reported crash environment): the test crashes with a SIGSEGV before the fix and passes after it. `upb-test --gtest_filter=*MiniTable*:*Decode*:*Enum*` is green (228 tests).