### PR TITLE
Add proto2mcp to global extension registry (1311-1313)

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -588,3 +588,8 @@ about your project (name and website) so we can add an entry for you.
 
     *   Website: https://goteleport.com
     *   Extensions: 1310
+
+1.  proto2mcp
+
+    *   Website: https://github.com/protocgen/proto2mcp
+    *   Extensions: 1311-1313


### PR DESCRIPTION
## Extension Registration Request

**Project:** proto2mcp
**Website:** https://github.com/protocgen/proto2mcp
**Requested Extensions:** 1311-1313

### About proto2mcp

proto2mcp is a protoc/buf plugin that generates [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) servers from Protobuf service definitions. It enables existing gRPC/ConnectRPC services to be securely exposed as LLM tools with:

- Automatic JSON Schema generation from proto messages
- Multitenancy support via interceptor middleware
- `buf.validate` constraint mapping for LLM input validation
- ConnectRPC client forwarding

### Extension Usage

proto2mcp uses custom options on three descriptor types:

| Extension | Number | Purpose |
|---|---|---|
| `google.protobuf.MethodOptions` | 1311 | Per-method MCP tool configuration (name override, description, skip, hints) |
| `google.protobuf.ServiceOptions` | 1312 | Per-service MCP configuration (tool name prefix, description) |
| `google.protobuf.FileOptions` | 1313 | Per-file MCP configuration (skip entire file) |

### Example

```protobuf
import "protocgen/mcp/v1/options.proto";

service PatientService {
  option (protocgen.mcp.v1.service) = {
    tool_name_prefix: "Patient"
    description: "Patient management operations"
  };

  rpc GetPatient(GetPatientRequest) returns (GetPatientResponse) {
    option (protocgen.mcp.v1.method) = {
      description: "Retrieves a patient record by ID"
      read_only: true
    };
  }
}
```

### Related

proto2mcp is part of the [protocgen](https://github.com/protocgen) ecosystem, alongside [proto2type](https://github.com/protocgen/proto2type).