### PR TITLE
Disable ELF weak descriptor defaults with FilC

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -589,7 +589,7 @@
 #endif
 #if defined(__GNUC__) && defined(__clang__) && !defined(__APPLE__) && \
     !defined(_MSC_VER) && !defined(_WIN32) && !defined(__wasm__) &&   \
-    !defined(__EMSCRIPTEN__)
+    !defined(__EMSCRIPTEN__) && !defined(__FILC__)
 #define PROTOBUF_DESCRIPTOR_WEAK_MESSAGES_ALLOWED
 #endif
 


### PR DESCRIPTION
FilC preserves pointer capabilities through instrumented references, while GNU ld-style synthesized `__start_<section>` and `__stop_<section>` symbols are emitted only under their raw ELF names. Clang's FilC symbol transformation therefore leaves `__start_pb_defaults` and `__stop_pb_defaults` unresolved when linking `protoc`.

Exclude FilC from `PROTOBUF_DESCRIPTOR_WEAK_MESSAGES_ALLOWED`, selecting protobuf's existing no-op weak-default initialization path used on platforms without this ELF extension.

Validated with FilC 0.684 by rebuilding `generated_message_util.cc`, `libprotobuf`, and linking `protoc` successfully. Before this change the final link failed on `pizlonated___start_pb_defaults` and `pizlonated___stop_pb_defaults`.
