### PR TITLE
[Ruby] Return Enumerator when RepeatedField#each is called without a block

### DIFF
--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -93,6 +93,12 @@ module Google
         self.size == 0
       end
 
+      alias_method :raw_each, :each
+      def each(&block)
+        return enum_for(:each) { size } unless block_given?
+        raw_each(&block)
+      end
+
       # array aliases into enumerable
       alias_method :slice, :[]
       alias_method :values_at, :select

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -147,6 +147,16 @@ class RepeatedFieldTest < Test::Unit::TestCase
     assert_equal 5, count
     result = m.repeated_string.each{|val| val + '_junk'}
     assert_equal ['string'] * 5, result
+
+    enum = m.repeated_string.each
+    assert_instance_of Enumerator, enum
+    assert_equal 5, enum.size
+    assert_equal ['string'] * 5, enum.to_a
+
+    empty_enum = TestMessage.new.repeated_string.each
+    assert_instance_of Enumerator, empty_enum
+    assert_equal 0, empty_enum.size
+    assert_equal [], empty_enum.to_a
   end
 
 


### PR DESCRIPTION
### Summary

Calling \Google::Protobuf::RepeatedField#each\ without a block previously raised \LocalJumpError\ (no block given (yield)) in both native C extension and FFI implementations. This behavior is inconsistent with standard Ruby \Enumerable\ and \Array#each\ conventions where blockless calls return an \Enumerator\.

### Fix

This patch wraps \#each\ in \Google::Protobuf::RepeatedField\ (\uby/lib/google/protobuf/repeated_field.rb\) so that:
1. Calling \#each\ without a block returns a sized \Enumerator\ via \enum_for(:each) { size }\.
2. Calling \#each\ with a block continues to delegate directly to the underlying native/FFI implementation (\aw_each\) and returns \self\.
3. Adds unit test coverage in \uby/tests/repeated_field_test.rb\ verifying \Enumerator\ instance, size, and element array conversion for both non-empty and empty repeated fields.

Fixes #29521.