### PR TITLE
upb: validate message tags before consuming depth

### DIFF
--- a/upb/wire/decode_fast/field_message.c
+++ b/upb/wire/decode_fast/field_message.c
@@ -75,19 +75,18 @@ void upb_DecodeFast_Message(upb_Decoder* d, const char** ptr, upb_Message* msg,
       table->UPB_ONLYBITS(fields), submsg_ofs, upb_MiniTableSubInternal);
   const upb_MiniTable* subtablep = sub->UPB_PRIVATE(submsg);
 
+  uint16_t expected = upb_DecodeFastData_GetExpectedTag(*data);
+  uint16_t actual = upb_DecodeFastData2_GetOriginalTag(data2);
+  if (UPB_UNLIKELY(!upb_DecodeFast_TagMatches(expected, actual, tagsize))) {
+    UPB_DECODEFAST_EXIT(kUpb_DecodeFastNext_FallbackMismatchedSlot, ret);
+    return;
+  }
+
   upb_DecodeFast_MessageContext ctx = {subtablep,
                                        card == kUpb_DecodeFast_Repeated};
 
   if (subtablep == NULL) {
-    // Unlinked messages are treated as unknown fields. Go straight to unknown
-    // decoder if the tag matches.
-    uint16_t expected = upb_DecodeFastData_GetExpectedTag(*data);
-    uint16_t actual = upb_DecodeFastData2_GetOriginalTag(data2);
-    if (UPB_UNLIKELY(!upb_DecodeFast_TagMatches(expected, actual, tagsize))) {
-      UPB_DECODEFAST_EXIT(kUpb_DecodeFastNext_FallbackMismatchedSlot, ret);
-      return;
-    }
-
+    // Unlinked messages are treated as unknown fields.
 #ifndef NDEBUG
     uint16_t case_offset = upb_DecodeFastData_GetCaseOffset(*data);
     if (case_offset != 0) {

--- a/upb/wire/decode_test.cc
+++ b/upb/wire/decode_test.cc
@@ -760,6 +760,33 @@ TEST(DecodeTest, DecodeExtensionAsUnknownWithPreexistingUnknown) {
                                          &ext_iter));
 }
 
+TEST(DecodeTest, MismatchedMessageSlotDoesNotConsumeDepth) {
+  upb::Arena mt_arena;
+
+  auto [mt, field] =
+      test::MiniTable::MakeSingleFieldTable<test::field_types::Message>(
+          1, kUpb_DecodeFast_Scalar, mt_arena.ptr());
+  const upb_MiniTable* subs[1] = {mt};
+  ASSERT_TRUE(
+      upb_MiniTable_Link(const_cast<upb_MiniTable*>(mt), subs, 1, nullptr, 0));
+
+  // The outer field is a message. Inside it, field 1 has the varint wire type,
+  // so it is preserved as unknown instead of recursing into another message.
+  const std::string payload("\x0a\x02\x08\x01", 4);
+  const int depth_one = upb_Decode_LimitDepth(0, 1);
+
+  for (int extra_options : GetDecodeOptionsToTest()) {
+    upb::Arena msg_arena;
+    upb_Message* msg = upb_Message_New(mt, msg_arena.ptr());
+    ASSERT_NE(msg, nullptr);
+
+    const upb_DecodeStatus result =
+        upb_Decode(payload.data(), payload.size(), msg, mt, nullptr,
+                   depth_one | extra_options, msg_arena.ptr());
+    EXPECT_EQ(result, kUpb_DecodeStatus_Ok) << upb_DecodeStatus_String(result);
+  }
+}
+
 TEST(DecodeTest, DecodeGroupFieldFromDelimitedWireFormatAsUnknown) {
   upb::Arena mt_arena;
   upb::Arena msg_arena;


### PR DESCRIPTION
## Summary

- Validate a linked-message fasttable slot against the actual tag before entering the message path.
- Keep mismatched tags on the existing fallback path.
- Add a regression test for a valid unknown field at an exact recursion-depth boundary.

Without this ordering, the fast decoder can return `MaxDepthExceeded` for a valid message that the generic decoder accepts because it consumes depth before discovering that the tag does not match the message slot.

## Testing

- `DecodeTest.MismatchedMessageSlotDoesNotConsumeDepth` passes with the fast and generic decoders.
- Full sanitized `upb-test`: 535 passed, 1 existing skip.
- Patched current-main differential fuzzing: 1,000,000 executions with no decoder mismatch or sanitizer finding.
- Patched v36 differential fuzzing: 3,000,000 executions with no decoder mismatch or sanitizer finding.
