### PR TITLE
Propagate recursion depth into unknown-field decoding (Python)

### DIFF
--- a/python/google/protobuf/internal/decoder.py
+++ b/python/google/protobuf/internal/decoder.py
@@ -910,7 +910,9 @@ def MessageSetItemDecoder(descriptor):
         break
       else:
         field_number, wire_type = DecodeTag(tag_bytes)
-        _, pos = _DecodeUnknownField(buffer, pos, end, field_number, wire_type)
+        _, pos = _DecodeUnknownField(
+            buffer, pos, end, field_number, wire_type, current_depth
+        )
         if pos == -1:
           raise _DecodeError('Unexpected end-group tag.')
 

--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -2045,6 +2045,33 @@ class TestRecursiveGroup(unittest.TestCase):
       test_msg.ParseFromString(data)
       decoder.SetRecursionLimit(decoder.DEFAULT_RECURSION_LIMIT)
 
+  def testRecursionLimitNotResetByUnknownFields(self):
+    # Regression test: nesting known messages to near the recursion limit and
+    # then hiding further nested *unknown* groups beneath them must not reset
+    # the depth counter.  The pure-Python decoder previously dropped
+    # current_depth when handling unknown fields, so the unknown groups were
+    # counted from zero again -- a bypass of the recursion limit enforced by
+    # the fix for GHSA-8qvm-5x2c-j2w7.
+    if api_implementation.Type() != 'python':
+      return
+    start_group = encoder.TagBytes(4, wire_format.WIRETYPE_START_GROUP)
+    end_group = encoder.TagBytes(4, wire_format.WIRETYPE_END_GROUP)
+    sub_tag = encoder.TagBytes(1, wire_format.WIRETYPE_LENGTH_DELIMITED)
+    decoder.SetRecursionLimit(20)
+    try:
+      # 15 levels of known SelfRecursive.sub nesting wrapping 10 nested unknown
+      # groups: 15 + 10 = 25 total levels exceeds the limit of 20, but the 10
+      # unknown groups on their own stay under it.  Without the counter being
+      # propagated into the unknown-field decoder this payload parses cleanly.
+      payload = start_group * 10 + end_group * 10
+      for _ in range(15):
+        payload = sub_tag + encoder._VarintBytes(len(payload)) + payload
+      with self.assertRaises(message.DecodeError) as context:
+        self_recursive_pb2.SelfRecursive().ParseFromString(payload)
+      self.assertIn('too many levels of nesting', str(context.exception))
+    finally:
+      decoder.SetRecursionLimit(decoder.DEFAULT_RECURSION_LIMIT)
+
 
 # Class to test proto2-only features (required, extensions, etc.)
 @testing_refleaks.TestCase

--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -1393,7 +1393,7 @@ def _AddMergeFromStringMethod(message_descriptor, cls):
         if field_number == 0:
           raise message_mod.DecodeError('Field number 0 is illegal.')
         data, new_pos = decoder._DecodeUnknownField(
-            buffer, new_pos, end, field_number, wire_type
+            buffer, new_pos, end, field_number, wire_type, current_depth
         )  # pylint: disable=protected-access
         if new_pos == -1:
           return pos


### PR DESCRIPTION
The pure-Python decoder tracks nesting depth via current_depth to enforce the recursion limit (the fix for GHSA-8qvm-5x2c-j2w7). Two unknown-field decode sites dropped that counter, letting it reset to zero:

  * python_message.py: the main InternalParse loop called decoder._DecodeUnknownField() without current_depth, so any unknown group at the top level of a message restarted depth counting from 0.
  * decoder.py: MessageSetItemDecoder.DecodeItem() did the same for unknown fields inside a MessageSet item.

An attacker could nest known messages to ~recursion_limit and then hide further nested unknown groups beneath them, reaching roughly twice the intended depth before Python's own stack limit -- a RecursionError / DoS that bypasses the limit. This threads current_depth into both call sites so unknown groups are counted against the same limit as known fields.

Adds a regression test that nests known messages near the limit and then appends unknown groups that push the total over it.

Fixes #26437.