### PR TITLE
Reserve extension numbers 1376-1380 for firestore-proto-codec

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -603,3 +603,8 @@ about your project (name and website) so we can add an entry for you.
 
     *   Website: https://github.com/flyteorg/flyte
     *   Extensions: 1364-1373
+
+1.  firestore-proto-codec
+
+    *   Website: https://github.com/willbinge/firestore-proto-codec
+    *   Extensions: 1376-1380


### PR DESCRIPTION
Requesting a block of custom option numbers for
[firestore-proto-codec](https://github.com/willbinge/firestore-proto-codec), a
cross-language specification and codec for encoding protobuf messages as
Firestore values.

* Project: firestore-proto-codec
* Website: https://github.com/willbinge/firestore-proto-codec
* Requested: 1376-1380

### Why

The project publishes `codebinge/firestore/codec/v1/options.proto` as part of
its public interface: consumers annotate their own schemas with it, and the
file ships inside the Dart, TypeScript and Java packages, so its descriptors
routinely share a pool with third-party protos.

It currently declares a single `FieldOptions` extension in the 50000-99999
internal range. That range is documented as shared scratch space for in-house
use, so a collision there is its expected behaviour rather than bad luck —
#29013 reports exactly this failure mode, where two published extensions
claiming the same `google.protobuf.FieldOptions` tag broke extension
registration at import time for anyone importing both schemas. Moving to a
globally unique number before the packages are published is the fix.

### Why a block of five

One number is in active use today, on `google.protobuf.FieldOptions`. The
encoding specification already anticipates a second extend site on
`MessageOptions`, to mark a whole message as a geo-point type rather than
annotating its fields individually.

Since extension numbers are consumed per extend site rather than per option
message, and since the number is baked into every generated artifact and every
consumer `.proto` — making a later change breaking for downstream users — we
would rather not come back for a second request. Five follows the precedent of
similarly sized entries in the registry.

### Note on the requested range

We deliberately skipped 1374-1375, claimed by the currently open #29568.
Starting at 1376 avoids conflicting with that pending request. Happy to
renumber if the maintainers would prefer a different block, or if #29568 does
not land.
