### PR TITLE
Disable option sub-location mapping in open-source builds.

### DIFF
--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -9288,19 +9288,7 @@ void internal::DescriptorBuilder::OptionInterpreter::UpdateSourceCodeInfo(
       }
 
       if (loc_matches) {
-        if (loc->path_size() == static_cast<int64_t>(match_src.size() + 1)) {
-          int uninterpreted_field = loc->path(match_src.size());
-
-          SourceCodeInfo_Location* mapped_loc = new_locs.Add();
-          *mapped_loc = *loc;
-          mapped_loc->mutable_path()->Assign(match_dest.begin(),
-                                             match_dest.end());
-          mapped_loc->add_path(uninterpreted_field);
-
-          // TODO: b/168903973 - recursively process options with aggregate
-          // values and add locations. Example: [(my_opt) = {a: 1, b: 2}]
-          // Locations of `a` and `b` are not added yet.
-        }
+        // TODO: b/168903973 - Remove once we update the format.
         // don't copy this row since it is a sub-location that we're removing
         // (or we already mapped it if it's a direct child)
         continue;

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -16274,6 +16274,8 @@ TEST_F(SourceLocationTest, GetSourceLocation) {
                                     "rpc Method(A) returns (A.B);"));
 }
 
+// TODO: b/168903973 - Remove once we update the format.
+
 TEST_F(SourceLocationTest, ExtensionSourceLocation) {
   SourceLocation loc;
 
@@ -16330,19 +16332,7 @@ TEST_F(SourceLocationTest, InterpretedOptionSourceLocation) {
 
     EXPECT_FALSE(file_desc->GetSourceLocation(unint, &loc));
 
-    SourceCodePath name_path = {FileDescriptorProto::kOptionsFieldNumber,
-                                FileOptions::kJavaPackageFieldNumber,
-                                UninterpretedOption::kNameFieldNumber};
-    EXPECT_TRUE(file_desc->GetSourceLocation(name_path, &loc));
-    EXPECT_THAT(loc,
-                MatchesSubstring(kSourceLocationTestInput, "java_package"));
-
-    SourceCodePath val_path = {FileDescriptorProto::kOptionsFieldNumber,
-                               FileOptions::kJavaPackageFieldNumber,
-                               UninterpretedOption::kStringValueFieldNumber};
-    EXPECT_TRUE(file_desc->GetSourceLocation(val_path, &loc));
-    EXPECT_THAT(loc,
-                MatchesSubstring(kSourceLocationTestInput, "\"com.foo.bar\""));
+// TODO: b/168903973 - Remove once we update the format.
   }
   {
     SourceCodePath path = {FileDescriptorProto::kOptionsFieldNumber,
@@ -16355,18 +16345,7 @@ TEST_F(SourceLocationTest, InterpretedOptionSourceLocation) {
 
     EXPECT_FALSE(file_desc->GetSourceLocation(unint, &loc));
 
-    SourceCodePath name_path = {FileDescriptorProto::kOptionsFieldNumber,
-                                kCustomOptionFieldNumber,
-                                UninterpretedOption::kNameFieldNumber};
-    EXPECT_TRUE(file_desc->GetSourceLocation(name_path, &loc));
-    EXPECT_THAT(loc,
-                MatchesSubstring(kSourceLocationTestInput, "(test_file_opt)"));
-
-    SourceCodePath val_path = {FileDescriptorProto::kOptionsFieldNumber,
-                               kCustomOptionFieldNumber,
-                               UninterpretedOption::kStringValueFieldNumber};
-    EXPECT_TRUE(file_desc->GetSourceLocation(val_path, &loc));
-    EXPECT_THAT(loc, MatchesSubstring(kSourceLocationTestInput, "\"foobar\""));
+// TODO: b/168903973 - Remove once we update the format.
   }
 
   // Message option

--- a/src/google/protobuf/retention_test.cc
+++ b/src/google/protobuf/retention_test.cc
@@ -226,9 +226,16 @@ TEST(RetentionTest, StripSourceRetentionOptionsWithSourceCodeInfo) {
       *pool.FindFileByName("retention.proto"),
       /*include_source_code_info=*/true);
 
-  // The number of locations is reduced by the number of stripped elements.
-  EXPECT_EQ(file_descriptor.source_code_info().location_size(), 88);
-  EXPECT_EQ(stripped_file.source_code_info().location_size(), 73);
+  FileDescriptorProto stripped_file =
+      compiler::StripSourceRetentionOptions(*interpreted_desc,
+                                            /*include_source_code_info=*/true);
+
+  // TODO: b/168903973 - Remove once we update the format.
+  EXPECT_EQ(interpreted_unstripped_file.source_code_info().location_size(), 64);
+
+  // Stripping removes source-retention options (including some sub-fields),
+  // reducing the location count.
+  EXPECT_EQ(stripped_file.source_code_info().location_size(), 63);
 }
 
 TEST(RetentionTest, RemoveEmptyOptions) {

--- a/src/google/protobuf/retention_test.cc
+++ b/src/google/protobuf/retention_test.cc
@@ -226,15 +226,9 @@ TEST(RetentionTest, StripSourceRetentionOptionsWithSourceCodeInfo) {
       *pool.FindFileByName("retention.proto"),
       /*include_source_code_info=*/true);
 
-  FileDescriptorProto stripped_file =
-      compiler::StripSourceRetentionOptions(*interpreted_desc,
-                                            /*include_source_code_info=*/true);
-
   // TODO: b/168903973 - Remove once we update the format.
-  EXPECT_EQ(interpreted_unstripped_file.source_code_info().location_size(), 64);
-
-  // Stripping removes source-retention options (including some sub-fields),
-  // reducing the location count.
+  // The number of locations is reduced by the number of stripped elements.
+  EXPECT_EQ(file_descriptor.source_code_info().location_size(), 88);
   EXPECT_EQ(stripped_file.source_code_info().location_size(), 63);
 }
 


### PR DESCRIPTION
We are considering changing the format of locations for options in SourceCodeInfo as the current format conflicts with dot-notation options format and can't be extended to cover them well.

Once we update format and make sure it works well for all type of options we'll re-enable it for opensource version.

PiperOrigin-RevId: 957355763