### PR TITLE
[Java] prevent overflow in CodedOutputStream array range validation

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java
@@ -1061,7 +1061,7 @@ public abstract class CodedOutputStream extends ByteOutput {
       if (buffer == null) {
         throw new NullPointerException("buffer");
       }
-      if ((offset | length | (buffer.length - (offset + length))) < 0) {
+      if (offset < 0 || length < 0 || offset > buffer.length - length) {
         throw new IllegalArgumentException(
             String.format(
                 Locale.US,

--- a/java/core/src/test/java/com/google/protobuf/CodedOutputStreamTest.java
+++ b/java/core/src/test/java/com/google/protobuf/CodedOutputStreamTest.java
@@ -315,6 +315,34 @@ public class CodedOutputStreamTest {
   }
 
   @Test
+  public void testNewInstanceWithArraySliceValidatesRange() throws Exception {
+    // This test exercises an array-only factory, so run it once rather than for every output type.
+    assume().that(outputType).isEqualTo(OutputType.ARRAY);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CodedOutputStream.newInstance(new byte[0], 2, Integer.MAX_VALUE));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CodedOutputStream.newInstance(new byte[1], Integer.MAX_VALUE, Integer.MAX_VALUE));
+    assertThrows(
+        IllegalArgumentException.class, () -> CodedOutputStream.newInstance(new byte[1], -1, 1));
+    assertThrows(
+        IllegalArgumentException.class, () -> CodedOutputStream.newInstance(new byte[1], 0, -1));
+
+    byte[] sliceBytes = new byte[4];
+    CodedOutputStream slice = CodedOutputStream.newInstance(sliceBytes, 1, 2);
+    slice.writeUInt32NoTag(1);
+    assertThat(slice.spaceLeft()).isEqualTo(1);
+    assertThat(sliceBytes).isEqualTo(new byte[] {0, 1, 0, 0});
+
+    byte[] wholeArrayBytes = new byte[1];
+    CodedOutputStream wholeArray = CodedOutputStream.newInstance(wholeArrayBytes);
+    wholeArray.writeUInt32NoTag(1);
+    assertThat(wholeArrayBytes).isEqualTo(new byte[] {1});
+  }
+
+  @Test
   public void testWriteFixed32NoTag_outOfBounds_throws() throws Exception {
     for (int i = 0; i < 4; i++) {
       Coder coder = outputType.newCoder(i);

--- a/java/core/src/test/java/com/google/protobuf/CodedOutputStreamTest.java
+++ b/java/core/src/test/java/com/google/protobuf/CodedOutputStreamTest.java
@@ -330,6 +330,15 @@ public class CodedOutputStreamTest {
     assertThrows(
         IllegalArgumentException.class, () -> CodedOutputStream.newInstance(new byte[1], 0, -1));
 
+    CodedOutputStream emptyArray = CodedOutputStream.newInstance(new byte[0], 0, 0);
+    assertThat(emptyArray.spaceLeft()).isEqualTo(0);
+
+    CodedOutputStream emptySliceAtStart = CodedOutputStream.newInstance(new byte[1], 0, 0);
+    assertThat(emptySliceAtStart.spaceLeft()).isEqualTo(0);
+
+    CodedOutputStream emptySliceAtEnd = CodedOutputStream.newInstance(new byte[1], 1, 0);
+    assertThat(emptySliceAtEnd.spaceLeft()).isEqualTo(0);
+
     byte[] sliceBytes = new byte[4];
     CodedOutputStream slice = CodedOutputStream.newInstance(sliceBytes, 1, 2);
     slice.writeUInt32NoTag(1);


### PR DESCRIPTION
 ## Summary

  This PR fixes an integer overflow in `CodedOutputStream` array-slice validation.

  ## Analysis

  `ArrayEncoder` validates that `offset + length` remains within the supplied byte array.

  The existing check performs this addition before validating the result. Large positive values can overflow the signed integer range, allowing an invalid slice to be accepted.

  The resulting encoder can report a large writable range beyond the supplied array.

  ## The Fix

  Validate `offset` and `length` separately and compare `offset` against `buffer.length - length`.

  This avoids the overflowing addition while preserving valid zero-length slices at the beginning and end of an array.

  ## Testing

  - Added regression coverage for overflowing positive ranges
  - Added negative offset and length controls
  - Added valid ordinary and zero-length boundary cases
  - Ran `//java/core:CodedOutputStreamTest`
  - Ran `//java/core:core_tests`: 75 tests passed

