### PR TITLE
fix: prevent out-of-bounds reads during upb extension promotion

### DIFF
--- a/upb/message/promote.c
+++ b/upb/message/promote.c
@@ -162,7 +162,8 @@ upb_GetExtension_Status upb_Message_GetOrPromoteExtension(
         const char* unknown_begin = ptr;
         ptr = upb_WireReader_ReadTag(ptr, &tag, &stream);
         if (!ptr) return kUpb_GetExtension_ParseError;
-        if (field_number == upb_WireReader_GetFieldNumber(tag)) {
+        if (field_number == upb_WireReader_GetFieldNumber(tag) &&
+            upb_WireReader_GetWireType(tag) == kUpb_WireType_Delimited) {
           upb_StringView data;
           found_count++;
           upb_EpsCopyCapture capture;

--- a/upb/message/promote_test.cc
+++ b/upb/message/promote_test.cc
@@ -142,6 +142,26 @@ TEST(GeneratedCode, PromoteFromMultiple) {
   upb_Arena_Free(arena);
 }
 
+TEST(GeneratedCode, DoesNotPromoteExtensionWithWrongWireType) {
+  upb::Arena arena;
+  const char serialized[] = {
+      static_cast<char>(0xd8), 0x60, 0x02, 0x08, 0x2a,
+  };
+  upb_test_EmptyMessageWithExtensions* msg =
+      upb_test_EmptyMessageWithExtensions_parse(serialized, sizeof(serialized),
+                                                arena.ptr());
+  ASSERT_NE(msg, nullptr);
+
+  upb_MessageValue value;
+  upb_GetExtension_Status status = upb_Message_GetOrPromoteExtension(
+      UPB_UPCAST(msg), upb_test_ModelExtension1_model_ext_ext, 0, arena.ptr(),
+      &value);
+
+  EXPECT_EQ(kUpb_GetExtension_NotPresent, status);
+  EXPECT_EQ(0, upb_Message_ExtensionCount(UPB_UPCAST(msg)));
+  EXPECT_EQ(sizeof(serialized), GetUnknownLength(UPB_UPCAST(msg)));
+}
+
 TEST(GeneratedCode, Extensions) {
   upb_Arena* arena = upb_Arena_New();
   upb_test_ModelWithExtensions* msg = upb_test_ModelWithExtensions_new(arena);


### PR DESCRIPTION
## Summary

  This PR fixes an out-of-bounds read in upb’s deferred extension-promotion path.

  ## Analysis

  Extension promotion previously matched unknown fields using only the requested field number. It did not verify that the captured field used the length-delimited wire type expected for a message extension.

  A matching field encoded with another wire type could therefore have its scalar value interpreted as a message length. This could make the nested parser read beyond the captured unknown field.

  ## The Fix

  Require both the extension field number and the expected length-delimited wire type before attempting promotion. A field with an incompatible wire type remains in the unknown-field data.

  ## Testing

  - Added a regression test using a matching field number with an incompatible wire type
  - Confirmed that the test fails without the fix and passes with it
  - Ran `//upb/message:promote_test`
  - Ran the supported μpb test suite: 75 tests passed and 2 were skipped

