### PR TITLE
Reserve extension 1310 for the Teleport API module

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -583,3 +583,8 @@ about your project (name and website) so we can add an entry for you.
 
     *   Website: https://motif.io
     *   Extensions: 1309
+
+1.  Teleport
+
+    *   Website: https://goteleport.com
+    *   Extensions: 1310


### PR DESCRIPTION
This adds an entry to the global extension registry (`docs/options.md`) reserving extension number 1310 for Teleport.

* Project: Teleport
* Website: https://goteleport.com
* Extension number: 1310
