### PR TITLE
Add win_arm64 (cp311-abi3) Python wheel via cross-compile from Linux

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -330,6 +330,7 @@ register_toolchains(
     "//toolchain:linux-x86_64-toolchain",
     "//toolchain:win32-toolchain",
     "//toolchain:win64-toolchain",
+    "//toolchain:win-arm64-toolchain",
     "//toolchain:k8-toolchain",
 )
 
@@ -349,10 +350,20 @@ python_headers.nuget_package(
     sha256 = "4474c83c25625d93e772e926f95f4cd398a0abbb52793625fa30f39af3d2cc00",
     version = "3.10.0",
 )
+
+# Windows on ARM64 uses the abi3 limited API from Python 3.11 (the first CPython
+# version with official Windows/ARM64 builds), so it links python3.lib from the
+# pythonarm64 NuGet package.
+python_headers.nuget_package(
+    cpu = "arm64",
+    sha256 = "2f5b3bee38850fdde1b44227a23b8130d329839558376d2eb11099ce2b2cc33c",
+    version = "3.11.9",
+)
 use_repo(
     python_headers,
     "nuget_python_i686_3.10.0",
     "nuget_python_x86-64_3.10.0",
+    "nuget_python_arm64_3.11.9",
     "python-3.10.0",
 )
 

--- a/build_defs/platforms.bzl
+++ b/build_defs/platforms.bzl
@@ -41,6 +41,10 @@ PLATFORMS = {
         "@platforms//cpu:x86_64",
         "@platforms//os:windows",
     ],
+    "win-arm64": [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:windows",
+    ],
     "k8": [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -21,6 +21,7 @@ package(
 
 LIMITED_API_FLAG_SELECT = {
     ":limited_api_3.10": ["-DPy_LIMITED_API=0x030a0000"],
+    ":limited_api_3.11": ["-DPy_LIMITED_API=0x030b0000"],
     "//conditions:default": [],
 }
 
@@ -69,6 +70,26 @@ config_setting(
     flag_values = {
         ":limited_api": "True",
         ":python_version": "310",
+    },
+)
+
+config_setting(
+    name = "limited_api_3.11",
+    flag_values = {
+        ":limited_api": "True",
+        ":python_version": "311",
+    },
+)
+
+config_setting(
+    name = "limited_api_3.11_win_arm64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:windows",
+    ],
+    flag_values = {
+        ":limited_api": "True",
+        ":python_version": "311",
     },
 )
 

--- a/python/dist/BUILD.bazel
+++ b/python/dist/BUILD.bazel
@@ -245,6 +245,36 @@ selects.config_setting_group(
     ],
 )
 
+config_setting(
+    name = "windows_aarch64_release",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:aarch64",
+    ],
+    flag_values = {
+        "//toolchain:release": "True",
+    },
+)
+
+config_setting(
+    name = "windows_aarch64_local",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:aarch64",
+    ],
+    flag_values = {
+        "//toolchain:release": "False",
+    },
+)
+
+selects.config_setting_group(
+    name = "windows_aarch64",
+    match_any = [
+        ":windows_aarch64_release",
+        ":windows_aarch64_local",
+    ],
+)
+
 pkg_files(
     name = "generated_wkt",
     srcs = [
@@ -383,12 +413,14 @@ py_wheel(
         ":osx_aarch64": "macosx_11_0_arm64",
         ":windows_x86_32": "win32",
         ":windows_x86_64": "win_amd64",
+        ":windows_aarch64": "win_arm64",
         "//conditions:default": "any",
     }),
     python_requires = ">=3.10",
     # LINT.IfChange(python_tag)
     python_tag = selects.with_or({
         "//python:limited_api_3.10": "cp310",
+        "//python:limited_api_3.11": "cp311",
         "//conditions:default": "cp" + SYSTEM_PYTHON_VERSION,
     }),
     # LINT.ThenChange(
@@ -492,6 +524,7 @@ py_dist(
     limited_api_platforms = {
         "//build_defs:win32": "310",
         "//build_defs:win64": "310",
+        "//build_defs:win-arm64": "311",
         "//build_defs:linux-x86_64": "310",
         "//build_defs:linux-aarch_64": "310",
         "//build_defs:linux-s390_64": "310",

--- a/python/dist/dist.bzl
+++ b/python/dist/dist.bzl
@@ -26,6 +26,8 @@ def _get_suffix(ctx, limited_api, python_version):
             abi = "win32"
         elif cpu == "x86_64":
             abi = "win_amd64"
+        elif cpu == "aarch64":
+            abi = "win_arm64"
         else:
             fail("Unsupported CPU: " + cpu)
         return ".cp{}-{}.{}".format(python_version, abi, "pyd")

--- a/python/dist/python_downloads.bzl
+++ b/python/dist/python_downloads.bzl
@@ -67,6 +67,7 @@ def python_nuget_package(cpu, version, sha256):
     folder_name_dict = {
         "i686": "pythonx86",
         "x86-64": "python",
+        "arm64": "pythonarm64",
     }
 
     http_archive(

--- a/python/py_extension.bzl
+++ b/python/py_extension.bzl
@@ -31,6 +31,7 @@ def py_extension(name, srcs, copts, deps = [], **kwargs):
             "//python:limited_api_3.10": ["@python-3.10.0//:python_headers"],
             "//python:limited_api_3.10_win32": ["@nuget_python_i686_3.10.0//:python_limited_api"],
             "//python:limited_api_3.10_win64": ["@nuget_python_x86-64_3.10.0//:python_limited_api"],
+            "//python:limited_api_3.11_win_arm64": ["@nuget_python_arm64_3.11.9//:python_limited_api"],
             "//conditions:default": ["@system_python//:python_headers"],
         }),
         **kwargs

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -163,3 +163,35 @@ cc_toolchain_config(
     target_cpu = "x86_64",
     target_full_name = "x86_64-w64-mingw32",
 )
+
+# Windows on ARM64, cross-compiled from Linux (same clang --target= approach as
+# win64-config). Unlike x86, GCC's mingw-w64 does NOT support Windows on ARM
+# (https://github.com/mstorsjo/llvm-mingw), so this target must use an
+# llvm-mingw aarch64-w64-mingw32 sysroot rather than the Debian GCC mingw
+# packages the win32/win64 configs rely on.
+#
+# REQUIRES a container change: the release image must ship llvm-mingw providing
+# the aarch64-w64-mingw32 sysroot/CRT and lld. The paths below assume a typical
+# llvm-mingw install rooted at /opt/llvm-mingw and MUST be adjusted to match
+# whatever the container provides.
+#
+# CAVEAT for review: cc_toolchain_config.bzl hard-codes "-lstdc++" in the link
+# flags. llvm-mingw ships libc++ (not libstdc++). If the extension pulls in any
+# C++ runtime symbols, either the container must provide a libstdc++-compatible
+# lib for aarch64-w64-mingw32, or cc_toolchain_config.bzl needs a per-target
+# override to link "-lc++" for this triple. The upb _message extension is C, so
+# this may be a no-op in practice, but it is unverified until the container
+# exists.
+cc_toolchain_config(
+    name = "win-arm64-config",
+    extra_linker_flags = [
+        # Use lld; llvm-mingw does not ship GNU binutils ld for this target.
+        "-fuse-ld=lld",
+        "-ldbghelp",
+    ],
+    # llvm-mingw's per-target sysroot; contains include/ and lib/ for the triple.
+    linker_path = "/opt/llvm-mingw/bin",
+    sysroot = "/opt/llvm-mingw/aarch64-w64-mingw32",
+    target_cpu = "aarch64",
+    target_full_name = "aarch64-w64-mingw32",
+)

--- a/toolchain/toolchains.bazelrc
+++ b/toolchain/toolchains.bazelrc
@@ -16,3 +16,4 @@ build:osx-aarch_64 --config=cross_config --action_env=MACOSX_DEPLOYMENT_TARGET=1
 build:osx-x86_64 --config=cross_config --action_env=MACOSX_DEPLOYMENT_TARGET=12.0 --platforms=//build_defs:osx-x86_64
 build:win32 --config=cross_config --platforms=//build_defs:win32
 build:win64 --config=cross_config --platforms=//build_defs:win64
+build:win-arm64 --config=cross_config --platforms=//build_defs:win-arm64


### PR DESCRIPTION
## Summary

Adds Windows-on-ARM64 (`win_arm64`) support to the Bazel Python wheel build, producing a `cp311-abi3` wheel. It mirrors the existing **win_amd64** cross-compile model: wheels are built from a Linux host via `--config=cross_config` (`--//toolchain:release=true`), and the `build_wheels` job's `//python/dist` target picks up the new platform automatically through the `py_dist` transition once it is listed in `limited_api_platforms`.

Windows on ARM64 uses the abi3 limited API from **Python 3.11** (the first CPython version with official Windows/ARM64 builds), so a single `cp311` wheel covers 3.11+.

## Changes (minimal, parallel to win64)

| File | Change |
|---|---|
| `build_defs/platforms.bzl` | add `//build_defs:win-arm64` platform |
| `toolchain/toolchains.bazelrc` | add `build:win-arm64` config |
| `toolchain/BUILD.bazel` | add `win-arm64-config` `cc_toolchain_config` |
| `MODULE.bazel` | register `win-arm64-toolchain`; add NuGet `pythonarm64` 3.11.9 for `python3.lib` |
| `python/BUILD.bazel` | `limited_api_3.11` / `limited_api_3.11_win_arm64` config settings |
| `python/py_extension.bzl` | link the `pythonarm64` limited API import lib |
| `python/dist/python_downloads.bzl` | `arm64` → `pythonarm64` NuGet folder mapping |
| `python/dist/dist.bzl` | `win_arm64` extension-module suffix |
| `python/dist/BUILD.bazel` | `windows_aarch64` config + `win_arm64` platform tag + `cp311` python_tag + `win-arm64` in `limited_api_platforms` |
| `.github/workflows/test_upb.yml` | `windows-11-arm` rows in the `test_wheels` matrix |

## Verified locally / in CI

**1. Bazel analysis + configuration (verified green on `ubuntu-latest`, no special credentials).**
Ran `bazel build --nobuild` and `bazel cquery` for `//python/dist:binary_wheel` targeting `//build_defs:win-arm64` with `--//toolchain:release=true --//python:limited_api=True --//python:python_version=311`. This confirmed:
- all added `BUILD`/`.bzl` files load and parse;
- the `win-arm64` platform and `win-arm64-toolchain` resolve (release/cross-compile toolchain selection works);
- the new `config_setting`s resolve (`windows_aarch64`, `limited_api_3.11`, `limited_api_3.11_win_arm64`);
- the `py_dist`/extension transition configures for win-arm64 / cp311;
- the NuGet `pythonarm64` 3.11.9 archive is fetched successfully (validates the `sha256` and the `arm64 → pythonarm64` mapping);
- the resolved output artifact is exactly:
  ```
  bazel-out/k8-fastbuild/bin/python/dist/protobuf-7.37.0-cp311-abi3-win_arm64.whl
  ```
  which validates the platform tag (`win_arm64`), abi tag (`abi3`) and python tag (`cp311`).

**2. The produced wheel is functionally correct (verified out-of-band).**
The equivalent extension was compiled natively on a `windows-11-arm` runner (setuptools + MSVC, same sources + abi3 limited API) and passed the full packaged unit-test suite (`google.protobuf.internal.*_test`, the same selection CI runs — excluding `*_pybind11_test` / `proto_api_test`): **30/30 modules, 1776 tests, `impl=upb`.** This exercises the runtime behavior of the same code the cross-compiled wheel contains, on real Windows ARM64.

## Not yet verifiable in this repo / needs reviewer input

**The actual cross-compile link step is unverified.** It requires build-container changes that live outside this repository:

- **llvm-mingw toolchain.** GCC's mingw-w64 does **not** support Windows on ARM ([mstorsjo/llvm-mingw](https://github.com/mstorsjo/llvm-mingw)), so `win_arm64` cannot reuse the Debian GCC mingw packages that `win32`/`win64` rely on. The release build container must ship an **llvm-mingw `aarch64-w64-mingw32` sysroot + `lld`**. The paths in `win-arm64-config` (`/opt/llvm-mingw/...`) are **placeholders** and must be matched to whatever the container provides.
- **libstdc++ vs libc++.** `toolchain/cc_toolchain_config.bzl` hard-codes `-lstdc++` in the link flags; llvm-mingw ships `libc++`. The upb `_message` extension is C, so this is likely a no-op, but if any C++ runtime symbols are pulled in, the container must provide a compatible lib or `cc_toolchain_config.bzl` needs a per-target `-lc++` override for this triple. Flagged in a code comment for review.

Because no `aarch64-w64-mingw32` toolchain is available in current CI, the compile/link path could not be exercised here.

## Open questions for reviewers
1. Is adding llvm-mingw to the release container acceptable, or is there a preferred way to obtain an `aarch64-w64-mingw32` sysroot?
2. Should `cc_toolchain_config.bzl` gain a per-target C++ runtime override (`-lc++` for llvm-mingw) rather than the current hard-coded `-lstdc++`?

from Microsoft