### PR TITLE
[Ruby FFI] Fix Map#merge private method calls on peer instances

### DIFF
--- a/ruby/lib/google/protobuf/ffi/map.rb
+++ b/ruby/lib/google/protobuf/ffi/map.rb
@@ -337,7 +337,7 @@ module Google
             Google::Protobuf::FFI.map_set(@map_ptr, key_message_value, value_message_value, arena)
           end
         when Google::Protobuf::Map
-          unless key_type == other.send(:key_type) and value_type == other.send(:value_type) and descriptor == other.descriptor
+          unless key_type == other.send(:key_type) and value_type == other.send(:value_type) and descriptor == other.send(:descriptor)
             raise ArgumentError.new "Attempt to merge Map with mismatching types" #TODO Improve error message by adding type information
           end
           arena.fuse(other.send(:arena))
@@ -353,7 +353,7 @@ module Google
       end
 
       def internal_merge(other)
-        internal_dup.internal_merge_into_self(other)
+        internal_dup.send(:internal_merge_into_self, other)
       end
 
       def initialize(key_type, value_type, value_type_class: nil, initial_values: nil, arena: nil, map: nil, descriptor: nil, name: nil)

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -498,6 +498,55 @@ module CommonTests
     assert_nil m_msg.delete("a")
   end
 
+  def test_map_merge
+    m = Google::Protobuf::Map.new(:string, :int32)
+    m["asdf"] = 1
+    m["jkl;"] = 42
+
+    # Merging with a Hash
+    merged = m.merge({ "asdf" => 10, "new" => 100 })
+    assert_equal({ "asdf" => 1, "jkl;" => 42 }, m.to_h)
+    assert_equal({ "asdf" => 10, "jkl;" => 42, "new" => 100 }, merged.to_h)
+
+    # Merging with a compatible Map
+    m2 = Google::Protobuf::Map.new(:string, :int32)
+    m2["asdf"] = 20
+    m2["other"] = 200
+    merged2 = m.merge(m2)
+    assert_equal({ "asdf" => 1, "jkl;" => 42 }, m.to_h)
+    assert_equal({ "asdf" => 20, "other" => 200 }, m2.to_h)
+    assert_equal({ "asdf" => 20, "jkl;" => 42, "other" => 200 }, merged2.to_h)
+
+    # Merging compatible Map with message value type
+    msg1 = proto_module::TestMessage.new(:optional_int32 => 1)
+    msg2 = proto_module::TestMessage.new(:optional_int32 => 2)
+    m_msg1 = Google::Protobuf::Map.new(:string, :message, proto_module::TestMessage, { "a" => msg1 })
+    m_msg2 = Google::Protobuf::Map.new(:string, :message, proto_module::TestMessage, { "b" => msg2 })
+    merged_msg = m_msg1.merge(m_msg2)
+    assert_equal 1, m_msg1.length
+    assert_equal 1, m_msg2.length
+    assert_equal 2, merged_msg.length
+    assert_equal msg1, merged_msg["a"]
+    assert_equal msg2, merged_msg["b"]
+
+    # Merging with a mismatched Map raises ArgumentError
+    m_mismatch = Google::Protobuf::Map.new(:string, :string)
+    assert_raises ArgumentError do
+      m.merge(m_mismatch)
+    end
+
+    # Merging with mismatched message descriptor raises ArgumentError
+    m_msg_mismatch = Google::Protobuf::Map.new(:string, :message, proto_module::TestMessage2)
+    assert_raises ArgumentError do
+      m_msg1.merge(m_msg_mismatch)
+    end
+
+    # Merging with an invalid type raises ArgumentError
+    assert_raises ArgumentError do
+      m.merge(42)
+    end
+  end
+
   # This is a regression test for a bug in Map.hash. It used to return an
   # inconsistent result when there was a collision in the map (two keys mapping
   # to the same hash table entry).


### PR DESCRIPTION
### Summary

In the FFI implementation of \Google::Protobuf::Map#merge\, calling private methods with explicit receivers raised \NoMethodError\:
- When merging with a \Map\, \other.descriptor\ attempted to call the private \descriptor\ reader on \other\.
- When merging with either \Hash\ or \Map\, \internal_dup.internal_merge_into_self(other)\ called the private \internal_merge_into_self\ method on \internal_dup\.

### Fix

This patch aligns with the existing reflective access conventions in \Google::Protobuf::Map\ by:
1. Accessing \other.send(:descriptor)\ instead of \other.descriptor\.
2. Calling \internal_dup.send(:internal_merge_into_self, other)\ instead of \internal_dup.internal_merge_into_self(other)\.
3. Adding comprehensive test coverage in \uby/tests/common_tests.rb\ to verify merging with \Hash\ and \Map\, result immutability of inputs, compatible message value types, and expected \ArgumentError\ upon type or message descriptor mismatches.

Fixes #29520.