### PR TITLE
Do not define _POSIX_C_SOURCE on the BSDs

### DIFF
--- a/src/google/protobuf/io/zero_copy_stream_impl.cc
+++ b/src/google/protobuf/io/zero_copy_stream_impl.cc
@@ -10,7 +10,13 @@
 //  Sanjay Ghemawat, Jeff Dean, and others.
 
 // We request posix_close if available. See the comment on "robust_close".
+// Not on the BSDs: there _POSIX_C_SOURCE hides everything outside POSIX,
+// including the isascii that libc++'s <locale> uses, and their libc has no
+// posix_close to request.
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && \
+    !defined(__DragonFly__)
 #define _POSIX_C_SOURCE 202405L
+#endif
 
 #ifndef _MSC_VER
 #include <fcntl.h>


### PR DESCRIPTION
zero_copy_stream_impl.cc defines _POSIX_C_SOURCE 202405L before its
includes so that posix_close is visible where a libc provides it. On
FreeBSD the same macro tells sys/cdefs.h to hide everything outside
POSIX, and the file then includes <istream>, whose libc++ <__locale>
uses isascii; that is a BSD extension, so the build stops on

    /usr/include/c++/v1/__locale:530:12: error: use of undeclared
    identifier 'isascii'

The BSD libcs have no posix_close, so the define buys nothing there.
Leave it out on the four of them.

Checked on FreeBSD 15.1 with clang 19: a three-line file that defines
the macro and includes <istream> fails as above, and the same file
without the define compiles. Then, with this change applied to the
36.0 that Bazel pins, Bazel builds from source on FreeBSD 15.1 and
OpenBSD 7.9 with nothing passed in for it; without the change, and
nothing else different, the FreeBSD build stops on this one file with
the four isascii errors.
