### PR TITLE
Validate filename-derived module names in Python code generation

### DIFF
--- a/src/google/protobuf/compiler/python/generator.cc
+++ b/src/google/protobuf/compiler/python/generator.cc
@@ -214,6 +214,10 @@ bool Generator::Generate(const FileDescriptor* file,
   GeneratorOptions options = ParseParameter(parameter, error);
   if (!error->empty()) return false;
 
+  if (!ValidatePythonModuleNames(file, error)) {
+    return false;
+  }
+
   // Generate pyi typing information
   if (options.generate_pyi) {
     python::PyiGenerator pyi_generator;

--- a/src/google/protobuf/compiler/python/helpers.cc
+++ b/src/google/protobuf/compiler/python/helpers.cc
@@ -11,7 +11,9 @@
 #include <string>
 #include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "absl/log/absl_check.h"
+#include "absl/strings/ascii.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
@@ -32,6 +34,80 @@ std::string ModuleName(absl::string_view filename) {
   std::string basename = StripProto(filename);
   absl::StrReplaceAll({{"-", "_"}, {"/", "."}}, &basename);
   return absl::StrCat(basename, "_pb2");
+}
+
+// Returns whether a module name can be safely emitted into generated Python
+// import statements without introducing Python syntax.
+bool IsSafePythonModuleName(absl::string_view module_name) {
+  for (absl::string_view component : absl::StrSplit(module_name, '.')) {
+    if (component.empty()) {
+      return false;
+    }
+
+    const unsigned char first =
+        static_cast<unsigned char>(component.front());
+    if (!(absl::ascii_isalpha(first) || first == '_')) {
+      return false;
+    }
+
+    for (char character : component.substr(1)) {
+      const unsigned char value = static_cast<unsigned char>(character);
+      if (!(absl::ascii_isalnum(value) || value == '_')) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+namespace {
+
+bool ValidateModuleAndPublicDependencies(
+    const FileDescriptor* file,
+    absl::flat_hash_set<const FileDescriptor*>* visited,
+    std::string* error) {
+  if (!visited->insert(file).second) {
+    return true;
+  }
+
+  const std::string module_name = ModuleName(file->name());
+  if (!IsSafePythonModuleName(module_name)) {
+    *error = absl::StrCat(
+        file->name(),
+        ": Cannot generate Python code because the file name produces an "
+        "invalid Python module name: ",
+        module_name);
+    return false;
+  }
+
+  for (int i = 0; i < file->public_dependency_count(); ++i) {
+    if (!ValidateModuleAndPublicDependencies(
+            file->public_dependency(i), visited, error)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+}  // namespace
+
+bool ValidatePythonModuleNames(const FileDescriptor* file, std::string* error) {
+  absl::flat_hash_set<const FileDescriptor*> visited;
+
+  if (!ValidateModuleAndPublicDependencies(file, &visited, error)) {
+    return false;
+  }
+
+  for (int i = 0; i < file->dependency_count(); ++i) {
+    if (!ValidateModuleAndPublicDependencies(
+            file->dependency(i), &visited, error)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 std::string StrippedModuleName(absl::string_view filename) {

--- a/src/google/protobuf/compiler/python/helpers.h
+++ b/src/google/protobuf/compiler/python/helpers.h
@@ -21,6 +21,8 @@ namespace compiler {
 namespace python {
 
 std::string ModuleName(absl::string_view filename);
+bool IsSafePythonModuleName(absl::string_view module_name);
+bool ValidatePythonModuleNames(const FileDescriptor* file, std::string* error);
 std::string StrippedModuleName(absl::string_view filename);
 bool ContainsPythonKeyword(absl::string_view module_name);
 bool IsPythonKeyword(absl::string_view name);

--- a/src/google/protobuf/compiler/python/plugin_unittest.cc
+++ b/src/google/protobuf/compiler/python/plugin_unittest.cc
@@ -22,6 +22,7 @@
 #include "google/protobuf/compiler/command_line_interface_tester.h"
 #include "google/protobuf/compiler/cpp/generator.h"
 #include "google/protobuf/compiler/python/generator.h"
+#include "google/protobuf/compiler/python/pyi_generator.h"
 #include "google/protobuf/cpp_features.pb.h"
 #include "google/protobuf/io/printer.h"
 #include "google/protobuf/io/zero_copy_stream.h"
@@ -120,6 +121,54 @@ class PythonGeneratorTest : public CommandLineInterfaceTester,
         google::protobuf::DescriptorProto::descriptor()->file()->DebugString());
   }
 };
+
+TEST_P(PythonGeneratorTest, RejectsUnsafeDependencyModuleName) {
+  CreateTempFile("os;payload#.proto", R"schema(
+syntax = "proto3";
+)schema");
+
+  CreateTempFile("main.proto", R"schema(
+syntax = "proto3";
+import "os;payload#.proto";
+message Main {}
+)schema");
+
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--python_out=$tmpdir main.proto");
+
+  ExpectErrorSubstring("invalid Python module name");
+  EXPECT_FALSE(
+      File::Exists(absl::StrCat(temp_directory(), "/main_pb2.py")));
+}
+
+class PyiGeneratorTest : public CommandLineInterfaceTester {
+ protected:
+  PyiGeneratorTest() {
+    RegisterGenerator("--pyi_out", std::make_unique<PyiGenerator>(),
+                      "Python pyi test generator");
+  }
+};
+
+TEST_F(PyiGeneratorTest, RejectsUnsafeDependencyModuleName) {
+  CreateTempFile("os;payload#.proto", R"schema(
+syntax = "proto3";
+)schema");
+
+  CreateTempFile("main.proto", R"schema(
+syntax = "proto3";
+import "os;payload#.proto";
+message Main {}
+)schema");
+
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--pyi_out=$tmpdir main.proto");
+
+  ExpectErrorSubstring("invalid Python module name");
+  EXPECT_FALSE(
+      File::Exists(absl::StrCat(temp_directory(), "/main_pb2.pyi")));
+}
 
 TEST_P(PythonGeneratorTest, PythonWithCppFeatures) {
   // Test that the presence of C++ features does not break Python generation.

--- a/src/google/protobuf/compiler/python/pyi_generator.cc
+++ b/src/google/protobuf/compiler/python/pyi_generator.cc
@@ -610,6 +610,11 @@ bool PyiGenerator::Generate(const FileDescriptor* file,
   import_map_.clear();
   // Calculate file name.
   file_ = file;
+
+  if (!ValidatePythonModuleNames(file, error)) {
+    return false;
+  }
+
   // In google3, devtools/python/bazel/pytype/pytype_impl.bzl uses --pyi_out to
   // directly set the output file name.
   std::vector<std::pair<std::string, std::string> > options;


### PR DESCRIPTION
## Summary

Validates filename-derived Python module names before emitting generated Python import statements.

The Python generators derive module names from `.proto` filenames. Previously, filenames containing Python syntax characters could be inserted into generated `_pb2.py` or `.pyi` import statements.

This change rejects filenames whose derived module path contains invalid Python identifier components.

Fixes #28615.

## Changes

* Add shared validation for filename-derived Python module names.
* Validate the input file and imported dependencies before creating output.
* Recursively validate public dependencies.
* Apply validation to both `--python_out` and standalone `--pyi_out`.
* Add regression tests confirming unsafe dependency filenames are rejected.
* Confirm no partial generated output is created after validation fails.

## Example

A dependency filename such as:

```text
os;payload#.proto
```

previously produced unsafe Python source during generation.

With this change, `protoc` exits with an error similar to:

```text
Cannot generate Python code because the file name produces an invalid Python module name
```

## Testing

```text
bazel test //src/google/protobuf/compiler/python:plugin_unittest --test_output=errors --nocache_test_results
```

Result:

```text
//src/google/protobuf/compiler/python:plugin_unittest PASSED
```

The original proof of concept was also tested against the patched `protoc` binary:

* `protoc` returned a nonzero exit code.
* The injected payload did not execute.
* No unsafe `main_pb2.py` output was created.
