### PR TITLE
[36.x] Fix Rust GHA build by enabling "full" feature for syn

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -212,7 +212,7 @@ crate.spec(
 )
 crate.spec(
     package = "syn",
-    version = ">=2",
+    version = "2",
 )
 crate.from_specs()
 use_repo(crate, crate_index = "crates")


### PR DESCRIPTION
Cherry-pick of cl/950977436

Equivalent commit: 8eb950cb858c1475a0dd82f295b2d170016a2a56