### PR TITLE
Fix locale-dependent upb default parsing

### DIFF
--- a/upb/reflection/field_def.c
+++ b/upb/reflection/field_def.c
@@ -9,6 +9,7 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <locale.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -85,6 +86,54 @@ struct upb_FieldDef {
   upb_FieldType type_;
   upb_Label label_;
 };
+
+static double upb_NoLocaleStrtod(const char* str, char** end) {
+#if defined(_WIN32)
+  _locale_t c_locale = _create_locale(LC_NUMERIC, "C");
+  if (c_locale == NULL) {
+    return strtod(str, end);
+  }
+  double val = _strtod_l(str, end, c_locale);
+  _free_locale(c_locale);
+  return val;
+#elif defined(LC_NUMERIC_MASK)
+  locale_t c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
+  if (c_locale == (locale_t)0) {
+    return strtod(str, end);
+  }
+  locale_t previous_locale = uselocale(c_locale);
+  double val = strtod(str, end);
+  uselocale(previous_locale);
+  freelocale(c_locale);
+  return val;
+#else
+  return strtod(str, end);
+#endif
+}
+
+static float upb_NoLocaleStrtof(const char* str, char** end) {
+#if defined(_WIN32)
+  _locale_t c_locale = _create_locale(LC_NUMERIC, "C");
+  if (c_locale == NULL) {
+    return strtof(str, end);
+  }
+  float val = _strtof_l(str, end, c_locale);
+  _free_locale(c_locale);
+  return val;
+#elif defined(LC_NUMERIC_MASK)
+  locale_t c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
+  if (c_locale == (locale_t)0) {
+    return strtof(str, end);
+  }
+  locale_t previous_locale = uselocale(c_locale);
+  float val = strtof(str, end);
+  uselocale(previous_locale);
+  freelocale(c_locale);
+  return val;
+#else
+  return strtof(str, end);
+#endif
+}
 
 upb_FieldDef* _upb_FieldDef_At(const upb_FieldDef* f, int i) {
   return (upb_FieldDef*)&f[i];
@@ -483,7 +532,7 @@ static void parse_default(upb_DefBuilder* ctx, const char* str, size_t len,
       break;
     }
     case kUpb_CType_Double: {
-      double val = strtod(str, &end);
+      double val = upb_NoLocaleStrtod(str, &end);
       if (errno == ERANGE || *end) {
         goto invalid;
       }
@@ -491,7 +540,7 @@ static void parse_default(upb_DefBuilder* ctx, const char* str, size_t len,
       break;
     }
     case kUpb_CType_Float: {
-      float val = strtof(str, &end);
+      float val = upb_NoLocaleStrtof(str, &end);
       if (errno == ERANGE || *end) {
         goto invalid;
       }

--- a/upb/reflection/reflection_test.cc
+++ b/upb/reflection/reflection_test.cc
@@ -1,5 +1,6 @@
 
 #include <cstring>
+#include <clocale>
 #include <string>
 #include <string_view>
 
@@ -128,6 +129,48 @@ TEST(ReflectionTest, EnumDefault) {
                           .value();
   upb::EnumDefPtr e = pool.FindEnumByName("FooEnum");
   EXPECT_EQ(e.default_value(), 1);
+}
+
+TEST(ReflectionTest, FloatingPointDefaultsIgnoreNumericLocale) {
+  const char* current_locale = std::setlocale(LC_NUMERIC, nullptr);
+  const std::string saved_locale = current_locale ? current_locale : "C";
+
+  if (std::setlocale(LC_NUMERIC, "en_DK.utf8") == nullptr) {
+    GTEST_SKIP() << "en_DK.utf8 locale unavailable";
+  }
+
+  absl::StatusOr<upb::DefPool> pool = LoadDescriptorProto(
+      R"pb(
+        syntax: "proto2"
+        name: "F"
+        message_type {
+          name: "FloatingPointDefaults"
+          field {
+            name: "double_value"
+            number: 1
+            type: TYPE_DOUBLE
+            default_value: "0.9995"
+          }
+          field {
+            name: "float_value"
+            number: 2
+            type: TYPE_FLOAT
+            default_value: "0.9995"
+          }
+        }
+      )pb");
+
+  std::setlocale(LC_NUMERIC, saved_locale.c_str());
+  ASSERT_TRUE(pool.ok()) << pool.status();
+
+  upb::MessageDefPtr message = pool->FindMessageByName("FloatingPointDefaults");
+  ASSERT_TRUE(message);
+  upb::FieldDefPtr double_field = message.FindFieldByName("double_value");
+  ASSERT_TRUE(double_field);
+  upb::FieldDefPtr float_field = message.FindFieldByName("float_value");
+  ASSERT_TRUE(float_field);
+  EXPECT_DOUBLE_EQ(double_field.default_value().double_val, 0.9995);
+  EXPECT_FLOAT_EQ(float_field.default_value().float_val, 0.9995f);
 }
 
 TEST(ReflectionTest, ImplicitPresenceWithDefault) {


### PR DESCRIPTION
## Summary
- add a regression covering floating-point proto2 defaults under a comma-decimal locale
- parse default double/float values with a C numeric locale in upb reflection

Fixes #28796.

## Testing
- compile a standalone locale repro against the pre-fix build-clang/libupbd.a (fails)
- rebuild build/libupbd.a with this patch and rerun the same repro (passes)
