### PR TITLE
build(bazel): disable fully_static_link under asan configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,6 +56,8 @@ build:san-common --config=dbg --strip=never --copt=-O1 --copt=-fno-omit-frame-po
 build:san-common --dynamic_mode=off
 
 build:asan --config=san-common --copt=-fsanitize=address --linkopt=-fsanitize=address
+# LLVM 15+ ASAN prohibits static linkage (-static) on Linux (__asan::AsanDoesNotSupportStaticLinkage).
+build:asan --features=-fully_static_link
 
 build:msan --config=san-common --copt=-fsanitize=memory --linkopt=-fsanitize=memory
 build:msan --copt=-fsanitize-memory-track-origins


### PR DESCRIPTION
LLVM 15+ compiler-rt prohibits static linking (-static) with AddressSanitizer on Linux via __asan::AsanDoesNotSupportStaticLinkage(), which fails on targets like //:protoc_static when linking with LLD 18. Disable the fully_static_link feature under --config=asan.