### PR TITLE
Enable DEP and ASLR for Windows Python extension

### DIFF
--- a/python/py_extension.bzl
+++ b/python/py_extension.bzl
@@ -22,7 +22,16 @@ def py_extension(name, srcs, copts, deps = [], **kwargs):
                 "//python/dist:osx_x86_64",
                 "//python/dist:osx_aarch64",
             ): ["-Wl,-undefined,dynamic_lookup"],
-            "//python/dist:windows_x86_32": ["-static-libgcc"],
+            "//python/dist:windows_x86_32": [
+                "-static-libgcc",
+                "-Wl,--dynamicbase",
+                "-Wl,--nxcompat",
+            ],
+            "//python/dist:windows_x86_64": [
+                "-Wl,--dynamicbase",
+                "-Wl,--high-entropy-va",
+                "-Wl,--nxcompat",
+            ],
             "//conditions:default": [],
         }),
         linkshared = True,


### PR DESCRIPTION
This adds explicit MinGW linker hardening flags to the Windows Python extension build.

- Windows x86 now links with `--dynamicbase` and `--nxcompat` while preserving `-static-libgcc`.
- Windows x86-64 now links with `--dynamicbase`, `--high-entropy-va`, and `--nxcompat`.
- Other platforms are unchanged.

Fixes #28688.

Verification:
- Confirmed the published 7.35.1 win32 and win_amd64 `_message.pyd` files both have PE DLL characteristics `0x0`.
- Cross-built `//python:_message_binary` with the repository toolchain for win32 and win64.
- Confirmed the patched win32 binary has `DYNAMIC_BASE | NX_COMPAT` (`0x140`).
- Confirmed the patched win64 binary has `DYNAMIC_BASE | HIGH_ENTROPY_VA | NX_COMPAT` (`0x160`).
- Built `//python:_message_binary` natively as a regression check.