### PR TITLE
Cherrypick rust iter_mut() fixes to 36.x

### DIFF
--- a/rust/repeated.rs
+++ b/rust/repeated.rs
@@ -569,8 +569,8 @@ impl<'borrow, T: Singular> iter::IntoIterator for &'borrow RepeatedMut<'_, T> {
 
 /// An iterator over the mutable values inside of a [`RepeatedMut`].
 ///
-/// **WARNING**: This is transitioning to a **Lending Iterator**. Standard `for` loops will soon be
-/// unsupported. Use `while let Some(item) = iter.next()` instead.
+/// **WARNING**: This has transitioned to a **Lending Iterator**. Standard `for` loops are not
+/// supported anymore. Use `while let Some(item) = iter.next()` instead.
 pub struct RepeatedMutIter<'msg, T> {
     inner: InnerRepeatedMut<'msg>,
     current_index: usize,
@@ -618,59 +618,6 @@ impl<'msg, T: Message> RepeatedMutIter<'msg, T> {
         Some(val)
     }
 }
-
-impl<'msg, T: Message> iter::Iterator for RepeatedMutIter<'msg, T> {
-    type Item = Mut<'msg, T>;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current_index >= self.end_index {
-            return None;
-        }
-        let index = self.current_index;
-        self.current_index += 1;
-
-        // SAFETY: index is valid.
-        let val = unsafe {
-            let temp_repeated = RepeatedMut::from_inner(Private, self.inner);
-            T::repeated_get_mut_unchecked(Private, temp_repeated, index)
-        };
-
-        Some(val)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.len();
-        (len, Some(len))
-    }
-}
-
-impl<'msg, T: Message> ExactSizeIterator for RepeatedMutIter<'msg, T> {
-    fn len(&self) -> usize {
-        self.end_index - self.current_index
-    }
-}
-
-impl<'msg, T: Message> iter::DoubleEndedIterator for RepeatedMutIter<'msg, T> {
-    #[inline]
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.current_index >= self.end_index {
-            return None;
-        }
-        self.end_index -= 1;
-        let index = self.end_index;
-
-        // SAFETY: index is guaranteed to be in bounds.
-        let val = unsafe {
-            let temp_repeated = RepeatedMut::from_inner(Private, self.inner);
-            T::repeated_get_mut_unchecked(Private, temp_repeated, index)
-        };
-
-        Some(val)
-    }
-}
-
-impl<'msg, T: Message> FusedIterator for RepeatedMutIter<'msg, T> {}
 
 impl<'msg, T: Message> RepeatedMut<'msg, T> {
     /// Returns an iterator that allows modifying each value.

--- a/rust/repeated.rs
+++ b/rust/repeated.rs
@@ -568,11 +568,55 @@ impl<'borrow, T: Singular> iter::IntoIterator for &'borrow RepeatedMut<'_, T> {
 }
 
 /// An iterator over the mutable values inside of a [`RepeatedMut`].
+///
+/// **WARNING**: This is transitioning to a **Lending Iterator**. Standard `for` loops will soon be
+/// unsupported. Use `while let Some(item) = iter.next()` instead.
 pub struct RepeatedMutIter<'msg, T> {
     inner: InnerRepeatedMut<'msg>,
     current_index: usize,
     end_index: usize,
     _phantom: PhantomData<&'msg mut T>,
+}
+
+impl<'msg, T: Message> RepeatedMutIter<'msg, T> {
+    #[inline]
+    pub fn next(&mut self) -> Option<Mut<'_, T>> {
+        if self.current_index >= self.end_index {
+            return None;
+        }
+        let index = self.current_index;
+        self.current_index += 1;
+
+        // SAFETY: index is valid.
+        let val = unsafe {
+            let temp_repeated = RepeatedMut::from_inner(Private, self.inner);
+            T::repeated_get_mut_unchecked(Private, temp_repeated, index)
+        };
+
+        Some(val)
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.end_index - self.current_index
+    }
+
+    #[inline]
+    pub fn next_back(&mut self) -> Option<Mut<'_, T>> {
+        if self.current_index >= self.end_index {
+            return None;
+        }
+        self.end_index -= 1;
+        let index = self.end_index;
+
+        // SAFETY: index is guaranteed to be in bounds.
+        let val = unsafe {
+            let temp_repeated = RepeatedMut::from_inner(Private, self.inner);
+            T::repeated_get_mut_unchecked(Private, temp_repeated, index)
+        };
+
+        Some(val)
+    }
 }
 
 impl<'msg, T: Message> iter::Iterator for RepeatedMutIter<'msg, T> {

--- a/rust/test/shared/accessors_repeated_test.rs
+++ b/rust/test/shared/accessors_repeated_test.rs
@@ -274,6 +274,61 @@ fn test_repeated_message_iter_mut() {
 }
 
 #[gtest]
+fn test_repeated_message_iter_mut_custom_next() {
+    let mut msg = TestAllTypes::new();
+    for i in 0..3 {
+        let mut nested = NestedMessage::new();
+        nested.set_bb(i);
+        msg.repeated_nested_message_mut().push(nested);
+    }
+
+    let mut iter = msg.repeated_nested_message_mut().iter_mut();
+
+    assert_that!(iter.len(), eq(3));
+    assert_that!(iter.size_hint(), eq((3, Some(3))));
+
+    while let Some(mut nested) = iter.next() {
+        let bb = nested.bb();
+        nested.set_bb(bb + 10);
+    }
+
+    assert_that!(iter.len(), eq(0));
+    assert_that!(iter.size_hint(), eq((0, Some(0))));
+
+    assert_that!(msg.repeated_nested_message().get(0).unwrap().bb(), eq(10));
+    assert_that!(msg.repeated_nested_message().get(1).unwrap().bb(), eq(11));
+    assert_that!(msg.repeated_nested_message().get(2).unwrap().bb(), eq(12));
+}
+
+#[gtest]
+fn test_repeated_message_iter_mut_custom_next_back() {
+    let mut msg = TestAllTypes::new();
+    for i in 0..3 {
+        let mut nested = NestedMessage::new();
+        nested.set_bb(i);
+        msg.repeated_nested_message_mut().push(nested);
+    }
+
+    let mut iter = msg.repeated_nested_message_mut().iter_mut();
+
+    if let Some(mut nested) = iter.next_back() {
+        nested.set_bb(200);
+    }
+    if let Some(mut nested) = iter.next_back() {
+        nested.set_bb(100);
+    }
+    if let Some(mut nested) = iter.next_back() {
+        nested.set_bb(0);
+    }
+
+    assert_that!(iter.next_back(), none());
+
+    assert_that!(msg.repeated_nested_message().get(0).unwrap().bb(), eq(0));
+    assert_that!(msg.repeated_nested_message().get(1).unwrap().bb(), eq(100));
+    assert_that!(msg.repeated_nested_message().get(2).unwrap().bb(), eq(200));
+}
+
+#[gtest]
 fn test_repeated_message_setter() {
     let mut msg = TestAllTypes::new();
     let mut nested = NestedMessage::new();

--- a/rust/test/shared/accessors_repeated_test.rs
+++ b/rust/test/shared/accessors_repeated_test.rs
@@ -255,25 +255,6 @@ fn test_repeated_message_iter_mut_empty() {
 }
 
 #[gtest]
-fn test_repeated_message_iter_mut() {
-    let mut msg = TestAllTypes::new();
-    for i in 0..3 {
-        let mut nested = NestedMessage::new();
-        nested.set_bb(i);
-        msg.repeated_nested_message_mut().push(nested);
-    }
-
-    for mut nested in msg.repeated_nested_message_mut().iter_mut() {
-        let bb = nested.bb();
-        nested.set_bb(bb + 1);
-    }
-
-    assert_that!(msg.repeated_nested_message().get(0).unwrap().bb(), eq(1));
-    assert_that!(msg.repeated_nested_message().get(1).unwrap().bb(), eq(2));
-    assert_that!(msg.repeated_nested_message().get(2).unwrap().bb(), eq(3));
-}
-
-#[gtest]
 fn test_repeated_message_iter_mut_custom_next() {
     let mut msg = TestAllTypes::new();
     for i in 0..3 {
@@ -285,7 +266,6 @@ fn test_repeated_message_iter_mut_custom_next() {
     let mut iter = msg.repeated_nested_message_mut().iter_mut();
 
     assert_that!(iter.len(), eq(3));
-    assert_that!(iter.size_hint(), eq((3, Some(3))));
 
     while let Some(mut nested) = iter.next() {
         let bb = nested.bb();
@@ -293,7 +273,6 @@ fn test_repeated_message_iter_mut_custom_next() {
     }
 
     assert_that!(iter.len(), eq(0));
-    assert_that!(iter.size_hint(), eq((0, Some(0))));
 
     assert_that!(msg.repeated_nested_message().get(0).unwrap().bb(), eq(10));
     assert_that!(msg.repeated_nested_message().get(1).unwrap().bb(), eq(11));


### PR DESCRIPTION
Switch to `while let Some(item) = iter.next()` from for loops on a RepeatedMutIter instance.