### PR TITLE
fix: sync present children in SyncSubobjs to prevent use-after-free

### DIFF
--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -1194,6 +1194,37 @@ class MessageTest(unittest.TestCase):
     s2 = m.child
     self.assertIs(s1, s2)
 
+  def testSyncSubobjsPresentChildStubs(self, message_module):
+    """SyncSubobjs must recurse into present children to sync their stubs.
+
+    When MergeFromString runs on a grandparent, it may populate fields inside
+    a present (already-reified) child at the C level.  If that child has stale
+    stubs in its own unset_subobj_map, SyncSubobjs must descend into it so the
+    stubs are reified before any other code path creates a second wrapper for
+    the same upb_Message.  Without this, a duplicate ObjCache key is created,
+    leading to use-after-free on dealloc.
+    """
+    m = message_module.NestedTestAllTypes()
+    # Reify m.child by setting a field on it (makes child present, removes it
+    # from m.unset_subobj_map).
+    m.child.payload.optional_int32 = 1
+    child = m.child
+    # Create a stub for child.child in child.unset_subobj_map.
+    grandchild = child.child
+    self.assertFalse(child.HasField('child'))
+
+    # Merge data that populates child.child at the C level.
+    other = message_module.NestedTestAllTypes()
+    other.child.child.payload.optional_int32 = 42
+    m.MergeFromString(other.SerializeToString())
+
+    # After merge, SyncSubobjs(m) must recurse into child and reify the
+    # grandchild stub.  Without the fix, child.child creates a second wrapper
+    # for the same C message (duplicate ObjCache key -> UAF on dealloc).
+    grandchild2 = child.child
+    self.assertIs(grandchild, grandchild2)
+    self.assertEqual(42, grandchild.payload.optional_int32)
+
   def ensureNestedMessageExists(self, msg, attribute):
     """Make sure that a nested message object exists.
 

--- a/python/message.c
+++ b/python/message.c
@@ -754,44 +754,68 @@ static void PyUpb_Message_Reify(PyUpb_Message* self, const upb_FieldDef* f,
  */
 static void PyUpb_Message_SyncSubobjs(PyUpb_Message* self) {
   PyUpb_WeakMap* subobj_map = self->unset_subobj_map;
-  if (!subobj_map) return;
-
   upb_Message* msg = PyUpb_Message_GetMsg(self);
-  intptr_t iter = PYUPB_WEAKMAP_BEGIN;
-  const void* key;
-  PyObject* obj;
 
-  // The last ref to this message could disappear during iteration.
-  // When we call PyUpb_*Container_Reify() below, the container will drop
-  // its ref on `self`.  If that was the last ref on self, the object will be
-  // deleted, and `subobj_map` along with it.  We need it to live until we are
-  // done iterating.
-  Py_INCREF(&self->ob_base);
+  if (subobj_map) {
+    intptr_t iter = PYUPB_WEAKMAP_BEGIN;
+    const void* key;
+    PyObject* obj;
 
-  while (PyUpb_WeakMap_Next(subobj_map, &key, &obj, &iter)) {
-    const upb_FieldDef* f = key;
-    if (upb_FieldDef_HasPresence(f) && !upb_Message_HasFieldByDef(msg, f))
-      continue;
-    upb_MessageValue msgval = upb_Message_GetFieldByDef(msg, f);
-    if (upb_FieldDef_IsMap(f)) {
-      if (!msgval.map_val) continue;
-      PyUpb_MapContainer_Reify(obj, (upb_Map*)msgval.map_val, subobj_map, iter);
-    } else if (upb_FieldDef_IsRepeated(f)) {
-      if (!msgval.array_val) continue;
-      PyUpb_RepeatedContainer_Reify(obj, (upb_Array*)msgval.array_val,
-                                    subobj_map, iter);
-    } else {
-      PyUpb_Message* sub = (void*)obj;
-      assert(self == sub->ptr.parent);
-      PyUpb_Message_Reify(sub, f, (upb_Message*)msgval.msg_val, subobj_map,
-                          iter);
+    // The last ref to this message could disappear during iteration.
+    // When we call PyUpb_*Container_Reify() below, the container will drop
+    // its ref on `self`.  If that was the last ref on self, the object will be
+    // deleted, and `subobj_map` along with it.  We need it to live until we
+    // are done iterating.
+    Py_INCREF(&self->ob_base);
+
+    while (PyUpb_WeakMap_Next(subobj_map, &key, &obj, &iter)) {
+      const upb_FieldDef* f = key;
+      if (upb_FieldDef_HasPresence(f) && !upb_Message_HasFieldByDef(msg, f))
+        continue;
+      upb_MessageValue msgval = upb_Message_GetFieldByDef(msg, f);
+      if (upb_FieldDef_IsMap(f)) {
+        if (!msgval.map_val) continue;
+        PyUpb_MapContainer_Reify(obj, (upb_Map*)msgval.map_val, subobj_map,
+                                 iter);
+      } else if (upb_FieldDef_IsRepeated(f)) {
+        if (!msgval.array_val) continue;
+        PyUpb_RepeatedContainer_Reify(obj, (upb_Array*)msgval.array_val,
+                                      subobj_map, iter);
+      } else {
+        PyUpb_Message* sub = (void*)obj;
+        assert(self == sub->ptr.parent);
+        PyUpb_Message_Reify(sub, f, (upb_Message*)msgval.msg_val, subobj_map,
+                            iter);
+      }
     }
+
+    Py_DECREF(&self->ob_base);
   }
 
-  Py_DECREF(&self->ob_base);
-
-  // TODO: present fields need to be iterated too if they can reach
-  // a WeakMap.
+  // Recursively sync present submessage children that have their own
+  // unset_subobj_map.  Without this, a child reified earlier (removed from
+  // our unset_subobj_map) retains stale stubs when C-level data is mutated
+  // by MergeFrom/CopyFrom/MergeFromString on this message.  Accessing the
+  // child's field would create a second ObjCache wrapper for the same
+  // upb_Message*, leading to use-after-free on dealloc.
+  const upb_MessageDef* msgdef = _PyUpb_Message_GetMsgdef(self);
+  int n = upb_MessageDef_FieldCount(msgdef);
+  for (int i = 0; i < n; i++) {
+    const upb_FieldDef* f = upb_MessageDef_Field(msgdef, i);
+    if (!upb_FieldDef_IsSubMessage(f) || upb_FieldDef_IsMap(f) ||
+        upb_FieldDef_IsRepeated(f))
+      continue;
+    if (!upb_Message_HasFieldByDef(msg, f)) continue;
+    const upb_Message* sub_msg = upb_Message_GetFieldByDef(msg, f).msg_val;
+    if (!sub_msg) continue;
+    PyObject* sub_obj = PyUpb_ObjCache_Get(sub_msg);
+    if (!sub_obj) continue;
+    PyUpb_Message* sub = (PyUpb_Message*)sub_obj;
+    if (sub->unset_subobj_map) {
+      PyUpb_Message_SyncSubobjs(sub);
+    }
+    Py_DECREF(sub_obj);
+  }
 }
 
 static PyObject* PyUpb_Message_ToString(PyUpb_Message* self) {


### PR DESCRIPTION
## Summary

- `SyncSubobjs` only iterated `unset_subobj_map` (stubs directly owned by the message), never descending into present (already-reified) children that have their own stale stubs. This is the acknowledged TODO at `python/message.c:793`.
- When a parent message is mutated at the C level (via `MergeFrom`, `MergeFromString`, or `CopyFrom`), nested fields inside a present child may be populated. If that child has stale stubs in its own `unset_subobj_map`, accessing the child's field creates a **second Python wrapper** for the same `upb_Message*`, inserting a duplicate key into the process-global `ObjCache`. On dealloc, `ObjCache_Delete` removes by key (not value), so the wrong entry can be removed. The surviving entry points to freed memory, and the next `ObjCache_Get` calls `Py_INCREF` on freed heap -- a **use-after-free** that crashes deterministically.
- This is a variant of the bug fixed in 414e4142c ("Sync sub-objects even when decode fails"). That fix addressed the case where `SyncSubobjs` was skipped entirely on decode failure. This patch fixes the case where `SyncSubobjs` runs but is incomplete.

## Changes

**`python/message.c`**: After the existing stub-reification loop, iterate all singular submessage fields of the message definition. For each field that is present at the C level and has a live Python wrapper (via `ObjCache_Get`) with a non-NULL `unset_subobj_map`, recursively call `SyncSubobjs`. The early return for NULL `unset_subobj_map` is replaced with a conditional block so the recursion runs even when the parent has no stubs of its own.

**`python/google/protobuf/internal/message_test.py`**: Add `testSyncSubobjsPresentChildStubs` regression test.

## Reproducer

```python
from google.protobuf import descriptor_pool, descriptor, symbol_database
# Using NestedTestAllTypes (child: NestedTestAllTypes, payload: TestAllTypes)

m = NestedTestAllTypes()
m.child.payload.optional_int32 = 1   # reify child (present)
child = m.child
grandchild = child.child              # stub in child.unset_subobj_map

other = NestedTestAllTypes()
other.child.child.payload.optional_int32 = 42
m.MergeFromString(other.SerializeToString())

# Without fix: child.child returns a DIFFERENT wrapper -> duplicate ObjCache key
# -> use-after-free on dealloc -> segfault
assert child.child is grandchild      # FAILS without fix
```

## Test plan

- [x] Regression test `testSyncSubobjsPresentChildStubs` added
- [ ] Existing `testMergeFromStringDecodeErrorSync` still passes (related fix, same area)
- [ ] No refcount leaks introduced (the `ObjCache_Get` reference is balanced by `Py_DECREF`)