### PR TITLE
Add a bazel "last_green" continuous test which is currently passing.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,15 +13,12 @@ build --@rules_rust//rust/settings:experimental_use_cc_common_link=True
 # upcoming breaking changes in Bazel. This list was generated for Bazel 6 by
 # running bazelisk with the --migrate flag and filtering out all flags that
 # default to true or are deprecated.
-build --incompatible_check_sharding_support
 build --incompatible_config_setting_private_default_visibility
 build --incompatible_default_to_explicit_init_py
-build --incompatible_disable_native_android_rules
 build --incompatible_disable_starlark_host_transitions
 build --incompatible_disable_target_provider_fields
 build --incompatible_disallow_empty_glob
 build --incompatible_dont_use_javasourceinfoprovider
-build --incompatible_enable_android_toolchain_resolution
 build --incompatible_enable_apple_toolchain_resolution
 build --incompatible_exclusive_test_sandboxed
 build --incompatible_top_level_aspects_require_providers

--- a/.github/workflows/test_cpp.yml
+++ b/.github/workflows/test_cpp.yml
@@ -636,3 +636,22 @@ jobs:
           credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
           bazel-cache: cpp_linux/abseil_head
           bazel: test //src/... --override_module=abseil-cpp=abseil-cpp-head
+
+  linux-bazel-last-green:
+    name: ${{ inputs.continuous-prefix }} Linux Bazel last_green
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pending changes
+        if: ${{ inputs.continuous-run }}
+        uses: protocolbuffers/protobuf-ci/checkout@v6
+        with:
+          ref: ${{ inputs.safe-checkout }}
+      - name: Run tests
+        if: ${{ inputs.continuous-run }}
+        uses: protocolbuffers/protobuf-ci/bazel-docker@v6
+        with:
+          image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:9.2.0-4d8e80ef93b0219fb907af9dd4596b92946995d8
+          credentials: ${{ secrets.GAR_SERVICE_ACCOUNT }}
+          bazel-cache: cpp_linux/bazel_last_green
+          bash: USE_BAZEL_VERSION=last_green bazelisk test //src/... //third_party/utf8_range/... --cxxopt=-Wno-self-assign-overloaded
+


### PR DESCRIPTION
Also removed some build flags that have been removed in bazel 10 and should not have side effects to the current protobuf bazel version.