### PR TITLE
ruby: validate RepeatedField assignment before resizing in FFI

### DIFF
--- a/ruby/lib/google/protobuf/ffi/repeated_field.rb
+++ b/ruby/lib/google/protobuf/ffi/repeated_field.rb
@@ -138,6 +138,9 @@ module Google
         count = length
         index += count if index < 0
         return nil if index < 0
+
+        converted = convert_ruby_to_upb(value, arena, type, descriptor)
+
         if index >= count
           resize(index+1)
           empty_message_value = Google::Protobuf::FFI::MessageValue.new # Implicitly clear
@@ -145,7 +148,7 @@ module Google
             Google::Protobuf::FFI.array_set(array, i, empty_message_value)
           end
         end
-        Google::Protobuf::FFI.array_set(array, index, convert_ruby_to_upb(value, arena, type, descriptor))
+        Google::Protobuf::FFI.array_set(array, index, converted)
         nil
       end
 

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -290,6 +290,17 @@ class RepeatedFieldTest < Test::Unit::TestCase
     # end
   end
 
+  def test_failed_out_of_bounds_assignment_does_not_resize
+    repeated = Google::Protobuf::RepeatedField.new(:int32)
+    repeated.push(1, 2)
+
+    assert_raises(Google::Protobuf::TypeError) do
+      repeated[4] = 'bad'
+    end
+
+    assert_equal [1, 2], repeated.to_a
+  end
+
   def test_push
     m = TestMessage.new
     reference_arr = %w[foo bar baz]


### PR DESCRIPTION


The Ruby FFI implementation of `RepeatedField#[]=` currently resizes the underlying array before validating the assigned value.

If an out-of-bounds assignment uses an invalid value, conversion raises `TypeError` or `RangeError`, but the repeated field has already been resized and any intervening elements have already been filled with default values.


