### PR TITLE
test(bcr): cover both prefer_prebuilt_protoc cases in .bcr/presubmit.yml

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,12 +4,17 @@ bcr_test_module:
   matrix:
     platform: ["debian12", "macos_arm64", "ubuntu2404", "windows"]
     bazel: [8.x, 9.x]
+    prefer_prebuilt_protoc: ["true", "false"]
 
   tasks:
     verify_targets:
-      name: "Verify build targets"
+      name: "Verify build targets (prefer_prebuilt_protoc=${{ prefer_prebuilt_protoc }})"
       platform: ${{ platform }}
       bazel: ${{ bazel }}
+      build_flags:
+      - '--@com_google_protobuf//bazel/toolchains:prefer_prebuilt_protoc=${{ prefer_prebuilt_protoc }}'
+      test_flags:
+      - '--@com_google_protobuf//bazel/toolchains:prefer_prebuilt_protoc=${{ prefer_prebuilt_protoc }}'
       build_targets:
       - '//...'
       - '@com_google_protobuf//:protobuf'
@@ -19,4 +24,6 @@ bcr_test_module:
       - '@com_google_protobuf//:protoc'
       - '@com_google_protobuf//:test_messages_proto2_cc_proto'
       - '@com_google_protobuf//:test_messages_proto3_cc_proto'
+      test_targets:
+      - '//...'
 # LINT.ThenChange(<ROOT_DIR>/.bazelci/presubmit.yml)


### PR DESCRIPTION
### Description

This PR improves `.bcr/presubmit.yml` to:
1. Add `prefer_prebuilt_protoc: ["true", "false"]` to the `matrix` definition.
2. Pass `--@com_google_protobuf//bazel/toolchains:prefer_prebuilt_protoc=${{ prefer_prebuilt_protoc }}` in both `build_flags` and `test_flags`.
3. Add `test_targets: ["//..."]` so tests in `examples` are actually executed during presubmit.

This ensures both building from source and downloading prebuilt `protoc` toolchains are continuously tested across all supported platforms before publishing to BCR, preventing regressions like #29537.