### PR TITLE
Reject oversized length prefixes in DecodeDelimited 

### DIFF
--- a/src/google/protobuf/io/coded_stream.cc
+++ b/src/google/protobuf/io/coded_stream.cc
@@ -149,8 +149,8 @@ CodedInputStream::IncrementRecursionDepthAndPushLimit(int byte_limit) {
 }
 
 CodedInputStream::Limit CodedInputStream::ReadLengthAndPushLimit() {
-  uint32_t length;
-  return PushLimit(ReadVarint32(&length) ? length : 0);
+  int length;
+  return PushLimit(ReadVarintSizeAsInt(&length) ? length : 0);
 }
 
 bool CodedInputStream::DecrementRecursionDepthAndPopLimit(Limit limit) {

--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -420,7 +420,7 @@ class PROTOBUF_EXPORT PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED CodedInputStream {
   PROTOBUF_FUTURE_ADD_EARLY_NODISCARD std::pair<CodedInputStream::Limit, int>
   IncrementRecursionDepthAndPushLimit(int byte_limit);
 
-  // Shorthand for PushLimit(ReadVarint32(&length) ? length : 0).
+  // Shorthand for PushLimit(ReadVarintSizeAsInt(&length) ? length : 0).
   PROTOBUF_FUTURE_ADD_EARLY_NODISCARD Limit ReadLengthAndPushLimit();
 
   // Helper that is equivalent to: {

--- a/src/google/protobuf/json/internal/untyped_message.cc
+++ b/src/google/protobuf/json/internal/untyped_message.cc
@@ -463,10 +463,12 @@ absl::Status UntypedMessage::DecodeDelimited(io::CodedInputStream& stream,
   if (!stream.IncrementRecursionDepth()) {
     return MakeTooDeepError();
   }
-  auto limit = stream.ReadLengthAndPushLimit();
-  if (limit == 0) {
-    return MakeUnexpectedEofError();
+  int length;
+  if (!stream.ReadVarintSizeAsInt(&length)) {
+    stream.DecrementRecursionDepth();
+    return MakeMalformedLengthDelimError();
   }
+  auto limit = stream.PushLimit(length);
 
   switch (field.proto().kind()) {
     case Field::TYPE_STRING:

--- a/src/google/protobuf/json/json_test.cc
+++ b/src/google/protobuf/json/json_test.cc
@@ -1619,6 +1619,30 @@ TEST_P(JsonTest, MalformedLengthDelimitedField) {
   ASSERT_THAT(s, StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
+TEST_P(JsonTest, KnownMessageOversizedLengthRejected) {
+  std::string out;
+  // Known TYPE_MESSAGE with a valid small length, then a sibling.
+  absl::Status honest = BinaryToJsonString(
+      resolver_.get(), "type.googleapis.com/proto3.TestMessage",
+      "\x5a\x02\x08\x07\x20\x01", &out);
+  ASSERT_OK(honest);
+  EXPECT_THAT(out, ContainsRegex("messageValue"));
+  EXPECT_THAT(out, ContainsRegex("uint32Value"));
+
+  // Same fields with length prefix 0x80000000.
+  out.clear();
+  absl::Status evil_threshold = BinaryToJsonString(
+      resolver_.get(), "type.googleapis.com/proto3.TestMessage",
+      "\x5a\x80\x80\x80\x80\x08\x08\x07\x20\x01", &out);
+  ASSERT_THAT(evil_threshold, StatusIs(absl::StatusCode::kInvalidArgument));
+
+  out.clear();
+  absl::Status evil_max = BinaryToJsonString(
+      resolver_.get(), "type.googleapis.com/proto3.TestMessage",
+      "\x5a\xff\xff\xff\xff\x0f\x08\x07\x20\x01", &out);
+  ASSERT_THAT(evil_max, StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
 TEST_P(JsonTest, DeeplyNestedGroupsRejected) {
   // Verify that deeply nested TYPE_GROUP fields are rejected with an error
   // rather than causing unbounded stack recursion.


### PR DESCRIPTION
## Summary

`ReadLengthAndPushLimit` passes `ReadVarint32` directly to `PushLimit(int)`. For length prefixes `>= 2^31` (e.g. `0x80000000`), that `uint32` becomes negative. `PushLimit` keeps the prior limit, so the delimited region has no child boundary. 

`DecodeDelimited` (the known length-delimited path used by `BinaryToJsonString`) then returns `OK` while a later sibling on the wire is absent from the JSON (`TYPE_MESSAGE` absorbs it). Callers that trust that status have no signal the message was parsed incorrectly. 

For comparison, the header requires `ReadVarintSizeAsInt` for sizes ("truncating would result in misparsing the payload"). Wire-lite follows that, but this helper does not.

## Fix

- `ReadLengthAndPushLimit`: use `ReadVarintSizeAsInt`. On failure, `PushLimit(0)` (same convention as unreadable-varint path).
- `DecodeDelimited`: return an error on that failure. 

## Test plan

- [x] Reproduced on unfixed code: known `message_value` with length `0x80000000` plus a later `uint32_value` sibling → `OK` and JSON missing `uint32Value`.
- [x] `JsonTest.KnownMessageOversizedLengthRejected` on this change: that wire correctly returns `InvalidArgument`. And honest small length still parses.
- [ ] Existing JSON tests pass (CI)