### PR TITLE
Fix missing CheckedAdd in packed fixed-size field parsing

### DIFF
--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -1527,7 +1527,7 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   while (size > nbytes) {
     int num = nbytes / sizeof(T);
     int old_entries = out->size();
-    out->ReserveWithArena(arena, old_entries + num);
+    out->ReserveWithArena(arena, internal::CheckedAdd(old_entries, num));
     int block_size = num * sizeof(T);
     auto dst = out->AddNAlreadyReserved(num);
 #ifdef ABSL_IS_LITTLE_ENDIAN
@@ -1547,7 +1547,7 @@ const char* EpsCopyInputStream::ReadPackedFixed(const char* ptr, Arena* arena,
   int block_size = num * sizeof(T);
   if (num == 0) return size == block_size ? ptr : nullptr;
   int old_entries = out->size();
-  out->ReserveWithArena(arena, old_entries + num);
+  out->ReserveWithArena(arena, internal::CheckedAdd(old_entries, num));
   auto dst = out->AddNAlreadyReserved(num);
 #ifdef ABSL_IS_LITTLE_ENDIAN
   ABSL_CHECK(dst != nullptr) << out << "," << num;

--- a/src/google/protobuf/wire_format_lite.h
+++ b/src/google/protobuf/wire_format_lite.h
@@ -1131,7 +1131,7 @@ inline bool WireFormatLite::ReadPackedFixedSizePrimitive(
   if (new_bytes <= buffer_size) {
     // Fast-path that pre-allocates *values to the final size.
 #if defined(ABSL_IS_LITTLE_ENDIAN)
-    values->resize(old_entries + new_entries, 0);
+    values->resize(internal::CheckedAdd(old_entries, new_entries), 0);
     // values->mutable_data() may change after resize(), so do this after:
     void* dest = reinterpret_cast<void*>(values->mutable_data() + old_entries);
     if (!input->ReadRaw(dest, new_bytes)) {
@@ -1139,7 +1139,7 @@ inline bool WireFormatLite::ReadPackedFixedSizePrimitive(
       return false;
     }
 #else
-    values->Reserve(old_entries + new_entries);
+    values->Reserve(internal::CheckedAdd(old_entries, new_entries));
     CType value;
     for (int i = 0; i < new_entries; ++i) {
       if (!ReadPrimitive<CType, DeclaredType>(input, &value)) return false;


### PR DESCRIPTION
`ReadPackedFixed` (V2/`EpsCopyInputStream` path, `parse_context.h`) and `ReadPackedFixedSizePrimitive` (V1/`CodedInputStream` path, `wire_format_lite.h`) compute `old_entries + num` using plain `int` arithmetic. When a `RepeatedField` accumulates more than `INT_MAX` elements across multiple packed fields with the same field number, this is signed integer overflow — undefined behavior per C++.

The analogous varint path (`ReadPackedVarintArrayWithField`, `parse_context.h:1593/1606/1617`) already uses `internal::CheckedAdd` for this same computation. This patch extends the same protection to the 4 fixed-size sites.

**V1 little-endian fast path impact:** The overflow causes `resize()` to receive a negative value, which truncates the array. The subsequent `ReadRaw()` then writes attacker-controlled data past the buffer.

**V2 path impact:** `AddNAlreadyReserved` catches the inconsistency via `int64_t` arithmetic and aborts, but the preceding signed overflow is still UB that compilers may optimize around.

**Testing:** `full-test` (ASAN) and `lite-test` both pass with zero regressions. The existing `ParsedPackedOverflow` and `RepeatedVarintOverflow` tests verify the `CheckedAdd` integration for the varint path; this patch brings the fixed-size paths to parity.