### PR TITLE
[Ruby] Return Enumerator when ListValue#each is called without a block

### DIFF
--- a/ruby/lib/google/protobuf/well_known_types.rb
+++ b/ruby/lib/google/protobuf/well_known_types.rb
@@ -194,6 +194,7 @@ module Google
       end
 
       def each
+        return enum_for(:each) unless block_given?
         self.values.each { |x| yield(x.to_ruby) }
       end
 

--- a/ruby/tests/well_known_types_test.rb
+++ b/ruby/tests/well_known_types_test.rb
@@ -116,10 +116,14 @@ class TestWellKnownTypes < Test::Unit::TestCase
     # Test ListValue#each with and without a block
     elements = []
     struct["sublist"].each { |x| elements << x }
-    assert_equal should_equal["sublist"], elements
+    assert_equal struct["sublist"].length, elements.length
+    assert_equal "abc", elements[0]
+    assert_equal 123, elements[1]
+    assert_equal({"deepkey" => "deepval"}, elements[2].to_h)
+    assert_nil elements[3]
     enum = struct["sublist"].each
     assert_instance_of Enumerator, enum
-    assert_equal should_equal["sublist"], enum.to_a
+    assert_equal elements, enum.to_a
 
     assert_raises Google::Protobuf::UnexpectedStructType do
       struct[123] = 5

--- a/ruby/tests/well_known_types_test.rb
+++ b/ruby/tests/well_known_types_test.rb
@@ -113,6 +113,14 @@ class TestWellKnownTypes < Test::Unit::TestCase
     assert_equal should_equal, struct.to_h
     assert_equal should_equal["sublist"].length, struct["sublist"].length
 
+    # Test ListValue#each with and without a block
+    elements = []
+    struct["sublist"].each { |x| elements << x }
+    assert_equal should_equal["sublist"], elements
+    enum = struct["sublist"].each
+    assert_instance_of Enumerator, enum
+    assert_equal should_equal["sublist"], enum.to_a
+
     assert_raises Google::Protobuf::UnexpectedStructType do
       struct[123] = 5
     end


### PR DESCRIPTION
Fixes #29518.

### Problem
`Google::Protobuf::ListValue` includes `Enumerable`, but its `each` method previously unconditionally yielded:
```ruby
def each
  self.values.each { |x| yield(x.to_ruby) }
end
```
Calling `ListValue#each` without a block raised `LocalJumpError: no block given (yield)`, diverging from standard Ruby `Enumerable` contracts where calling `each` blocklessly returns an `Enumerator`.

### Solution
1. Add `return enum_for(:each) unless block_given?` at the top of `ListValue#each` in `ruby/lib/google/protobuf/well_known_types.rb`.
2. Add unit test coverage in `ruby/tests/well_known_types_test.rb` verifying that `list.each` without a block returns an `Enumerator` and yields equivalent values.
