### PR TITLE
Fix PHP Timestamp::toDateTime use-after-free on failed DateTime parse

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -1409,7 +1409,17 @@ PHP_METHOD(google_protobuf_Timestamp, toDateTime) {
   upb_MessageValue seconds = Message_getval(intern, "seconds");
   upb_MessageValue nanos = Message_getval(intern, "nanos");
 
-  // Get formatted time string.
+  // Proto requires nanos in [0, 999999999]. Out-of-range values make
+  // date_create_from_format("U.u", ...) fail; returning Z_OBJ of that failed
+  // zval hands back a freed zend_object (use-after-free).
+  if (nanos.int32_val < 0 || nanos.int32_val > 999999999) {
+    zend_throw_exception_ex(NULL, 0,
+                            "Timestamp nanos out of range: must be in "
+                            "[0, 999999999]");
+    return;
+  }
+
+  // Get formatted time string. Microseconds must fit %06d (0..999999).
   char formatted_time[32];
   snprintf(formatted_time, sizeof(formatted_time), "%" PRId64 ".%06" PRId32,
            seconds.int64_val, nanos.int32_val / 1000);
@@ -1431,13 +1441,25 @@ PHP_METHOD(google_protobuf_Timestamp, toDateTime) {
 
   if (call_user_function(EG(function_table), NULL, &function_name, &datetime, 2,
                          params) == FAILURE) {
-    zend_error(E_ERROR, "Cannot create DateTime.");
+    zval_ptr_dtor(&function_name);
+    zval_ptr_dtor(&format_string);
+    zval_ptr_dtor(&formatted_time_php);
+    zend_throw_exception_ex(NULL, 0, "Cannot create DateTime.");
     return;
   }
 
-  zval_dtor(&function_name);
-  zval_dtor(&format_string);
-  zval_dtor(&formatted_time_php);
+  zval_ptr_dtor(&function_name);
+  zval_ptr_dtor(&format_string);
+  zval_ptr_dtor(&formatted_time_php);
+
+  // call_user_function can succeed while date_create_from_format returns
+  // false. On that path PHP destroys the temporary DateTime but may leave a
+  // stale object pointer in the zval value union — do not ZVAL_OBJ it.
+  if (Z_TYPE(datetime) != IS_OBJECT) {
+    zval_ptr_dtor(&datetime);
+    zend_throw_exception_ex(NULL, 0, "Cannot create DateTime from Timestamp.");
+    return;
+  }
 
   ZVAL_OBJ(return_value, Z_OBJ(datetime));
 }

--- a/php/src/Google/Protobuf/Internal/TimestampBase.php
+++ b/php/src/Google/Protobuf/Internal/TimestampBase.php
@@ -22,11 +22,28 @@ class TimestampBase extends \Google\Protobuf\Internal\Message
     /**
      * Converts Timestamp to PHP DateTime.
      *
+     * Nanos must be in [0, 999999999] per timestamp.proto. Seconds should be
+     * in [-62135596800, 253402300799] (0001-01-01T00:00:00Z through
+     * 9999-12-31T23:59:59Z); values outside that range may fail conversion.
+     *
      * @return \DateTime $datetime
+     * @throws \UnexpectedValueException if the Timestamp cannot be converted
      */
     public function toDateTime()
     {
-        $time = sprintf('%s.%06d', $this->seconds, $this->nanos / 1000);
-        return \DateTime::createFromFormat('U.u', $time);
+        if ($this->nanos < 0 || $this->nanos > 999999999) {
+            throw new \UnexpectedValueException(
+                'Timestamp nanos out of range: must be in [0, 999999999]'
+            );
+        }
+
+        $time = sprintf('%s.%06d', $this->seconds, intdiv($this->nanos, 1000));
+        $datetime = \DateTime::createFromFormat('U.u', $time);
+        if ($datetime === false) {
+            throw new \UnexpectedValueException(
+                'Cannot create DateTime from Timestamp.'
+            );
+        }
+        return $datetime;
     }
 }

--- a/php/tests/WellKnownTest.php
+++ b/php/tests/WellKnownTest.php
@@ -356,6 +356,31 @@ class WellKnownTest extends TestBase {
         $this->assertSame($from->format('u'), $to->format('u'));
     }
 
+    /**
+     * Out-of-range nanos must not be converted via date_create_from_format
+     * ("U.u"); the C extension previously returned a freed DateTime object.
+     *
+     * @dataProvider outOfRangeNanosProvider
+     */
+    public function testTimestampToDateTimeRejectsOutOfRangeNanos($nanos)
+    {
+        $timestamp = new Timestamp();
+        $timestamp->setSeconds(0);
+        $timestamp->setNanos($nanos);
+
+        $this->expectException(\Exception::class);
+        $timestamp->toDateTime();
+    }
+
+    public function outOfRangeNanosProvider()
+    {
+        return [
+            'int32 max' => [2147483647],
+            'negative' => [-1000],
+            'one billion' => [1000000000],
+        ];
+    }
+
     public function testType()
     {
         $m = new Type();


### PR DESCRIPTION
## Summary
- `Timestamp::toDateTime()` in the PHP C extension formats seconds/nanos and calls `date_create_from_format('U.u', ...)`. It only checked whether `call_user_function` returned `FAILURE`, not whether the PHP function returned a `DateTime` object.
- On parse failure (reliably triggered by out-of-range nanos such as `2147483647` or `-1000`), `date_create_from_format` destroys the temporary `DateTime` and returns `false`, but can leave a stale object pointer in the zval value union. The extension then did `ZVAL_OBJ(return_value, Z_OBJ(datetime))`, handing a **freed** `zend_object` back to PHP (CWE-416).
- This change:
  - Rejects nanos outside `[0, 999999999]` before formatting (per `timestamp.proto`).
  - Requires `Z_TYPE(datetime) == IS_OBJECT` after the call; otherwise throws and destroys the retval.
  - Mirrors the same validation/error handling in pure-PHP `TimestampBase::toDateTime()`.
  - Adds a regression test for out-of-range nanos.

Google's Bug Hunter / OSS VRP team reviewed this as a security report and advised public disclosure on GitHub (not tracked as a security bug by their escalation criteria).

## Test plan
- [ ] `php/tests/WellKnownTest.php` — existing `testTimestamp` still passes
- [ ] New `testTimestampToDateTimeRejectsOutOfRangeNanos` fails closed for `INT32_MAX`, negative, and `1e9` nanos (C extension and pure PHP)
- [ ] Manual: with C extension loaded, `setNanos(2147483647); toDateTime()` throws instead of returning a corrupt `DateTime`

Made with [Cursor](https://cursor.com)