### PR TITLE
Guard against NULL sub-enum table in upb_MiniTableEnum_CheckValue

### DIFF
--- a/upb/mini_descriptor/internal/encode_test.cc
+++ b/upb/mini_descriptor/internal/encode_test.cc
@@ -325,6 +325,20 @@ TEST(MiniTableEnumTest, PositiveAndNegative) {
   }
 }
 
+// Regression test: a closed-enum field whose sub-enum table has not been linked
+// resolves to a NULL upb_MiniTableEnum (see upb_MiniTable_GetSubEnumTable).
+// Decoding untrusted wire data against such a table previously dereferenced the
+// NULL pointer inside CheckValue -- a remotely reachable crash for callers that
+// build MiniTables from untrusted mini descriptors.  CheckValue must instead
+// report every value as unrecognized without dereferencing the NULL table.  The
+// listed values cover each internal branch (val < 64, the mask range, and the
+// value list) to prove none of them touch the table when it is NULL.
+TEST(MiniTableEnumTest, CheckValueOnNullTable) {
+  for (uint32_t val : {0u, 5u, 63u, 64u, 100u, 70000u, UINT32_MAX}) {
+    EXPECT_FALSE(upb_MiniTableEnum_CheckValue(nullptr, val)) << val;
+  }
+}
+
 TEST_P(MiniTableTest, Extendible) {
   upb::Arena arena;
   upb::MtDataEncoder e;

--- a/upb/mini_table/internal/enum.h
+++ b/upb/mini_table/internal/enum.h
@@ -8,6 +8,7 @@
 #ifndef UPB_MINI_TABLE_INTERNAL_ENUM_H_
 #define UPB_MINI_TABLE_INTERNAL_ENUM_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 // Must be last.
@@ -25,6 +26,11 @@ extern "C" {
 
 UPB_API_INLINE bool upb_MiniTableEnum_CheckValue(
     const struct upb_MiniTableEnum* e, uint32_t val) {
+  // A closed-enum field whose sub-enum table has not been linked resolves to a
+  // NULL table here (upb_MiniTable_GetSubEnumTable returns NULL for unlinked
+  // fields).  Report every value as unrecognized so callers route it to the
+  // unknown-field set instead of dereferencing NULL.
+  if (UPB_UNLIKELY(e == NULL)) return false;
   if (UPB_LIKELY(val < 64)) {
     const uint64_t mask =
         e->UPB_PRIVATE(data)[0] | ((uint64_t)e->UPB_PRIVATE(data)[1] << 32);


### PR DESCRIPTION
A closed-enum field whose sub-enum table has not been linked resolves to a NULL upb_MiniTableEnum via upb_MiniTable_GetSubEnumTable(), which is a documented return value for unlinked fields. The varint and packed enum decode paths in upb/wire/decode.c call upb_MiniTableEnum_CheckValue() on that pointer without a NULL check, so decoding untrusted wire data against a MiniTable built from an untrusted mini descriptor dereferences NULL and crashes (reliably reproducible SIGSEGV; remote DoS for such callers).

Add a NULL guard at the single chokepoint in CheckValue that reports every value as unrecognized, routing it to the unknown-field set exactly as an out-of-range closed-enum value already is. UPB_UNLIKELY keeps the hot decode path unaffected. Adds a regression test covering all three internal branches on a NULL table.

Fixes #26857.