### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/test_bazel.yml
+++ b/.github/workflows/test_bazel.yml
@@ -52,7 +52,7 @@ jobs:
       # opaque errors about coursier (see
       # https://github.com/bazel-contrib/rules_jvm_external/issues/1337).
       - name: Pin to Java 11
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         if: ${{ !matrix.continuous-only || inputs.continuous-run }}
         with:
           distribution: 'temurin'


### PR DESCRIPTION
Upgrade the SHA-pinned `actions/setup-java` reference in the Bazel test workflow from v5.2.0 to v6.0.0.

The action remains pinned to the full release SHA.

Tests were not run (workflow-only change).