### PR TITLE
[Ruby] Fix RepeatedField#values_at delegation to Array

### DIFF
--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -52,7 +52,8 @@ module Google
         :pack, :permutation, :product, :pretty_print, :pretty_print_cycle,
         :rassoc, :repeated_combination, :repeated_permutation, :reverse,
         :rindex, :rotate, :sample, :shuffle, :shelljoin,
-        :to_s, :transpose, :union, :uniq, :|
+        :to_s, :transpose, :union, :uniq, :|,
+        :values_at
 
 
       def first(n=nil)
@@ -95,7 +96,6 @@ module Google
 
       # array aliases into enumerable
       alias_method :slice, :[]
-      alias_method :values_at, :select
       alias_method :map, :collect
 
 

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -37,6 +37,15 @@ class RepeatedFieldTest < Test::Unit::TestCase
     end
   end
 
+  def test_values_at
+    m = TestMessage.new
+    fill_test_msg(m)
+    assert_equal [-10, -11], m.repeated_int32.values_at(0, 1)
+    assert_equal [-11, nil], m.repeated_int32.values_at(1, 10)
+    assert_equal ['foo', 'bar'], m.repeated_string.values_at(0..1)
+    assert_equal ['bar', 'foo'], m.repeated_string.values_at(1, 0)
+  end
+
   def test_first
     m = TestMessage.new
     repeated_field_names(TestMessage).each do |field_name|


### PR DESCRIPTION
Fixes #29516.

### Problem
`Google::Protobuf::RepeatedField#values_at` was previously aliased to `Enumerable#select` in `ruby/lib/google/protobuf/repeated_field.rb`:
```ruby
alias_method :values_at, :select
```
Because `select` expects a block and takes 0 positional arguments, invoking `repeated_field.values_at(...)` with index or range arguments raised `ArgumentError: wrong number of arguments`, breaking the expected Array-like interface.

### Solution
1. Add `:values_at` to `def_delegators :to_ary` in `RepeatedField`, delegating index and range resolution directly to the underlying `Array#values_at`.
2. Remove the faulty `alias_method :values_at, :select`.
3. Add regression tests in `ruby/tests/repeated_field_test.rb` verifying positive/negative indices, out-of-bounds indices returning `nil`, and range arguments.
