### PR TITLE
ruby: make bigdecimal a development dependency

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-gem "bigdecimal"
-
 # FFI is required for JRuby platforms, but optional elsewhere
 if defined? $JRUBY_VERSION
   gem "ffi", "~>1", platforms: %i[jruby]
@@ -15,6 +13,7 @@ end
 
 group :test do
   gem "test-unit", '~> 3.7'
+  gem "bigdecimal"
 end
 
 group :development do

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -39,8 +39,6 @@ Gem::Specification.new do |s|
     ]
   end
   s.required_ruby_version = '>= 3.2'
-  # bigdecimal must be used as a non-built in gem as of ruby-3.4
-  s.add_dependency "bigdecimal"
   # TODO: evaluate removing Rakefile and moving logic to extconf.rb, so that we
   # can remove this runtime dependency on rake. See the discussion here for
   # more details:
@@ -51,4 +49,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake-compiler", "~> 1.3"
   s.add_development_dependency "rake-compiler-dock", "~> 1.11"
   s.add_development_dependency "test-unit", '~> 3.7'
+  # bigdecimal is used in tests. It's no longer a built-in gem as of Ruby 3.4
+  # so an explicit dependency is needed.
+  s.add_development_dependency "bigdecimal"
 end


### PR DESCRIPTION
Fixes #28927

I ran into this while packaging the OpenTelemetry Ruby auto-instrumentation as a prebuilt gem bundle (see #28927 for the full write up). The tl;dr: `bigdecimal` is only used by the test suite, so it only needs to be a development dependency. The only references are:

https://github.com/protocolbuffers/protobuf/blob/8baed752ce1781eee1e025585b60373fe27564c3/ruby/tests/common_tests.rb#L9

https://github.com/protocolbuffers/protobuf/blob/8baed752ce1781eee1e025585b60373fe27564c3/ruby/tests/common_tests.rb#L1708

As a runtime dependency it causes pain for anyone vendoring the gem. `bigdecimal` is a native extension with no precompiled build, so it has to be compiled from source for each Ruby ABI, making it the one gem that stops a prebuilt bundle from working across Ruby versions, despite never being loaded at runtime.

This PR moves `bigdecimal` from a runtime to a development dependency. For consistency it also moves `bigdecimal` into the `test` group in the Gemfile, since that's the only environment that needs it.
