### PR TITLE
Fasttable: reject invalid field numbers in the mismatch path

### DIFF
--- a/upb/wire/decode_fast/field_mismatch.c
+++ b/upb/wire/decode_fast/field_mismatch.c
@@ -105,8 +105,12 @@ UPB_PRESERVE_NONE upb_FastDecoder_Return _upb_FastDecoder_DecodeCheckMiniTable(
 #endif
   uint32_t gap_lo, gap_hi;
   upb_DecodeFastNext ret;
-  if (UPB_PRIVATE(_upb_MiniTable_FindUnknownGap)(table, field_num, &gap_lo,
-                                                 &gap_hi)) {
+  if (UPB_UNLIKELY(field_num == 0 || field_num >= ((uint32_t)1 << 29))) {
+    // Field number 0 (and >= 2^29) is invalid; the generic decoder rejects it,
+    // and _upb_MiniTable_FindUnknownGap requires number != 0.
+    UPB_DECODEFAST_ERROR(d, kUpb_DecodeStatus_Malformed, &ret);
+  } else if (UPB_PRIVATE(_upb_MiniTable_FindUnknownGap)(table, field_num,
+                                                        &gap_lo, &gap_hi)) {
     data = upb_DecodeFast_PackGaps(gap_lo, gap_hi);
     ret = kUpb_DecodeFastNext_DecodeUnknownValue;
   } else {

--- a/upb/wire/decode_test.cc
+++ b/upb/wire/decode_test.cc
@@ -786,6 +786,39 @@ TEST(DecodeTest, FieldZeroRejected) {
   }
 }
 
+TEST(FastTableFieldZero, RejectsFieldNumberZero) {
+#if UPB_FASTTABLE
+  upb::Arena mt_arena;
+  auto [mt, field] = MiniTable::MakeSingleFieldTable<field_types::String>(
+      1, kUpb_DecodeFast_Scalar, mt_arena.ptr());
+  (void)field;
+  // Field number 0 (and >= 2^29) is invalid; the generic decoder rejects it.
+  // Each payload is a field-0 tag (normal and overlong) with a valid value, so
+  // the field number is the only reason to reject.
+  const std::vector<std::string> payloads = {
+      std::string("\x00\x01", 2),          // field 0 wire type 0, value 1
+      std::string("\x80\x80\x00\x01", 4),  // overlong field 0 wt 0, value 1
+  };
+  for (const std::string& payload : payloads) {
+    upb::Arena a2;
+    upb_Message* m2 = upb_Message_New(mt, a2.ptr());
+    upb_DecodeStatus gen =
+        upb_Decode(payload.data(), payload.size(), m2, mt, nullptr,
+                   kUpb_DecodeOption_DisableFastTable, a2.ptr());
+    EXPECT_EQ(gen, kUpb_DecodeStatus_Malformed) << "generic must reject field 0";
+
+    upb::Arena a1;
+    upb_Message* m1 = upb_Message_New(mt, a1.ptr());
+    upb_DecodeStatus fast =
+        upb_Decode(payload.data(), payload.size(), m1, mt, nullptr, 0,
+                   a1.ptr());
+    EXPECT_EQ(fast, kUpb_DecodeStatus_Malformed)
+        << "fasttable accepted field 0 for payload; got "
+        << upb_DecodeStatus_String(fast);
+  }
+#endif
+}
+
 }  // namespace
 
 }  // namespace test


### PR DESCRIPTION
The fasttable's mismatched-slot path (`_upb_FastDecoder_DecodeCheckMiniTable`) passes the parsed field number straight to `_upb_MiniTable_FindUnknownGap`, which requires `number != 0` (and `< 2^29`). A top-level field numbered 0 — e.g. tag bytes `00 01`, or the overlong form `80 80 00 01` — trips that assert and aborts the process in debug builds, and is silently accepted as an unknown field in release builds (decode returns `Ok`).

The generic decoder rejects field number 0, and the fasttable's own `DecodeUnknown` path already checks for it in `field_unknown.c`; the mismatch path was just missing the same check. The existing `FieldZeroRejected` test only exercises paths that fall back to the generic decoder (empty message, group, MessageSet), so this path wasn't covered.

This rejects `field_num == 0` and `field_num >= 2^29` with `Malformed` before the `FindUnknownGap` call, mirroring the existing check, and adds a regression test for both the normal and overlong encodings.

Tested with `--//upb:fasttable_enabled=true`:
- before: debug build aborts on `Assertion \`number != 0' failed`; release returns `Ok`
- after: both return `Malformed`, matching the generic decoder