### PR TITLE
Cherrypick rust naming collision fixes to 36.x

### DIFF
--- a/src/google/protobuf/compiler/rust/extension.cc
+++ b/src/google/protobuf/compiler/rust/extension.cc
@@ -9,7 +9,6 @@
 
 #include <string>
 
-#include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
 #include "google/protobuf/compiler/cpp/names.h"
 #include "google/protobuf/compiler/rust/accessors/default_value.h"
@@ -55,7 +54,7 @@ void GenerateRs(Context& ctx, const FieldDescriptor& extension,
 
   // The extension symbol defined by both backends is the same.
   ctx.Emit({{"extendee", RsTypePath(ctx, *extension.containing_type())},
-            {"extension", absl::AsciiStrToUpper(extension.name())},
+            {"extension", ExtensionRsName(extension)},
             {"type", extension.is_repeated()
                          ? absl::StrCat("::protobuf::Repeated<",
                                         RsTypePath(ctx, extension), ">")

--- a/src/google/protobuf/compiler/rust/generator.cc
+++ b/src/google/protobuf/compiler/rust/generator.cc
@@ -112,6 +112,59 @@ void EmitPublicImports(const RustGeneratorContext& rust_generator_context,
   }
 }
 
+// Checks whether any two files in the crate export symbols that would collide
+// at the crate root when re-exported via `pub use <file_mod>::*;`.
+//
+// Return true if there is at least one collision in this crate.
+bool CrateHasSymbolCollision(const std::vector<const FileDescriptor*>& files) {
+  absl::flat_hash_set<std::string> type_names;
+  absl::flat_hash_set<std::string> value_names;
+
+  // Returns true if `symbol` was already contributed by an earlier symbol.
+  auto collides = [](absl::flat_hash_set<std::string>& names,
+                     const std::string& symbol) {
+    return !names.insert(symbol).second;
+  };
+
+  for (const FileDescriptor* file : files) {
+    for (int i = 0; i < file->message_type_count(); ++i) {
+      const Descriptor* msg = file->message_type(i);
+      std::string name = MessageRsName(*msg);
+      // A top-level message is emitted as 'Msg, MsgView, MsgMut'
+      if (collides(type_names, name) ||
+          collides(type_names, absl::StrCat(name, "View")) ||
+          collides(type_names, absl::StrCat(name, "Mut"))) {
+        return true;
+      }
+
+      // A submodule is emitted if the message has nested messages, enums,
+      // extensions, or oneofs.
+      if (msg->nested_type_count() > 0 || msg->enum_type_count() > 0 ||
+          msg->extension_count() > 0 || msg->real_oneof_decl_count() > 0) {
+        if (collides(type_names, RsSafeName(CamelToSnakeCase(msg->name())))) {
+          return true;
+        }
+      }
+    }
+
+    // Enums
+    for (int i = 0; i < file->enum_type_count(); ++i) {
+      if (collides(type_names, EnumRsName(*file->enum_type(i)))) {
+        return true;
+      }
+    }
+
+    // Extensions are emitted as `pub const <ext>`.
+    for (int i = 0; i < file->extension_count(); ++i) {
+      if (collides(value_names, ExtensionRsName(*file->extension(i)))) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 void EmitEntryPointRsFile(GeneratorContext* generator_context,
                           Context& ctx_without_printer,
                           const std::vector<const FileDescriptor*>& files) {
@@ -125,31 +178,50 @@ void EmitEntryPointRsFile(GeneratorContext* generator_context,
   io::Printer printer(outfile.get());
   Context ctx = ctx_without_printer.WithPrinter(&printer);
 
-  // Declare the submodules for all of the the generated code and pub re-export
-  // all of them into a flat namespace.
+  // Declare the submodules for all of the generated code and, where safe,
+  // pub re-export all of them into a flat namespace.
   RelativePath primary_relpath(entry_point_rs_file_path);
+  const bool has_collision = CrateHasSymbolCollision(files);
+
   for (const FileDescriptor* file : files) {
     std::string non_primary_file_path = GetRsFile(ctx, *file);
     std::string relative_mod_path =
         primary_relpath.Relative(RelativePath(non_primary_file_path));
+    std::string mod_name = RustModuleName(*file);
+
     // Expose each generated .proto file as a public module named after its
     // (flattened) file path, providing a fully-qualified path to every type
     // (e.g. `my_crate::google_network_api_proto::Config`). See
     // RustModuleName for how the module name is derived from the path.
     //
-    // The flat `pub use` re-export into the crate root is also emitted so that
-    // existing consumers relying on the crate-root namespace continue to work.
-    ctx.Emit(
-        {{"file_path", relative_mod_path}, {"mod_name", RustModuleName(*file)}},
-        R"rs(
+    // The flat `pub use` re-export into the crate root is conditionally emitted
+    ctx.Emit({{"file_path", relative_mod_path}, {"mod_name", mod_name}},
+             R"rs(
               #[path="$file_path$"]
               #[allow(nonstandard_style, unused)]
               pub mod $mod_name$;
-
-              #[allow(nonstandard_style, unused)]
-              #[doc(inline)]
-              pub use $mod_name$::*;
             )rs");
+
+    if (!has_collision) {
+      ctx.Emit({{"mod_name", mod_name}},
+               R"rs(
+                #[allow(nonstandard_style, unused)]
+                #[doc(inline)]
+                pub use $mod_name$::*;
+              )rs");
+    }
+  }
+
+  // When the crate has cross-file symbol collisions, the flat `pub use`
+  // re-exports above are omitted for every file. Emit a single breadcrumb (not
+  // one per file) explaining why, so consumers know to use fully-qualified
+  // paths.
+  if (has_collision) {
+    ctx.Emit(R"rs(
+            // Crate-root re-exports (`pub use <mod>::*`) are disabled because
+            // this crate contains symbol name collisions across file modules.
+            // Use fully-qualified paths, e.g. `<crate>::<module>::YourType`.
+          )rs");
   }
 
   auto v = ctx.printer().WithVars({

--- a/src/google/protobuf/compiler/rust/generator.cc
+++ b/src/google/protobuf/compiler/rust/generator.cc
@@ -132,20 +132,23 @@ void EmitEntryPointRsFile(GeneratorContext* generator_context,
     std::string non_primary_file_path = GetRsFile(ctx, *file);
     std::string relative_mod_path =
         primary_relpath.Relative(RelativePath(non_primary_file_path));
-    // Temporarily emit these re-exported mods as pub to avoid issues with
-    // Crubit. In a future change we should change these back to be private
-    // mods.
-    ctx.Emit({{"file_path", relative_mod_path},
-              {"mod_name", RustInternalModuleName(*file)}},
-             R"rs(
+    // Expose each generated .proto file as a public module named after its
+    // (flattened) file path, providing a fully-qualified path to every type
+    // (e.g. `my_crate::google_network_api_proto::Config`). See
+    // RustModuleName for how the module name is derived from the path.
+    //
+    // The flat `pub use` re-export into the crate root is also emitted so that
+    // existing consumers relying on the crate-root namespace continue to work.
+    ctx.Emit(
+        {{"file_path", relative_mod_path}, {"mod_name", RustModuleName(*file)}},
+        R"rs(
               #[path="$file_path$"]
-              #[allow(nonstandard_style, unused, unreachable_pub)]
-              #[doc(hidden)]
-              mod internal_do_not_use_$mod_name$;
+              #[allow(nonstandard_style, unused)]
+              pub mod $mod_name$;
 
               #[allow(nonstandard_style, unused)]
               #[doc(inline)]
-              pub use internal_do_not_use_$mod_name$::*;
+              pub use $mod_name$::*;
             )rs");
   }
 
@@ -214,7 +217,7 @@ bool RustGenerator::Generate(const FileDescriptor* file,
                                               &*import_path_to_crate_name);
 
   std::vector<std::string> modules;
-  modules.emplace_back(RustInternalModuleName(*file));
+  modules.emplace_back(RustModuleName(*file));
   Context ctx_without_printer(&*opts, &rust_generator_context, nullptr,
                               std::move(modules));
 

--- a/src/google/protobuf/compiler/rust/generator_test.cc
+++ b/src/google/protobuf/compiler/rust/generator_test.cc
@@ -434,6 +434,211 @@ TEST_F(RustGeneratorTest, EmitsQualifiedExtendeePathForExtensions) {
               HasSubstr("ExtensionId<super::super::foo_proto::Target, i32>"));
 }
 
+TEST_F(RustGeneratorTest, DropsReexportForEntireCrate) {
+  CreateTempFile("a.proto", R"schema(
+    syntax = "proto2";
+    package pkg_a;
+    message Foo { optional int32 x = 1; })schema");
+  CreateTempFile("b.proto", R"schema(
+    syntax = "proto2";
+    package pkg_b;
+    message Foo { optional int32 y = 1; })schema");
+  CreateTempFile("c.proto", R"schema(
+    syntax = "proto2";
+    package pkg_c;
+    message Unique { optional int32 z = 1; })schema");
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "a.proto b.proto c.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  EXPECT_THAT(entry_point, HasSubstr("pub mod a_proto;"));
+  EXPECT_THAT(entry_point, HasSubstr("pub mod b_proto;"));
+  EXPECT_THAT(entry_point, HasSubstr("pub mod c_proto;"));
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use a_proto::*;")));
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use b_proto::*;")));
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use c_proto::*;")));
+}
+
+TEST_F(RustGeneratorTest, DropsReexportOnEnumCollision) {
+  CreateTempFile("a.proto", R"schema(
+    syntax = "proto2";
+    package pkg_a;
+    enum Status { UNKNOWN = 0; OK = 1; })schema");
+  CreateTempFile("b.proto", R"schema(
+    syntax = "proto2";
+    package pkg_b;
+    enum Status { PENDING = 0; DONE = 1; })schema");
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "a.proto b.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  EXPECT_THAT(entry_point, HasSubstr("pub mod a_proto;"));
+  EXPECT_THAT(entry_point, HasSubstr("pub mod b_proto;"));
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use a_proto::*;")));
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use b_proto::*;")));
+}
+
+TEST_F(RustGeneratorTest, KeepsReexportForNonCollidingFiles) {
+  CreateTempFile("a.proto", R"schema(
+    syntax = "proto2";
+    package pkg_a;
+    message Alpha {
+      optional int32 x = 1;
+    })schema");
+  CreateTempFile("b.proto", R"schema(
+    syntax = "proto2";
+    package pkg_b;
+    message Beta {
+      optional int32 y = 1;
+    })schema");
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "a.proto b.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  EXPECT_THAT(entry_point, HasSubstr("pub use a_proto::*;"));
+  EXPECT_THAT(entry_point, HasSubstr("pub use b_proto::*;"));
+}
+
+TEST_F(RustGeneratorTest, DropsReexportOnViewCollision) {
+  CreateTempFile("a.proto", R"schema(
+    syntax = "proto2";
+    package pkg_a;
+    message BarView { optional int32 x = 1; })schema");
+  CreateTempFile("b.proto", R"schema(
+    syntax = "proto2";
+    package pkg_b;
+    message Bar { optional int32 y = 1; })schema");
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "a.proto b.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use a_proto::*;")));
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use b_proto::*;")));
+}
+
+TEST_F(RustGeneratorTest, DropsReexportOnMutCollision) {
+  CreateTempFile("a.proto", R"schema(
+    syntax = "proto2";
+    package pkg_a;
+    message QuxMut { optional int32 x = 1; })schema");
+  CreateTempFile("b.proto", R"schema(
+    syntax = "proto2";
+    package pkg_b;
+    message Qux { optional int32 y = 1; })schema");
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "a.proto b.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use a_proto::*;")));
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use b_proto::*;")));
+}
+
+TEST_F(RustGeneratorTest, DropsReexportOnSubmoduleCollision) {
+  CreateTempFile("a.proto", R"schema(
+    syntax = "proto2";
+    package pkg_a;
+    message data { optional int32 x = 1; })schema");
+  CreateTempFile("b.proto", R"schema(
+    syntax = "proto2";
+    package pkg_b;
+    message Data {
+      message Row { optional int32 v = 1; }
+      optional Row row = 1;
+    })schema");
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "a.proto b.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use a_proto::*;")));
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use b_proto::*;")));
+}
+
+TEST_F(RustGeneratorTest, DropsReexportOnExtensionCollision) {
+  CreateTempFile("a.proto", R"schema(
+    syntax = "proto2";
+    package pkg_a;
+    message TargetA { extensions 100 to 200; }
+    extend TargetA { optional int32 shared = 100; })schema");
+  CreateTempFile("b.proto", R"schema(
+    syntax = "proto2";
+    package pkg_b;
+    message TargetB { extensions 100 to 200; }
+    extend TargetB { optional int32 shared = 100; })schema");
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "a.proto b.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use a_proto::*;")));
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub use b_proto::*;")));
+}
+
+TEST_F(RustGeneratorTest, KeepsReexportForCrateWithFeaturesButNoCollision) {
+  CreateTempFile("a.proto", R"schema(
+    syntax = "proto2";
+    package pkg_a;
+    message AlphaMsg {
+      message AlphaInner { optional int32 v = 1; }
+      extensions 100 to 200;
+      oneof alpha_choice {
+        int32 a = 1;
+        int32 b = 2;
+      }
+    }
+    enum AlphaEnum { AE0 = 0; AE1 = 1; }
+    extend AlphaMsg { optional int32 alpha_ext = 100; })schema");
+  CreateTempFile("b.proto", R"schema(
+    syntax = "proto2";
+    package pkg_b;
+    message BetaMsg {
+      message BetaInner { optional int32 v = 1; }
+      extensions 100 to 200;
+      oneof beta_choice {
+        int32 a = 1;
+        int32 b = 2;
+      }
+    }
+    enum BetaEnum { BE0 = 0; BE1 = 1; }
+    extend BetaMsg { optional int32 beta_ext = 100; })schema");
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "a.proto b.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  EXPECT_THAT(entry_point, HasSubstr("pub use a_proto::*;"));
+  EXPECT_THAT(entry_point, HasSubstr("pub use b_proto::*;"));
+}
+
 }  // namespace
 }  // namespace rust
 }  // namespace compiler

--- a/src/google/protobuf/compiler/rust/generator_test.cc
+++ b/src/google/protobuf/compiler/rust/generator_test.cc
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "google/protobuf/descriptor.pb.h"
@@ -291,6 +292,146 @@ TEST_F(RustGeneratorTest, EmitsReadableModuleNameForHyphenatedFile) {
   // no `_2d_` hex escaping is used for a plain hyphen.
   EXPECT_THAT(entry_point, HasSubstr("pub mod my_service_proto;"));
   EXPECT_THAT(entry_point, Not(HasSubstr("_2d_")));
+}
+
+TEST_F(RustGeneratorTest, EmitsQualifiedPathForSameFileMessageReference) {
+  // Foo uses Bar from the same file.
+  constexpr absl::string_view kFooProto = R"schema(
+    syntax = "proto2";
+    package foo;
+    message Bar {}
+    message Foo {
+      optional Bar bar = 1;
+    })schema";
+  CreateTempFile("foo.proto", kFooProto);
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "foo.proto");
+  ExpectNoErrors();
+
+  std::string foo = FileContents("foo.c.pb.rs");
+  EXPECT_THAT(foo, HasSubstr("super::foo_proto::BarView"));
+  EXPECT_THAT(foo, Not(HasSubstr("super::BarView")));
+}
+
+TEST_F(RustGeneratorTest, EmitsQualifiedPathForCrossFileMessageReference) {
+  constexpr absl::string_view kBarProto = R"schema(
+    syntax = "proto2";
+    package bar;
+    message Bar {})schema";
+
+  // Foo uses Bar from a different file in the same crate.
+  constexpr absl::string_view kFooProto = R"schema(
+    syntax = "proto2";
+    package foo;
+    import "bar.proto";
+    message Foo {
+      optional bar.Bar bar = 1;
+    })schema";
+  CreateTempFile("bar.proto", kBarProto);
+  CreateTempFile("foo.proto", kFooProto);
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "foo.proto bar.proto");
+  ExpectNoErrors();
+
+  std::string foo = FileContents("foo.c.pb.rs");
+  EXPECT_THAT(foo, HasSubstr("super::bar_proto::BarView"));
+  EXPECT_THAT(foo, Not(HasSubstr("super::BarView")));
+}
+
+TEST_F(RustGeneratorTest, EmitsQualifiedPathForNestedContainingType) {
+  constexpr absl::string_view kProto = R"schema(
+    syntax = "proto2";
+    package foo;
+    message Wrapper {
+      message Nested {}
+      enum Kind {
+        K0 = 0;
+        K1 = 1;
+      }
+    }
+    message User {
+      optional Wrapper.Nested nested = 1;
+      optional Wrapper.Kind kind = 2;
+    })schema";
+  CreateTempFile("foo.proto", kProto);
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "foo.proto");
+  ExpectNoErrors();
+
+  std::string foo = FileContents("foo.c.pb.rs");
+  EXPECT_THAT(foo, HasSubstr("super::foo_proto::wrapper::NestedView"));
+  EXPECT_THAT(foo, HasSubstr("super::foo_proto::wrapper::Kind"));
+}
+
+TEST_F(RustGeneratorTest, EmitsQualifiedPathForCrossCrateMessageReference) {
+  constexpr absl::string_view kBarProto = R"schema(
+    syntax = "proto2";
+    package bar;
+    message Bar {})schema";
+  // Foo uses Bar from a different crate.
+  constexpr absl::string_view kFooProto = R"schema(
+    syntax = "proto2";
+    package foo;
+    import "bar.proto";
+    message Foo {
+      optional bar.Bar bar = 1;
+    })schema";
+  CreateTempFile("bar.proto", kBarProto);
+  CreateTempFile("foo.proto", kFooProto);
+  CreateTempFile("mapping.txt", "bar_crate\n1\nbar.proto\n");
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp,"
+      "crate_mapping=$tmpdir/mapping.txt "
+      "foo.proto");
+  ExpectNoErrors();
+
+  std::string foo = FileContents("foo.c.pb.rs");
+  EXPECT_THAT(foo, HasSubstr("::bar_crate::bar_proto::BarView"));
+  EXPECT_THAT(foo, HasSubstr("IntoProxied<::bar_crate::bar_proto::Bar>"));
+  EXPECT_THAT(foo, Not(HasSubstr("::bar_crate::BarView")));
+}
+
+TEST_F(RustGeneratorTest, EmitsQualifiedExtendeePathForExtensions) {
+  constexpr absl::string_view kFooProto = R"schema(
+    syntax = "proto2";
+    package foo;
+    message Target {
+      optional int32 val = 1;
+      extensions 100 to 200;
+    }
+    extend Target {
+      optional int32 top_ext = 100;
+    }
+    message Container {
+      extend Target {
+        optional int32 nested_ext = 101;
+      }
+    })schema";
+  CreateTempFile("foo.proto", kFooProto);
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "foo.proto");
+  ExpectNoErrors();
+
+  std::string foo = FileContents("foo.c.pb.rs");
+  // top_ext
+  EXPECT_THAT(foo, HasSubstr("ExtensionId<super::foo_proto::Target, i32>"));
+  // nested_ext
+  EXPECT_THAT(foo,
+              HasSubstr("ExtensionId<super::super::foo_proto::Target, i32>"));
 }
 
 }  // namespace

--- a/src/google/protobuf/compiler/rust/generator_test.cc
+++ b/src/google/protobuf/compiler/rust/generator_test.cc
@@ -203,6 +203,96 @@ TEST_F(RustGeneratorTest, EmitsEnumMetadata) {
       "Alias1", GeneratedCodeInfo::Annotation::NONE, 1);
 }
 
+TEST_F(RustGeneratorTest, EmitsPublicFileModuleInEntryPoint) {
+  constexpr absl::string_view kFooProto = R"schema(
+    syntax = "proto2";
+    package foo;
+    message Message {
+    })schema";
+  CreateTempFile("foo.proto", kFooProto);
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "foo.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  EXPECT_THAT(entry_point, HasSubstr("pub mod foo_proto;"));
+  EXPECT_THAT(entry_point, HasSubstr("pub use foo_proto::*;"));
+  EXPECT_THAT(entry_point, Not(HasSubstr("internal_do_not_use_")));
+  EXPECT_THAT(entry_point, Not(HasSubstr("#[doc(hidden)]")));
+}
+
+TEST_F(RustGeneratorTest, EmitsPublicFileModulesForMultiFileCrate) {
+  constexpr absl::string_view kFooProto = R"schema(
+    syntax = "proto2";
+    package foo;
+    message Config {
+    })schema";
+  constexpr absl::string_view kBarProto = R"schema(
+    syntax = "proto2";
+    package bar;
+    message Config {
+    })schema";
+  CreateTempFile("foo.proto", kFooProto);
+  CreateTempFile("bar.proto", kBarProto);
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "foo.proto bar.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  EXPECT_THAT(entry_point, HasSubstr("pub mod foo_proto;"));
+  EXPECT_THAT(entry_point, HasSubstr("pub mod bar_proto;"));
+  EXPECT_THAT(entry_point, Not(HasSubstr("internal_do_not_use_")));
+}
+
+TEST_F(RustGeneratorTest, EmitsValidIdentifierForLeadingDigitFile) {
+  constexpr absl::string_view kProto = R"schema(
+    syntax = "proto2";
+    package sample;
+    message Config {}
+  )schema";
+  CreateTempFile("0.1.proto", kProto);
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "0.1.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  // A leading non-letter gets a `pb_` prefix so the module name is a valid
+  // identifier (`0.1.proto` must not produce `pub mod 0_1_proto;`).
+  EXPECT_THAT(entry_point, HasSubstr("pub mod pb_0_1_proto;"));
+  EXPECT_THAT(entry_point, HasSubstr("pub use pb_0_1_proto::*;"));
+  EXPECT_THAT(entry_point, Not(HasSubstr("pub mod 0_1_proto;")));
+}
+
+TEST_F(RustGeneratorTest, EmitsReadableModuleNameForHyphenatedFile) {
+  constexpr absl::string_view kProto = R"schema(
+    syntax = "proto2";
+    package sample;
+    message A {}
+  )schema";
+  CreateTempFile("my-service.proto", kProto);
+  RunProtoc(
+      "protocol_compiler --proto_path=$tmpdir "
+      "--rust_out=$tmpdir "
+      "--rust_opt=experimental-codegen=enabled,kernel=cpp "
+      "my-service.proto");
+  ExpectNoErrors();
+
+  std::string entry_point = FileContents("generated.rs");
+  // Separators collapse to `_` and the `.proto` extension becomes `_proto`;
+  // no `_2d_` hex escaping is used for a plain hyphen.
+  EXPECT_THAT(entry_point, HasSubstr("pub mod my_service_proto;"));
+  EXPECT_THAT(entry_point, Not(HasSubstr("_2d_")));
+}
+
 }  // namespace
 }  // namespace rust
 }  // namespace compiler

--- a/src/google/protobuf/compiler/rust/naming.cc
+++ b/src/google/protobuf/compiler/rust/naming.cc
@@ -391,6 +391,10 @@ std::string EnumRsName(const EnumDescriptor& desc) {
   return name;
 }
 
+std::string ExtensionRsName(const FieldDescriptor& extension) {
+  return absl::AsciiStrToUpper(extension.name());
+}
+
 std::string EnumValueRsName(const EnumValueDescriptor& value) {
   MultiCasePrefixStripper stripper(value.type()->name());
   return EnumValueRsName(stripper, value.name());

--- a/src/google/protobuf/compiler/rust/naming.cc
+++ b/src/google/protobuf/compiler/rust/naming.cc
@@ -206,14 +206,17 @@ static std::string RustModuleForContainingType(
     parent = parent->containing_type();
   }
 
-  // Reverse the vector to get submodules in outer-to-inner order).
+  // Reverse the vector to get submodules in outer-to-inner order.
   std::reverse(modules.begin(), modules.end());
 
-  // If there are any modules at all, push an empty string on the end so that
-  // we get the trailing ::
-  if (!modules.empty()) {
-    modules.push_back("");
-  }
+  // Every type is defined inside its file's mod. References becomes the
+  // canonical `super::<file_mod>::<type_mod>` path instead of relying on the
+  // crate-root re-export, which will be disabled soon.
+  modules.insert(modules.begin(), RustModuleName(file));
+
+  // Push an empty string on the end so that we get the trailing :: to connect
+  // to the type mod name.
+  modules.push_back("");
 
   std::string crate_relative = absl::StrJoin(modules, "::");
 

--- a/src/google/protobuf/compiler/rust/naming.cc
+++ b/src/google/protobuf/compiler/rust/naming.cc
@@ -241,13 +241,36 @@ std::string RustModule(Context& ctx, const OneofDescriptor& oneof) {
                                      *oneof.file());
 }
 
-std::string RustInternalModuleName(const FileDescriptor& file) {
-  return RsSafeName(
-      absl::StrReplaceAll(StripProto(file.name()), {
-                                                       {"_", "__"},
-                                                       {"/", "_s"},
-                                                       {"-", "__"},
-                                                   }));
+std::string RustModuleName(const FileDescriptor& file) {
+  // Derive a readable and (mostly) unique Rust module name from the full
+  // proto file path, e.g. `foo/bar/baz.proto` becomes `foo_bar_baz_proto`.
+  absl::string_view name = file.name();
+  absl::string_view prefix = "pb_";
+
+  std::string result;
+  result.reserve(name.size() + prefix.size());
+
+  // Rust identifiers must start with a letter or underscore. If the path begins
+  // with anything else (e.g. a digit), prepend `pb_` so the result is valid.
+  if (name.empty() || !absl::ascii_isalpha(name[0])) {
+    result += prefix;
+  }
+
+  for (char c : name) {
+    // Common path/file separators (`/`, `-`, `.`, and `_`) all collapse to a
+    // single underscore for better readability.
+    if (c == '/' || c == '-' || c == '.' || c == '_') {
+      result += '_';
+    } else if (absl::ascii_isalnum(c)) {
+      result += c;
+    } else {
+      // Escape any other characters that aren't valid in Rust identifiers
+      // by substituting them with an underscore followed by their hex value
+      // and another underscore.
+      absl::StrAppendFormat(&result, "_%02x_", static_cast<unsigned char>(c));
+    }
+  }
+  return RsSafeName(result);
 }
 
 std::string FieldInfoComment(Context& ctx, const FieldDescriptor& field) {

--- a/src/google/protobuf/compiler/rust/naming.h
+++ b/src/google/protobuf/compiler/rust/naming.h
@@ -64,6 +64,12 @@ std::string MessageRsName(const Descriptor& desc);
 std::string EnumRsName(const EnumDescriptor& desc);
 std::string EnumValueRsName(const EnumValueDescriptor& value);
 
+// Returns the Rust identifier for a message extension, emitted as a
+// `pub const <NAME>: ExtensionId<...>`. Centralizing this here keeps the name
+// used by the code generator in sync with any future mangling (e.g. for
+// extension names that are not valid Rust identifiers).
+std::string ExtensionRsName(const FieldDescriptor& extension);
+
 std::string OneofViewEnumRsName(const OneofDescriptor& oneof);
 std::string OneofCaseEnumRsName(const OneofDescriptor& oneof);
 

--- a/src/google/protobuf/compiler/rust/naming.h
+++ b/src/google/protobuf/compiler/rust/naming.h
@@ -106,7 +106,7 @@ std::string RustModule(Context& ctx, const Descriptor& msg);
 std::string RustModule(Context& ctx, const EnumDescriptor& enum_);
 std::string RustModule(Context& ctx, const OneofDescriptor& oneof);
 
-std::string RustInternalModuleName(const FileDescriptor& file);
+std::string RustModuleName(const FileDescriptor& file);
 
 template <typename Desc>
 std::string GetUnderscoreDelimitedFullName(Context& ctx, const Desc& desc);

--- a/src/google/protobuf/compiler/rust/naming_test.cc
+++ b/src/google/protobuf/compiler/rust/naming_test.cc
@@ -9,16 +9,41 @@
 #include "google/protobuf/io/zero_copy_stream_impl_lite.h"
 
 using google::protobuf::compiler::rust::CamelToSnakeCase;
-using google::protobuf::compiler::rust::RustInternalModuleName;
+using google::protobuf::compiler::rust::RustModuleName;
 using google::protobuf::compiler::rust::ScreamingSnakeToUpperCamelCase;
 
 namespace {
-TEST(RustProtoNaming, RustInternalModuleName) {
-  google::protobuf::FileDescriptorProto foo_file;
-  foo_file.set_name("strong_bad/lol.proto");
-  google::protobuf::DescriptorPool pool;
-  const google::protobuf::FileDescriptor* fd = pool.BuildFile(foo_file);
-  EXPECT_EQ(RustInternalModuleName(*fd), "strong__bad_slol");
+TEST(RustProtoNaming, RustModuleName) {
+  auto get_internal_module_name = [](const std::string& name) {
+    google::protobuf::FileDescriptorProto file_proto;
+    file_proto.set_name(name);
+    google::protobuf::DescriptorPool pool;
+    return RustModuleName(*pool.BuildFile(file_proto));
+  };
+
+  EXPECT_EQ(get_internal_module_name("strong_bad/lol.proto"),
+            "strong_bad_lol_proto");
+  EXPECT_EQ(get_internal_module_name("0.1.proto"), "pb_0_1_proto");
+  EXPECT_EQ(get_internal_module_name("2fa.proto"), "pb_2fa_proto");
+  EXPECT_EQ(get_internal_module_name("_.proto"), "pb___proto");
+  EXPECT_EQ(get_internal_module_name("abc   .proto"), "abc_20__20__20__proto");
+  EXPECT_EQ(get_internal_module_name("hello (2).proto"),
+            "hello_20__28_2_29__proto");
+  EXPECT_EQ(get_internal_module_name("k8s.min.proto"), "k8s_min_proto");
+  EXPECT_EQ(get_internal_module_name("c++.proto"), "c_2b__2b__proto");
+  EXPECT_EQ(get_internal_module_name("hello,world.proto"),
+            "hello_2c_world_proto");
+  EXPECT_EQ(get_internal_module_name("hello..world.proto"),
+            "hello__world_proto");
+  EXPECT_EQ(get_internal_module_name("hello_你好.proto"),
+            "hello__e4__bd__a0__e5__a5__bd__proto");
+  // Common separators (`/`, `-`, `.`, `_`) all collapse to a single underscore,
+  // so files differing only by these separators intentionally map to the same
+  // module name (any collision surfaces as a rustc E0428 error at build time).
+  EXPECT_EQ(get_internal_module_name("my-message.proto"), "my_message_proto");
+  EXPECT_EQ(get_internal_module_name("my_message.proto"), "my_message_proto");
+  EXPECT_EQ(get_internal_module_name("foo-bar.proto"),
+            get_internal_module_name("foo_bar.proto"));
 }
 
 TEST(RustProtoNaming, CamelToSnakeCase) {


### PR DESCRIPTION
Expose generated per-file Rust proto modules as public. Detects single-crate cross-file symbol collisions and conditionally emits crate-root re-exports.

1. Add a Collision detection algorithm (CrateHasRootSymbolCollision)
2. Based on return value of the algorith, conditionally emits pub use super::*
3. Changed one usage in protobuf to use fully-qualified name where there's actually a collision
