### PR TITLE
upb: reject repeated message extensions in GetOrPromoteExtension

### DIFF
--- a/upb/message/promote.c
+++ b/upb/message/promote.c
@@ -120,6 +120,13 @@ upb_GetExtension_Status upb_Message_GetOrPromoteExtension(
     int decode_options, upb_Arena* arena, upb_MessageValue* value) {
   UPB_ASSERT(!upb_Message_IsFrozen(msg));
   UPB_ASSERT(upb_MiniTableExtension_CType(ext_table) == kUpb_CType_Message);
+  // Promotion stores a upb_Message* in the extension slot. Repeated
+  // extensions are read as upb_Array* by the encoder and accessors, so
+  // promoting a repeated message extension is a type confusion. Repeated
+  // unknowns should use upb_MiniTable_PromoteUnknownToMessageArray.
+  if (!upb_MiniTableField_IsScalar(upb_MiniTableExtension_ToField(ext_table))) {
+    return kUpb_GetExtension_ParseError;
+  }
   const upb_Extension* extension =
       UPB_PRIVATE(_upb_Message_Getext)(msg, ext_table);
   if (extension) {

--- a/upb/message/promote.h
+++ b/upb/message/promote.h
@@ -42,7 +42,7 @@ typedef enum {
 
 // Returns a message value or promotes an unknown field to an extension.
 //
-// TODO: Only supports extension fields that are messages,
+// TODO: Only supports singular message extensions,
 // expand support to include non-message types.
 UPB_NODISCARD upb_GetExtension_Status upb_Message_GetOrPromoteExtension(
     upb_Message* msg, const upb_MiniTableExtension* ext_table,

--- a/upb/message/promote_test.cc
+++ b/upb/message/promote_test.cc
@@ -708,4 +708,50 @@ TEST(GeneratedCode, PromoteNonCanonicalExtensionWithDifferentMinitable) {
   upb_FindUnknownRet found = upb_Message_FindUnknown(UPB_UPCAST(msg), 1547, 0);
   EXPECT_EQ(kUpb_FindUnknown_NotPresent, found.status);
 }
+
+TEST(GeneratedCode, GetOrPromoteExtensionRejectsRepeatedMessage) {
+  upb::Arena arena;
+  upb_Status status;
+  upb_Status_Clear(&status);
+
+  upb::MtDataEncoder sub_enc;
+  ASSERT_TRUE(sub_enc.StartMessage(0));
+  ASSERT_TRUE(sub_enc.PutField(kUpb_FieldType_Int32, 1, 0));
+  upb_MiniTable* sub = upb_MiniTable_Build(
+      sub_enc.data().data(), sub_enc.data().size(), arena.ptr(), &status);
+  ASSERT_TRUE(status.ok);
+
+  upb::MtDataEncoder parent_enc;
+  ASSERT_TRUE(parent_enc.StartMessage(kUpb_MessageModifier_IsExtendable));
+  upb_MiniTable* parent = upb_MiniTable_Build(
+      parent_enc.data().data(), parent_enc.data().size(), arena.ptr(),
+      &status);
+  ASSERT_TRUE(status.ok);
+
+  upb::MtDataEncoder ext_enc;
+  ASSERT_TRUE(ext_enc.EncodeExtension(kUpb_FieldType_Message, 107,
+                                      kUpb_FieldModifier_IsRepeated));
+  upb_MiniTableExtension* repeated_ext = upb_MiniTableExtension_BuildMessage(
+      ext_enc.data().data(), ext_enc.data().size(), parent, sub, arena.ptr(),
+      &status);
+  ASSERT_TRUE(status.ok);
+  ASSERT_NE(repeated_ext, nullptr);
+
+  upb_Message* msg = upb_Message_New(parent, arena.ptr());
+  upb_MessageValue value;
+  EXPECT_EQ(kUpb_GetExtension_ParseError,
+            upb_Message_GetOrPromoteExtension(msg, repeated_ext, 0,
+                                              arena.ptr(), &value));
+
+  // Singular message extensions are unchanged (NotPresent on empty msg).
+  upb::MtDataEncoder singular_enc;
+  ASSERT_TRUE(singular_enc.EncodeExtension(kUpb_FieldType_Message, 108, 0));
+  upb_MiniTableExtension* singular_ext = upb_MiniTableExtension_BuildMessage(
+      singular_enc.data().data(), singular_enc.data().size(), parent, sub,
+      arena.ptr(), &status);
+  ASSERT_TRUE(status.ok);
+  EXPECT_EQ(kUpb_GetExtension_NotPresent,
+            upb_Message_GetOrPromoteExtension(msg, singular_ext, 0,
+                                              arena.ptr(), &value));
+}
 }  // namespace


### PR DESCRIPTION
`upb_Message_GetOrPromoteExtension` asserts `CType == Message` but does not check cardinality.

The function stores a `upb_Message*` in the extension slot. Repeated extensions are consumed as `upb_Array*` by the encoder and by `GetExtensionMutableArray`. Promoting a repeated message extension therefore confuses a message for an array.

This change returns `kUpb_GetExtension_ParseError` for non-scalar extensions. Repeated unknowns should go through `upb_MiniTable_PromoteUnknownToMessageArray`, which already exists and is covered by `PromoteUnknownRepeatedMessageOld`.

Singular message extensions are unchanged (existing `promote_test` cases plus a NotPresent control in the new test).
