### PR TITLE
Fail release prep on mismatched protoc hashes

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -31,6 +31,36 @@ INTEGRITY_ASSET_URL=$(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name=="t
 
 curl -sSL -o "${INTEGRITY_FILE}" "$INTEGRITY_ASSET_URL"
 
+# Validate the trusted, pre-computed hashes against the uploaded artifacts.
+INTEGRITY_ERRORS=$(echo "$RELEASE_JSON" | jq -r --rawfile integrity "${INTEGRITY_FILE}" '
+  . as $release
+  | [$integrity
+     | scan("\\\"(protoc-[^\\\"]+\\.zip)\\\"[[:space:]]*:[[:space:]]*\\\"([^\\\"]*)\\\"")
+     | {name: .[0], expected: .[1]}] as $expected
+  | if ($expected | length) == 0 then
+      "tool_integrity.bzl does not contain any protoc hashes"
+    else
+      $expected[]
+      | . as $entry
+      | ($release.assets | map(select(.name == $entry.name)) | first) as $asset
+      | if ($entry.expected | test("^[0-9a-f]{64}$") | not) then
+          "invalid hash for \($entry.name): \($entry.expected)"
+        elif $asset == null then
+          "missing release asset: \($entry.name)"
+        elif ($asset.digest // "") != ("sha256:" + $entry.expected) then
+          "hash mismatch for \($entry.name): expected \($entry.expected), got \($asset.digest // "no digest")"
+        else
+          empty
+        end
+    end
+')
+
+if [[ -n "$INTEGRITY_ERRORS" ]]; then
+  echo "Release binary integrity validation failed:" >&2
+  echo "$INTEGRITY_ERRORS" >&2
+  exit 1
+fi
+
 # Append that generated file back into the archive
 tar --file $ARCHIVE_TMP --append ${INTEGRITY_FILE}
 

--- a/.github/workflows/release_prep_test.sh
+++ b/.github/workflows/release_prep_test.sh
@@ -88,26 +88,36 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -n "$outfile" ]]; then
-  cat <<'BZL' > "$outfile"
+  osx_hash="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  if [[ "${MOCK_INTEGRITY_MISMATCH:-0}" == "1" ]]; then
+    osx_hash="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  elif [[ "${MOCK_INVALID_HASH:-0}" == "1" ]]; then
+    osx_hash="not-a-sha256"
+  fi
+  cat <<BZL > "$outfile"
 RELEASE_VERSION="v99.0"
 RELEASED_BINARY_INTEGRITY = {
     "protoc-99.0-linux-x86_64.zip": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "protoc-99.0-osx-aarch_64.zip": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "protoc-99.0-osx-aarch_64.zip": "$osx_hash",
     "protoc-99.0-win64.zip": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
 }
 BZL
 else
-  cat <<'JSON'
+  osx_asset='    {
+      "name": "protoc-99.0-osx-aarch_64.zip",
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },'
+  if [[ "${MOCK_MISSING_ASSET:-0}" == "1" ]]; then
+    osx_asset=""
+  fi
+  cat <<JSON
 {
   "assets": [
     {
       "name": "protoc-99.0-linux-x86_64.zip",
       "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     },
-    {
-      "name": "protoc-99.0-osx-aarch_64.zip",
-      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-    },
+$osx_asset
     {
       "name": "protoc-99.0-win64.zip",
       "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
@@ -217,6 +227,40 @@ else
 fi
 
 rm -rf "$EXTRACT_DIR"
+
+# 11. A stale pre-computed hash prevents release archive creation
+rm -f "$ARCHIVE"
+if MISMATCH_OUTPUT=$(MOCK_INTEGRITY_MISMATCH=1 bash "$RELEASE_PREP" "$TAG" 2>&1); then
+  fail "mismatched release binary hash should fail"
+else
+  assert_contains "mismatched release binary hash fails" \
+    "Release binary integrity validation failed" "$MISMATCH_OUTPUT"
+  assert_contains "mismatch identifies the affected asset" \
+    "hash mismatch for protoc-99.0-osx-aarch_64.zip" "$MISMATCH_OUTPUT"
+fi
+assert_file_absent "$ARCHIVE" "mismatched hash does not produce an archive"
+
+# 12. A missing release asset also prevents release archive creation
+if MISSING_OUTPUT=$(MOCK_MISSING_ASSET=1 bash "$RELEASE_PREP" "$TAG" 2>&1); then
+  fail "missing release binary should fail"
+else
+  assert_contains "missing release binary fails" \
+    "Release binary integrity validation failed" "$MISSING_OUTPUT"
+  assert_contains "missing binary identifies the affected asset" \
+    "missing release asset: protoc-99.0-osx-aarch_64.zip" "$MISSING_OUTPUT"
+fi
+assert_file_absent "$ARCHIVE" "missing binary does not produce an archive"
+
+# 13. A malformed pre-computed hash also prevents release archive creation
+if INVALID_OUTPUT=$(MOCK_INVALID_HASH=1 bash "$RELEASE_PREP" "$TAG" 2>&1); then
+  fail "malformed release binary hash should fail"
+else
+  assert_contains "malformed release binary hash fails" \
+    "Release binary integrity validation failed" "$INVALID_OUTPUT"
+  assert_contains "malformed hash identifies the affected asset" \
+    "invalid hash for protoc-99.0-osx-aarch_64.zip: not-a-sha256" "$INVALID_OUTPUT"
+fi
+assert_file_absent "$ARCHIVE" "malformed hash does not produce an archive"
 
 ##############################
 echo


### PR DESCRIPTION
## Summary

- compare the trusted precomputed `protoc-*.zip` hashes with final release asset digests before creating the Bazel release archive
- fail closed on malformed hashes, missing assets, or digest mismatches
- add regressions for each failure mode and verify no archive is emitted

The v36.0 release exposed a gap in the current flow: `release_prep.sh` downloads `tool_integrity.bzl` and packages it without checking that its precomputed hashes still describe the uploaded binaries. This keeps the precomputed file as the trusted side of the check instead of silently replacing it with current release metadata.

This prevents future Bazel archive publication when the two sources disagree. It does not rewrite the already-published v36.0 artifacts or fix the internal process that generated their stale macOS hashes.

Related to #29313.

## Test coverage

- `bash -n .github/workflows/release_prep.sh`
- `bash -n .github/workflows/release_prep_test.sh`
- `git diff --check`
- direct Ubuntu 24.04 run of `release_prep_test.sh` with the repository's jq dependency
- verified that public v36.0 metadata fails closed and names both mismatched macOS assets

