### PR TITLE
Fix out-of-bounds memmove when deleting an empty extended slice

### DIFF
--- a/python/minimal_test.py
+++ b/python/minimal_test.py
@@ -84,6 +84,13 @@ class TestMessageExtension(unittest.TestCase):
     test_slice(11, 3, -2)
     test_slice(11, 3, -3)
     test_slice(10, 25, 4)
+    # Empty extended slices must be no-ops (regression: these used to make
+    # PyUpb_RepeatedContainer_DeleteSubscript underflow size_t and memmove
+    # out of bounds).
+    test_slice(5, 5, 2)
+    test_slice(0, 0, 2)
+    test_slice(2, 2, 2)
+    test_slice(20, 20, 2)
 
   def testExtensionsErrors(self):
     msg = unittest_pb2.TestAllTypes()

--- a/python/repeated.c
+++ b/python/repeated.c
@@ -853,6 +853,12 @@ static int PyUpb_RepeatedContainer_DeleteSubscript(upb_Array* arr,
                                                    Py_ssize_t idx,
                                                    Py_ssize_t count,
                                                    Py_ssize_t step) {
+  // An empty slice deletes nothing.  Without this, the step>1 branch below
+  // sets src = start + 1, which can exceed the array size and make
+  // `tail = upb_Array_Size(arr) - src` underflow size_t, turning the
+  // subsequent upb_Array_Move() into an out-of-bounds memmove.
+  if (count == 0) return 0;
+
   // Normalize direction: deletion is order-independent.
   Py_ssize_t start = idx;
   if (step < 0) {


### PR DESCRIPTION
Fixes #29672.

`PyUpb_RepeatedContainer_DeleteSubscript()` assumed at least one element was selected in the
`step > 1` branch. For an empty extended slice (`count == 0`) whose normalized `start` equals
the array length, it set `src = start + 1 > size`, so `tail = upb_Array_Size(arr) - src`
underflowed `size_t` and the following `upb_Array_Move()` performed a `memmove` of ~2^64
bytes (access violation). When `start < len(array)` the same branch silently dropped one
element instead of being a no-op.

Repro on `protobuf==7.36.1` (upb runtime):

```python
from google.protobuf import descriptor_pb2
f = descriptor_pb2.FileDescriptorProto()
del f.dependency[::2]        # empty repeated field; a no-op in Python
# -> Windows fatal exception: access violation (0xC0000005)
```

The fix treats a zero-length deletion as a no-op, which matches `list` and the pure-Python
runtime. Regression cases for empty ranges are added to
`minimal_test.py:test_repeated_field_slice_delete`, which previously only covered non-empty
ranges.
