### PR TITLE
Fix quadratic pure-Python recursive map parsing

### DIFF
--- a/python/build_targets.bzl
+++ b/python/build_targets.bzl
@@ -460,6 +460,12 @@ def build_targets(name):
     )
 
     internal_py_test(
+        name = "recursive_map_test",
+        srcs = ["google/protobuf/internal/recursive_map_test.py"],
+        env = {"PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python"},
+    )
+
+    internal_py_test(
         name = "wire_format_test",
         srcs = ["google/protobuf/internal/wire_format_test.py"],
     )

--- a/python/google/protobuf/internal/containers.py
+++ b/python/google/protobuf/internal/containers.py
@@ -651,6 +651,14 @@ class MessageMap(MutableMapping[_K, _V]):
     del self._values[key]
     self._message_listener.Modified()
 
+  def _SetItem(self, key: _K, value: _V) -> None:
+    """Transfers ownership of a message value into the map."""
+    self._AssureWritable()
+    key = self._key_checker.CheckValue(key)
+    value._SetListener(self._message_listener)
+    self._values[key] = value
+    self._message_listener.Modified()
+
   def __len__(self) -> int:
     return len(self._values)
 

--- a/python/google/protobuf/internal/decoder.py
+++ b/python/google/protobuf/internal/decoder.py
@@ -1035,7 +1035,7 @@ def MapDecoder(field_descriptor, new_default, is_message_map):
       current_depth -= 1
 
       if is_message_map:
-        value[submsg.key].CopyFrom(submsg.value)
+        value._SetItem(submsg.key, submsg.value)
       else:
         value[submsg.key] = submsg.value
 

--- a/python/google/protobuf/internal/recursive_map_test.py
+++ b/python/google/protobuf/internal/recursive_map_test.py
@@ -1,0 +1,99 @@
+# Protocol Buffers - Google's data interchange format
+# Copyright 2008 Google Inc.  All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+"""Tests for recursive message-valued maps."""
+
+import unittest
+from unittest import mock
+
+from google.protobuf import message
+from google.protobuf import struct_pb2
+from google.protobuf import text_format
+
+
+def _Varint(value):
+  output = bytearray()
+  while True:
+    byte = value & 0x7F
+    value >>= 7
+    output.append(byte | 0x80 if value else byte)
+    if not value:
+      return bytes(output)
+
+
+def _MessageField(field_number, payload):
+  return bytes([(field_number << 3) | 2]) + _Varint(len(payload)) + payload
+
+
+def _BinaryStruct(depth):
+  inner = b''
+  for _ in range(depth):
+    inner = _MessageField(
+        1, b'\x0a\x01k' + _MessageField(2, _MessageField(5, inner))
+    )
+  return inner
+
+
+def _AssertStructDepth(test_case, parsed, depth):
+  original_bytes = parsed.SerializeToString()
+  current = parsed
+  for _ in range(depth):
+    test_case.assertIn('k', current.fields)
+    current = current.fields['k'].struct_value
+  test_case.assertFalse(current.fields)
+  current.fields['leaf'].string_value = 'value'
+  test_case.assertNotEqual(original_bytes, parsed.SerializeToString())
+
+
+class RecursiveMapTest(unittest.TestCase):
+
+  def _ParseWithoutMessageCopies(self, parse):
+    copy_calls = 0
+    original_copy_from = message.Message.CopyFrom
+
+    def CountCopyFrom(destination, source):
+      nonlocal copy_calls
+      copy_calls += 1
+      original_copy_from(destination, source)
+
+    with mock.patch.object(message.Message, 'CopyFrom', CountCopyFrom):
+      parsed = parse()
+
+    self.assertEqual(0, copy_calls)
+    return parsed
+
+  def testTextFormatParseDoesNotCopyRecursiveMapValues(self):
+    # Given a text-format Struct nested through message-valued maps.
+    depth = 8
+    payload = ('fields { key: "k" value { struct_value { ' * depth) + (
+        '} } }' * depth
+    )
+
+    # When the payload is parsed.
+    parsed = self._ParseWithoutMessageCopies(
+        lambda: text_format.Parse(payload, struct_pb2.Struct())
+    )
+
+    # Then the nested values are transferred without deep-copying each level.
+    _AssertStructDepth(self, parsed, depth)
+
+  def testBinaryParseDoesNotCopyRecursiveMapValues(self):
+    # Given a binary Struct nested through message-valued maps.
+    depth = 8
+    payload = _BinaryStruct(depth)
+
+    # When the payload is parsed.
+    parsed = self._ParseWithoutMessageCopies(
+        lambda: struct_pb2.Struct.FromString(payload)
+    )
+
+    # Then the nested values are transferred without deep-copying each level.
+    _AssertStructDepth(self, parsed, depth)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/python/google/protobuf/text_format.py
+++ b/python/google/protobuf/text_format.py
@@ -1248,8 +1248,12 @@ class _Parser(object):
     if is_map_entry:
       value_cpptype = field.message_type.fields_by_name['value'].cpp_type
       if value_cpptype == descriptor.FieldDescriptor.CPPTYPE_MESSAGE:
-        value = getattr(message, field.name)[sub_message.key]
-        value.CopyFrom(sub_message.value)
+        map_field = getattr(message, field.name)
+        set_item = getattr(map_field, '_SetItem', None)
+        if set_item is None:
+          map_field[sub_message.key].CopyFrom(sub_message.value)
+        else:
+          set_item(sub_message.key, sub_message.value)
       else:
         getattr(message, field.name)[sub_message.key] = sub_message.value
 


### PR DESCRIPTION
Fixes #28864.

The pure-Python binary decoder and text-format parser deep-copied message-valued map entries after parsing each nested level. Recursive maps therefore copied the accumulated subtree repeatedly and took quadratic time.

This change adds an internal MessageMap ownership-transfer operation. The pure-Python decoder uses it directly; text_format uses it when the pure-Python map container is present and preserves the existing CopyFrom path for the upb/C++ containers.

The regression tests verify both binary and text parsing make no per-level Message.CopyFrom calls, preserve the parsed structure, and keep descendant mutation notifications connected to the owning message.

Local benchmark after the change (depth 50/100/200/400):
- text: 0.0012 / 0.0018 / 0.0046 / 0.0075 seconds
- binary: 0.0003 / 0.0006 / 0.0012 / 0.0024 seconds

Validation:
- Bazel 9.0.0: //python:recursive_map_test, //python:decoder_test, //python:text_format_test (3/3 passed)
- py_compile on all changed Python files
- git diff --check