### PR TITLE
Resolve "py_wheel license metadata still non-SPDX text despite setup.py fix in https://github.com/protocolbuffers/protobuf/pull/9441"

### DIFF
--- a/python/dist/BUILD.bazel
+++ b/python/dist/BUILD.bazel
@@ -363,7 +363,7 @@ py_wheel(
         "//:LICENSE": "LICENSE",
     },
     homepage = "https://developers.google.com/protocol-buffers/",
-    license = "3-Clause BSD License",
+    license = "BSD-3-Clause",
     platform = select({
         ":linux_x86_64_local": "linux_x86_64",
         ":linux_x86_64_release": "manylinux2014_x86_64",
@@ -423,7 +423,7 @@ py_wheel(
         "//:LICENSE": "LICENSE",
     },
     homepage = "https://developers.google.com/protocol-buffers/",
-    license = "3-Clause BSD License",
+    license = "BSD-3-Clause",
     platform = "any",
     python_requires = ">=3.10",
     python_tag = "py3",


### PR DESCRIPTION
This PR aligns the license METADATA field in the Python wheel to be SPDX-compliant.

Tested via:

```bash
❯ bazel build //python/dist:pure_python_wheel 
❯ unzip -p bazel-bin/python/dist/protobuf-*-py3-none-any.whl "*.dist-info/METADATA" | grep -E "^Version|^License|^Name"
Name: protobuf
License: BSD-3-Clause
Version: 7.37.0
```

Closes #29440