### PR TITLE
Fix the JRuby Maven build by matching jruby-complete to the version CI uses

### DIFF
--- a/ruby/pom.xml
+++ b/ruby/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.jruby</groupId>
             <artifactId>jruby-complete</artifactId>
-            <version>9.2.20.1</version>
+            <version>9.4.9.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
On JRuby, `rake compile` runs `mvn --batch-mode package`, which compiles `ruby/src/main/java` against the `jruby-complete` version pinned in `ruby/pom.xml. That is still 9.2.20.1.

Since #21733, added `typeClass.newInstance(context, value)` to RubyMessage.setFieldInternal, the Maven build no longer compiles. That call needs the `RubyClass.newInstance(ThreadContext, IRubyObject)` overload, which only exists in JRuby 9.4 and later:

    ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java:[1098,62]
    incompatible types: org.jruby.runtime.builtin.IRubyObject cannot be
    converted to org.jruby.runtime.Block

CI does not catch this because CI uses 9.4.
This commit bump jruby-complete to 9.4.9.0, the JRuby version already used throughout `.github/workflows/test_ruby.yml`.