### PR TITLE
Added introspection elements to descriptor_pool and file_descriptor 

### DIFF
--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -214,6 +214,71 @@ static VALUE DescriptorPool_lookup(VALUE _self, VALUE name) {
  *
  * @return [DescriptorPool]
  */
+static VALUE DescriptorPool_find_file_by_name(VALUE _self, VALUE name) {
+  DescriptorPool* self = ruby_to_DescriptorPool(_self);
+  if (SYMBOL_P(name)) {
+    name = rb_sym2str(name);
+  }
+  const char* name_str = StringValueCStr(name);
+  const upb_FileDef* filedef = upb_DefPool_FindFileByName(self->symtab, name_str);
+  if (filedef) {
+    return get_filedef_obj(_self, filedef);
+  }
+  return Qnil;
+}
+
+
+struct ext_ensure_args {
+  VALUE pool_self;
+  const upb_FieldDef** exts;
+  size_t count;
+  VALUE ary;
+};
+
+static VALUE build_ext_array(VALUE arg) {
+  struct ext_ensure_args* args = (struct ext_ensure_args*)arg;
+  for (size_t i = 0; i < args->count; i++) {
+    VALUE ext_obj = get_fielddef_obj(args->pool_self, args->exts[i]);
+    rb_ary_push(args->ary, ext_obj);
+  }
+  return Qnil;
+}
+
+static VALUE free_ext_array(VALUE arg) {
+  struct ext_ensure_args* args = (struct ext_ensure_args*)arg;
+  upb_gfree((void*)args->exts);
+  return Qnil;
+}
+
+static VALUE DescriptorPool_find_all_extensions(VALUE _self, VALUE extendee) {
+  DescriptorPool* self = ruby_to_DescriptorPool(_self);
+  const upb_MessageDef* msgdef = Descriptor_GetMsgDef(extendee);
+  size_t count;
+
+  const upb_FieldDef** exts = upb_DefPool_GetAllExtensions(self->symtab, msgdef, &count);
+  VALUE ary = rb_ary_new2(count);
+  if (exts) {
+    struct ext_ensure_args args = { _self, exts, count, ary };
+    rb_ensure(build_ext_array, (VALUE)&args, free_ext_array, (VALUE)&args);
+  }
+  rb_obj_freeze(ary);
+  return ary;
+}
+
+static VALUE DescriptorPool_find_extension_by_number(VALUE _self, VALUE extendee, VALUE number) {
+  DescriptorPool* self = ruby_to_DescriptorPool(_self);
+  const upb_MessageDef* msgdef = Descriptor_GetMsgDef(extendee);
+  int32_t num = NUM2INT(rb_to_int(number));
+
+  const upb_FieldDef* fielddef = upb_DefPool_FindExtensionByNumber(
+      self->symtab, msgdef, num);
+  if (fielddef) {
+    return get_fielddef_obj(_self, fielddef);
+  }
+
+  return Qnil;
+}
+
 static VALUE DescriptorPool_generated_pool(VALUE _self) {
   return generated_pool;
 }
@@ -224,6 +289,9 @@ static void DescriptorPool_register(VALUE module) {
   rb_define_method(klass, "add_serialized_file",
                    DescriptorPool_add_serialized_file, 1);
   rb_define_method(klass, "lookup", DescriptorPool_lookup, 1);
+  rb_define_method(klass, "find_file_by_name", DescriptorPool_find_file_by_name, 1);
+  rb_define_method(klass, "find_extension_by_number", DescriptorPool_find_extension_by_number, 2);
+  rb_define_method(klass, "find_all_extensions", DescriptorPool_find_all_extensions, 1);
   rb_define_singleton_method(klass, "generated_pool",
                              DescriptorPool_generated_pool, 0);
   rb_gc_register_address(&cDescriptorPool);
@@ -694,6 +762,31 @@ err:
   return Qnil;
 }
 
+/*
+ * call-seq:
+ *     FileDescriptor.dependencies => Array<FileDescriptor>
+ *
+ * Returns an array of FileDescriptors that this file depends on.
+ */
+static VALUE FileDescriptor_dependencies(VALUE _self) {
+  FileDescriptor* self = ruby_to_FileDescriptor(_self);
+  VALUE ivar_name = rb_intern("@dependencies");
+  VALUE memoized = rb_ivar_get(_self, ivar_name);
+  if (!NIL_P(memoized)) {
+    return memoized;
+  }
+  int count = upb_FileDef_DependencyCount(self->filedef);
+  VALUE ary = rb_ary_new2(count);
+  for (int i = 0; i < count; i++) {
+    const upb_FileDef* dep = upb_FileDef_Dependency(self->filedef, i);
+    VALUE dep_obj = get_filedef_obj(self->descriptor_pool, dep);
+    rb_ary_push(ary, dep_obj);
+  }
+  rb_obj_freeze(ary);
+  rb_ivar_set(_self, ivar_name, ary);
+  return ary;
+}
+
 static void FileDescriptor_register(VALUE module) {
   VALUE klass = rb_define_class_under(module, "FileDescriptor", rb_cObject);
   rb_define_alloc_func(klass, FileDescriptor_alloc);
@@ -701,6 +794,7 @@ static void FileDescriptor_register(VALUE module) {
   rb_define_method(klass, "name", FileDescriptor_name, 0);
   rb_define_method(klass, "options", FileDescriptor_options, 0);
   rb_define_method(klass, "to_proto", FileDescriptor_to_proto, 0);
+  rb_define_method(klass, "dependencies", FileDescriptor_dependencies, 0);
   rb_gc_register_address(&cFileDescriptor);
   cFileDescriptor = klass;
 }

--- a/ruby/lib/google/protobuf/ffi/descriptor_pool.rb
+++ b/ruby/lib/google/protobuf/ffi/descriptor_pool.rb
@@ -7,6 +7,12 @@
 
 module Google
   module Protobuf
+    module LibC
+      extend ::FFI::Library
+      ffi_lib ::FFI::Library::LIBC
+      attach_function :free, [:pointer], :void
+    end
+
     class FFI
       # DefPool
       attach_function :add_serialized_file,   :upb_DefPool_AddFile,            [:DefPool, :FileDescriptorProto, Status.by_ref], :FileDef
@@ -19,6 +25,8 @@ module Google
       attach_function :lookup_msg,            :upb_DefPool_FindMessageByName,  [:DefPool, :string], Descriptor
       attach_function :lookup_service,        :upb_DefPool_FindServiceByName,  [:DefPool, :string], ServiceDescriptor
       attach_function :lookup_file,           :upb_DefPool_FindFileByName,     [:DefPool, :string], FileDescriptor
+      attach_function :find_all_extensions_ffi, :upb_DefPool_GetAllExtensions, [:DefPool, Descriptor, :pointer], :pointer
+      attach_function :find_extension_by_number_ffi, :upb_DefPool_FindExtensionByNumber, [:DefPool, Descriptor, :int32], FieldDescriptor
 
         # FileDescriptorProto
       attach_function :parse,                 :FileDescriptorProto_parse,      [:binary_string, :size_t, Internal::Arena], :FileDescriptorProto
@@ -65,6 +73,28 @@ module Google
           Google::Protobuf::FFI.lookup_file(@descriptor_pool, name)
       end
 
+      def find_file_by_name(name)
+        Google::Protobuf::FFI.lookup_file(@descriptor_pool, name)
+      end
+
+      def find_all_extensions(message_descriptor)
+        count_ptr = ::FFI::MemoryPointer.new(:size_t, 1)
+        exts_ptr = Google::Protobuf::FFI.find_all_extensions_ffi(@descriptor_pool, message_descriptor, count_ptr)
+
+        return [].freeze if exts_ptr.null?
+
+        begin
+          count = count_ptr.read(:size_t)
+          exts_ptr.read_array_of_pointer(count).map! { |ptr| get_field_descriptor(ptr) }.freeze
+        ensure
+          Google::Protobuf::LibC.free(exts_ptr)
+        end
+      end
+
+      def find_extension_by_number(message_descriptor, number)
+        Google::Protobuf::FFI.find_extension_by_number_ffi(@descriptor_pool, message_descriptor, number)
+      end
+
       def self.generated_pool
         @@generated_pool ||= DescriptorPool.new
       end
@@ -77,6 +107,11 @@ module Google
       def get_file_descriptor file_def
         return nil if file_def.null?
         @descriptor_class_by_def[file_def.address] ||= FileDescriptor.new(file_def, self)
+      end
+
+      def get_field_descriptor field_def
+        return nil if field_def.null?
+        @descriptor_class_by_def[field_def.address] ||= FieldDescriptor.new(field_def, self)
       end
     end
   end

--- a/ruby/lib/google/protobuf/ffi/file_descriptor.rb
+++ b/ruby/lib/google/protobuf/ffi/file_descriptor.rb
@@ -13,6 +13,8 @@ module Google
       attach_function :file_def_pool,   :upb_FileDef_Pool,   [:FileDef], :DefPool
       attach_function :file_options,    :FileDescriptor_serialized_options,  [:FileDef, :pointer, Internal::Arena], :pointer
       attach_function :file_to_proto,   :FileDescriptor_serialized_to_proto,  [:FileDef, :pointer, Internal::Arena], :pointer
+      attach_function :file_def_dependency_count, :upb_FileDef_DependencyCount,      [:FileDef], :int
+      attach_function :file_def_dependency,       :upb_FileDef_Dependency,           [:FileDef, :int], FileDescriptor
     end
 
     class FileDescriptor
@@ -78,6 +80,13 @@ module Google
           temporary_arena = Google::Protobuf::FFI.create_arena
           buffer = Google::Protobuf::FFI.file_to_proto(@file_def, size_ptr, temporary_arena)
           Google::Protobuf::FileDescriptorProto.decode(buffer.read_string_length(size_ptr.read(:size_t)).force_encoding("ASCII-8BIT").freeze)
+        end
+      end
+
+      def dependencies
+        @dependencies ||= begin
+          count = Google::Protobuf::FFI.file_def_dependency_count(@file_def)
+          Array.new(count) { |index| Google::Protobuf::FFI.file_def_dependency(@file_def, index) }.freeze
         end
       end
     end

--- a/ruby/tests/BUILD.bazel
+++ b/ruby/tests/BUILD.bazel
@@ -255,6 +255,20 @@ rb_test(
     ],
 )
 
+rb_test(
+    name = "descriptor_pool_test",
+    srcs = ["descriptor_pool_test.rb"],
+    args = [
+        "-Iruby/lib:ruby",
+        "ruby/tests/descriptor_pool_test.rb",
+    ],
+    deps = [
+        ":test_ruby_protos",
+        "//ruby:protobuf",
+        "@protobuf_bundle",
+    ],
+)
+
 pkg_files(
     name = "dist_files",
     srcs = glob([

--- a/ruby/tests/descriptor_pool_test.rb
+++ b/ruby/tests/descriptor_pool_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require 'google/protobuf'
+
+$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__)))
+require 'basic_test_pb'
+require 'google/protobuf/descriptor_pb'
+
+class DescriptorPoolTest < Test::Unit::TestCase
+  def test_introspection
+    pool = Google::Protobuf::DescriptorPool.generated_pool
+
+    file_descriptor = pool.find_file_by_name('basic_test.proto')
+    
+    refute_nil file_descriptor
+    assert_equal 'basic_test.proto', file_descriptor.name
+    assert_nil pool.find_file_by_name('non_existent.proto')
+    assert_raise(TypeError) { pool.find_extension_by_number(123, 123) }
+    
+    deps = file_descriptor.dependencies
+    assert_kind_of Array, deps
+    assert_predicate deps, :frozen?
+  end
+
+  def test_extensions_introspection
+    pool = Google::Protobuf::DescriptorPool.new
+    ext_test_fd = Google::Protobuf::FileDescriptorProto.new(
+      name: 'test/ext_test_get_all.proto',
+      package: 'test.ext.getall',
+      syntax: 'proto2',
+      message_type: [
+        Google::Protobuf::DescriptorProto.new(
+          name: 'MessageWithExtensions',
+          extension_range: [
+            Google::Protobuf::DescriptorProto::ExtensionRange.new(start: 100, end: 1000)
+          ]
+        )
+      ],
+      extension: [
+        Google::Protobuf::FieldDescriptorProto.new(
+          name: 'field_a', number: 124, type: :TYPE_INT64,
+          label: :LABEL_OPTIONAL, extendee: '.test.ext.getall.MessageWithExtensions'
+        ),
+        Google::Protobuf::FieldDescriptorProto.new(
+          name: 'field_b', number: 125, type: :TYPE_STRING,
+          label: :LABEL_OPTIONAL, extendee: '.test.ext.getall.MessageWithExtensions'
+        )
+      ]
+    )
+    pool.add_serialized_file(Google::Protobuf::FileDescriptorProto.encode(ext_test_fd))
+
+    message_descriptor = pool.lookup('test.ext.getall.MessageWithExtensions')
+    refute_nil message_descriptor
+
+    extensions = pool.find_all_extensions(message_descriptor)
+    
+    assert_kind_of Array, extensions
+    assert_predicate extensions, :frozen?
+    assert_equal 2, extensions.size
+    assert_equal [124, 125], extensions.map(&:number).sort
+
+    ext_a = pool.find_extension_by_number(message_descriptor, 124)
+    refute_nil ext_a
+    assert_equal 'field_a', ext_a.name
+    assert_same ext_a, extensions.find { |e| e.number == 124 }
+
+    ext_b = pool.find_extension_by_number(message_descriptor, 125)
+    refute_nil ext_b
+    assert_equal 'field_b', ext_b.name
+    assert_same ext_b, extensions.find { |e| e.number == 125 }
+
+    assert_nil pool.find_extension_by_number(message_descriptor, 999)
+  end
+end


### PR DESCRIPTION
This PR enhances the introspection capabilities of `google-protobuf` ruby gem to CRuby Native C Extension and JRuby/CRuby FFI bindings.

Exposed Introspection Elements:
  - `Google::Protobuf::DescriptorPool#find_all_extensions`: Wraps `upb_DefPool_GetAllExtensions` to get all message extensions.
 - `Google::Protobuf::DescriptorPool#find_file_by_name`: Wraps `upb_DefPool_FindFileByName` to retrieve a specific FileDescriptor.
 - `Google::Protobuf::DescriptorPool#find_extension_by_number`: Wraps `upb_DefPool_FindExtensionByNumber` to expose a target extension FieldDescriptor  by number.
 - `Google::Protobuf::FileDescriptor#dependencies`: Wraps `upb_FileDef_DependencyCount` and `upb_FileDef_Dependency` to extract all imported dependencies.