### PR TITLE
fix: [upb] roll back extensions after failed file addition

### DIFF
--- a/upb/reflection/def_pool.c
+++ b/upb/reflection/def_pool.c
@@ -367,6 +367,16 @@ const upb_FileDef* upb_DefPool_FindFileContainingSymbol(const upb_DefPool* s,
 }
 
 static void remove_filedef(upb_DefPool* s, upb_FileDef* file) {
+  intptr_t ext_iter = UPB_INTTABLE_BEGIN;
+  uintptr_t ext_key;
+  upb_value ext_val;
+  while (upb_inttable_next(&s->exts, &ext_key, &ext_val, &ext_iter)) {
+    const upb_FieldDef* ext = upb_value_getconstptr(ext_val);
+    if (upb_FieldDef_File(ext) == file) {
+      upb_inttable_removeiter(&s->exts, &ext_iter);
+    }
+  }
+
   intptr_t iter = UPB_INTTABLE_BEGIN;
   upb_StringView key;
   upb_value val;

--- a/upb/reflection/reflection_test.cc
+++ b/upb/reflection/reflection_test.cc
@@ -14,6 +14,7 @@
 #include "absl/strings/str_join.h"
 #include "google/protobuf/unittest.upbdefs.h"
 #include "upb/base/status.hpp"
+#include "upb/mem/alloc.h"
 #include "upb/mem/arena.hpp"
 #include "upb/reflection/def.h"
 #include "upb/reflection/def.hpp"
@@ -68,6 +69,51 @@ TEST(ReflectionTest, OpenEnumWithNonZeroDefault) {
                             .status();
   EXPECT_EQ(std::string_view(status.message()),
             "for open enums, the first value must be zero (BadEnum)");
+}
+
+TEST(ReflectionTest, FailedAddFileDoesNotRetainExtensions) {
+  // Add a valid message with one available extension number.
+  google::protobuf::FileDescriptorProto base;
+  base.set_name("base.proto");
+  base.set_package("base");
+  base.set_syntax("proto2");
+  auto* target = base.add_message_type();
+  target->set_name("Target");
+  auto* range = target->add_extension_range();
+  range->set_start(100);
+  range->set_end(101);
+
+  // This file is rejected because both extensions use that number.
+  google::protobuf::FileDescriptorProto duplicate;
+  duplicate.set_name("duplicate.proto");
+  duplicate.set_package("duplicate");
+  duplicate.set_syntax("proto2");
+  duplicate.add_dependency("base.proto");
+  for (const char* name : {"first", "second"}) {
+    auto* extension = duplicate.add_extension();
+    extension->set_name(name);
+    extension->set_extendee(".base.Target");
+    extension->set_number(100);
+    extension->set_label(
+        google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL);
+    extension->set_type(google::protobuf::FieldDescriptorProto::TYPE_INT32);
+  }
+
+  upb::Arena arena;
+  upb::DefPool pool;
+  upb::Status status;
+  ASSERT_TRUE(pool.AddFile(ToUpbDescriptorSet(base, arena), &status));
+  status.Clear();
+  EXPECT_FALSE(pool.AddFile(ToUpbDescriptorSet(duplicate, arena), &status));
+
+  upb::MessageDefPtr message = pool.FindMessageByName("base.Target");
+  ASSERT_TRUE(message);
+  // A failed addition must not leave extensions in the pool.
+  size_t count;
+  const upb_FieldDef** extensions =
+      upb_DefPool_GetAllExtensions(pool.ptr(), message.ptr(), &count);
+  EXPECT_EQ(count, 0);
+  upb_gfree(extensions);
 }
 
 TEST(ReflectionTest, EnumDefault) {


### PR DESCRIPTION
## Summary

  This PR fixes a use-after-free in upb’s failed file-definition rollback.

  ## Analysis

  When adding a file fails, `remove_filedef()` removes definitions belonging to that file from the symbol table.

  Extensions are also registered separately in the `DefPool` extension table. These entries were not removed by the existing rollback.

  The failed file’s builder arena was then discarded while the extension table still contained pointers to its `FieldDef` objects. Subsequent extension enumeration could therefore access definitions from the freed arena.

  ## The Fix

  Remove extension-table entries belonging to the rejected file as part of `remove_filedef()`, before the builder arena is discarded.

  The extension registry already rolls back its own partial batch insertion, so no changes there are required.

  ## Testing

  - Added regression coverage using a rejected file containing duplicate extension numbers
  - Confirmed that the test fails before the fix because two extensions remain in the pool
  - Confirmed that the test passes after the fix with no retained extensions
  - Ran `//upb/reflection:reflection_test`
  - Ran the supported μpb test suite: 75 tests passed and 2 were skipped
 
