### PR TITLE
Allow later enum aliases to overwrite in C# custom JSON enum mapping.

### DIFF
--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -774,8 +774,7 @@ namespace Google.Protobuf
             {
                 var jsonOptions = value.GetOptions()?.GetExtension(
                     Pb.Enumvalue.JsonEnumvalueOptionsExtensions.Json);
-                if (jsonOptions != null && jsonOptions.HasString &&
-                    !map.ContainsKey(jsonOptions.String))
+                if (jsonOptions != null && jsonOptions.HasString)
                 {
                     map[jsonOptions.String] = value;
                 }


### PR DESCRIPTION
When constructing the custom JSON enum name map in C# JsonParser, remove the ContainsKey check so that subsequent aliased enum values overwrite earlier ones, aligning with the "last match wins" semantics used across C++, Java, PHP, and Python.

PiperOrigin-RevId: 970656172