### PR TITLE
[Ruby] Materialize message class on demand in Descriptor_DefToClass and decode_options

### DIFF
--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -25,6 +25,7 @@ static VALUE get_oneofdef_obj(VALUE descriptor_pool, const upb_OneofDef* def);
 static VALUE get_servicedef_obj(VALUE descriptor_pool,
                                 const upb_ServiceDef* def);
 static VALUE get_methoddef_obj(VALUE descriptor_pool, const upb_MethodDef* def);
+static VALUE Descriptor_msgclass(VALUE _self);
 
 // A distinct object that is not accessible from Ruby.  We use this as a
 // constructor argument to enforce that certain objects cannot be created from
@@ -288,9 +289,8 @@ static VALUE decode_options(VALUE self, const char* option_type, int size,
   }
 
   VALUE desc_rb = get_msgdef_obj(descriptor_pool, msgdef);
-  const Descriptor* desc = ruby_to_Descriptor(desc_rb);
-
-  options_rb = Message_decode_bytes(size, bytes, 0, desc->klass, false);
+  options_rb =
+      Message_decode_bytes(size, bytes, 0, Descriptor_msgclass(desc_rb), false);
 
   // Strip features from the options proto to keep it internal.
   const upb_MessageDef* decoded_desc = NULL;
@@ -2115,8 +2115,7 @@ VALUE Descriptor_DefToClass(const upb_MessageDef* m) {
   VALUE pool = ObjectCache_Get(symtab);
   PBRUBY_ASSERT(pool != Qnil);
   VALUE desc_rb = get_msgdef_obj(pool, m);
-  const Descriptor* desc = ruby_to_Descriptor(desc_rb);
-  return desc->klass;
+  return Descriptor_msgclass(desc_rb);
 }
 
 const upb_MessageDef* Descriptor_GetMsgDef(VALUE desc_rb) {

--- a/ruby/tests/service_test.rb
+++ b/ruby/tests/service_test.rb
@@ -41,6 +41,20 @@ class ServiceTest < Test::Unit::TestCase
     assert_equal 8325, extension_field.get(@test_service.options).int_option_value
   end
 
+  def test_service_options_extensions_in_rebuilt_pool
+    omit "JRuby and FFI do not support service options extensions" if defined?(JRUBY_VERSION) || Google::Protobuf::IMPLEMENTATION != :NATIVE
+    pool = Google::Protobuf::DescriptorPool.new
+    descriptor_proto_bytes = Google::Protobuf::FileDescriptorProto.descriptor.file_descriptor.to_proto.to_proto
+    pool.add_serialized_file(descriptor_proto_bytes)
+
+    service_proto_bytes = @test_service.file_descriptor.to_proto.to_proto
+    pool.add_serialized_file(service_proto_bytes)
+
+    service_desc = pool.lookup(@test_service.name)
+    extension_field = pool.lookup('service_test_protos.test_options')
+    assert_equal 8325, extension_field.get(service_desc.options).int_option_value
+  end
+
   def test_service_to_proto
     assert_instance_of Google::Protobuf::ServiceDescriptorProto, @test_service.to_proto
   end


### PR DESCRIPTION
### Summary of Changes

When reading message-typed custom options or submessages from a `Google::Protobuf::DescriptorPool` rebuilt dynamically from serialized `FileDescriptorProto`s (such as in a protoc plugin receiving a `CodeGeneratorRequest` or arbitrary dynamic pools), calling `field_descriptor.get(options)` raises:

```text
TypeError: wrong argument type nil (expected Google::Protobuf::Descriptor)
```

#### Root Cause
1. In `ruby/ext/google/protobuf_c/defs.c`, `Descriptor_DefToClass(const upb_MessageDef* m)` retrieves the `Descriptor` Ruby wrapper object `desc_rb` via `get_msgdef_obj(pool, m)` and then directly returns `desc->klass`.
2. In `DescriptorPool.generated_pool`, Ruby classes are created when generated `*_pb.rb` files are loaded via `.msgclass`. However, in a rebuilt or dynamic `DescriptorPool` created via `add_serialized_file`, `.msgclass` has not been invoked on every submessage or option message type, leaving `desc->klass == Qnil`.
3. Consequently, `Descriptor_DefToClass` returns `Qnil`. When `Message_alloc(klass)` runs in `Message_GetRubyWrapper`, it attempts `Descriptor_GetMsgDef(rb_ivar_get(Qnil, ...))` which invokes `ruby_to_Descriptor(Qnil)` and raises `TypeError: wrong argument type nil (expected Google::Protobuf::Descriptor)`.
4. Similarly, `decode_options` passed `desc->klass` directly to `Message_decode_bytes` without ensuring that the options message class had been materialized.

#### Solution
- Forward-declare `static VALUE Descriptor_msgclass(VALUE _self);`.
- In `decode_options`, replace `desc->klass` with `Descriptor_msgclass(desc_rb)` when calling `Message_decode_bytes`.
- In `Descriptor_DefToClass`, replace `return desc->klass;` with `return Descriptor_msgclass(desc_rb);`.
- This ensures that whenever a Ruby class for a message type is needed, `Descriptor_msgclass` lazily constructs it via `build_class_from_descriptor`, caches it in `self->klass`, and returns the valid class.
- Added unit test `test_service_options_extensions_in_rebuilt_pool` in `ruby/tests/service_test.rb` verifying that message-typed options in a rebuilt `DescriptorPool` can be read and decoded correctly.

Closes #28390.
