### PR TITLE
Register extension numbers 1374-1375 for durable

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -603,3 +603,8 @@ about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/flyteorg/flyte
     *   Extensions: 1364-1373
+
+1.  durable
+
+    *   Website: https://github.com/dangra/durable
+    *   Extensions: 1374-1375


### PR DESCRIPTION
durable (https://github.com/dangra/durable) is a Go library for durable linear pipelines, declared via protobuf message options. It uses two extensions of google.protobuf.MessageOptions — durable.v1.step and durable.v1.pipeline — and requests the next two free numbers, 1374-1375.