### PR TITLE
Fix MSVC conversion and shadowing warnings (C4267, C4458)

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -698,11 +698,12 @@ struct KeyNode : NodeBase {
 // random iteration order.
 inline map_index_t Hash(absl::string_view k, void* salt) {
   const uintptr_t salt_int = reinterpret_cast<uintptr_t>(salt);
-  return absl::HashOf(k, absl::rotr(salt_int, k.size()));
+  return static_cast<map_index_t>(
+      absl::HashOf(k, absl::rotr(salt_int, k.size())));
 }
 inline map_index_t Hash(uint64_t k, void* salt) {
   const uintptr_t salt_int = reinterpret_cast<uintptr_t>(salt);
-  return absl::HashOf(k, absl::rotr(salt_int, k));
+  return static_cast<map_index_t>(absl::HashOf(k, absl::rotr(salt_int, k)));
 }
 
 // KeyMapBase is a chaining hash map.

--- a/src/google/protobuf/micro_string.h
+++ b/src/google/protobuf/micro_string.h
@@ -83,12 +83,12 @@ class PROTOBUF_EXPORT MicroString {
 
     void SetExternalBuffer(absl::string_view buffer) {
       payload = const_cast<char*>(buffer.data());
-      size = buffer.size();
+      size = static_cast<uint32_t>(buffer.size());
     }
 
-    void SetInitialSize(size_t size) {
-      PoisonMemoryRegion(owned_head() + size, capacity - size);
-      this->size = size;
+    void SetInitialSize(size_t new_size) {
+      PoisonMemoryRegion(owned_head() + new_size, capacity - new_size);
+      this->size = static_cast<uint32_t>(new_size);
     }
 
     void Unpoison() { UnpoisonMemoryRegion(owned_head(), capacity); }
@@ -96,7 +96,7 @@ class PROTOBUF_EXPORT MicroString {
     void ChangeSize(size_t new_size) {
       PoisonMemoryRegion(owned_head() + new_size, capacity - new_size);
       UnpoisonMemoryRegion(owned_head(), new_size);
-      size = new_size;
+      size = static_cast<uint32_t>(new_size);
     }
   };
 
@@ -108,9 +108,9 @@ class PROTOBUF_EXPORT MicroString {
     const char* data() const { return reinterpret_cast<const char*>(this + 1); }
     absl::string_view view() const { return {data(), size}; }
 
-    void SetInitialSize(uint8_t size) {
-      PoisonMemoryRegion(data() + size, capacity - size);
-      this->size = size;
+    void SetInitialSize(uint8_t new_size) {
+      PoisonMemoryRegion(data() + new_size, capacity - new_size);
+      this->size = new_size;
     }
 
     void Unpoison() { UnpoisonMemoryRegion(data(), capacity); }

--- a/src/google/protobuf/repeated_ptr_field.h
+++ b/src/google/protobuf/repeated_ptr_field.h
@@ -2152,16 +2152,17 @@ class RustRepeatedMessageHelper {
   }
 
   static void Reserve(RepeatedPtrFieldBase& field, size_t additional) {
-    field.ReserveWithArena(field.GetArena(), field.size() + additional);
+    field.ReserveWithArena(field.GetArena(),
+                           static_cast<int>(field.size() + additional));
   }
 
   static const MessageLite& At(const RepeatedPtrFieldBase& field,
                                size_t index) {
-    return field.at<GenericTypeHandler<MessageLite>>(index);
+    return field.at<GenericTypeHandler<MessageLite>>(static_cast<int>(index));
   }
 
   static MessageLite& At(RepeatedPtrFieldBase& field, size_t index) {
-    return field.at<GenericTypeHandler<MessageLite>>(index);
+    return field.at<GenericTypeHandler<MessageLite>>(static_cast<int>(index));
   }
 };
 


### PR DESCRIPTION
Make `size_t` narrowing conversions explicit with `static_cast` and rename shadowing parameters.

The casts are safe because the values are bounded by the fields they are assigned to: `MicroString` sizes are limited by the `uint32_t` capacity field, map hashes intentionally truncate to `map_index_t`, and `RepeatedPtrField` indices and sizes are `int` internally.

This fixes MSVC warnings C4267 in `micro_string.h`, `map.h` and `repeated_ptr_field.h` and C4458 in `micro_string.h` for every consumer that compiles these headers at a high warning level (`/W4`).