### PR TITLE
python: enable NX and ASLR for Windows extension

### DIFF
--- a/python/py_extension.bzl
+++ b/python/py_extension.bzl
@@ -22,7 +22,16 @@ def py_extension(name, srcs, copts, deps = [], **kwargs):
                 "//python/dist:osx_x86_64",
                 "//python/dist:osx_aarch64",
             ): ["-Wl,-undefined,dynamic_lookup"],
-            "//python/dist:windows_x86_32": ["-static-libgcc"],
+            "//python/dist:windows_x86_32": [
+                "-static-libgcc",
+                "-Wl,--dynamicbase",
+                "-Wl,--nxcompat",
+            ],
+            "//python/dist:windows_x86_64": [
+                "-Wl,--dynamicbase",
+                "-Wl,--high-entropy-va",
+                "-Wl,--nxcompat",
+            ],
             "//conditions:default": [],
         }) + select({
             "//conditions:default": [],


### PR DESCRIPTION
Fixes #28688.

Issue #28688 reports that the Windows Python wheel's
`google/_upb/_message.pyd` is produced without PE DLL characteristics
for ASLR and DEP/NX.

This change adds explicit MinGW linker options for the Windows Python
extension:

- x86: `--dynamicbase`, `--nxcompat`
- x86_64: `--dynamicbase`, `--nxcompat`, `--high-entropy-va`

The existing `-static-libgcc` option for x86 is preserved.

These flags opt the generated PE extension into standard Windows exploit
mitigations. This is a hardening change and does not claim to fix an
underlying memory-safety vulnerability.

Reported originally in #28688.