### PR TITLE
Fix heap buffer overflow in repeated scalar reverse self-assignment

### DIFF
--- a/python/repeated.c
+++ b/python/repeated.c
@@ -759,8 +759,22 @@ static bool PyUpb_SetSubscriptBulkCb(const void* data, Py_ssize_t count,
   // Fast paths for subset assignment when not growing the array
   // (count <= ctx->count).
   if (count <= ctx->count) {
-    if (data != target) {
-      memmove(target, data, count * itemsize);
+    if (ctx->step == 1) {
+      if (data != target) {
+        memmove(target, data, count * itemsize);
+      }
+    } else {
+      char* tmp = (char*)malloc(count * itemsize);
+      if (!tmp) {
+        PyErr_NoMemory();
+        return false;
+      }
+      memcpy(tmp, data, count * itemsize);
+      for (Py_ssize_t i = 0; i < count; i++) {
+        memcpy(dst + (ctx->index + i * ctx->step) * itemsize,
+               tmp + i * itemsize, itemsize);
+      }
+      free(tmp);
     }
     if (count < ctx->count) {
       upb_Array_Move(ctx->arr, ctx->index + count, ctx->index + ctx->count,


### PR DESCRIPTION
## Summary

`PyUpb_SetSubscriptBulkCb` in `python/repeated.c` has a heap buffer overflow when a repeated scalar field is assigned to a reverse slice of itself (e.g., `msg.repeated_int32[::-1] = msg.repeated_int32`).

The `kSubset` fast path (line 762) performs `memmove(target, data, count * itemsize)` where `target = dst + index * itemsize`. For a reverse slice `[::-1]`, `index = len - 1` but `count = len`, so the `memmove` writes `(len-1) * itemsize` bytes past the end of the buffer.

## Root Cause

When `PyUpb_ArrayOverlaps` classifies the assignment as `kSubset` (source and destination are the same array), the code assumes a contiguous forward copy is safe. This is correct for `step == 1` but incorrect for `step == -1`, where `ctx->index` points to the last element rather than the first.

## Fix

When `step != 1`, copy source data into a temporary buffer, then scatter elements according to the step direction. This matches the existing `kDisjoint` branch which already handles `step != 1` correctly (line 741-746).

## Reproduction

```c
// Minimal C harness — compile with: cc -O0 -g -fsanitize=address poc.c
// Triggers: heap-buffer-overflow in memmove at repeated.c:763
```

With a length-16 `int32` field, `field[::-1] = field` writes 60 bytes past the 64-byte allocation.

**ASan output:**
```
==PID==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x506000000060
WRITE of size 64 at 0x506000000060 thread T0
    #0 in memmove
    #1 in PyUpb_SetSubscriptBulkCb python/repeated.c:763
```

## Test Plan

- [x] Existing tests pass (no behavior change for `step == 1` path)
- [x] Reverse self-assignment `field[::-1] = field` no longer crashes
- [x] ASan clean on the reproduction case