### PR TITLE
Fix the JRuby Maven build by matching jruby-complete to the version CI uses.

### DIFF
--- a/ruby/pom.xml
+++ b/ruby/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.jruby</groupId>
             <artifactId>jruby-complete</artifactId>
-            <version>9.2.20.1</version>
+            <version>9.4.9.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Problem

On JRuby, `rake compile` runs `mvn --batch-mode package` (`ruby/Rakefile`), which compiles `ruby/src/main/java` against the `jruby-complete` version pinned in `ruby/pom.xml`. That pin is still `9.2.20.1`.

Since #21733 added `typeClass.newInstance(context, value)` to `RubyMessage.setFieldInternal`, that build no longer compiles. The call needs the `RubyClass.newInstance(ThreadContext, IRubyObject)` overload, which only exists in JRuby 9.4 and later:

```
[ERROR] ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java:[1098,62]
        incompatible types: org.jruby.runtime.builtin.IRubyObject
        cannot be converted to org.jruby.runtime.Block
[INFO] BUILD FAILURE
```

## Why CI does not catch this

Every JRuby job in `.github/workflows/test_ruby.yml` runs `bazel test //ruby/...`, and `//ruby/src/main/java:protobuf_java` declares:

```python
deps = [
    "//java/core",
    "//java/util",
    "@ruby//:jars",
]
```

`@ruby//:jars` is the jars of the JRuby toolchain actually in use (9.4.9.0), not the Maven pin. So the Bazel path compiles fine while the Maven path is broken, and no job fails. The Maven path is only exercised when building the JRuby gem locally or via `rake gem:java`.

## Fix

Bump `jruby-complete` to `9.4.9.0` — the JRuby version already used throughout `.github/workflows/test_ruby.yml`.

## Verification

With unmodified sources at `42daaf634a`:

| `jruby-complete` | `mvn --batch-mode clean package` |
| --- | --- |
| `9.2.20.1` (before) | `BUILD FAILURE` at `RubyMessage.java:[1098,62]` |
| `9.4.9.0` (after) | `BUILD SUCCESS` |

Full JRuby test suite on `jruby-9.4.9.0` after the change:

```
$ cd ruby && bundle exec rake test
ok rake test: 334 runs, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)