### PR TITLE
Java JsonFormat: print fully qualified extension names by default

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -79,7 +79,7 @@ public class JsonFormat {
 
   /** Creates a {@link Printer} with default configurations. */
   public static Printer printer() {
-    boolean printingFullyQualifiedExtensionNamesDefaultValue = false;
+    boolean printingFullyQualifiedExtensionNamesDefaultValue = true;
     return new Printer(
         com.google.protobuf.TypeRegistry.getEmptyTypeRegistry(),
         TypeRegistry.getEmptyTypeRegistry(),

--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -206,6 +206,75 @@ public class JsonFormatTest {
   }
 
   @Test
+  public void testExtensionFields_defaultPrinter_printsFullyQualifiedNamesAndRoundTrips()
+      throws Exception {
+    TypeRegistry registry =
+        TypeRegistry.newBuilder().add(TestAllTypesProto2.getDescriptor()).build();
+    JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(registry);
+    TestAllTypesProto2 message =
+        TestAllTypesProto2.newBuilder()
+            .setExtension(JsonTestProto2.extensionInt32, 123)
+            .setExtension(
+                JsonTestProto2.extensionRepeatedBool, ImmutableList.of(true, false, false))
+            .setExtension(
+                JsonTestProto2.extensionNestedMessage,
+                TestAllTypesProto2.NestedMessage.newBuilder().setValue(789).build())
+            .build();
+
+    String json = printer.print(message);
+
+    String expectedJsonWithFullnames =
+        "{\n"
+            + "  \"[json_test_proto2.extension_int32]\": 123,\n"
+            + "  \"[json_test_proto2.extension_repeated_bool]\": [true, false, false],\n"
+            + "  \"[json_test_proto2.extension_nested_message]\": {\n"
+            + "    \"value\": 789\n"
+            + "  }\n"
+            + "}";
+    assertThat(json).isEqualTo(expectedJsonWithFullnames);
+    // Assert round-trip success.
+    JsonFormat.Parser parser =
+        JsonFormat.parser()
+            .usingTypeRegistry(registry)
+            .usingExtensionRegistry(makeExtensionRegistry());
+    Message.Builder builder = message.newBuilderForType();
+    parser.merge(json, builder);
+    Message parsedMessage = builder.build();
+    assertThat(parsedMessage.toString()).isEqualTo(message.toString());
+  }
+
+  @Test
+  public void
+      testExtensionFields_defaultPrinter_withSameShortName_doesNotDuplicateKeysAndRoundTrips()
+          throws Exception {
+    TypeRegistry registry =
+        TypeRegistry.newBuilder().add(TestAllTypesProto2.getDescriptor()).build();
+    JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(registry);
+    TestAllTypesProto2 message =
+        TestAllTypesProto2.newBuilder()
+            .setExtensionSameName("Field entry")
+            .setExtension(JsonTestProto2.extensionSameName, "Extension entry")
+            .build();
+
+    String json = printer.print(message);
+    String expectedJsonWithFullnames =
+        "{\n"
+            + "  \"extensionSameName\": \"Field entry\",\n"
+            + "  \"[json_test_proto2.extension_same_name]\": \"Extension entry\"\n"
+            + "}";
+    assertThat(json).isEqualTo(expectedJsonWithFullnames);
+    // Assert round-trip success.
+    JsonFormat.Parser parser =
+        JsonFormat.parser()
+            .usingTypeRegistry(registry)
+            .usingExtensionRegistry(makeExtensionRegistry());
+    Message.Builder builder = message.newBuilderForType();
+    parser.merge(json, builder);
+    Message parsedMessage = builder.build();
+    assertThat(parsedMessage.toString()).isEqualTo(message.toString());
+  }
+
+  @Test
   public void
       testExtensionFields_printingFullyQualifiedExtensionNames_arePrintedWithFullyQualifiedName()
           throws Exception {


### PR DESCRIPTION
## Summary

`JsonFormat.printer()` was serializing extensions with short keys (e.g. `"extensionInt32"`) instead of ProtoJSON fully qualified keys (`"[json_test_proto2.extension_int32]"`). That output:

- cannot be parsed back as extensions
- can collide with regular field names (silent data corruption)
- can emit duplicate JSON keys when two extensions share a short name

C++ and Python already print `"[package.extension_name]"`. This change flips the existing `printingFullyQualifiedExtensionNames` default to `true`. The previous short-name behavior remains available via `printingDeprecatedNonConformantShortExtensionNames()` for any internal clients that still depend on it.

Fixes #27499

## Test plan

- [x] New regression tests fail when the default is left as short names
- [x] New regression tests pass with this change
- [x] `bazel test //java/util:tests` (all 8 targets)