### PR TITLE
Bundle the upb extension in the //:protobuf_python Bazel target by default

### DIFF
--- a/conformance/BUILD
+++ b/conformance/BUILD
@@ -521,7 +521,6 @@ py_binary(
         "//conformance/test_protos:test_messages_edition_unstable_py_pb2",
         "//editions:test_messages_proto2_editions_py_pb2",
         "//editions:test_messages_proto3_editions_py_pb2",
-        "//python:_message",  # Make upb visible if we need it.
         "//python:conformance_test_py_proto",
     ],
 )

--- a/python/build_targets.bzl
+++ b/python/build_targets.bzl
@@ -40,7 +40,21 @@ def build_targets(name):
         deps = [
             ":python_srcs",
             ":well_known_types_py_pb2",
-        ],
+        ] + select({
+            # Bundle the native upb extension by default so that
+            # google._upb._message is importable and api_implementation selects
+            # the fast upb backend -- matching the behavior of the published
+            # wheel, where upb is the default. Without this, bazel consumers of
+            # :protobuf_python silently fall back to the pure-Python backend.
+            #
+            # Omit it under use_fast_cpp_protos (the user explicitly opted into
+            # the cpp backend, which is bundled via data above), and where
+            # python is unavailable (:_message is target_incompatible there).
+            ":use_fast_cpp_protos": [],
+            "@system_python//:none": [],
+            "@system_python//:unsupported": [],
+            "//conditions:default": [":_message"],
+        }),
     )
 
     native.config_setting(


### PR DESCRIPTION
The //:protobuf_python py_library only bundles the cpp backend extensions, and only under --define=use_fast_cpp_protos=true. It never depends on the upb extension (//python:_message). As a result, a Bazel target that depends on //:protobuf_python gets google._upb._message on its runfiles path only if some other dependency happens to ship it; otherwise api_implementation falls back to the pure-Python backend. This diverges from the published PyPI wheel, where upb is the default and requires no special setup (see python/README.md).

This appears to be an oversight rather than intent. The protobuf_python target was introduced in b3cbea18e ("[Bazel] Move Python rules to //python") with only the cpp backend in its data select, shortly after a27ce12d3 made upb the top-priority auto-selected backend in api_implementation.py, and google/_upb has never appeared in this target's data/deps since. The gap is already worked around in-tree: conformance/BUILD's conformance_python depends on //:protobuf_python and then adds //python:_message separately with the comment "Make upb visible if we need it."

Add :_message to the default deps of protobuf_python so upb is importable, and thus auto-selected, out of the box. It is omitted under use_fast_cpp_protos (the user explicitly opted into the cpp backend) and where python is unavailable, since :_message is target_compatible_with-incompatible under @system_python//:none and //:unsupported. Remove the now-redundant explicit //python:_message dependency from conformance/conformance_python.

Verified with `bazel cquery 'somepath(//:protobuf_python, //python:_message)'`: a path exists in the default config and is absent under --define=use_fast_cpp_protos=true.

Fixes #28602