### PR TITLE
Fasttable: avoid truncating large delimited sizes in DecodeSizeSlow

### DIFF
--- a/upb/wire/decode_fast/cardinality.h
+++ b/upb/wire/decode_fast/cardinality.h
@@ -440,9 +440,9 @@ bool upb_DecodeFast_Unpacked(upb_Decoder* d, const char** ptr, upb_Message* msg,
 UPB_FORCEINLINE bool _upb_DecodeFast_DecodeSizeSlow(const char** pp,
                                                     int* size) {
   const char* ptr = *pp;
-  uint32_t val = (ptr[0] & 0x7f) | ((ptr[1] & 0x7f) << 7);
+  uint64_t val = (ptr[0] & 0x7f) | ((uint64_t)(ptr[1] & 0x7f) << 7);
   for (int i = 2; i < 5; i++) {
-    uint32_t byte = (uint8_t)ptr[i];
+    uint64_t byte = (uint8_t)ptr[i];
     val |= (byte & 0x7f) << (i * 7);
     if (!(byte & 0x80)) {
       if (UPB_UNLIKELY(val > INT32_MAX)) return false;

--- a/upb/wire/decode_test.cc
+++ b/upb/wire/decode_test.cc
@@ -786,6 +786,30 @@ TEST(DecodeTest, FieldZeroRejected) {
   }
 }
 
+TEST(FastTableSize, OverlongDelimitedSizeMustMatchGenericDecoder) {
+#if UPB_FASTTABLE
+  upb::Arena mt_arena;
+  auto [mt, field] = MiniTable::MakeSingleFieldTable<field_types::Bytes>(
+      1, kUpb_DecodeFast_Scalar, mt_arena.ptr());
+  (void)field;
+  // Field 1 (bytes, delimited) with a 5-byte size varint whose true value is
+  // 2^32 (bytes 80 80 80 80 10). The generic decoder accumulates the size in
+  // uint64_t and rejects any value > INT32_MAX as malformed. The fasttable's
+  // _upb_DecodeFast_DecodeSizeSlow accumulated in uint32_t, so 2^32 truncated
+  // to 0 and the field was accepted as empty. Both decoders must agree.
+  const std::string payload("\x0A\x80\x80\x80\x80\x10", 6);
+  for (int options : GetDecodeOptionsToTest()) {
+    upb::Arena msg_arena;
+    upb_Message* msg = upb_Message_New(mt, msg_arena.ptr());
+    upb_DecodeStatus result =
+        upb_Decode(payload.data(), payload.size(), msg, mt, nullptr, options,
+                   msg_arena.ptr());
+    EXPECT_EQ(result, kUpb_DecodeStatus_Malformed)
+        << "options=" << options << " got " << upb_DecodeStatus_String(result);
+  }
+#endif
+}
+
 }  // namespace
 
 }  // namespace test


### PR DESCRIPTION
`_upb_DecodeFast_DecodeSizeSlow` accumulated the size varint in a `uint32_t`. For a 5-byte size whose true value is `>= 2^32`, the fifth byte's shift by 28 overflows the `uint32_t` and the high bits are dropped *before* the `val > INT32_MAX` check. So a malformed size such as `80 80 80 80 10` (true value `2^32`) truncates to `0` and is accepted as an empty field, where the generic decoder returns `Malformed`.

The generic decoder accumulates the size in `uint64_t` (`upb_WireReader_ReadLongSize`) and rejects anything over `INT32_MAX`. This does the same — accumulate in `uint64_t` so the `INT32_MAX` check sees the full value — and adds a regression test (`80 80 80 80 10` on a bytes field).

Tested with `--//upb:fasttable_enabled=true`:
- before: fasttable returns `Ok` (empty field), generic returns `Malformed`
- after: both return `Malformed`