### PR TITLE
[Ruby] Fix source_code_uri in gemspec using nonexistent v4.x tags

### DIFF
--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -1,7 +1,9 @@
 Gem::Specification.new do |s|
   s.name        = "google-protobuf"
   s.version     = "4.37.0"
-  git_tag       = "v#{s.version.to_s.sub('.rc.', '-rc')}" # Converts X.Y.Z.rc.N to vX.Y.Z-rcN, used for the git tag
+  # Ruby gem versions carry a "4." major prefix (e.g. 4.37.0) while repository tags
+  # follow protoc versions (e.g. v37.0 or v37.0-rc1).
+  git_tag       = "v#{s.version.to_s.sub(/^4\./, '').sub('.rc.', '-rc')}" # Converts 4.X.Y.rc.N to vX.Y-rcN, used for the git tag
   s.licenses    = ["BSD-3-Clause"]
   s.summary     = "Protocol Buffers"
   s.description = "Protocol Buffers are Google's data interchange format."

--- a/ruby/tests/ruby_version.rb
+++ b/ruby/tests/ruby_version.rb
@@ -30,4 +30,30 @@ class RubyVersionTest < Test::Unit::TestCase
     assert actual.start_with?(expected), "Version #{actual} found, expecting #{expected}"
   end
 
+  def test_gemspec_source_code_uri_tag_pattern
+    # Ruby gem versions carry a "4." major prefix (e.g. 4.37.0) while repository
+    # tags follow protoc versions (e.g. v37.0 or v37.0-rc1).
+    to_git_tag = ->(ver) { "v#{ver.to_s.sub(/^4\./, '').sub('.rc.', '-rc')}" }
+
+    assert_equal "v37.0", to_git_tag.call("4.37.0")
+    assert_equal "v36.1", to_git_tag.call("4.36.1")
+    assert_equal "v36.0", to_git_tag.call("4.36.0")
+    assert_equal "v36.0-rc1", to_git_tag.call("4.36.0.rc.1")
+    assert_equal "v36.0-rc2", to_git_tag.call("4.36.0.rc.2")
+  end
+
+  def test_gemspec_source_code_uri
+    gemspec_candidates = [
+      "ruby/google-protobuf.gemspec",
+      "google-protobuf.gemspec",
+      File.expand_path("../../google-protobuf.gemspec", __FILE__)
+    ]
+    gemspec = gemspec_candidates.find { |f| File.file?(f) }
+    return unless gemspec
+
+    content = File.read(gemspec)
+    assert_no_match(/"v#\{s\.version\.to_s\.sub\('\.rc\.', '-rc'\)\}"/, content)
+    assert_match(/git_tag\s*=\s*"v#\{s\.version\.to_s\.sub\(\/\^4\\\.\/, ''\)\.sub\('\.rc\.', '-rc'\)\}"/, content)
+  end
+
 end


### PR DESCRIPTION
Closes #29519.

### Problem

The Ruby gemspec derives `source_code_uri` metadata as:
```ruby
git_tag = "v#{s.version.to_s.sub('.rc.', '-rc')}"
s.metadata = { "source_code_uri" => "https://github.com/protocolbuffers/protobuf/tree/#{git_tag}/ruby" }
```

However, Ruby gem versions carry a `4.` major version prefix (e.g., `4.36.0`, `4.36.1`, `4.37.0`), while repository release tags omit the gem major prefix and follow protoc versioning (e.g., `v36.0`, `v36.1`, `v37.0`, and RC tags like `v36.0-rc1`).

As a result, on RubyGems (https://rubygems.org/gems/google-protobuf), the `Source Code` link for published versions (e.g. 4.36.1) points to `https://github.com/protocolbuffers/protobuf/tree/v4.36.1/ruby`, which returns HTTP 404 because `v4.36.1` does not exist in the repository (the actual tag is `v36.1`).

### Solution

- Update `git_tag` in `ruby/google-protobuf.gemspec` to strip the `4.` prefix:
  ```ruby
  # Ruby gem versions carry a "4." major prefix (e.g. 4.37.0) while repository tags
  # follow protoc versions (e.g. v37.0 or v37.0-rc1).
  git_tag = "v#{s.version.to_s.sub(/^4\./, '').sub('.rc.', '-rc')}"
  ```
- Add unit tests in `ruby/tests/ruby_version.rb` verifying the tag derivation pattern across release versions (`4.36.0` -> `v36.0`, `4.36.1` -> `v36.1`, `4.37.0` -> `v37.0`) and release candidate versions (`4.36.0.rc.1` -> `v36.0-rc1`, `4.36.0.rc.2` -> `v36.0-rc2`), as well as checking the gemspec metadata content when available.
