### PR TITLE
Add a plugins attribute to proto_lang_toolchain so multiple protoc plugins can be run

### DIFF
--- a/bazel/common/proto_common.bzl
+++ b/bazel/common/proto_common.bzl
@@ -197,6 +197,12 @@ def _compile(
     if proto_lang_toolchain_info.plugin:
         tools.append(proto_lang_toolchain_info.plugin)
         args.add(proto_lang_toolchain_info.plugin.executable, format = proto_lang_toolchain_info.plugin_format_flag)
+    for plugin in getattr(proto_lang_toolchain_info, "plugins", []):
+        if plugin.plugin:
+            tools.append(plugin.plugin)
+            args.add(plugin.plugin.executable, format = "--plugin=protoc-gen-%s=%%s" % plugin.name)
+        if plugin_output:
+            args.add(plugin_output, format = "--%s_out=%%s" % plugin.name)
 
     # Protoc searches for .protos -I paths in order they are given and then
     # uses the path within the directory as the package.

--- a/bazel/common/proto_lang_toolchain_info.bzl
+++ b/bazel/common/proto_lang_toolchain_info.bzl
@@ -10,6 +10,9 @@ ProtoLangToolchainInfo = provider(
           a path to single file or a directory in case of multiple files.""",
         plugin_format_flag = "(str) Format string used when passing plugin to proto compiler.",
         plugin = "(FilesToRunProvider) Proto compiler plugin.",
+        plugins = """(list[ProtoPluginInfo]) Additional proto compiler plugins. Each one is
+          passed to the proto compiler as --plugin=protoc-gen-<name>=<executable> and
+          --<name>_out pointing at the same output location as $(OUT) in `command_line`.""",
         runtime = "(Target) Runtime.",
         provided_proto_sources = "(list[File]) Proto sources provided by the toolchain.",
         proto_compiler = "(FilesToRunProvider) Proto compiler.",

--- a/bazel/private/BUILD
+++ b/bazel/private/BUILD
@@ -116,12 +116,21 @@ bzl_library(
 )
 
 bzl_library(
+    name = "proto_plugin_rule_bzl",
+    srcs = [
+        "proto_plugin_rule.bzl",
+    ],
+    visibility = ["//bazel:__subpackages__"],
+)
+
+bzl_library(
     name = "proto_lang_toolchain_rule_bzl",
     srcs = [
         "proto_lang_toolchain_rule.bzl",
     ],
     visibility = ["//bazel:__subpackages__"],
     deps = [
+        ":proto_plugin_rule_bzl",
         ":toolchain_helpers_bzl",
         "//bazel/common:proto_common_bzl",
         "//bazel/common:proto_info_bzl",

--- a/bazel/private/proto_lang_toolchain_rule.bzl
+++ b/bazel/private/proto_lang_toolchain_rule.bzl
@@ -12,11 +12,14 @@ load("@proto_bazel_features//:features.bzl", "bazel_features")
 load("//bazel/common:proto_common.bzl", "proto_common")
 load("//bazel/common:proto_info.bzl", "ProtoInfo")
 load("//bazel/common:proto_lang_toolchain_info.bzl", "ProtoLangToolchainInfo")
+load("//bazel/private:proto_plugin_rule.bzl", "ProtoPluginInfo")
 load("//bazel/private:toolchain_helpers.bzl", "toolchains")
 
 def _rule_impl(ctx):
     if ctx.attr.blacklisted_protos and ctx.attr.denylisted_protos:
         fail("Only one of 'denylisted_protos' and 'blacklisted_protos' can be set (prefer 'denylisted_protos').")
+    if ctx.attr.plugin != None and ctx.attr.plugins:
+        fail("Only one of 'plugin' and 'plugins' can be set.")
     denylisted_protos = ctx.attr.denylisted_protos or ctx.attr.blacklisted_protos
     provided_proto_sources = depset(transitive = [bp[ProtoInfo].transitive_sources for bp in denylisted_protos]).to_list()
 
@@ -44,6 +47,7 @@ def _rule_impl(ctx):
         output_files = ctx.attr.output_files,
         plugin_format_flag = ctx.attr.plugin_format_flag,
         plugin = plugin,
+        plugins = [p[ProtoPluginInfo] for p in ctx.attr.plugins],
         runtime = ctx.attr.runtime,
         provided_proto_sources = provided_proto_sources,
         proto_compiler = proto_compiler,
@@ -116,7 +120,20 @@ The value must contain a single %s which is replaced with plugin executable.
             doc = """
 If provided, will be made available to the action that calls the proto-compiler, and will be
 passed to the proto-compiler:
-<code>--plugin=protoc-gen-PLUGIN=&lt;executable&gt;.</code>""",
+<code>--plugin=protoc-gen-PLUGIN=&lt;executable&gt;.</code>
+Mutually exclusive with <code>plugins</code>.""",
+        ),
+        "plugins": attr.label_list(
+            cfg = "exec",
+            providers = [ProtoPluginInfo],
+            doc = """
+<code>proto_plugin</code> targets to run in the same proto-compiler invocation.
+Mutually exclusive with <code>plugin</code>.
+Each plugin will be made available to the action and passed to the proto-compiler as
+<code>--plugin=protoc-gen-&lt;name&gt;=&lt;executable&gt;</code> together with
+<code>--&lt;name&gt;_out</code> pointing at the same output location as <code>$(OUT)</code>
+in <code>command_line</code>, so plugins can add to the primary generator's output via
+insertion points.""",
         ),
         "runtime": attr.label(doc = """
 A language-specific library that the generated code is compiled against.

--- a/bazel/private/proto_plugin_rule.bzl
+++ b/bazel/private/proto_plugin_rule.bzl
@@ -1,0 +1,56 @@
+# Protocol Buffers - Google's data interchange format
+# Copyright 2024 Google Inc.  All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+#
+"""Implementation of the proto_plugin rule."""
+
+ProtoPluginInfo = provider(
+    doc = "Describes an additional protoc plugin run by proto_lang_toolchain.",
+    fields = {
+        "name": "(str) The plugin name, passed to the proto compiler as " +
+                "--plugin=protoc-gen-<name> and --<name>_out. Set by the rule's " +
+                "`plugin_name` attribute, defaulting to the target's name.",
+        "plugin": "(FilesToRunProvider|None) The plugin executable, or None if the " +
+                  "plugin is built into the proto compiler itself.",
+    },
+)
+
+def _proto_plugin_impl(ctx):
+    return [
+        ProtoPluginInfo(
+            name = ctx.attr.plugin_name or ctx.label.name,
+            plugin = ctx.attr.runtime[DefaultInfo].files_to_run if ctx.attr.runtime else None,
+        ),
+    ]
+
+proto_plugin = rule(
+    implementation = _proto_plugin_impl,
+    doc = """
+Describes a protoc plugin that can be passed to the <code>plugins</code> attribute of
+<code>proto_lang_toolchain</code>. For each plugin the proto compiler is invoked with
+<code>--plugin=protoc-gen-&lt;name&gt;=&lt;runtime&gt;</code> and <code>--&lt;name&gt;_out</code>
+pointing at the same output location as the <code>$(OUT)</code> in the toolchain's
+<code>command_line</code>, so plugins can add code to the primary generator's output via
+insertion points.
+
+<p><code>&lt;name&gt;</code> is the <code>plugin_name</code> attribute, or the target's name
+when that attribute is not set.""",
+    attrs = {
+        "plugin_name": attr.string(
+            doc = """
+The name protoc knows the plugin by, used for both
+<code>--plugin=protoc-gen-&lt;plugin_name&gt;</code> and <code>--&lt;plugin_name&gt;_out</code>.
+protoc requires the two to match, so this single name drives both flags.
+Defaults to the target's name.""",
+        ),
+        "runtime": attr.label(
+            doc = "The plugin binary. If absent, assume the plugin is a built-in to protoc itself.",
+            cfg = "target",
+            executable = True,
+        ),
+    },
+    provides = [ProtoPluginInfo],
+)

--- a/bazel/tests/proto_common_compile_tests.bzl
+++ b/bazel/tests/proto_common_compile_tests.bzl
@@ -30,6 +30,9 @@ def proto_common_compile_test_suite(name):
             _test_compile_noplugin,
             _test_compile_with_plugin_output,
             _test_compile_with_directory_plugin_output,
+            _test_compile_with_plugins,
+            _test_compile_with_plugins_no_plugin_output,
+            _test_toolchain_plugin_and_plugins_are_exclusive,
             _test_compile_additional_args,
             _test_compile_additional_tools,
             _test_compile_additional_tools_no_plugin,
@@ -161,6 +164,94 @@ def _test_compile_with_directory_plugin_output_impl(env, target):
             matching.equals_wrapper("-I."),
             matching.str_endswith("/A.proto"),
         ],
+    )
+
+# Verifies usage of `proto_common.compile` with a toolchain that sets `plugins`.
+def _test_compile_with_plugins(name):
+    util.helper_target(
+        compile_rule,
+        name = name + "_compile",
+        proto_dep = ":simple_proto",
+        plugin_output = "single",
+        toolchain = "//bazel/tests/testdata:toolchain_plugins",
+    )
+
+    analysis_test(
+        name = name,
+        target = name + "_compile",
+        impl = _test_compile_with_plugins_impl,
+    )
+
+def _test_compile_with_plugins_impl(env, target):
+    action = env.expect.that_target(target).action_named("MyMnemonic")
+    action.argv().contains_exactly_predicates(
+        [
+            _match_proto_compiler(),
+            matching.str_matches("--java_out=param1,param2:*out*test_compile_with_plugins_compile"),
+            # ":grpc_plugin" has an executable, so it gets both --plugin= and
+            # --grpc_out=. Both use its plugin_name ("grpc"), not its target name.
+            matching.str_matches("--plugin=protoc-gen-grpc=*out*testdata/plugin"),
+            matching.str_matches("--grpc_out=*out*test_compile_with_plugins_compile"),
+            # ":builtin" has no executable, so it only gets --builtin_out=, and no
+            # plugin_name, so protoc sees it under its target name.
+            matching.str_matches("--builtin_out=*out*test_compile_with_plugins_compile"),
+            matching.equals_wrapper("-I."),
+            matching.str_endswith("/A.proto"),
+        ],
+    ).in_order()
+    action.inputs().contains_at_least_predicates(
+        [
+            matching.any(matching.file_basename_equals("plugin"), matching.file_basename_equals("plugin.exe")),
+        ],
+    )
+
+# Verifies a toolchain with `plugins` passes no `--<name>_out` when there's no plugin output.
+def _test_compile_with_plugins_no_plugin_output(name):
+    util.helper_target(
+        compile_rule,
+        name = name + "_compile",
+        proto_dep = ":simple_proto",
+        toolchain = "//bazel/tests/testdata:toolchain_plugins",
+    )
+
+    analysis_test(
+        name = name,
+        target = name + "_compile",
+        impl = _test_compile_with_plugins_no_plugin_output_impl,
+    )
+
+def _test_compile_with_plugins_no_plugin_output_impl(env, target):
+    action = env.expect.that_target(target).action_named("MyMnemonic")
+    action.argv().contains_exactly_predicates(
+        [
+            _match_proto_compiler(),
+            matching.str_matches("--plugin=protoc-gen-grpc=*out*testdata/plugin"),
+            matching.equals_wrapper("-I."),
+            matching.str_endswith("/A.proto"),
+        ],
+    ).in_order()
+
+# Verifies a toolchain cannot set both `plugin` and `plugins`.
+def _test_toolchain_plugin_and_plugins_are_exclusive(name):
+    util.helper_target(
+        proto_lang_toolchain,
+        name = name + "_toolchain",
+        command_line = "--java_out=$(OUT)",
+        plugin = "//bazel/tests/testdata:plugin",
+        plugin_format_flag = "--plugin=%s",
+        plugins = ["//bazel/tests/testdata:grpc_plugin"],
+    )
+
+    analysis_test(
+        name = name,
+        target = name + "_toolchain",
+        impl = _test_toolchain_plugin_and_plugins_are_exclusive_impl,
+        expect_failure = True,
+    )
+
+def _test_toolchain_plugin_and_plugins_are_exclusive_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.str_matches("Only one of 'plugin' and 'plugins' can be set."),
     )
 
 # Verifies usage of `proto_common.compile` with `additional_args` parameter

--- a/bazel/tests/testdata/BUILD
+++ b/bazel/tests/testdata/BUILD
@@ -2,6 +2,7 @@ load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//bazel:proto_library.bzl", "proto_library")
 load("//bazel/toolchains:proto_lang_toolchain.bzl", "proto_lang_toolchain")
+load("//bazel/toolchains:proto_plugin.bzl", "proto_plugin")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -31,6 +32,47 @@ proto_lang_toolchain(
     mnemonic = "MyMnemonic",
     progress_message = "Progress Message %{label}",
     runtime = ":runtime",
+    tags = [
+        "manual",
+        "nobuilder",
+        "notap",
+    ],
+)
+
+proto_lang_toolchain(
+    name = "toolchain_plugins",
+    blacklisted_protos = [":denied"],
+    command_line = "--java_out=param1,param2:$(OUT)",
+    mnemonic = "MyMnemonic",
+    plugins = [
+        ":grpc_plugin",
+        ":builtin",
+    ],
+    progress_message = "Progress Message %{label}",
+    runtime = ":runtime",
+    tags = [
+        "manual",
+        "nobuilder",
+        "notap",
+    ],
+)
+
+# A plugin with its own executable, whose protoc name differs from its target name.
+proto_plugin(
+    name = "grpc_plugin",
+    plugin_name = "grpc",
+    runtime = ":plugin",
+    tags = [
+        "manual",
+        "nobuilder",
+        "notap",
+    ],
+)
+
+# A plugin that is built into protoc itself, so it has no executable. It has no
+# plugin_name either, so protoc sees it under the target's name.
+proto_plugin(
+    name = "builtin",
     tags = [
         "manual",
         "nobuilder",

--- a/bazel/toolchains/BUILD
+++ b/bazel/toolchains/BUILD
@@ -28,12 +28,24 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "proto_plugin_bzl",
+    srcs = [
+        "proto_plugin.bzl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bazel/private:proto_plugin_rule_bzl",
+    ],
+)
+
 filegroup(
     name = "for_bazel_tests",
     testonly = True,
     srcs = [
         "BUILD",
         "proto_lang_toolchain_bzl",
+        "proto_plugin_bzl",
         "proto_toolchain_bzl",
     ],
     visibility = [

--- a/bazel/toolchains/proto_plugin.bzl
+++ b/bazel/toolchains/proto_plugin.bzl
@@ -1,0 +1,13 @@
+# Protocol Buffers - Google's data interchange format
+# Copyright 2024 Google Inc.  All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+#
+"""proto_plugin rule"""
+
+load("//bazel/private:proto_plugin_rule.bzl", _ProtoPluginInfo = "ProtoPluginInfo", _proto_plugin = "proto_plugin")
+
+ProtoPluginInfo = _ProtoPluginInfo
+proto_plugin = _proto_plugin


### PR DESCRIPTION
We run two protoc plugins with our build and there is currently no straightforward way to use multiple protoc plugins with Bazel. This PR adds a plugins attribute that allows one to specify as many protoc plugins as they want.