### PR TITLE
Fix integer overflow in CodedInputStream::ReadLengthAndPushLimit

### DIFF
--- a/src/google/protobuf/io/coded_stream.cc
+++ b/src/google/protobuf/io/coded_stream.cc
@@ -149,8 +149,8 @@ CodedInputStream::IncrementRecursionDepthAndPushLimit(int byte_limit) {
 }
 
 CodedInputStream::Limit CodedInputStream::ReadLengthAndPushLimit() {
-  uint32_t length;
-  return PushLimit(ReadVarint32(&length) ? length : 0);
+  int length;
+  return PushLimit(ReadVarintSizeAsInt(&length) ? length : 0);
 }
 
 bool CodedInputStream::DecrementRecursionDepthAndPopLimit(Limit limit) {

--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -420,7 +420,7 @@ class PROTOBUF_EXPORT PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED CodedInputStream {
   PROTOBUF_FUTURE_ADD_EARLY_NODISCARD std::pair<CodedInputStream::Limit, int>
   IncrementRecursionDepthAndPushLimit(int byte_limit);
 
-  // Shorthand for PushLimit(ReadVarint32(&length) ? length : 0).
+  // Shorthand for PushLimit(ReadVarintSizeAsInt(&length) ? length : 0).
   PROTOBUF_FUTURE_ADD_EARLY_NODISCARD Limit ReadLengthAndPushLimit();
 
   // Helper that is equivalent to: {

--- a/src/google/protobuf/io/coded_stream_unittest.cc
+++ b/src/google/protobuf/io/coded_stream_unittest.cc
@@ -1576,6 +1576,58 @@ TEST_F(CodedStreamTest, RecursionLimit) {
   EXPECT_FALSE(coded_input.IncrementRecursionDepth());  // 7
 }
 
+TEST_F(CodedStreamTest, ReadLengthAndPushLimitBoundaries) {
+  // 1. Normal case: length 5 followed by "hello"
+  {
+    uint8_t bytes[] = {0x05, 'h', 'e', 'l', 'l', 'o'};
+    ArrayInputStream input(bytes, sizeof(bytes));
+    CodedInputStream coded_input(&input);
+
+    CodedInputStream::Limit limit = coded_input.ReadLengthAndPushLimit();
+    EXPECT_EQ(5, coded_input.BytesUntilLimit());
+    std::string str;
+    EXPECT_TRUE(coded_input.ReadString(&str, 5));
+    EXPECT_EQ("hello", str);
+    EXPECT_TRUE(coded_input.ConsumedEntireMessage());
+    coded_input.PopLimit(limit);
+  }
+
+  // 2. INT_MAX boundary: length = INT_MAX (0x7FFFFFFF)
+  {
+    uint8_t bytes[] = {0xFF, 0xFF, 0xFF, 0xFF, 0x07};
+    ArrayInputStream input(bytes, sizeof(bytes));
+    CodedInputStream coded_input(&input);
+
+    CodedInputStream::Limit limit = coded_input.ReadLengthAndPushLimit();
+    EXPECT_EQ(-1, coded_input.BytesUntilLimit());
+    coded_input.PopLimit(limit);
+  }
+
+  // 3. Overflow boundary: 0x80000000 (INT_MAX + 1)
+  {
+    uint8_t bytes[] = {0x80, 0x80, 0x80, 0x80, 0x08, 'h', 'e', 'l', 'l', 'o'};
+    ArrayInputStream input(bytes, sizeof(bytes));
+    CodedInputStream coded_input(&input);
+
+    CodedInputStream::Limit limit = coded_input.ReadLengthAndPushLimit();
+    EXPECT_EQ(0, coded_input.BytesUntilLimit());
+    EXPECT_TRUE(coded_input.ConsumedEntireMessage());
+    coded_input.PopLimit(limit);
+  }
+
+  // 4. Maximum 32-bit unsigned integer: UINT_MAX (0xFFFFFFFF)
+  {
+    uint8_t bytes[] = {0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 't', 'e', 's', 't'};
+    ArrayInputStream input(bytes, sizeof(bytes));
+    CodedInputStream coded_input(&input);
+
+    CodedInputStream::Limit limit = coded_input.ReadLengthAndPushLimit();
+    EXPECT_EQ(0, coded_input.BytesUntilLimit());
+    EXPECT_TRUE(coded_input.ConsumedEntireMessage());
+    coded_input.PopLimit(limit);
+  }
+}
+
 
 class ReallyBigInputStream : public ZeroCopyInputStream {
  public:


### PR DESCRIPTION
When `ReadVarint32` decodes a length > `INT_MAX`, casting `uint32_t` to signed `int` makes `byte_limit` negative. Because `PushLimit` guards against negative values (`byte_limit >= 0`), the requested limit was skipped, leaving the stream bounded by the outer limit rather than bounding to 0.

This patch clamps lengths > `INT_MAX` to `0` so `PushLimit(0)` is invoked to immediately bound the stream, and adds unit test coverage for normal length, `INT_MAX`, `0x80000000`, and `UINT_MAX` cases.