### PR TITLE
use zval_ptr_dtor_nogc instead of its alias zval_dtor

### DIFF
--- a/php/ext/google/protobuf/map.c
+++ b/php/ext/google/protobuf/map.c
@@ -191,7 +191,7 @@ upb_Map* MapField_GetUpbMap(zval* val, MapField_Type type, upb_Arena* arena) {
 
       upb_Map_Set(map, upb_key, upb_val, arena);
       zend_hash_move_forward_ex(table, &pos);
-      zval_dtor(&php_key);
+      zval_ptr_dtor_nogc(&php_key);
     }
   } else if (Z_TYPE_P(val) == IS_OBJECT &&
              Z_OBJCE_P(val) == MapField_class_entry) {

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -1260,7 +1260,7 @@ PHP_METHOD(google_protobuf_Any, unpack) {
                  upb_MessageDef_MiniTable(desc->msgdef), NULL, 0,
                  Arena_Get(&msg->arena)) != kUpb_DecodeStatus_Ok) {
     zend_throw_exception_ex(NULL, 0, "Error occurred during parsing");
-    zval_dtor(&ret);
+    zval_ptr_dtor_nogc(&ret);
     return;
   }
 
@@ -1365,8 +1365,8 @@ PHP_METHOD(google_protobuf_Timestamp, fromDateTime) {
       return;
     }
 
-    zval_dtor(&retval);
-    zval_dtor(&function_name);
+    zval_ptr_dtor_nogc(&retval);
+    zval_ptr_dtor_nogc(&function_name);
   }
 
   upb_MessageValue timestamp_nanos;
@@ -1393,9 +1393,9 @@ PHP_METHOD(google_protobuf_Timestamp, fromDateTime) {
 
     timestamp_nanos.int32_val *= 1000;
 
-    zval_dtor(&retval);
-    zval_dtor(&function_name);
-    zval_dtor(&format_string);
+    zval_ptr_dtor_nogc(&retval);
+    zval_ptr_dtor_nogc(&function_name);
+    zval_ptr_dtor_nogc(&format_string);
   }
 
   Message_setval(intern, "seconds", timestamp_seconds);
@@ -1435,9 +1435,9 @@ PHP_METHOD(google_protobuf_Timestamp, toDateTime) {
     return;
   }
 
-  zval_dtor(&function_name);
-  zval_dtor(&format_string);
-  zval_dtor(&formatted_time_php);
+  zval_ptr_dtor_nogc(&function_name);
+  zval_ptr_dtor_nogc(&format_string);
+  zval_ptr_dtor_nogc(&formatted_time_php);
 
   ZVAL_OBJ(return_value, Z_OBJ(datetime));
 }


### PR DESCRIPTION
Needed for PHP 8.6.0beta3

```
  . The zval_dtor() alias of zval_ptr_dtor_nogc() has been removed.
    Call zval_ptr_dtor_nogc() directly instead.

```

`zval_ptr_dtor_nogc` exists since PHP 7.0