### PR TITLE
[Ruby] Fix blockless RepeatedField mutators returning corrupting proxy enumerators

### DIFF
--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -115,24 +115,16 @@ module Google
         def define_array_wrapper_with_result_method(method_name)
           define_method(method_name) do |*args, &block|
             # result can be an Enumerator, Array, or nil
-            # Enumerator can sometimes be returned if a block is an optional argument and it is not passed in
+            # Enumerator is returned if a block is an optional argument and it is not passed in
             # nil usually specifies that no change was made
             result = self.to_a.send(method_name, *args, &block)
+            return enum_for(method_name, *args) { self.size } if result.is_a?(Enumerator)
             if result
-              new_arr = result.to_a
-              self.replace(new_arr)
-              if result.is_a?(Enumerator)
-                # generate a fresh enum; rewinding the exiting one, in Ruby 2.2, will
-                # reset the enum with the same length, but all the #next calls will
-                # return nil
-                result = new_arr.to_enum
-                # generate a wrapper enum so any changes which occur by a chained
-                # enum can be captured
-                ie = ProxyingEnumerator.new(self, result)
-                result = ie.to_enum
-              end
+              self.replace(result)
+              self
+            else
+              nil
             end
-            result
           end
         end
         private :define_array_wrapper_with_result_method
@@ -144,32 +136,11 @@ module Google
       end
 
 
-      %w(collect! compact! delete_if each_index fill flatten! insert reverse!
-        rotate! select! shuffle! sort! sort_by! uniq!).each do |method_name|
+      %w(collect! compact! delete_if each_index fill flatten! insert keep_if
+        reject! reverse! rotate! select! shuffle! sort! sort_by! uniq!).each do |method_name|
         define_array_wrapper_with_result_method(method_name)
       end
-      alias_method :keep_if, :select!
       alias_method :map!, :collect!
-      alias_method :reject!, :delete_if
-
-
-      # propagates changes made by user of enumerator back to the original repeated field.
-      # This only applies in cases where the calling function which created the enumerator,
-      # such as #sort!, modifies itself rather than a new array, such as #sort
-      class ProxyingEnumerator < Struct.new(:repeated_field, :external_enumerator)
-        def each(*args, &block)
-          results = []
-          external_enumerator.each_with_index do |val, i|
-            result = yield(val)
-            results << result
-            #nil means no change occurred from yield; usually occurs when #to_a is called
-            if result
-              repeated_field[i] = result if result != val
-            end
-          end
-          results
-        end
-      end
 
 
     end

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -577,6 +577,92 @@ class RepeatedFieldTest < Test::Unit::TestCase
     assert_equal m.repeated_string, result
   end
 
+  def test_blockless_mutators
+    m = TestMessage.new
+    m.repeated_int32 += [1, 2, 3, 4, 5]
+
+    # delete_if without block returns Enumerator; executing each deletes matching elements
+    enum = m.repeated_int32.delete_if
+    assert_instance_of Enumerator, enum
+    assert_equal 5, enum.size
+    assert_equal [1, 2, 3, 4, 5], m.repeated_int32.to_a
+    result = enum.each { |v| v.even? }
+    assert_equal [1, 3, 5], m.repeated_int32.to_a
+    assert_same m.repeated_int32, result
+
+    # select! without block returns Enumerator; returns self when modified, nil when unchanged
+    m.repeated_int32.clear
+    m.repeated_int32 += [1, 2, 3, 4]
+    enum = m.repeated_int32.select!
+    assert_instance_of Enumerator, enum
+    assert_equal 4, enum.size
+    result = enum.each { |v| v > 2 }
+    assert_equal [3, 4], m.repeated_int32.to_a
+    assert_same m.repeated_int32, result
+
+    # select! without changes returns nil
+    enum = m.repeated_int32.select!
+    result = enum.each { |v| v > 0 }
+    assert_equal [3, 4], m.repeated_int32.to_a
+    assert_nil result
+
+    # reject! without block returns Enumerator; returns self when modified, nil when unchanged
+    m.repeated_int32.clear
+    m.repeated_int32 += [1, 2, 3, 4]
+    enum = m.repeated_int32.reject!
+    assert_instance_of Enumerator, enum
+    assert_equal 4, enum.size
+    result = enum.each { |v| v.even? }
+    assert_equal [1, 3], m.repeated_int32.to_a
+    assert_same m.repeated_int32, result
+
+    enum = m.repeated_int32.reject!
+    result = enum.each { |v| v.even? }
+    assert_equal [1, 3], m.repeated_int32.to_a
+    assert_nil result
+
+    # keep_if without block returns Enumerator; always returns self
+    m.repeated_int32.clear
+    m.repeated_int32 += [1, 2, 3, 4]
+    enum = m.repeated_int32.keep_if
+    assert_instance_of Enumerator, enum
+    assert_equal 4, enum.size
+    result = enum.each { |v| v.odd? }
+    assert_equal [1, 3], m.repeated_int32.to_a
+    assert_same m.repeated_int32, result
+
+    # collect! / map! without block returns Enumerator
+    m.repeated_int32.clear
+    m.repeated_int32 += [1, 2, 3]
+    enum = m.repeated_int32.collect!
+    assert_instance_of Enumerator, enum
+    assert_equal 3, enum.size
+    result = enum.each { |v| v * 10 }
+    assert_equal [10, 20, 30], m.repeated_int32.to_a
+    assert_same m.repeated_int32, result
+
+    # sort_by! without block returns Enumerator
+    m.repeated_int32.clear
+    m.repeated_int32 += [1, 2, 3]
+    enum = m.repeated_int32.sort_by!
+    assert_instance_of Enumerator, enum
+    assert_equal 3, enum.size
+    result = enum.each { |v| -v }
+    assert_equal [3, 2, 1], m.repeated_int32.to_a
+    assert_same m.repeated_int32, result
+
+    # each_index without block returns Enumerator
+    m.repeated_int32.clear
+    m.repeated_int32 += [10, 20, 30]
+    enum = m.repeated_int32.each_index
+    assert_instance_of Enumerator, enum
+    assert_equal 3, enum.size
+    indices = []
+    result = enum.each { |i| indices << i }
+    assert_equal [0, 1, 2], indices
+    assert_same m.repeated_int32, result
+  end
+
   def test_subarray_len_exceeds_size
   # Regression: RepeatedField#[beg, len] with len > size used to read past
   # the end of the underlying upb_Array buffer, returning adjacent arena


### PR DESCRIPTION
### Summary

Blockless `Google::Protobuf::RepeatedField` mutators such as `delete_if`, `select!`, `reject!`, `keep_if`, `collect!`, `sort_by!`, and `each_index` previously returned `ProxyingEnumerator`.

`ProxyingEnumerator#each` attempted to assign the block's predicate/transform result directly into field slots via `repeated_field[i] = result if result != val`. For predicate methods like `delete_if` and `select!`, this caused booleans (`true`/`false`) to be assigned directly into field elements, resulting in:
1. `TypeError` exceptions on typed non-boolean fields (such as `int32`, `string`, or sub-message fields).
2. Field corruption on boolean fields instead of deleting/filtering matching elements.
3. Divergence from Ruby `Array` receiver/nil return semantics.

### Fix

This patch:
1. Updates `define_array_wrapper_with_result_method` in `ruby/lib/google/protobuf/repeated_field.rb` to return `enum_for(method_name, *args) { self.size }` when called without a block, without prematurely mutating `self`.
2. When the returned `Enumerator` is subsequently iterated with a block, `enum_for` re-invokes the mutator on `RepeatedField` with the block, correctly modifying `self` and returning `self` (or `nil` if no change occurred, matching the Ruby `Array` contract).
3. Defines `keep_if` and `reject!` directly via `define_array_wrapper_with_result_method` so they delegate to native `Array#keep_if` and `Array#reject!` rather than aliasing to `select!` and `delete_if`.
4. Removes the broken and obsolete 14-line `ProxyingEnumerator` class.
5. Adds regression tests in `ruby/tests/repeated_field_test.rb` covering blockless invocation of `delete_if`, `select!`, `reject!`, `keep_if`, `collect!`, `sort_by!`, and `each_index`.

Fixes #29517.
