### PR TITLE
Migrate packed varint pre-scan to spans

### DIFF
--- a/src/google/protobuf/generated_message_tctable_lite_test.cc
+++ b/src/google/protobuf/generated_message_tctable_lite_test.cc
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -20,6 +21,7 @@
 #include "absl/strings/str_replace.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
+#include "absl/types/span.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/descriptor_database.h"
 #include "google/protobuf/descriptor_visitor.h"
@@ -51,6 +53,42 @@ using ::testing::ElementsAreArray;
 using ::testing::Eq;
 using ::testing::Not;
 using ::testing::Optional;
+
+TEST(PackedVarintPreScan, CountVarintsStaysWithinSpan) {
+  std::array<char, 24> bytes{};
+  for (size_t i = 0; i < bytes.size(); ++i) {
+    bytes[i] = static_cast<char>((i % 3 == 0) ? 0x80 : 0x01);
+  }
+
+  for (size_t length = 8; length <= bytes.size(); ++length) {
+    const absl::Span<const char> data(bytes.data(), length);
+    int expected = 0;
+    for (char byte : data) {
+      if ((static_cast<uint8_t>(byte) & 0x80) == 0) ++expected;
+    }
+    EXPECT_EQ(CountVarintsAssumingLargeArray(data), expected)
+        << "length=" << length;
+  }
+}
+
+TEST(PackedVarintPreScan, VerifyBoolsStaysWithinSpan) {
+  std::array<char, 24> bytes{};
+  for (size_t i = 0; i < bytes.size(); ++i) {
+    bytes[i] = static_cast<char>(i & 1);
+  }
+
+  for (size_t length = 8; length <= bytes.size(); ++length) {
+    const absl::Span<const char> data(bytes.data(), length);
+    EXPECT_TRUE(VerifyBoolsAssumingLargeArray(data)) << "length=" << length;
+
+    const size_t bad_index = length - 1;
+    const char saved = bytes[bad_index];
+    bytes[bad_index] = 2;
+    EXPECT_FALSE(VerifyBoolsAssumingLargeArray(data))
+        << "length=" << length << " bad_index=" << bad_index;
+    bytes[bad_index] = saved;
+  }
+}
 
 // The fast parser's dispatch table Xors two bytes of incoming data with
 // the data in TcFieldData, so we reproduce that here:

--- a/src/google/protobuf/parse_context.cc
+++ b/src/google/protobuf/parse_context.cc
@@ -806,46 +806,64 @@ const char* EpsCopyInputStream::ReadMicroStringFallback(const char* ptr,
   return ptr;
 }
 
-int CountVarintsAssumingLargeArray(const char* ptr, const char* end) {
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wunsafe-buffer-usage"
+#endif
+
+int CountVarintsAssumingLargeArray(absl::Span<const char> data) {
   // The number of varints is the number of bytes with the highest bit clear.
   // This is easier to compute as the total number of bytes, minus the number
   // of bytes with the highest bit set.
-  int num_varints = end - ptr;
-  ABSL_DCHECK_GE(num_varints, int{sizeof(uint64_t)});
+  const size_t size = data.size();
+  int num_varints = static_cast<int>(size);
+  ABSL_DCHECK_GE(size, sizeof(uint64_t));
+  PROTOBUF_ASSUME(size >= sizeof(uint64_t));
 
-  // Count in whole blocks, except for the last one.
-  const char* const limit = end - sizeof(uint64_t);
-  while (ptr < limit) {
-    num_varints -=
-        absl::popcount(EndianHelper<8>::Load(ptr) & 0x8080808080808080);
-    ptr += sizeof(uint64_t);
+  // Keep the final 8-byte window before shrinking the span. Walking a shrinking
+  // span keeps extent information attached to the cursor, and lets optimized
+  // builds use the same tight load/popcount loop as the old pointer walk.
+  const auto tail = data.last(sizeof(uint64_t));
+  while (data.size() > sizeof(uint64_t)) {
+    num_varints -= absl::popcount(EndianHelper<8>::Load(data.data()) &
+                                  0x8080808080808080);
+    data.remove_prefix(sizeof(uint64_t));
   }
 
-  // Count in the last, possibly incomplete block.
+  // Count the final, possibly overlapping window, masking bytes already seen.
   return num_varints -
-         absl::popcount(EndianHelper<8>::Load(limit) &
-                        (0x8080808080808080 << ((ptr - limit) * 8)));
+         absl::popcount(EndianHelper<8>::Load(tail.data()) &
+                        (0x8080808080808080
+                         << ((sizeof(uint64_t) - data.size()) * 8)));
 }
 
-bool VerifyBoolsAssumingLargeArray(const char* ptr, const char* end) {
-  ABSL_DCHECK_GE(end - ptr, int{sizeof(uint64_t)});
+bool VerifyBoolsAssumingLargeArray(absl::Span<const char> data) {
+  const size_t size = data.size();
+  ABSL_DCHECK_GE(size, sizeof(uint64_t));
+  PROTOBUF_ASSUME(size >= sizeof(uint64_t));
 
-  // Verify whole blocks, except for the last one.
+  // Verify whole blocks, except for the last one. Retain the final window before
+  // shrinking so the loop itself only advances an extent-carrying span.
+  const auto tail = data.last(sizeof(uint64_t));
   uint64_t bit_or = 0;
-  const char* const limit = end - sizeof(uint64_t);
-  while (ptr < limit) {
+  while (data.size() > sizeof(uint64_t)) {
     uint64_t block;
-    std::memcpy(&block, ptr, 8);
+    std::memcpy(&block, data.data(), sizeof(block));
     bit_or |= block;
-    ptr += 8;
+    data.remove_prefix(sizeof(uint64_t));
   }
-  // Verify the last, possibly incomplete block.
+
+  // Verify the last, possibly overlapping block.
   uint64_t block;
-  std::memcpy(&block, limit, 8);
+  std::memcpy(&block, tail.data(), sizeof(block));
   bit_or |= block;
 
   return (bit_or & ~0x0101010101010101) == 0;
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 }  // namespace internal
 }  // namespace protobuf

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -67,14 +67,14 @@ inline void WriteVarint(uint32_t num, uint64_t val, UnknownFieldSet* unknown);
 inline void WriteLengthDelimited(uint32_t num, absl::string_view val,
                                  UnknownFieldSet* unknown);
 
-// Counts the number of varints in the array, assuming that end - ptr >= 8.
+// Counts the number of varints in the array, assuming that data.size() >= 8.
 // If varints are valid only up to some point, then returns at least the number
 // of valid varints.
-int CountVarintsAssumingLargeArray(const char* ptr, const char* end);
+int CountVarintsAssumingLargeArray(absl::Span<const char> data);
 
 // Checks if each byte in the array is a valid representation for a bool, i.e.
-// 0 or 1, assuming that end - ptr >= 8. Optimized for the result being true.
-bool VerifyBoolsAssumingLargeArray(const char* ptr, const char* end);
+// 0 or 1, assuming that data.size() >= 8. Optimized for the result being true.
+bool VerifyBoolsAssumingLargeArray(absl::Span<const char> data);
 
 
 // The basic abstraction the parser is designed for is a slight modification
@@ -1573,46 +1573,58 @@ const char* EpsCopyInputStream::ReadPackedVarintArray(const char* ptr,
   return ptr;
 }
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wunsafe-buffer-usage"
+#endif
+
 template <typename Convert, typename T>
 const char* EpsCopyInputStream::ReadPackedVarintArrayWithField(
     const char* ptr, const char* end, Arena* arena, Convert conv,
     RepeatedField<T>& out) {
   ABSL_DCHECK_EQ(arena, out.GetArena());
 
-  // If we have enough bytes, we will spend more cpu cycles growing repeated
-  // field, than parsing, so count the number of ints first and preallocate.
-  // Assume that varint are valid and just count the number of bytes with
-  // continuation bit not set. In a valid varint there is only 1 such byte.
-  if (end - ptr >= 16) {
+  // The packed-field fast path does not need the parser's slop-byte overread
+  // invariant. Keep the logical payload extent attached to the pointer so all
+  // pre-scan and one-byte operations stay within the declared field.
+  const ptrdiff_t data_size = end - ptr;
+  if (data_size >= 16) {
+    const absl::Span<const char> data(ptr, static_cast<size_t>(data_size));
+
+    // If we have enough bytes, we will spend more cpu cycles growing repeated
+    // field than parsing, so count the number of ints first and preallocate.
+    // Assume that varints are valid and just count the number of bytes with
+    // continuation bit not set. In a valid varint there is only 1 such byte.
     if constexpr (std::is_same_v<T, bool> && sizeof(bool) == sizeof(uint8_t)) {
       if (absl::bit_cast<uint8_t>(false) == 0 &&  // Not constexpr on MSVC.
           absl::bit_cast<uint8_t>(true) == 1) {
-        if (VerifyBoolsAssumingLargeArray(ptr, end)) {
+        if (VerifyBoolsAssumingLargeArray(data)) {
           // Each byte is 0 or 1.
-          const int count = end - ptr;
+          const int count = static_cast<int>(data.size());
           out.ReserveWithArena(arena, internal::CheckedAdd(out.size(), count));
           T* x = out.AddNAlreadyReserved(count);
           // For T being bool, conv must be equivalent to a conversion to bool
           // (zigzag encoding is not applicable), so it can be skipped.
-          std::memcpy(x, ptr, count);
+          std::memcpy(x, data.data(), data.size());
           return end;
         }
       }
     }
-    int count = CountVarintsAssumingLargeArray(ptr, end);
-    if (count == end - ptr) {
+    int count = CountVarintsAssumingLargeArray(data);
+    if (count == static_cast<int>(data.size())) {
       // We have exactly one element per byte, so avoid the costly varint
       // parsing.
       out.ReserveWithArena(arena, internal::CheckedAdd(out.size(), count));
       T* x = out.AddNAlreadyReserved(count);
-      for (; ptr != end; ++ptr) {
-        *x = conv(static_cast<uint8_t>(*ptr));
+      for (char byte : data) {
+        *x = conv(static_cast<uint8_t>(byte));
         ++x;
       }
+      ptr = end;
     } else {
-      // We can overread, so if the last byte has a continuation bit set,
-      // we need to account for that.
-      if (end[-1] & 0x80) count++;
+      // The remaining parser intentionally uses the slop-byte invariant. The
+      // pre-scan itself remains bounded to the declared field.
+      if (static_cast<uint8_t>(data.back()) & 0x80) count++;
       int old_size = out.size();
       out.ReserveWithArena(arena, internal::CheckedAdd(old_size, count));
       T* x = out.AddNAlreadyReserved(count);
@@ -1633,6 +1645,10 @@ const char* EpsCopyInputStream::ReadPackedVarintArrayWithField(
     });
   }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 template <typename Convert, typename T>
 const char* EpsCopyInputStream::ReadPackedVarintWithField(


### PR DESCRIPTION
## Summary

Migrate the packed repeated-varint pre-scan in `parse_context` from raw pointer/end walking to `absl::Span<const char>`.

The optimized parser still retains its intentional slop-byte overread path for varint decoding. This change narrows the safe portion around it: the pre-scan, boolean fast path, one-byte iteration, and last-byte continuation check now operate on a buffer object that carries its extent.

### Changes

- change `CountVarintsAssumingLargeArray` and `VerifyBoolsAssumingLargeArray` to accept `absl::Span<const char>`
- use bounded `last()`, `remove_prefix()`, and `back()` operations instead of raw pointer walking / `end[-1]`
- keep the packed one-byte fast path inside the span instead of incrementing the input pointer
- enable `-Wunsafe-buffer-usage` as an error around the migrated regions under Clang to prevent raw-buffer regressions there
- add boundary regression coverage for lengths 8 through 24, including the overlapping final 8-byte block

This is intentionally narrow and does not change the parser's slop-buffer invariant or public API/ABI.

This is complementary to #29618's broader Safe Buffers infrastructure work, but does not depend on it.

## Testing

- Release `libprotobuf` build with GCC 14
- Clang 21 compile of `parse_context.cc` with the local `-Wunsafe-buffer-usage` gates enabled
- boundary smoke test for both pre-scan helpers across lengths 8 through 24
- 250,000 randomized old-vs-new differential cases across lengths 8 through 512 for both helpers
- optimized codegen/microbenchmark check confirming the span walk does not add a per-block bounds check in the hot loop
- focused `generated_message_tctable_lite_test.cc` object compile on latest main
