### PR TITLE
fix 64-bit varint truncation in decode_fast

### DIFF
--- a/upb/wire/decode_fast/BUILD
+++ b/upb/wire/decode_fast/BUILD
@@ -197,6 +197,25 @@ cc_binary(
 )
 
 cc_test(
+    name = "varint_test",
+    srcs = ["varint_test.cc"],
+    copts = UPB_DEFAULT_CPPOPTS,
+    features = UPB_DEFAULT_FEATURES,
+    deps = [
+        ":combinations",
+        "//upb/mem",
+        "//upb/message",
+        "//upb/port",
+        "//upb/wire",
+        "//upb/wire/test_util:field_types",
+        "//upb/wire/test_util:make_mini_table",
+        "//upb/wire/test_util:wire_message",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "test_unknown",
     srcs = ["test_unknown.cc"],
     copts = UPB_DEFAULT_CPPOPTS,

--- a/upb/wire/decode_fast/cardinality.h
+++ b/upb/wire/decode_fast/cardinality.h
@@ -440,9 +440,9 @@ bool upb_DecodeFast_Unpacked(upb_Decoder* d, const char** ptr, upb_Message* msg,
 UPB_FORCEINLINE bool _upb_DecodeFast_DecodeSizeSlow(const char** pp,
                                                     int* size) {
   const char* ptr = *pp;
-  uint32_t val = (ptr[0] & 0x7f) | ((ptr[1] & 0x7f) << 7);
+  uint64_t val = (ptr[0] & 0x7f) | ((ptr[1] & 0x7f) << 7);
   for (int i = 2; i < 5; i++) {
-    uint32_t byte = (uint8_t)ptr[i];
+    uint64_t byte = (uint8_t)ptr[i];
     val |= (byte & 0x7f) << (i * 7);
     if (!(byte & 0x80)) {
       if (UPB_UNLIKELY(val > INT32_MAX)) return false;

--- a/upb/wire/decode_fast/field_varint.c
+++ b/upb/wire/decode_fast/field_varint.c
@@ -48,10 +48,11 @@ static UPB_PRESERVE_MOST void _upb_FastDecoder_AddEnumValueToUnknown(
   // unpacked.
   uint32_t varint_tag = (field_num << 3) | kUpb_WireType_Varint;
 
-  char buf[2 * kUpb_Decoder_EncodeVarint32MaxSize];
+  char buf[kUpb_Decoder_EncodeVarint32MaxSize +
+           kUpb_Decoder_EncodeVarint64MaxSize];
   char* end = buf;
   end = upb_Decoder_EncodeVarint32(varint_tag, end);
-  end = upb_Decoder_EncodeVarint32(val, end);
+  end = upb_Decoder_EncodeVarint64(val, end);
 
   if (!UPB_PRIVATE(_upb_Message_AddUnknown)(msg, buf, end - buf, &d->arena,
                                             kUpb_AddUnknown_Copy)) {

--- a/upb/wire/decode_fast/varint_test.cc
+++ b/upb/wire/decode_fast/varint_test.cc
@@ -1,0 +1,78 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2025 Google LLC.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+// This test requires fasttable support to work properly.
+// Run with `--//upb:fasttable_enabled=true`.
+
+#include <cstdint>
+#include <string>
+
+#include <gtest/gtest.h>
+#include "upb/mem/arena.hpp"
+#include "upb/message/message.h"
+#include "upb/wire/decode.h"
+#include "upb/wire/decode_fast/combinations.h"
+#include "upb/wire/test_util/field_types.h"
+#include "upb/wire/test_util/make_mini_table.h"
+#include "upb/wire/test_util/wire_message.h"
+
+// Must be last.
+#include "upb/port/def.inc"
+
+namespace upb {
+namespace test {
+namespace {
+
+TEST(DecodeFastVarintTest, RejectsSizeAboveInt32Max) {
+  upb::Arena arena;
+  const upb_MiniTable* mt =
+      MiniTable::MakeSingleFieldTable<field_types::String>(
+          1, kUpb_DecodeFast_Scalar, arena.ptr())
+          .first;
+
+  // Field 1, wire type 2, followed by the size varint 2^32, which is above the
+  // INT32_MAX cap that upb_WireReader_ReadSize() enforces.
+  const std::string payload("\x0a\x80\x80\x80\x80\x10", 6);
+
+  upb_Message* msg = upb_Message_New(mt, arena.ptr());
+  EXPECT_EQ(upb_Decode(payload.data(), payload.size(), msg, mt, nullptr, 0,
+                       arena.ptr()),
+            kUpb_DecodeStatus_Malformed);
+}
+
+TEST(DecodeFastVarintTest, KeepsFullEnumValueInUnknownFields) {
+  upb::Arena arena;
+  const upb_MiniTable* mt =
+      MiniTable::MakeSingleFieldTable<field_types::ClosedEnum>(
+          1, kUpb_DecodeFast_Scalar, arena.ptr())
+          .first;
+
+  // The low 32 bits are outside the test enum's range, so the value is
+  // unrecognized and lands in the unknown fields, where all 64 bits of it must
+  // survive.
+  const uint64_t value = (uint64_t{1} << 32) | (1 << 21);
+  const std::string payload =
+      ToBinaryPayload(wire_types::WireMessage{{1, wire_types::Varint(value)}});
+
+  upb_Message* msg = upb_Message_New(mt, arena.ptr());
+  ASSERT_EQ(upb_Decode(payload.data(), payload.size(), msg, mt, nullptr, 0,
+                       arena.ptr()),
+            kUpb_DecodeStatus_Ok);
+  ASSERT_TRUE(upb_Message_HasUnknown(msg));
+
+  uintptr_t iter = kUpb_Message_UnknownBegin;
+  upb_StringView unknown_data;
+  std::string captured_unknown;
+  while (upb_Message_NextUnknown(msg, &unknown_data, &iter)) {
+    captured_unknown.append(unknown_data.data, unknown_data.size);
+  }
+  EXPECT_EQ(captured_unknown, payload);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace upb

--- a/upb/wire/internal/decoder.h
+++ b/upb/wire/internal/decoder.h
@@ -39,6 +39,7 @@
 
 #define DECODE_NOGROUP (uint32_t)-1
 #define kUpb_Decoder_EncodeVarint32MaxSize 5
+#define kUpb_Decoder_EncodeVarint64MaxSize 10
 
 typedef union {
   bool bool_val;
@@ -263,6 +264,16 @@ UPB_INLINE bool _upb_Decoder_ReadString(upb_Decoder* d, const char** ptr,
 }
 
 UPB_INLINE char* upb_Decoder_EncodeVarint32(uint32_t val, char* ptr) {
+  do {
+    uint8_t byte = val & 0x7fU;
+    val >>= 7;
+    if (val) byte |= 0x80U;
+    *(ptr++) = byte;
+  } while (val);
+  return ptr;
+}
+
+UPB_INLINE char* upb_Decoder_EncodeVarint64(uint64_t val, char* ptr) {
   do {
     uint8_t byte = val & 0x7fU;
     val >>= 7;


### PR DESCRIPTION
The fasttable decoder handles two 64-bit wire values with 32-bit arithmetic, so it disagrees with the reference decoder on the same bytes. `_upb_DecodeFast_DecodeSizeSlow` accumulates a delimited size varint into a `uint32_t`, so the fifth byte's `<< 28` drops bits 32-34 before the `val > INT32_MAX` guard runs, and `80 80 80 80 10` (2^32) is accepted as an empty field where `_upb_WireReader_ReadLongSize` returns malformed. `_upb_FastDecoder_AddEnumValueToUnknown` has the same problem in the other direction: it re-encodes its `uint64_t val` with `EncodeVarint32`, so an unrecognized closed enum above `UINT32_MAX` reaches the unknown fields carrying only its low 32 bits.

Widening both to 64 bits keeps the fast path in step with the reference rather than checking for it at the call sites, since the two are meant to agree byte for byte and the reference already does the right thing. `_upb_DecodeFast_ParseLongTag` next door guards the same `<< 28` explicitly, so the size case now lines up with it. The test covers both and fails without the fix under `--//upb:fasttable_enabled=true`.