### PR TITLE
use size_t for grealloc byte sizes in three upb growth helpers

### DIFF
--- a/upb/message/internal/compare_unknown.c
+++ b/upb/message/internal/compare_unknown.c
@@ -131,11 +131,13 @@ static void upb_UnknownFields_SortRecursive(upb_UnknownField* arr, size_t start,
 static void upb_UnknownFields_Sort(upb_UnknownField_Context* ctx,
                                    upb_UnknownFields* fields) {
   if (ctx->tmp_size < fields->size) {
-    const int oldsize = ctx->tmp_size * sizeof(*ctx->tmp);
+    const size_t oldsize = ctx->tmp_size * sizeof(*ctx->tmp);
     ctx->tmp_size = UPB_MAX(8, ctx->tmp_size);
     while (ctx->tmp_size < fields->size) ctx->tmp_size *= 2;
-    const int newsize = ctx->tmp_size * sizeof(*ctx->tmp);
-    ctx->tmp = upb_grealloc(ctx->tmp, oldsize, newsize);
+    const size_t newsize = ctx->tmp_size * sizeof(*ctx->tmp);
+    upb_UnknownField* tmp = upb_grealloc(ctx->tmp, oldsize, newsize);
+    if (!tmp) upb_UnknownFields_OutOfMemory(ctx);
+    ctx->tmp = tmp;
   }
   upb_UnknownFields_SortRecursive(fields->fields, 0, fields->size, ctx->tmp);
 }

--- a/upb/message/internal/compare_unknown_test.cc
+++ b/upb/message/internal/compare_unknown_test.cc
@@ -118,6 +118,26 @@ TEST(CompareTest, UnknownFieldsOrdering) {
           {{1, Group({{2, Group({{4, Fixed64(123)}, {3, Fixed32(456)}})}})}}));
 }
 
+TEST(CompareTest, ManyUnsortedFields) {
+  // Enough fields to grow the sort scratch buffer through several doublings.
+  // uf1 is in descending tag order (forcing a sort) and uf2 is the ascending
+  // permutation with identical values, so they compare equal.
+  WireMessage descending;
+  WireMessage ascending;
+  const uint32_t n = 300;
+  for (uint32_t i = 0; i < n; i++) {
+    descending.push_back({n - i, Varint(i)});
+    ascending.push_back({i + 1, Varint(n - 1 - i)});
+  }
+  EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
+            CompareUnknown(descending, ascending));
+
+  // Flip a single value and the comparison must report inequality.
+  ascending[n / 2].value = Varint(0xdeadbeef);
+  EXPECT_EQ(kUpb_UnknownCompareResult_NotEqual,
+            CompareUnknown(descending, ascending));
+}
+
 TEST(CompareTest, LongVarint) {
   EXPECT_EQ(kUpb_UnknownCompareResult_Equal,
             CompareUnknownWithMaxDepth({{1, Varint(123)}, {2, Varint(456)}},

--- a/upb/message/map_sorter.c
+++ b/upb/message/map_sorter.c
@@ -111,9 +111,9 @@ static bool _upb_mapsorter_resize(_upb_mapsorter* s, _upb_sortedmap* sorted,
   sorted->end = sorted->start + size;
 
   if (sorted->end > s->cap) {
-    const int oldsize = s->cap * sizeof(*s->entries);
+    const size_t oldsize = s->cap * sizeof(*s->entries);
     s->cap = upb_RoundUpToPowerOfTwo(sorted->end);
-    const int newsize = s->cap * sizeof(*s->entries);
+    const size_t newsize = s->cap * sizeof(*s->entries);
     s->entries = upb_grealloc(s->entries, oldsize, newsize);
     if (!s->entries) return false;
   }

--- a/upb/util/required_fields.c
+++ b/upb/util/required_fields.c
@@ -170,11 +170,11 @@ static void upb_FieldPathVector_Reserve(upb_FindContext* ctx,
                                         upb_FieldPathVector* vec,
                                         size_t elems) {
   if (vec->cap - vec->size < elems) {
-    const int oldsize = vec->cap * sizeof(*vec->path);
+    const size_t oldsize = vec->cap * sizeof(*vec->path);
     size_t need = vec->size + elems;
     vec->cap = UPB_MAX(4, vec->cap);
     while (vec->cap < need) vec->cap *= 2;
-    const int newsize = vec->cap * sizeof(*vec->path);
+    const size_t newsize = vec->cap * sizeof(*vec->path);
     vec->path = upb_grealloc(vec->path, oldsize, newsize);
     if (!vec->path) {
       UPB_LONGJMP(ctx->err, 1);


### PR DESCRIPTION
1. `upb_UnknownFields_Sort` (upb/message/internal/compare_unknown.c), `upb_FieldPathVector_Reserve` (upb/util/required_fields.c) and `_upb_mapsorter_resize` (upb/message/map_sorter.c) each store a `<capacity> * sizeof(*ptr)` realloc byte count in an `int`, truncating the `size_t` product once the growing buffer passes INT_MAX bytes.
2. `upb_grealloc` takes `size_t`, so the negative value sign-extends to a ~18EB request (realloc yields NULL) or, at higher counts, wraps to a small/zero value that under-allocates while the capacity still claims the full element count, and the merge/copy that follows walks off the buffer.

Reached from untrusted data via `upb_Message_IsEqual` on decoded unknown fields, sorted `upb_Encode`, and `upb_util_HasUnsetRequired` respectively. Widened the byte-size locals to `size_t` at all three sites, and added to the sort the `upb_grealloc` NULL check that the other two helpers already had.