### PR TITLE
Replace system_python with rules_python

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,6 +40,11 @@ bazel_dep(name = "rules_kotlin", version = "2.3.20")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_python", version = "1.6.0")
+git_override(
+    module_name = "rules_python",
+    remote = "https://github.com/rsartor-cmd/rules_python",
+    commit = "f5cbb95c34512dac1920ed35d855b2c655b0a431",
+)
 bazel_dep(name = "rules_rust", version = "0.69.0")
 
 bazel_dep(name = "rules_ruby", version = "0.20.1", dev_dependency = True)

--- a/python/build_targets.bzl
+++ b/python/build_targets.bzl
@@ -19,6 +19,7 @@ load("//build_defs:cpp_opts.bzl", "COPTS")
 load("//conformance:defs.bzl", "conformance_test")
 load("//editions:defaults.bzl", "compile_edition_defaults", "embed_edition_defaults")
 load(":internal.bzl", "internal_copy_files", "internal_is_windows", "internal_py_test")
+load("@rules_python//python/cc:py_extension.bzl", "py_extension")
 
 def build_targets(name):
     """
@@ -116,6 +117,57 @@ def build_targets(name):
 
     cc_binary(
         name = "google/protobuf/pyext/_message.so",
+        srcs = native.glob([
+            "google/protobuf/pyext/*.cc",
+            "google/protobuf/pyext/*.h",
+        ]),
+        copts = COPTS + [
+            "-DGOOGLE_PROTOBUF_HAS_ONEOF=1",
+        ] + select({
+            "//conditions:default": [],
+            ":allow_oversize_protos": ["-DPROTOBUF_PYTHON_ALLOW_OVERSIZE_PROTOS=1"],
+        }),
+        linkopts = select({
+            "@platforms//os:osx": ["-Wl,-undefined,dynamic_lookup"],
+            "//conditions:default": [],
+        }),
+        includes = ["."],
+        linkshared = 1,
+        linkstatic = 1,
+        tags = [
+            # Exclude this target from wildcard expansion (//...) because it may
+            # not even be buildable. It will be built if it is needed according
+            # to :use_fast_cpp_protos.
+            # https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes
+            "manual",
+        ],
+        deps = [
+            ":proto_api",
+            ":breaking_changes",
+            "//src/google/protobuf",
+            "//src/google/protobuf:port",
+            "//src/google/protobuf:protobuf_lite",
+            "//src/google/protobuf/io",
+            "//src/google/protobuf/io:tokenizer",
+            "//src/google/protobuf/stubs:lite",
+            "//src/google/protobuf/util:differencer",
+            "@abseil-cpp//absl/base:core_headers",
+            "@abseil-cpp//absl/base:no_destructor",
+            "@abseil-cpp//absl/container:flat_hash_map",
+            "@abseil-cpp//absl/functional:function_ref",
+            "@abseil-cpp//absl/log:absl_check",
+            "@abseil-cpp//absl/log:absl_log",
+            "@abseil-cpp//absl/status",
+            "@abseil-cpp//absl/status:statusor",
+            "@abseil-cpp//absl/strings",
+            "@abseil-cpp//absl/synchronization",
+            "@abseil-cpp//absl/types:span",
+            "@system_python//:python_headers",
+        ],
+    )
+
+    py_extension(
+        name = "message_ext",
         srcs = native.glob([
             "google/protobuf/pyext/*.cc",
             "google/protobuf/pyext/*.h",

--- a/python/build_targets.bzl
+++ b/python/build_targets.bzl
@@ -34,7 +34,7 @@ def build_targets(name):
             "//conditions:default": [],
             ":use_fast_cpp_protos": [
                 ":google/protobuf/internal/_api_implementation.so",
-                ":google/protobuf/pyext/_message.so",
+                ":google/protobuf/pyext/_message",
             ],
         }),
         visibility = ["//:__pkg__"],
@@ -115,59 +115,8 @@ def build_targets(name):
         visibility = ["//python:__subpackages__"],
     )
 
-    cc_binary(
-        name = "google/protobuf/pyext/_message.so",
-        srcs = native.glob([
-            "google/protobuf/pyext/*.cc",
-            "google/protobuf/pyext/*.h",
-        ]),
-        copts = COPTS + [
-            "-DGOOGLE_PROTOBUF_HAS_ONEOF=1",
-        ] + select({
-            "//conditions:default": [],
-            ":allow_oversize_protos": ["-DPROTOBUF_PYTHON_ALLOW_OVERSIZE_PROTOS=1"],
-        }),
-        linkopts = select({
-            "@platforms//os:osx": ["-Wl,-undefined,dynamic_lookup"],
-            "//conditions:default": [],
-        }),
-        includes = ["."],
-        linkshared = 1,
-        linkstatic = 1,
-        tags = [
-            # Exclude this target from wildcard expansion (//...) because it may
-            # not even be buildable. It will be built if it is needed according
-            # to :use_fast_cpp_protos.
-            # https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes
-            "manual",
-        ],
-        deps = [
-            ":proto_api",
-            ":breaking_changes",
-            "//src/google/protobuf",
-            "//src/google/protobuf:port",
-            "//src/google/protobuf:protobuf_lite",
-            "//src/google/protobuf/io",
-            "//src/google/protobuf/io:tokenizer",
-            "//src/google/protobuf/stubs:lite",
-            "//src/google/protobuf/util:differencer",
-            "@abseil-cpp//absl/base:core_headers",
-            "@abseil-cpp//absl/base:no_destructor",
-            "@abseil-cpp//absl/container:flat_hash_map",
-            "@abseil-cpp//absl/functional:function_ref",
-            "@abseil-cpp//absl/log:absl_check",
-            "@abseil-cpp//absl/log:absl_log",
-            "@abseil-cpp//absl/status",
-            "@abseil-cpp//absl/status:statusor",
-            "@abseil-cpp//absl/strings",
-            "@abseil-cpp//absl/synchronization",
-            "@abseil-cpp//absl/types:span",
-            "@rules_python//python/cc:current_py_cc_headers",
-        ],
-    )
-
     py_extension(
-        name = "message_ext",
+        name = "google/protobuf/pyext/_message",
         srcs = native.glob([
             "google/protobuf/pyext/*.cc",
             "google/protobuf/pyext/*.h",
@@ -213,7 +162,6 @@ def build_targets(name):
             "@abseil-cpp//absl/strings",
             "@abseil-cpp//absl/synchronization",
             "@abseil-cpp//absl/types:span",
-            "@system_python//:python_headers",
         ],
     )
 
@@ -221,7 +169,7 @@ def build_targets(name):
         name = "aarch64_test",
         bazel_binaries = [
             "google/protobuf/internal/_api_implementation.so",
-            "google/protobuf/pyext/_message.so",
+            "google/protobuf/pyext/_message",
         ],
     )
 
@@ -229,7 +177,7 @@ def build_targets(name):
         name = "x86_64_test",
         bazel_binaries = [
             "google/protobuf/internal/_api_implementation.so",
-            "google/protobuf/pyext/_message.so",
+            "google/protobuf/pyext/_message",
         ],
     )
 

--- a/python/build_targets.bzl
+++ b/python/build_targets.bzl
@@ -100,7 +100,7 @@ def build_targets(name):
             # https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes
             "manual",
         ],
-        deps = ["@system_python//:python_headers"],
+        deps = ["@rules_python//python/cc:current_py_cc_headers"],
     )
 
     native.config_setting(
@@ -162,7 +162,7 @@ def build_targets(name):
             "@abseil-cpp//absl/strings",
             "@abseil-cpp//absl/synchronization",
             "@abseil-cpp//absl/types:span",
-            "@system_python//:python_headers",
+            "@rules_python//python/cc:current_py_cc_headers",
         ],
     )
 
@@ -536,7 +536,7 @@ def build_targets(name):
             "@abseil-cpp//absl/log:absl_check",
             "@abseil-cpp//absl/status",
             "@abseil-cpp//absl/status:statusor",
-            "@system_python//:python_headers",
+            "@rules_python//python/cc:current_py_cc_headers",
         ],
     )
 


### PR DESCRIPTION
This PR is a trial run for replacing the bespoke `system_python` mechanism for managing building of python C extension with the `py_extension` macro currently under development in `rules_python`.