### PR TITLE
fix: add ABSL_DCHECK for negative size in ParseFromArray

### DIFF
--- a/src/google/protobuf/message_lite.cc
+++ b/src/google/protobuf/message_lite.cc
@@ -423,6 +423,7 @@ bool MessageLite::ParsePartialFromString(absl::string_view data) {
 }
 
 bool MessageLite::ParseFromArray(const void* data, int size) {
+  ABSL_DCHECK(size >= 0);
   return ParseFrom<kParse>(as_string_view(data, size));
 }
 


### PR DESCRIPTION
### Problem

`MessageLite::ParseFromArray(const void* data, int size)` takes an `int size` parameter, but a negative value (e.g. `-1`) is cast to a huge `size_t` by `absl::string_view`'s constructor, causing pointer arithmetic overflow in the parsing context.

The sister method `ParseFromString` already has a safety check (`ABSL_PREDICT_FALSE(data.size() > INT_MAX)`), but `ParseFromArray` lacks one.

### Fix

Add an `ABSL_DCHECK(size >= 0)` before the `as_string_view` call, as recommended by the maintainer:

> We have discussed this (AI tools like to raise it :)) and have decided we would take a DCHECK here but not a graceful return. If you want to send a PR for that we would accept it.

Fixes #28065