### PR TITLE
Preserve accepted extension descriptors after conflicts

### DIFF
--- a/src/google/protobuf/descriptor_database.cc
+++ b/src/google/protobuf/descriptor_database.cc
@@ -787,14 +787,14 @@ bool EncodedDescriptorDatabase::DescriptorIndex::AddExtension(
   if (!field.extendee().empty() && field.extendee()[0] == '.') {
     // The extension is fully-qualified.  We can use it as a lookup key in
     // the by_symbol_ table.
-    if (!by_extension_
-             .insert({static_cast<int>(all_values_.size() - 1),
-                      EncodeString(field.extendee()), field.number()})
-             .second ||
-        std::binary_search(
+    if (std::binary_search(
             by_extension_flat_.begin(), by_extension_flat_.end(),
             std::make_pair(field.extendee().substr(1), field.number()),
-            by_extension_.key_comp())) {
+            by_extension_.key_comp()) ||
+        !by_extension_
+             .insert({static_cast<int>(all_values_.size() - 1),
+                      EncodeString(field.extendee()), field.number()})
+             .second) {
       ABSL_LOG(ERROR)
           << "Extension conflicts with extension already in database: "
              "extend "

--- a/src/google/protobuf/descriptor_database.cc
+++ b/src/google/protobuf/descriptor_database.cc
@@ -807,14 +807,14 @@ bool EncodedDescriptorDatabase::DescriptorIndex::AddExtension(
   if (!field.extendee().empty() && field.extendee()[0] == '.') {
     // The extension is fully-qualified.  We can use it as a lookup key in
     // the by_symbol_ table.
-    if (!by_extension_
-             .insert({static_cast<int>(all_values_.size() - 1),
-                      EncodeString(field.extendee()), field.number()})
-             .second ||
-        std::binary_search(
+    if (std::binary_search(
             by_extension_flat_.begin(), by_extension_flat_.end(),
             std::make_pair(field.extendee().substr(1), field.number()),
-            by_extension_.key_comp())) {
+            by_extension_.key_comp()) ||
+        !by_extension_
+             .insert({static_cast<int>(all_values_.size() - 1),
+                      EncodeString(field.extendee()), field.number()})
+             .second) {
       ABSL_LOG(ERROR)
           << "Extension conflicts with extension already in database: "
              "extend "

--- a/src/google/protobuf/descriptor_database_unittest.cc
+++ b/src/google/protobuf/descriptor_database_unittest.cc
@@ -530,6 +530,35 @@ TEST(EncodedDescriptorDatabaseExtraTest,
   EXPECT_THAT(files, ElementsAre("app.proto"));
 }
 
+TEST(EncodedDescriptorDatabaseExtraTest,
+     RejectedDuplicateExtensionDoesNotShadowOriginal) {
+  FileDescriptorProto file;
+  file.set_name("good.proto");
+  file.set_package("app");
+  auto* extension = file.add_extension();
+  extension->set_name("good_ext");
+  extension->set_extendee(".app.Target");
+  extension->set_number(123);
+  std::string data_good = file.SerializeAsString();
+
+  EncodedDescriptorDatabase db;
+  EXPECT_TRUE(db.Add(data_good.data(), data_good.size()));
+
+  FileDescriptorProto found_good;
+  EXPECT_TRUE(db.FindFileContainingExtension("app.Target", 123, &found_good));
+  EXPECT_EQ(found_good.name(), "good.proto");
+
+  file.set_name("evil.proto");
+  extension->set_name("evil_ext");
+  std::string data_evil = file.SerializeAsString();
+
+  EXPECT_FALSE(db.Add(data_evil.data(), data_evil.size()));
+
+  FileDescriptorProto found_final;
+  EXPECT_TRUE(db.FindFileContainingExtension("app.Target", 123, &found_final));
+  EXPECT_EQ(found_final.name(), "good.proto");
+}
+
 TEST(SimpleDescriptorDatabaseExtraTest, FindAllFileNames) {
   FileDescriptorProto f;
   f.set_name("foo.proto");


### PR DESCRIPTION
## Summary

- check the frozen extension index before inserting a new mutable index entry
- add a regression test proving a rejected duplicate extension cannot shadow the accepted descriptor

## Root cause

After `EnsureFlat()` moved an accepted extension into `by_extension_flat_`,
`AddExtension()` inserted a conflicting descriptor into `by_extension_` before
checking the frozen index. The method returned `false`, but the rejected entry
remained in the mutable index. The next merge placed that entry ahead of the
accepted one, so `FindFileContainingExtension()` returned the rejected file.

Checking `by_extension_flat_` first preserves the existing index when the add
operation fails, matching the duplicate-name handling in `AddFile()`.

## Impact

Callers can now rely on a failed `Add()` leaving extension lookups unchanged.
This is especially important when descriptors are assembled from multiple or
untrusted sources and rejection is used as the validation boundary.

## Test

`bazel test //src/google/protobuf:descriptor_database_unittest`
