### PR TITLE
Reserve extension numbers 1364-1373 for Flyte

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -593,3 +593,8 @@ about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/protocgen/proto2mcp
     *   Extensions: 1311-1313
+
+1.  Flyte
+
+    *   Website: https://github.com/flyteorg/flyte
+    *   Extensions: 1364-1373


### PR DESCRIPTION
Requesting a block of custom option numbers for [Flyte](https://github.com/flyteorg/flyte), an open source workflow orchestration platform.

* Project: Flyte
* Website: https://github.com/flyteorg/flyte
* Requested: 1364-1373

### Why

Flyte's IDL (`flyteidl2`) is published to the Buf Schema Registry, PyPI and npm, so its descriptors regularly share a descriptor pool with third-party protos. We currently declare a `desc` field option in the 50000-99999 private range, which has collided with another published extension claiming the same tag on `google.protobuf.FieldOptions`. That collision fails extension registration at import time for anyone importing both schemas. Moving to a globally unique number from this registry is the correct fix.

We are requesting a block of ten rather than a single number because `flyteidl2` is a large and actively evolving schema, and we would rather not come back for a second request. This follows the precedent of similarly sized projects in the registry.

### Note on the requested range

We deliberately skipped 1314-1363, which is claimed by the currently open #28919. Starting at 1364 avoids conflicting with that pending request. Happy to renumber if the maintainers would prefer a different block, or if #28919 does not land.