### PR TITLE
Ruby: Add `emit_defaults` option to `Message#to_h`

### DIFF
--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -112,7 +112,7 @@ static upb_Map* Map_GetMutable(VALUE _self) {
 }
 
 VALUE Map_CreateHash(const upb_Map* map, upb_CType key_type,
-                     TypeInfo val_info) {
+                     TypeInfo val_info, bool emit_defaults) {
   VALUE hash = rb_hash_new();
   TypeInfo key_info = TypeInfo_from_type(key_type);
 
@@ -122,7 +122,7 @@ VALUE Map_CreateHash(const upb_Map* map, upb_CType key_type,
   upb_MessageValue key, val;
   while (upb_Map_Next(map, &key, &val, &iter)) {
     VALUE key_val = Convert_UpbToRuby(key, key_info, Qnil);
-    VALUE val_val = Scalar_CreateHash(val, val_info);
+    VALUE val_val = Scalar_CreateHash(val, val_info, emit_defaults);
     rb_hash_aset(hash, key_val, val_val);
   }
 
@@ -719,7 +719,8 @@ VALUE Map_hash(VALUE _self) {
  */
 VALUE Map_to_h(VALUE _self) {
   Map* self = ruby_to_Map(_self);
-  return Map_CreateHash(self->map, self->key_type, self->value_type_info);
+  return Map_CreateHash(self->map, self->key_type, self->value_type_info,
+                        false);
 }
 
 /*

--- a/ruby/ext/google/protobuf_c/map.h
+++ b/ruby/ext/google/protobuf_c/map.h
@@ -31,7 +31,8 @@ void Map_Inspect(StringBuilder* b, const upb_Map* map, upb_CType key_type,
                  TypeInfo val_type);
 
 // Returns a new Hash object containing the contents of this Map.
-VALUE Map_CreateHash(const upb_Map* map, upb_CType key_type, TypeInfo val_info);
+VALUE Map_CreateHash(const upb_Map* map, upb_CType key_type, TypeInfo val_info,
+                     bool emit_defaults);
 
 // Returns a deep copy of this Map object.
 VALUE Map_deep_copy(VALUE obj);

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -801,13 +801,14 @@ static VALUE Message_inspect(VALUE _self) {
 // Support functions for Message_to_h //////////////////////////////////////////
 
 static VALUE RepeatedField_CreateArray(const upb_Array* arr,
-                                       TypeInfo type_info) {
+                                       TypeInfo type_info,
+                                       bool emit_defaults) {
   int size = arr ? upb_Array_Size(arr) : 0;
   VALUE ary = rb_ary_new2(size);
 
   for (int i = 0; i < size; i++) {
     upb_MessageValue msgval = upb_Array_Get(arr, i);
-    VALUE val = Scalar_CreateHash(msgval, type_info);
+    VALUE val = Scalar_CreateHash(msgval, type_info, emit_defaults);
     rb_ary_push(ary, val);
   }
 
@@ -815,10 +816,50 @@ static VALUE RepeatedField_CreateArray(const upb_Array* arr,
 }
 
 static VALUE Message_CreateHash(const upb_Message* msg,
-                                const upb_MessageDef* m) {
+                                const upb_MessageDef* m,
+                                bool emit_defaults) {
   if (!msg) return Qnil;
 
   VALUE hash = rb_hash_new();
+
+  if (emit_defaults) {
+    int n = upb_MessageDef_FieldCount(m);
+
+    for (int i = 0; i < n; i++) {
+      const upb_FieldDef* field = upb_MessageDef_Field(m, i);
+
+      if (upb_FieldDef_HasPresence(field) &&
+          !upb_Message_HasFieldByDef(msg, field)) {
+        continue;
+      }
+
+      TypeInfo type_info = TypeInfo_get(field);
+      upb_MessageValue val = upb_Message_GetFieldByDef(msg, field);
+      VALUE msg_value;
+
+      if (upb_FieldDef_IsMap(field)) {
+        const upb_MessageDef* entry_m = upb_FieldDef_MessageSubDef(field);
+        const upb_FieldDef* key_f =
+            upb_MessageDef_FindFieldByNumber(entry_m, 1);
+        const upb_FieldDef* val_f =
+            upb_MessageDef_FindFieldByNumber(entry_m, 2);
+        upb_CType key_type = upb_FieldDef_CType(key_f);
+        msg_value = Map_CreateHash(val.map_val, key_type,
+                                   TypeInfo_get(val_f), emit_defaults);
+      } else if (upb_FieldDef_IsRepeated(field)) {
+        msg_value =
+            RepeatedField_CreateArray(val.array_val, type_info, emit_defaults);
+      } else {
+        msg_value = Scalar_CreateHash(val, type_info, emit_defaults);
+      }
+
+      VALUE msg_key = ID2SYM(rb_intern(upb_FieldDef_Name(field)));
+      rb_hash_aset(hash, msg_key, msg_value);
+    }
+
+    return hash;
+  }
+
   size_t iter = kUpb_Message_Begin;
   const upb_DefPool* pool = upb_FileDef_Pool(upb_MessageDef_File(m));
   const upb_FieldDef* field;
@@ -839,11 +880,13 @@ static VALUE Message_CreateHash(const upb_Message* msg,
       const upb_FieldDef* key_f = upb_MessageDef_FindFieldByNumber(entry_m, 1);
       const upb_FieldDef* val_f = upb_MessageDef_FindFieldByNumber(entry_m, 2);
       upb_CType key_type = upb_FieldDef_CType(key_f);
-      msg_value = Map_CreateHash(val.map_val, key_type, TypeInfo_get(val_f));
+      msg_value = Map_CreateHash(val.map_val, key_type, TypeInfo_get(val_f),
+                                 emit_defaults);
     } else if (upb_FieldDef_IsRepeated(field)) {
-      msg_value = RepeatedField_CreateArray(val.array_val, type_info);
+      msg_value =
+          RepeatedField_CreateArray(val.array_val, type_info, emit_defaults);
     } else {
-      msg_value = Scalar_CreateHash(val, type_info);
+      msg_value = Scalar_CreateHash(val, type_info, emit_defaults);
     }
 
     VALUE msg_key = ID2SYM(rb_intern(upb_FieldDef_Name(field)));
@@ -853,9 +896,11 @@ static VALUE Message_CreateHash(const upb_Message* msg,
   return hash;
 }
 
-VALUE Scalar_CreateHash(upb_MessageValue msgval, TypeInfo type_info) {
+VALUE Scalar_CreateHash(upb_MessageValue msgval, TypeInfo type_info,
+                        bool emit_defaults) {
   if (type_info.type == kUpb_CType_Message) {
-    return Message_CreateHash(msgval.msg_val, type_info.def.msgdef);
+    return Message_CreateHash(msgval.msg_val, type_info.def.msgdef,
+                              emit_defaults);
   } else {
     return Convert_UpbToRuby(msgval, type_info, Qnil);
   }
@@ -866,11 +911,37 @@ VALUE Scalar_CreateHash(upb_MessageValue msgval, TypeInfo type_info) {
  *
  * Returns the message as a Ruby Hash object, with keys as symbols.
  *
+ * When +emit_defaults+ is true, fields that have no presence (implicit
+ * presence scalars and enums, and empty repeated fields / maps) are also
+ * emitted. Fields that do have presence are still emitted only when they are
+ * actually set.
+ *
+ * This matches the field selection used by #inspect and by .encode_json with
+ * the +emit_defaults+ option.
+ *
+ * @param kwargs [Hash]
+ * @option emit_defaults [Boolean] set true to also emit fields without
+ * presence (default is to omit them)
  * @return [Hash]
  */
-static VALUE Message_to_h(VALUE _self) {
+static VALUE Message_to_h(int argc, VALUE* argv, VALUE _self) {
   Message* self = ruby_to_Message(_self);
-  return Message_CreateHash(self->msg, self->msgdef);
+  VALUE kwargs = Qnil;
+  bool emit_defaults = false;
+
+  rb_scan_args_kw(RB_SCAN_ARGS_PASS_CALLED_KEYWORDS, argc, argv, ":", &kwargs);
+
+  if (!NIL_P(kwargs)) {
+    ID keyword_ids[1];
+    VALUE values[1];
+    keyword_ids[0] = rb_intern("emit_defaults");
+    rb_get_kwargs(kwargs, keyword_ids, 0, 1, values);
+    if (values[0] != Qundef) {
+      emit_defaults = RTEST(values[0]);
+    }
+  }
+
+  return Message_CreateHash(self->msg, self->msgdef, emit_defaults);
 }
 
 /*
@@ -1521,7 +1592,7 @@ static void Message_define_class(VALUE klass) {
   rb_define_method(klass, "freeze", Message_freeze, 0);
   rb_define_method(klass, "frozen?", Message_frozen, 0);
   rb_define_method(klass, "hash", Message_hash, 0);
-  rb_define_method(klass, "to_h", Message_to_h, 0);
+  rb_define_method(klass, "to_h", Message_to_h, -1);
   rb_define_method(klass, "inspect", Message_inspect, 0);
   rb_define_method(klass, "to_s", Message_inspect, 0);
   rb_define_method(klass, "[]", Message_index, 1);

--- a/ruby/ext/google/protobuf_c/message.h
+++ b/ruby/ext/google/protobuf_c/message.h
@@ -58,7 +58,8 @@ upb_Message* Message_deep_copy(const upb_Message* msg, const upb_MessageDef* m,
 void Message_CheckClass(VALUE klass);
 
 // Returns a new Hash object containing the contents of this message.
-VALUE Scalar_CreateHash(upb_MessageValue val, TypeInfo type_info);
+VALUE Scalar_CreateHash(upb_MessageValue val, TypeInfo type_info,
+                        bool emit_defaults);
 
 // Creates a message class or enum module for this descriptor, respectively.
 VALUE build_class_from_descriptor(VALUE descriptor);

--- a/ruby/lib/google/protobuf/ffi/internal/convert.rb
+++ b/ruby/lib/google/protobuf/ffi/internal/convert.rb
@@ -190,9 +190,31 @@ module Google
           end
         end
 
-        def to_h_internal(msg, message_descriptor)
+        def to_h_internal(msg, message_descriptor, emit_defaults = false)
           return nil if msg.nil? or msg.null?
           hash = {}
+
+          if emit_defaults
+            message_descriptor.each do |field_descriptor|
+              next if field_descriptor.has_presence? &&
+                      !Google::Protobuf::FFI.get_message_has(msg, field_descriptor)
+
+              message_value = Google::Protobuf::FFI.get_message_value(msg, field_descriptor)
+
+              if field_descriptor.map?
+                hash_entry = map_create_hash(message_value[:map_val], field_descriptor, emit_defaults)
+              elsif field_descriptor.repeated?
+                hash_entry = repeated_field_create_array(message_value[:array_val], field_descriptor, field_descriptor.type, emit_defaults)
+              else
+                hash_entry = scalar_create_hash(message_value, field_descriptor.type, field_descriptor: field_descriptor, emit_defaults: emit_defaults)
+              end
+
+              hash[field_descriptor.name.to_sym] = hash_entry
+            end
+
+            return hash
+          end
+
           iter = ::FFI::MemoryPointer.new(:size_t, 1)
           iter.write(:size_t, Google::Protobuf::FFI::Upb_Message_Begin)
           message_value = Google::Protobuf::FFI::MessageValue.new
@@ -202,11 +224,11 @@ module Google
             field_descriptor = FieldDescriptor.from_native field_def_ptr.get_pointer(0)
 
             if field_descriptor.map?
-              hash_entry = map_create_hash(message_value[:map_val], field_descriptor)
+              hash_entry = map_create_hash(message_value[:map_val], field_descriptor, emit_defaults)
             elsif field_descriptor.repeated?
-              hash_entry = repeated_field_create_array(message_value[:array_val], field_descriptor, field_descriptor.type)
+              hash_entry = repeated_field_create_array(message_value[:array_val], field_descriptor, field_descriptor.type, emit_defaults)
             else
-              hash_entry = scalar_create_hash(message_value, field_descriptor.type, field_descriptor: field_descriptor)
+              hash_entry = scalar_create_hash(message_value, field_descriptor.type, field_descriptor: field_descriptor, emit_defaults: emit_defaults)
             end
 
             hash[field_descriptor.name.to_sym] = hash_entry
@@ -215,7 +237,7 @@ module Google
           hash
         end
 
-        def map_create_hash(map_ptr, field_descriptor)
+        def map_create_hash(map_ptr, field_descriptor, emit_defaults = false)
           return {} if map_ptr.nil? or map_ptr.null?
           return_value = {}
 
@@ -233,24 +255,24 @@ module Google
             key_message_value = Google::Protobuf::FFI.map_key(map_ptr, iter_size_t)
             value_message_value = Google::Protobuf::FFI.map_value(map_ptr, iter_size_t)
             hash_key = convert_upb_to_ruby(key_message_value, key_field_type)
-            hash_value = scalar_create_hash(value_message_value, value_field_type, msg_or_enum_descriptor: value_field_def.subtype)
+            hash_value = scalar_create_hash(value_message_value, value_field_type, msg_or_enum_descriptor: value_field_def.subtype, emit_defaults: emit_defaults)
             return_value[hash_key] = hash_value
           end
           return_value
         end
 
-        def repeated_field_create_array(array, field_descriptor, type)
+        def repeated_field_create_array(array, field_descriptor, type, emit_defaults = false)
           return_value = []
           n = (array.nil? || array.null?) ? 0 : Google::Protobuf::FFI.array_size(array)
           0.upto(n - 1) do |i|
             message_value = Google::Protobuf::FFI.get_msgval_at(array, i)
-            return_value << scalar_create_hash(message_value, type, field_descriptor: field_descriptor)
+            return_value << scalar_create_hash(message_value, type, field_descriptor: field_descriptor, emit_defaults: emit_defaults)
           end
           return_value
         end
 
         # @param field_descriptor [FieldDescriptor] Descriptor of the field to convert to a hash.
-        def scalar_create_hash(message_value, type, field_descriptor: nil, msg_or_enum_descriptor: nil)
+        def scalar_create_hash(message_value, type, field_descriptor: nil, msg_or_enum_descriptor: nil, emit_defaults: false)
           if [:message, :enum].include? type
             if field_descriptor.nil?
               if msg_or_enum_descriptor.nil?
@@ -260,7 +282,7 @@ module Google
               msg_or_enum_descriptor = field_descriptor.subtype
             end
             if type == :message
-              to_h_internal(message_value[:msg_val], msg_or_enum_descriptor)
+              to_h_internal(message_value[:msg_val], msg_or_enum_descriptor, emit_defaults)
             elsif type == :enum
               convert_upb_to_ruby message_value, type, msg_or_enum_descriptor
             end

--- a/ruby/lib/google/protobuf/ffi/message.rb
+++ b/ruby/lib/google/protobuf/ffi/message.rb
@@ -137,8 +137,8 @@ module Google
             encoding.read(:pointer).read_string(size_ptr.read(:size_t)).hash
           end
 
-          def to_h
-            to_h_internal @msg, self.class.descriptor
+          def to_h(emit_defaults: false)
+            to_h_internal @msg, self.class.descriptor, emit_defaults
           end
 
           ##

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
@@ -355,13 +355,23 @@ public class RubyMap extends RubyObject {
 
   @JRubyMethod(name = "to_h")
   public RubyHash toHash(ThreadContext context) {
+    return toHashInternal(context, false);
+  }
+
+  RubyHash toHashInternal(ThreadContext context, boolean emitDefaults) {
     Map<IRubyObject, IRubyObject> mapForHash = new HashMap();
+    IRubyObject[] toHArgs =
+        emitDefaults
+            ? new IRubyObject[] {
+              RubyHash.newKwargs(context.runtime, "emit_defaults", context.runtime.getTrue())
+            }
+            : IRubyObject.NULL_ARRAY;
 
     table.forEach(
         (key, value) -> {
           if (!value.isNil()) {
             if (value.respondsTo("to_h")) {
-              value = Helpers.invoke(context, value, "to_h");
+              value = RubyMessage.invokeToHash(context, value, toHArgs);
             } else if (value.respondsTo("to_a")) {
               value = Helpers.invoke(context, value, "to_a");
             }

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
@@ -47,12 +47,15 @@ import com.google.protobuf.util.JsonFormat;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jruby.*;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
@@ -782,13 +785,67 @@ public class RubyMessage extends RubyObject {
     return ret;
   }
 
-  @JRubyMethod(name = "to_h")
-  public IRubyObject toHash(ThreadContext context) {
+  @JRubyMethod(name = "to_h", optional = 1)
+  public IRubyObject toHash(ThreadContext context, IRubyObject[] args) {
+    boolean emitDefaults = false;
+
+    if (args.length > 0 && !args[0].isNil()) {
+      RubyHash opts = args[0].convertToHash();
+      IRubyObject value = opts.fastARef(context.runtime.newSymbol("emit_defaults"));
+      emitDefaults = value != null && value.isTrue();
+    }
+
+    return toHashInternal(context, emitDefaults);
+  }
+
+  static IRubyObject invokeToHash(ThreadContext context, IRubyObject receiver, IRubyObject[] args) {
+    if (args.length == 0 || !toHashAcceptsOptions(context, receiver)) {
+      return Helpers.invoke(context, receiver, "to_h");
+    }
+
+    context.callInfo = ThreadContext.CALL_KEYWORD;
+    try {
+      return Helpers.invoke(context, receiver, "to_h", args);
+    } finally {
+      context.callInfo = 0;
+    }
+  }
+
+  // A user-supplied `to_h` override may take no arguments at all; passing it
+  // the options would raise ArgumentError. Fall back to a plain `to_h` call for
+  // those, so that overriding `to_h` keeps working. The subtree it returns then
+  // carries no defaults, which is also what the CRuby and FFI backends produce.
+  private static boolean toHashAcceptsOptions(ThreadContext context, IRubyObject receiver) {
+    DynamicMethod method = receiver.getMetaClass().searchMethod("to_h");
+    return method != null && !method.isUndefined() && !method.getSignature().isNoArguments();
+  }
+
+  private IRubyObject toHashInternal(ThreadContext context, boolean emitDefaults) {
     Ruby runtime = context.runtime;
     RubyHash ret = RubyHash.newHash(runtime);
     build(context, 0, SINK_MAXIMUM_NESTING); // Sync Ruby data to the Builder object.
-    for (Map.Entry<FieldDescriptor, Object> field : builder.getAllFields().entrySet()) {
-      FieldDescriptor fdef = field.getKey();
+    IRubyObject[] toHArgs =
+        emitDefaults
+            ? new IRubyObject[] {
+              RubyHash.newKwargs(runtime, "emit_defaults", runtime.getTrue())
+            }
+            : IRubyObject.NULL_ARRAY;
+
+    Collection<FieldDescriptor> fieldsToEmit;
+    if (emitDefaults) {
+      List<FieldDescriptor> present = new ArrayList<FieldDescriptor>();
+      for (FieldDescriptor fdef : descriptor.getFields()) {
+        if (fdef.hasPresence() && !builder.hasField(fdef)) {
+          continue;
+        }
+        present.add(fdef);
+      }
+      fieldsToEmit = present;
+    } else {
+      fieldsToEmit = builder.getAllFields().keySet();
+    }
+
+    for (FieldDescriptor fdef : fieldsToEmit) {
       IRubyObject value = getFieldInternal(context, fdef, !fdef.hasPresence());
 
       if (fdef.isRepeated() && !fdef.isMapField()) {
@@ -797,14 +854,20 @@ public class RubyMessage extends RubyObject {
         } else {
           RubyArray ary = value.convertToArray();
           for (int i = 0; i < ary.size(); i++) {
-            IRubyObject submsg = Helpers.invoke(context, ary.eltInternal(i), "to_h");
+            IRubyObject submsg =
+                invokeToHash(context, ary.eltInternal(i), toHArgs);
             ary.eltInternalSet(i, submsg);
           }
 
           value = ary.to_ary();
         }
+      } else if (emitDefaults && value instanceof RubyMap) {
+        // Map#to_h takes no options, so recurse into it directly rather than
+        // dispatching -- otherwise the messages stored as map values would be
+        // converted without the option.
+        value = ((RubyMap) value).toHashInternal(context, true);
       } else if (value.respondsTo("to_h")) {
-        value = Helpers.invoke(context, value, "to_h");
+        value = invokeToHash(context, value, toHArgs);
       } else if (value.respondsTo("to_a")) {
         value = Helpers.invoke(context, value, "to_a");
       }

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -507,6 +507,97 @@ module BasicTest
       assert_equal m.to_hash, m.to_h
     end
 
+    def test_to_h_emit_defaults
+      m = TestMessage.new
+      expected_result = {
+        :repeated_int32 => [],
+        :repeated_int64 => [],
+        :repeated_uint32 => [],
+        :repeated_uint64 => [],
+        :repeated_bool => [],
+        :repeated_float => [],
+        :repeated_double => [],
+        :repeated_string => [],
+        :repeated_bytes => [],
+        :repeated_msg => [],
+        :repeated_enum => [],
+      }
+      assert_equal expected_result, m.to_h(emit_defaults: true)
+
+      m = TestMessage.new(
+        :optional_bool => true,
+        :optional_string => 'foo',
+        :repeated_string => ['bar1', 'bar2'],
+      )
+      expected_result = {
+        :optional_bool => true,
+        :optional_string => 'foo',
+        :repeated_int32 => [],
+        :repeated_int64 => [],
+        :repeated_uint32 => [],
+        :repeated_uint64 => [],
+        :repeated_bool => [],
+        :repeated_float => [],
+        :repeated_double => [],
+        :repeated_string => ['bar1', 'bar2'],
+        :repeated_bytes => [],
+        :repeated_msg => [],
+        :repeated_enum => [],
+      }
+      assert_equal expected_result, m.to_h(emit_defaults: true)
+
+      m = TestSingularFields.new
+      expected_result = {
+        :singular_int32 => 0,
+        :singular_int64 => 0,
+        :singular_uint32 => 0,
+        :singular_uint64 => 0,
+        :singular_bool => false,
+        :singular_float => 0.0,
+        :singular_double => 0.0,
+        :singular_string => "",
+        :singular_bytes => "",
+        :singular_enum => :Default,
+      }
+      assert_equal expected_result, m.to_h(emit_defaults: true)
+
+      m = Enumer.new(:repeated_enum => [:A, :C])
+      expected_result = {
+        :optional_enum => :Default,
+        :repeated_enum => [:A, :C],
+        :a_const => "",
+      }
+      assert_equal expected_result, m.to_h(emit_defaults: true)
+
+      m = MapMessage.new
+      expected_result = {
+        :map_string_int32 => {},
+        :map_string_msg => {},
+        :map_string_enum => {},
+      }
+      assert_equal expected_result, m.to_h(emit_defaults: true)
+
+      m = TestMessage.new(:optional_msg => TestMessage2.new)
+      assert_equal({:optional_msg => {}}.merge(
+        TestMessage.new.to_h(emit_defaults: true)), m.to_h(emit_defaults: true))
+    end
+
+    def test_to_h_emit_defaults_reaches_map_values
+      m = MapOfSingularFields.new(
+        :map_string_singular => {"k" => TestSingularFields.new})
+
+      value = m.to_h(emit_defaults: true)[:map_string_singular]["k"]
+      assert_equal TestSingularFields.new.to_h(emit_defaults: true), value
+      assert !value.empty?, "map value should carry the restored defaults"
+
+      assert_equal({}, m.to_h[:map_string_singular]["k"])
+
+      assert_equal 0, m.map_string_singular.method(:to_h).arity
+      assert_raise(ArgumentError) do
+        m.map_string_singular.to_h(emit_defaults: true)
+      end
+    end
+
     def test_json_maps
       m = MapMessage.new(:map_string_int32 => {"a" => 1})
       expected = {mapStringInt32: {a: 1}, mapStringMsg: {}, mapStringEnum: {}}

--- a/ruby/tests/basic_proto2.rb
+++ b/ruby/tests/basic_proto2.rb
@@ -250,6 +250,50 @@ module BasicTestProto2
       assert_equal expected_result, m.to_h
     end
 
+    def test_to_h_emit_defaults
+      m = TestMessage.new
+      expected_result = {
+        :repeated_int32 => [],
+        :repeated_int64 => [],
+        :repeated_uint32 => [],
+        :repeated_uint64 => [],
+        :repeated_bool => [],
+        :repeated_float => [],
+        :repeated_double => [],
+        :repeated_string => [],
+        :repeated_bytes => [],
+        :repeated_msg => [],
+        :repeated_enum => [],
+      }
+      assert_equal expected_result, m.to_h(emit_defaults: true)
+
+      m = TestMessage.new(:optional_bool => true, :optional_double => -10.100001, :optional_string => 'foo', :repeated_string => ['bar1', 'bar2'])
+      expected_result = {
+        :optional_bool => true,
+        :optional_double => -10.100001,
+        :optional_string => 'foo',
+        :repeated_int32 => [],
+        :repeated_int64 => [],
+        :repeated_uint32 => [],
+        :repeated_uint64 => [],
+        :repeated_bool => [],
+        :repeated_float => [],
+        :repeated_double => [],
+        :repeated_string => ['bar1', 'bar2'],
+        :repeated_bytes => [],
+        :repeated_msg => [],
+        :repeated_enum => [],
+      }
+      assert_equal expected_result, m.to_h(emit_defaults: true)
+
+      # oneof members have presence: an unset oneof is never restored.
+      m = OneofMessage.new
+      assert_equal({}, m.to_h(emit_defaults: true))
+
+      m = OneofMessage.new(:a => "foo")
+      assert_equal m.to_h, m.to_h(emit_defaults: true)
+    end
+
     def test_respond_to
       # This test fails with JRuby 1.7.23, likely because of an old JRuby bug.
       return if RUBY_PLATFORM == "java"

--- a/ruby/tests/basic_test.proto
+++ b/ruby/tests/basic_test.proto
@@ -141,6 +141,10 @@ message MapMessage {
   map<string, TestEnum> map_string_enum = 3;
 }
 
+message MapOfSingularFields {
+  map<string, TestSingularFields> map_string_singular = 1;
+}
+
 message MapMessageWireEquiv {
   repeated MapMessageWireEquiv_entry1 map_string_int32 = 1;
   repeated MapMessageWireEquiv_entry2 map_string_msg = 2;


### PR DESCRIPTION
Since, #15234, `Message#to_h` remove unset sub-message fields. But, this is inconvenience sometimes. For example, an enum message has a default field, I expect to output it(Ref: #18913).

This adds `emit_defaults` option to `Message#to_h` to support it. We already support the same option on `encode_json`. This introduce the same behavior to `Message#to_h`(also, this matches the behavior with `#inspect`).