### PR TITLE
fix: prevent dangling reserved-name references in upb def-to-proto conversion

### DIFF
--- a/upb/util/def_to_proto.c
+++ b/upb/util/def_to_proto.c
@@ -355,7 +355,7 @@ static google_protobuf_EnumDescriptorProto* enumdef_toproto(upb_ToProto_Context*
   upb_StringView* res_names =
       google_protobuf_EnumDescriptorProto_resize_reserved_name(proto, n, ctx->arena);
   for (int i = 0; i < n; i++) {
-    res_names[i] = upb_EnumDef_ReservedName(e, i);
+    res_names[i] = strviewdup2(ctx, upb_EnumDef_ReservedName(e, i));
   }
 
   if (upb_EnumDef_HasOptions(e)) {
@@ -460,7 +460,7 @@ static google_protobuf_DescriptorProto* msgdef_toproto(upb_ToProto_Context* ctx,
   upb_StringView* res_names =
       google_protobuf_DescriptorProto_resize_reserved_name(proto, n, ctx->arena);
   for (int i = 0; i < n; i++) {
-    res_names[i] = upb_MessageDef_ReservedName(m, i);
+    res_names[i] = strviewdup2(ctx, upb_MessageDef_ReservedName(m, i));
   }
 
   if (upb_MessageDef_HasOptions(m)) {

--- a/upb/util/def_to_proto_test.cc
+++ b/upb/util/def_to_proto_test.cc
@@ -7,7 +7,6 @@
 
 #include "upb/util/def_to_proto.h"
 
-#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -154,6 +153,64 @@ TEST(DefToProto, TestRuntimeReflection) {
   upb::FileDefPtr file = defpool.FindFileByName(
       upb_util_def_to_proto_test_proto_upbdefinit.filename);
   CheckFile(file, file_desc);
+}
+
+TEST(DefToProto, ReservedNamesAreCopied) {
+  constexpr absl::string_view kMessageReservedName = "message_reserved_name";
+  constexpr absl::string_view kEnumReservedName = "enum_reserved_name";
+  google::protobuf::FileDescriptorProto file;
+  file.set_name("reserved_name.proto");
+  file.set_package("pkg");
+  file.add_message_type()->set_name("Message");
+  file.mutable_message_type(0)->add_reserved_name(kMessageReservedName);
+  google::protobuf::EnumDescriptorProto* enum_proto = file.add_enum_type();
+  enum_proto->set_name("Enum");
+  enum_proto->add_value()->set_name("VALUE");
+  enum_proto->mutable_value(0)->set_number(0);
+  enum_proto->add_reserved_name(kEnumReservedName);
+
+  upb::Arena source_arena;
+  upb::Arena destination_arena;
+  upb::Status status;
+  std::string serialized;
+  ASSERT_TRUE(file.SerializeToString(&serialized));
+  const google_protobuf_FileDescriptorProto* parsed =
+      google_protobuf_FileDescriptorProto_parse(
+          serialized.data(), serialized.size(), source_arena.ptr());
+  ASSERT_NE(parsed, nullptr);
+
+  upb::DefPool source_pool;
+  ASSERT_TRUE(source_pool.AddFile(parsed, &status));
+  ASSERT_TRUE(status.ok()) << status.error_message();
+  upb::MessageDefPtr message = source_pool.FindMessageByName("pkg.Message");
+  upb::EnumDefPtr enum_def = source_pool.FindEnumByName("pkg.Enum");
+  ASSERT_TRUE(message);
+  ASSERT_TRUE(enum_def);
+
+  google_protobuf_DescriptorProto* message_proto =
+      upb_MessageDef_ToProto(message.ptr(), destination_arena.ptr());
+  google_protobuf_EnumDescriptorProto* enum_proto_copy =
+      upb_EnumDef_ToProto(enum_def.ptr(), destination_arena.ptr());
+  ASSERT_NE(message_proto, nullptr);
+  ASSERT_NE(enum_proto_copy, nullptr);
+
+  size_t count;
+  const upb_StringView* message_names =
+      google_protobuf_DescriptorProto_reserved_name(message_proto, &count);
+  ASSERT_EQ(count, 1);
+  upb_StringView source_message_name =
+      upb_MessageDef_ReservedName(message.ptr(), 0);
+  EXPECT_EQ(absl::string_view(message_names[0].data, message_names[0].size),
+            kMessageReservedName);
+  EXPECT_NE(message_names[0].data, source_message_name.data);
+
+  const upb_StringView* enum_names =
+      google_protobuf_EnumDescriptorProto_reserved_name(enum_proto_copy, &count);
+  ASSERT_EQ(count, 1);
+  upb_StringView source_enum_name = upb_EnumDef_ReservedName(enum_def.ptr(), 0);
+  EXPECT_EQ(absl::string_view(enum_names[0].data, enum_names[0].size),
+            kEnumReservedName);
+  EXPECT_NE(enum_names[0].data, source_enum_name.data);
 }
 
 // Fuzz test regressions.


### PR DESCRIPTION
## Summary

  This PR fixes a use-after-free risk in upb’s definition-to-protobuf conversion.

  ## Analysis

  `upb_MessageDef_ToProto()` and `upb_EnumDef_ToProto()` previously copied reserved-name `upb_StringView` values directly into the converted descriptor.

  The string data remained owned by the source `DefPool`. If that pool was destroyed while the converted descriptor remained in use, its reserved-name fields contained dangling pointers.

  ## The Fix

  Copy message and enum reserved names into the destination arena using the existing `strviewdup2()` helper.

  This makes the converted descriptor independent of the source definition pool.

   ## Testing

  - Added regression coverage for message and enum reserved names
  - Confirmed that the test fails before the fix because the destination aliases the source strings
  - Confirmed that the test passes after the fix with independently owned strings
  - Ran the supported μpb test suite: 75 tests passed and 2 were skipped
 

