### PR TITLE
fix(csharp): cache extensions per descriptor

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Reflection/DescriptorsTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Reflection/DescriptorsTest.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using UnitTest.Issues.TestProtos;
 using static Google.Protobuf.Reflection.FeatureSet.Types;
 using proto2 = Google.Protobuf.TestProtos.Proto2;
@@ -28,6 +29,104 @@ namespace Google.Protobuf.Reflection
     /// </summary>
     public class DescriptorsTest
     {
+        [Test]
+        [NonParallelizable]
+        public void FileDescriptor_ConcurrentExtensionCaching()
+        {
+            var cachingEnabled = typeof(FileDescriptor).GetField(
+                "extensionCachingEnabled",
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            var originalCachingEnabled = cachingEnabled.GetValue(null);
+            try
+            {
+                // The performance test disables this process-wide cache.
+                cachingEnabled.SetValue(null, true);
+                var prefix = Guid.NewGuid().ToString("N");
+                var generatedInfo = new GeneratedClrTypeInfo(null, null, null);
+                var extensionDescriptor = UnittestCustomOptionsProto3Reflection.Descriptor;
+                var dependencies = Enumerable
+                    .Range(0, 4096)
+                    .Select(i =>
+                        FileDescriptor.FromGeneratedCode(
+                            new FileDescriptorProto
+                            {
+                                Name = $"{prefix}_{i}.proto",
+                                Dependency = { extensionDescriptor.Name },
+                            }.ToByteArray(),
+                            new[] { extensionDescriptor },
+                            generatedInfo
+                        )
+                    )
+                    .ToArray();
+
+                Parallel.For(
+                    0,
+                    dependencies.Length,
+                    i =>
+                    {
+                        // Exercise both distinct cache misses and concurrent access to shared dependencies.
+                        var fileDependencies = new[] { dependencies[i], dependencies[i / 2] }
+                            .Distinct()
+                            .ToArray();
+                        var proto = new FileDescriptorProto
+                        {
+                            Name = $"{prefix}_dependent_{i}.proto",
+                            Dependency = { fileDependencies.Select(dependency => dependency.Name) },
+                            Options = new FileOptions(),
+                        };
+                        proto.Options.SetExtension(
+                            UnittestCustomOptionsProto3Extensions.FileOpt1,
+                            (ulong)i + 1
+                        );
+                        var descriptor = FileDescriptor.FromGeneratedCode(
+                            proto.ToByteArray(),
+                            fileDependencies,
+                            generatedInfo
+                        );
+                        CollectionAssert.AreEqual(fileDependencies, descriptor.Dependencies);
+                        Assert.AreEqual(
+                            (ulong)i + 1,
+                            descriptor
+                                .GetOptions()
+                                .GetExtension(UnittestCustomOptionsProto3Extensions.FileOpt1)
+                        );
+                    }
+                );
+
+                // A different descriptor with the same name must not inherit cached extensions.
+                var unrelatedDependency = FileDescriptor.FromGeneratedCode(
+                    new FileDescriptorProto { Name = dependencies[0].Name }.ToByteArray(),
+                    Array.Empty<FileDescriptor>(),
+                    generatedInfo
+                );
+                var unrelatedProto = new FileDescriptorProto
+                {
+                    Name = $"{prefix}_unrelated.proto",
+                    Dependency = { unrelatedDependency.Name },
+                    Options = new FileOptions(),
+                };
+                unrelatedProto.Options.SetExtension(
+                    UnittestCustomOptionsProto3Extensions.FileOpt1,
+                    1UL
+                );
+                var unrelatedDescriptor = FileDescriptor.FromGeneratedCode(
+                    unrelatedProto.ToByteArray(),
+                    new[] { unrelatedDependency },
+                    generatedInfo
+                );
+                Assert.IsFalse(
+                    unrelatedDescriptor
+                        .GetOptions()
+                        .HasExtension(UnittestCustomOptionsProto3Extensions.FileOpt1)
+                );
+            }
+            finally
+            {
+                cachingEnabled.SetValue(null, originalCachingEnabled);
+            }
+        }
+
         [Test]
         public void FileDescriptor_GeneratedCode()
         {

--- a/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
@@ -68,7 +68,7 @@ namespace Google.Protobuf.Reflection
 
         private readonly Lazy<Dictionary<IDescriptor, DescriptorDeclaration>> declarations;
 
-        private static readonly Dictionary<string, List<Extension>> allDependedExtensionsCache = new();
+        private List<Extension> allDependedExtensionsCache;
         private static bool extensionCachingEnabled = true;
 
         /// <summary>
@@ -528,9 +528,13 @@ namespace Google.Protobuf.Reflection
 
         private static IEnumerable<Extension> GetAllDependedExtensions(FileDescriptor descriptor)
         {
-            if (extensionCachingEnabled && allDependedExtensionsCache.TryGetValue(descriptor.Name, out List<Extension> cachedExtensions))
+            if (extensionCachingEnabled)
             {
-                return cachedExtensions;
+                var cachedExtensions = Volatile.Read(ref descriptor.allDependedExtensionsCache);
+                if (cachedExtensions != null)
+                {
+                    return cachedExtensions;
+                }
             }
 
 #if WITH_BENCHMARKING
@@ -544,7 +548,9 @@ namespace Google.Protobuf.Reflection
 
             if (extensionCachingEnabled)
             {
-                allDependedExtensionsCache[descriptor.Name] = extensions;
+                // Publish only a complete list, which is never modified afterwards.
+                // Concurrent callers may compute the same list; reuse the first published result.
+                return Interlocked.CompareExchange(ref descriptor.allDependedExtensionsCache, extensions, null) ?? extensions;
             }
 
             return extensions;


### PR DESCRIPTION
Closes #29696.

- Cache extensions per descriptor; atomically publish completed lists to prevent concurrent corruption.
- Tests: Added a RED/GREEN UT

Synthetic retained parent/child initialisation, .NET 8 / ARM64:

| Cache | Median µs/pair | Allocated B/pair |
| --- | ---: | ---: |
| Original | 30.300 | 9,543 |
| Per-descriptor | 24.799 | 9,512 |

- [Public benchmark scripts, raw data, and limitations](https://gist.github.com/awe123343/5c0aedb2d8ee6b359abb1f588e5d3a1d).

