### PR TITLE
[c++] Expose allow_unknown_enum setter

### DIFF
--- a/src/google/protobuf/text_format.h
+++ b/src/google/protobuf/text_format.h
@@ -809,6 +809,14 @@ class PROTOBUF_EXPORT TextFormat {
     // if possible.
     void AllowUnknownField(bool allow) { allow_unknown_field_ = allow; }
 
+    // When an unknown enum value is met, parsing will fail if this option is
+    // set to false (the default). If true, unknown enums will be ignored and
+    // a warning message will be generated.
+    // Beware! Setting this option true may hide some errors (e.g. spelling
+    // error on enum name). This allows data loss; unlike binary format, text
+    // format cannot preserve unknown enums.  Avoid using this option
+    // if possible.
+    void AllowUnknownEnum(bool allow) { allow_unknown_enum_ = allow; }
 
     void AllowFieldNumber(bool allow) { allow_field_number_ = allow; }
 

--- a/src/google/protobuf/text_format_unittest.cc
+++ b/src/google/protobuf/text_format_unittest.cc
@@ -3093,6 +3093,22 @@ TEST(TextFormatUnknownFieldTest, TestUnknownField) {
   EXPECT_TRUE(parser.ParseFromString("unknown_field: [{a:1}, <b:2>]", &proto));
 }
 
+TEST(TextFormatUnknownFieldTest, TestUnknownEnum) {
+  proto2_unittest::TestAllTypes proto;
+  TextFormat::Parser parser;
+  std::string message_with_bad_enum =
+      "repeated_nested_enum: BAR_BAD\n"
+      "repeated_nested_enum: BAR\n";
+
+  // Unknown enums are not permitted by default.
+  EXPECT_FALSE(parser.ParseFromString(message_with_bad_enum, &proto));
+
+  parser.AllowUnknownEnum(true);
+  EXPECT_TRUE(parser.ParseFromString(message_with_bad_enum, &proto));
+  ASSERT_EQ(proto.repeated_nested_enum_size(), 1);
+  EXPECT_EQ(proto.repeated_nested_enum(0), proto2_unittest::TestAllTypes::BAR);
+}
+
 TEST(TextFormatUnknownFieldTest, TestAnyInUnknownField) {
   proto2_unittest::TestAllTypes proto;
   TextFormat::Parser parser;


### PR DESCRIPTION
Expose `AllowUnknownEnum`, matching `AllowUnknownField`. Useful when parsing text formats from across different commits when enums are reserved.