### PR TITLE
Add JSON and CPP option protos to C++ toolchain blacklisted_protos

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -602,7 +602,9 @@ proto_lang_toolchain(
     blacklisted_protos = [
         "//:compiler_plugin_proto",
         "//:cpp_features_proto",
+        "//:cpp_file_options_proto",
         "//:descriptor_proto",
+        "//:json_enumvalue_options_proto",
     ],
     command_line = "--cpp_out=$(OUT)",
     plugin = "//src/google/protobuf/compiler/cpp:protoc-gen-cpp",


### PR DESCRIPTION
Add `//:json_enumvalue_options_proto` and `//:cpp_file_options_proto` to `blacklisted_protos` in `proto_lang_toolchain(name = "cc_toolchain")`.

The generated C++ sources for these option protos (e.g., `json_enumvalue_options.pb.cc`) are built directly into the core protobuf C++ runtime library (`libprotobuf.so`). Without being listed in `blacklisted_protos`, any downstream `cc_proto_library` target depending on protos that import these options will generate and compile duplicate `.pb.cc` objects into separate shared libraries (e.g., `libjson_enumvalue_options_proto.so`), causing ODR violations, especially under ASAN mode.

PiperOrigin-RevId: 963673828