### PR TITLE
Cherry-pick fixes to release_integrity.sh

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -44,10 +44,8 @@ INTEGRITY_ASSET_URL=$(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name=="t
 
 # Check if the asset was found (jq emits "null" or empty if missing)
 if [[ -n "$INTEGRITY_ASSET_URL" && "$INTEGRITY_ASSET_URL" != "null" ]]; then
-  echo "Found pre-computed tool_integrity.bzl asset! Downloading."
   curl -sSL -o "${INTEGRITY_FILE}" "$INTEGRITY_ASSET_URL"
 else
-  echo "No pre-computed tool_integrity.bzl found. Falling back to dynamic API dictionary assembly."
   cat >"${INTEGRITY_FILE}" <<EOF
 """Generated during release by release_prep.sh"""
 

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -20,41 +20,16 @@ git archive --format=tar --prefix=${PREFIX}/ ${TAG} > $ARCHIVE_TMP
 # Delete the placeholder file
 tar --file $ARCHIVE_TMP --delete $INTEGRITY_FILE
 
-# Use jq to translate GitHub Releases json into a Starlark object
-filter_releases=$(cat <<'EOF'
-# Read the file assets already present on the release
-reduce .assets[] as $a (
-  # Start with an empty dictionary, and for each asset, add
-  {}; . + {
-    # The format required in starlark, i.e. "release-name": "deadbeef123"
-    ($a.name): ($a.digest | sub("^sha256:"; ""))
-  }
-)
-EOF
-)
-
 mkdir -p "$(dirname "$INTEGRITY_FILE")"
 
 # Fetch release payload once
 RELEASE_API_URL="https://api.github.com/repos/protocolbuffers/protobuf/releases/tags/${TAG}"
 RELEASE_JSON=$(curl -sSL "$RELEASE_API_URL")
 
-# Extract the download URL for tool_integrity.bzl if it exists
+# Extract the download URL for tool_integrity.bzl
 INTEGRITY_ASSET_URL=$(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name=="tool_integrity.bzl") | .browser_download_url')
 
-# Check if the asset was found (jq emits "null" or empty if missing)
-if [[ -n "$INTEGRITY_ASSET_URL" && "$INTEGRITY_ASSET_URL" != "null" ]]; then
-  curl -sSL -o "${INTEGRITY_FILE}" "$INTEGRITY_ASSET_URL"
-else
-  cat >"${INTEGRITY_FILE}" <<EOF
-"""Generated during release by release_prep.sh"""
-
-RELEASE_VERSION="${TAG}"
-RELEASED_BINARY_INTEGRITY = $(
-  echo "$RELEASE_JSON" | jq -f <(echo "$filter_releases")
-)
-EOF
-fi
+curl -sSL -o "${INTEGRITY_FILE}" "$INTEGRITY_ASSET_URL"
 
 # Append that generated file back into the archive
 tar --file $ARCHIVE_TMP --append ${INTEGRITY_FILE}

--- a/.github/workflows/release_prep_test.sh
+++ b/.github/workflows/release_prep_test.sh
@@ -66,11 +66,38 @@ ln -sf "$TAR" "$TEST_DIR/.mock_bin/tar"
 ln -sf "$(rlocation ${JQ_BIN#"external/"})" "$TEST_DIR/.mock_bin/jq"
 
 ##############################
-# Fixture: mock curl returning a GitHub Releases API response
+# Fixture: mock curl returning GitHub Releases API response & handling asset downloads
+# Handles two cases:
+# 1) When -o flag is provided, mocks downloading the integrity file .bzl,
+#    writing to path specified by the flag
+# 2) Otherwise, mocks retrieving the GitHub Releases API JSON, writing to stdout
 ##############################
 cat > "$TEST_DIR/.mock_bin/curl" <<'MOCK'
 #!/usr/bin/env bash
-cat <<'JSON'
+outfile=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      outfile="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$outfile" ]]; then
+  cat <<'BZL' > "$outfile"
+RELEASE_VERSION="v99.0"
+RELEASED_BINARY_INTEGRITY = {
+    "protoc-99.0-linux-x86_64.zip": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "protoc-99.0-osx-aarch_64.zip": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "protoc-99.0-win64.zip": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+}
+BZL
+else
+  cat <<'JSON'
 {
   "assets": [
     {
@@ -84,10 +111,15 @@ cat <<'JSON'
     {
       "name": "protoc-99.0-win64.zip",
       "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    {
+      "name": "tool_integrity.bzl",
+      "browser_download_url": "https://github.com/protocolbuffers/protobuf/releases/download/v99.0/tool_integrity.bzl"
     }
   ]
 }
 JSON
+fi
 MOCK
 chmod +x "$TEST_DIR/.mock_bin/curl"
 export PATH="$TEST_DIR/.mock_bin:$PATH"


### PR DESCRIPTION
Fixes issue where [release_bazel_module.yaml](https://github.com/protocolbuffers/protobuf/blob/main/.github/workflows/release_bazel_module.yaml) can clobber release notes with logs, as hit in v36.0-rc1 and v36.0-rc2.

Also removes fallback behavior