### PR TITLE
Apply last-key-wins semantics to duplicate map keys in DynamicMessage

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/DynamicMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/DynamicMessage.java
@@ -15,8 +15,10 @@ import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -415,6 +417,8 @@ public final class DynamicMessage extends AbstractMessage {
         }
       }
 
+      normalizeMapFields();
+
       DynamicMessage result =
           new DynamicMessage(
               type,
@@ -422,6 +426,56 @@ public final class DynamicMessage extends AbstractMessage {
               Arrays.copyOf(oneofCases, oneofCases.length),
               unknownFields);
       return result;
+    }
+
+
+    /**
+     * Collapses duplicate keys within map fields, keeping the last value seen.
+     *
+     * <p>The language guide requires that when a map is parsed from the wire and the same key
+     * appears more than once, the last value wins. Generated messages get this for free because
+     * they store map fields in a {@code MapField}, but {@code DynamicMessage} keeps them in a
+     * {@code FieldSet} as a plain list of {@code MapEntry} messages that is appended to
+     * unconditionally, so duplicate keys survived a parse. That made {@code DynamicMessage} and a
+     * generated message produce different results, and different serializations, for identical and
+     * well-formed wire input.
+     *
+     * <p>Normalizing once here rather than on every {@code addRepeatedField} keeps parsing linear;
+     * de-duplicating at insertion time would make parsing an n-entry map O(n^2).
+     */
+    private void normalizeMapFields() {
+      int numFields = type.getFieldCount();
+      for (int i = 0; i < numFields; i++) {
+        FieldDescriptor field = type.getField(i);
+        if (!field.isMapField()) {
+          continue;
+        }
+        // Map fields are repeated, so hasField() does not apply; getField() returns null when the
+        // field was never populated.
+        Object fieldValue = fields.getField(field);
+        if (!(fieldValue instanceof List)) {
+          continue;
+        }
+        List<?> entries = (List<?>) fieldValue;
+        if (entries.size() < 2) {
+          continue;
+        }
+        FieldDescriptor keyField = field.getMessageType().findFieldByNumber(1);
+        if (keyField == null) {
+          continue;
+        }
+        Map<Object, Object> lastValueByKey = new LinkedHashMap<>();
+        for (Object entry : entries) {
+          if (!(entry instanceof Message)) {
+            // A builder can be present while a caller is still mutating the field; leave it alone.
+            return;
+          }
+          lastValueByKey.put(((Message) entry).getField(keyField), entry);
+        }
+        if (lastValueByKey.size() != entries.size()) {
+          fields.setField(field, new ArrayList<Object>(lastValueByKey.values()));
+        }
+      }
     }
 
     @Override

--- a/java/core/src/test/java/com/google/protobuf/MapTest.java
+++ b/java/core/src/test/java/com/google/protobuf/MapTest.java
@@ -1626,4 +1626,50 @@ public class MapTest {
     builder.clearField(int2MessageMapField);
     assertThat(mapEntries).hasSize(1);
   }
+
+  @Test
+  public void testDuplicateMapKey_dynamicMessageMatchesGeneratedMessage() throws Exception {
+    // Hand-built wire bytes: string_to_int32_field (field 6) carrying the key "k" twice, with
+    // value 1 and then value 2. These cannot be produced through a builder, because a builder
+    // already applies map semantics; only the wire format can express a repeated key.
+    //   32 05 0a 01 6b 10 01   -> {"k": 1}
+    //   32 05 0a 01 6b 10 02   -> {"k": 2}
+    ByteString wire =
+        ByteString.copyFrom(
+            new byte[] {
+              0x32, 0x05, 0x0a, 0x01, 0x6b, 0x10, 0x01,
+              0x32, 0x05, 0x0a, 0x01, 0x6b, 0x10, 0x02
+            });
+
+    TestMap generated = TestMap.parseFrom(wire);
+    DynamicMessage dynamic = DynamicMessage.parseFrom(TestMap.getDescriptor(), wire);
+    FieldDescriptor mapField = TestMap.getDescriptor().findFieldByName("string_to_int32_field");
+
+    // The language guide requires the last value for a repeated key to win.
+    assertThat(generated.getStringToInt32FieldMap()).containsExactly("k", 2);
+    assertThat(dynamic.getRepeatedFieldCount(mapField)).isEqualTo(1);
+
+    // A DynamicMessage and a generated message must not disagree about identical wire input.
+    assertThat(dynamic.toByteString()).isEqualTo(generated.toByteString());
+  }
+
+  @Test
+  public void testDuplicateMapKey_dynamicMessagePreservesDistinctKeys() throws Exception {
+    // Same shape, but the two entries use different keys, so both must survive.
+    ByteString wire =
+        ByteString.copyFrom(
+            new byte[] {
+              0x32, 0x05, 0x0a, 0x01, 0x61, 0x10, 0x01,
+              0x32, 0x05, 0x0a, 0x01, 0x62, 0x10, 0x02
+            });
+
+    TestMap generated = TestMap.parseFrom(wire);
+    DynamicMessage dynamic = DynamicMessage.parseFrom(TestMap.getDescriptor(), wire);
+    FieldDescriptor mapField = TestMap.getDescriptor().findFieldByName("string_to_int32_field");
+
+    assertThat(generated.getStringToInt32FieldMap()).containsExactly("a", 1, "b", 2);
+    assertThat(dynamic.getRepeatedFieldCount(mapField)).isEqualTo(2);
+    assertThat(dynamic.toByteString()).isEqualTo(generated.toByteString());
+  }
+
 }


### PR DESCRIPTION
Fixes #29512.

## What

`DynamicMessage.Builder.buildPartial()` now normalizes map fields: entries are collapsed by key, keeping the last value seen, matching generated messages and the REQUIRED `ValidDataMap*.DuplicateKey` conformance test.

Before this change, identical well-formed wire input produced different results from a generated message and a `DynamicMessage`:

| | entries after parse | reserialized |
|---|---|---|
| generated message | 1 | `32050a016b1002` (7 B) |
| `DynamicMessage` (before) | 2 | `32050a016b100132050a016b1002` (14 B) |
| `DynamicMessage` (after) | 1 | `32050a016b1002` (7 B) |

The C++ implementation already handles this for dynamic messages via `DynamicMapField` (backed by a real map container); the Java `DynamicMessage` stored map entries in a plain `List` inside `FieldSet` and appended unconditionally.

## Why in `buildPartial()` rather than `addRepeatedField()`

De-duplicating on every insertion would make parsing an n-entry map **O(n²)**, since map entries arrive one at a time during a parse. Normalizing once during `buildPartial()` is a single pass and keeps parsing linear. `buildPartial()` already contains map-entry-specific handling (defaulting `MapEntry` fields), so this sits with related logic.

The pass is skipped entirely unless a map field holds at least two entries, and the field is only rewritten when a duplicate was actually found, so messages without duplicate keys are untouched. If a `Message.Builder` is encountered in the list (possible while a caller is mid-mutation), the method returns without changing anything, preserving existing behavior.

## Testing

Two tests added to `MapTest.java`:

- `testDuplicateMapKey_dynamicMessageMatchesGeneratedMessage` — a duplicate key collapses to the last value and the `DynamicMessage` matches the generated message byte-for-byte. **Fails without this change.**
- `testDuplicateMapKey_dynamicMessagePreservesDistinctKeys` — distinct keys are all preserved, guarding against over-collapsing. Passes before and after.

The wire bytes are hand-built because a builder already applies map semantics; only the wire format can express a repeated key.

Additionally verified against released `protobuf-java` 4.36.0 with a standalone harness comparing `DynamicMessage` to a generated message across: empty message, single entry, two distinct keys, duplicate key x2 and x3, duplicates interleaved with distinct keys, 50 distinct keys, and 50 keys each duplicated. **4 of 8 diverged before the change; 0 after.** Parse time stays linear on a worst-case all-duplicates message (10k to 80k entries, per-doubling ratios 0.83 / 1.38 / 1.12).

I was unable to run the full Bazel Java suite locally (the macOS toolchain here requires an Xcode version I don't have), so CI coverage on this PR is appreciated.
