### PR TITLE
Bound slop-region parsing with spans

### DIFF
--- a/src/google/protobuf/generated_message_tctable_lite_test.cc
+++ b/src/google/protobuf/generated_message_tctable_lite_test.cc
@@ -52,6 +52,27 @@ using ::testing::Eq;
 using ::testing::Not;
 using ::testing::Optional;
 
+TEST(ParseContextSlopRegion, FragmentedZeroCopyInputMatchesFlatParse) {
+  FileDescriptorProto source;
+  auto* location = source.mutable_source_code_info()->add_location();
+  for (int i = 0; i < 32; ++i) {
+    location->add_path(i * 3);
+    location->add_span(i * 5);
+  }
+  const std::string serialized = source.SerializeAsString();
+  ASSERT_GT(serialized.size(), 32u);
+
+  for (int block_size = 1; block_size <= 32; ++block_size) {
+    io::ArrayInputStream input(serialized.data(),
+                               static_cast<int>(serialized.size()), block_size);
+    FileDescriptorProto parsed;
+    ASSERT_TRUE(parsed.ParseFromZeroCopyStream(&input))
+        << "block_size=" << block_size;
+    EXPECT_EQ(parsed.SerializeAsString(), serialized)
+        << "block_size=" << block_size;
+  }
+}
+
 // The fast parser's dispatch table Xors two bytes of incoming data with
 // the data in TcFieldData, so we reproduce that here:
 TcFieldData Xor2SerializedBytes(TcFieldData tfd, const char* ptr) {

--- a/src/google/protobuf/parse_context.cc
+++ b/src/google/protobuf/parse_context.cc
@@ -41,29 +41,55 @@ namespace protobuf {
 namespace internal {
 
 namespace {
-bool ParsingEndsInBuffer(const char* ptr, const char* end, int depth) {
-  while (ptr < end) {
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wunsafe-buffer-usage"
+#endif
+
+// Parses within a logical window while retaining the parser's physical slop
+// bytes for the low-level tag/varint decoders. `readable` describes the full
+// allocation that may be read; [begin, end) describes the logical parse window.
+bool ParsingEndsInBuffer(absl::Span<const char> readable, size_t begin,
+                         size_t end, int depth) {
+  ABSL_DCHECK_LE(begin, end);
+  ABSL_DCHECK_LE(end, readable.size());
+
+  size_t pos = begin;
+  auto update_pos = [&](const char* ptr) {
+    if (ptr == nullptr) return false;
+    const ptrdiff_t offset = ptr - readable.data();
+    if (offset < 0 || static_cast<size_t>(offset) > end) return false;
+    pos = static_cast<size_t>(offset);
+    return true;
+  };
+
+  while (pos < end) {
     uint32_t tag;
-    ptr = ReadTag(ptr, &tag);
-    if (ptr == nullptr || ptr > end) return false;
-    // ending on 0 tag is allowed and is the major reason for the necessity of
+    if (!update_pos(ReadTag(readable.subspan(pos).data(), &tag))) return false;
+    // Ending on a 0 tag is allowed and is the major reason for the necessity of
     // this function.
     if (tag == 0) return true;
     switch (tag & 7) {
       case 0: {  // Varint
         uint64_t val;
-        ptr = VarintParse(ptr, &val);
-        if (ptr == nullptr) return false;
+        if (!update_pos(VarintParse(readable.subspan(pos).data(), &val))) {
+          return false;
+        }
         break;
       }
       case 1: {  // fixed64
-        ptr += 8;
+        if (end - pos < sizeof(uint64_t)) return false;
+        pos += sizeof(uint64_t);
         break;
       }
       case 2: {  // len delim
+        const char* ptr = readable.subspan(pos).data();
         int32_t size = ReadSize(&ptr);
-        if (ptr == nullptr || size > end - ptr) return false;
-        ptr += size;
+        if (!update_pos(ptr) || size < 0 ||
+            static_cast<size_t>(size) > end - pos) {
+          return false;
+        }
+        pos += static_cast<size_t>(size);
         break;
       }
       case 3: {  // start group
@@ -75,7 +101,8 @@ bool ParsingEndsInBuffer(const char* ptr, const char* end, int depth) {
         break;
       }
       case 5: {  // fixed32
-        ptr += 4;
+        if (end - pos < sizeof(uint32_t)) return false;
+        pos += sizeof(uint32_t);
         break;
       }
       default:
@@ -84,6 +111,10 @@ bool ParsingEndsInBuffer(const char* ptr, const char* end, int depth) {
   }
   return false;
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 }  // namespace
 
 bool EpsCopyInputStream::IsRequestedLessThanOrEqualTo(int requested,
@@ -101,14 +132,12 @@ bool EpsCopyInputStream::HasEnoughTillLimit(int requested, const char* ptr) {
 }
 
 // Only call if at start of tag.
-bool EpsCopyInputStream::ParseEndsInSlopRegion(const char* begin, int overrun,
-                                               int depth) {
-  constexpr int kSlopBytes = EpsCopyInputStream::kSlopBytes;
+bool EpsCopyInputStream::ParseEndsInSlopRegion(int overrun, int depth) {
   ABSL_DCHECK_GE(overrun, 0);
   ABSL_DCHECK_LE(overrun, kSlopBytes);
-  auto ptr = begin + overrun;
-  auto end = begin + kSlopBytes;
-  return ParsingEndsInBuffer(ptr, end, depth);
+  const absl::Span<const char> readable(patch_buffer_, kPatchBufferSize);
+  return ParsingEndsInBuffer(readable, static_cast<size_t>(overrun),
+                             kSlopBytes, depth);
 }
 
 const char* EpsCopyInputStream::NextBuffer(int overrun, int depth) {
@@ -127,7 +156,7 @@ const char* EpsCopyInputStream::NextBuffer(int overrun, int depth) {
   // patch_buffer_.
   std::memmove(patch_buffer_, buffer_end_, kSlopBytes);
   if (overall_limit_ > 0 &&
-      (depth < 0 || !ParseEndsInSlopRegion(patch_buffer_, overrun, depth))) {
+      (depth < 0 || !ParseEndsInSlopRegion(overrun, depth))) {
     const void* data;
     // ZeroCopyInputStream indicates Next may return 0 size buffers. Hence
     // we loop.

--- a/src/google/protobuf/parse_context.h
+++ b/src/google/protobuf/parse_context.h
@@ -603,7 +603,7 @@ class PROTOBUF_EXPORT EpsCopyInputStream {
   const char* ReadStringFallback(const char* ptr, int size, std::string* str);
   const char* ReadArrayFallback(const char* ptr, absl::Span<char> out);
   const char* ReadCordFallback(const char* ptr, int size, absl::Cord* cord);
-  static bool ParseEndsInSlopRegion(const char* begin, int overrun, int depth);
+  bool ParseEndsInSlopRegion(int overrun, int depth);
   bool StreamNext(const void** data) {
     bool res = zcis_->Next(data, &size_);
     if (res) overall_limit_ -= size_;


### PR DESCRIPTION
## Summary

Make the parser's slop-region termination check carry its physical readable extent separately from its logical parse window.

`EpsCopyInputStream` intentionally maintains a 32-byte patch buffer so low-level tag and varint decoders can read their documented slop bytes. Previously, `ParsingEndsInBuffer()` represented only the logical boundary as raw `ptr` / `end` pointers and advanced those pointers directly for fixed-width and length-delimited fields.

This change represents the full readable allocation as `absl::Span<const char>` and tracks the logical 16-byte slop window with offsets. The optimized low-level decoders keep their existing readable-slop invariant, while cursor movement in the termination check is bounded to the logical window before advancing.

### Changes

- pass the full patch-buffer extent into `ParsingEndsInBuffer()` as an `absl::Span<const char>`
- track the logical parse position and end as offsets instead of raw cursor/end pointers
- reject fixed32/fixed64 advances before they can cross the logical window
- bound length-delimited advances before updating the cursor
- make `ParseEndsInSlopRegion()` derive the readable extent from `patch_buffer_`
- enable `-Wunsafe-buffer-usage` as an error around the migrated parsing decision logic
- add fragmented `ZeroCopyInputStream` coverage across block sizes 1 through 32

The patch does not change the parser's slop-byte strategy or the low-level tag/varint decoder contract.

## Validation

- Clang 21 compile with `-Wunsafe-buffer-usage` promoted to an error in the migrated region
- focused test source object compile on current `main`
- local old-vs-new differential harness: 6,800,000 randomized seam cases across overrun positions 0 through 16 and depths 0 through 3, with no result differences
- fragmented parser smoke test across block sizes 1 through 64: PASS
